### PR TITLE
fix Docker API build — pin TypeScript and run tsc-alias

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ WORKDIR /usr/src/app
 
 COPY ./astros_api/package*.json ./
 
-RUN npm ci --python=/usr/bin/python3 && npm install typescript -g
+RUN npm ci --python=/usr/bin/python3
 
 COPY ./astros_api/ .
-RUN tsc
+RUN npx tsc && npx tsc-alias
 
 ARG JWT_KEY
 RUN printf '%s\n' \


### PR DESCRIPTION
Dockerfile was installing TypeScript globally (picking up latest, now 6.0) and running bare `tsc` without `tsc-alias`. Use the pinned version from npm ci and the same npx invocation the CI workflow uses.