### PR TITLE
DB safety Phase 1

### DIFF
--- a/.docs/plans/20260410-0807-db-safety-phase1-backup-readonly.md
+++ b/.docs/plans/20260410-0807-db-safety-phase1-backup-readonly.md
@@ -54,21 +54,21 @@ export function getDb(): Kysely<Database> {
 
 ## Tasks
 
-- [ ] Create `astros_api/src/system_status.ts` with a `SystemStatus` class:
+- [x] Create `astros_api/src/system_status.ts` with a `SystemStatus` class:
   - `isReadOnly(): boolean`
   - `enterReadOnly(reason: string): void` — logs at error level, notifies subscribers, sets `enteredAt` timestamp
   - `getState(): { readOnly: boolean; reason?: string; enteredAt?: string }`
   - `subscribe(cb): () => void` — returns unsubscribe fn, used by WebSocket
   - No disk persistence.
 
-- [ ] Create `astros_api/src/dal/backup.ts`:
+- [x] Create `astros_api/src/dal/backup.ts`:
   - `checkPendingMigrations(db, provider): Promise<string[]>` — queries `kysely_migration`, treats "table missing" as "all pending".
   - `getLastAppliedMigrationName(db): Promise<string | null>` — returns the latest row in `kysely_migration` by `timestamp`, or null.
   - `createBackup(rawSqlite, dbPath, lastMigrationName): Promise<string>` — builds `${dbPath}.backup-${lastMigrationName}`, calls `rawSqlite.backup(destPath)` (overwrites same-name), returns path.
   - `pruneOldBackups(appdataPath, keep = 5): void` — globs `database.sqlite3.backup-*`, sorts by mtime desc, unlinks index 5+.
   - `restoreBackup(backupPath, dbPath): void` — `fs.copyFileSync`.
 
-- [ ] Refactor `astros_api/src/dal/database.ts`:
+- [x] Refactor `astros_api/src/dal/database.ts`:
   - Replace `export const db` with `_db` module-local + `initializeDatabase()` and `getDb()`.
   - `initializeDatabase(systemStatus)` flow:
     1. In `NODE_ENV=test`: open `:memory:`, run migrations directly, return (no backup dance).
@@ -80,7 +80,7 @@ export function getDb(): Kysely<Database> {
     7. On migration failure: log, close connection, `restoreBackup()`, re-open connection, log "restored from backup after failed migration". If the restore throws → `systemStatus.enterReadOnly('migration failed and restore failed: ...')`.
   - Export `getDb()` for places that can't receive the connection via constructor.
 
-- [ ] Create `astros_api/src/write_guard.ts`:
+- [x] Create `astros_api/src/write_guard.ts`:
   - Export `writeGuard(systemStatus): RequestHandler`.
   - `BLOCKED_WRITE_METHODS = new Set(['POST','PUT','PATCH','DELETE'])`.
   - `ALLOWED_IN_READONLY: Array<{ method, path }>` = `/login`, `/reauth`, `/panicStop`, `/panicClear` (all POST).
@@ -88,35 +88,35 @@ export function getDb(): Kysely<Database> {
   - Logic: if not read-only, `next()`. Else: if allowlisted, `next()`. Else if method blocked OR (GET ∧ path in BLOCKED_GET_PATHS), send 503 `{ message, reason }`. Else `next()`.
   - `req.path` is relative to the router mount, so comparisons are `/login`, `/scripts/upload`, etc.
 
-- [ ] Create `astros_api/src/controllers/system_status_controller.ts`:
+- [x] Create `astros_api/src/controllers/system_status_controller.ts`:
   - `registerSystemStatusRoutes(router, systemStatus)` — **no authHandler**, public.
   - `GET /system/status` → returns `systemStatus.getState()`.
 
-- [ ] Wire it all up in `astros_api/src/api_server.ts`:
+- [x] Wire it all up in `astros_api/src/api_server.ts`:
   - Construct a `SystemStatus` on the `ApiServer` instance.
   - In `Init()`, call `await initializeDatabase(this.systemStatus)` and hold the connection on `this.db`. Pass it to all `register*Routes` calls.
   - In `configApi()`, install the `writeGuard(this.systemStatus)` middleware **before** `this.app.use('/api', this.router)`.
   - Register the new system status route.
   - In `runWebServices()`, on each WebSocket connection, immediately send `{ type: TransmissionType.systemStatus, data: systemStatus.getState() }`. Subscribe to `systemStatus` changes and broadcast to all connected clients when state changes.
 
-- [ ] Update `astros_api/src/models/index.ts` — add `TransmissionType.systemStatus` constant for the WebSocket message discrimination.
+- [x] Update `astros_api/src/models/index.ts` — add `TransmissionType.systemStatus` constant for the WebSocket message discrimination.
 
 ## Tests
 
-- [ ] `astros_api/src/system_status.test.ts` — state transitions, reason/timestamp capture, subscribe/unsubscribe, notifications.
-- [ ] `astros_api/src/dal/backup.test.ts` (use `os.tmpdir()` + `fs.mkdtempSync()`):
+- [x] `astros_api/src/system_status.test.ts` — state transitions, reason/timestamp capture, subscribe/unsubscribe, notifications.
+- [x] `astros_api/src/dal/backup.test.ts` (use `os.tmpdir()` + `fs.mkdtempSync()`):
   - `checkPendingMigrations` returns all migrations on a fresh DB with no `kysely_migration` table.
   - Returns `[]` on a fully-migrated DB.
   - `createBackup` writes a file with the expected name and byte-for-byte content.
   - Same-version backup overwrites (not duplicated).
   - `pruneOldBackups(5)` keeps the 5 newest by mtime, deletes older.
-- [ ] `astros_api/src/dal/database.integration.test.ts`:
+- [x] `astros_api/src/dal/database.integration.test.ts`:
   - Happy path: no pending migrations → no backup taken.
   - Happy path + pending migrations → backup + migrate succeed → backup retained.
   - Failing migration: inject a bad migration, verify backup taken, restore succeeds, system usable at pre-migration state.
   - Failing migration + failing restore (simulated via permission drop or mock): verify `SystemStatus` is read-only with clear reason.
   - Backup failure (simulated via read-only dir): verify `SystemStatus` is read-only and migration is skipped.
-- [ ] `astros_api/src/write_guard.test.ts`:
+- [x] `astros_api/src/write_guard.test.ts`:
   - Pass-through when not read-only (all methods + paths).
   - Blocks POST/PUT/PATCH/DELETE in read-only.
   - Allows all GETs in read-only EXCEPT the five serial-write paths.

--- a/astros_api/src/api_key_validator.test.ts
+++ b/astros_api/src/api_key_validator.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from './dal/types.js';
-import { migrateToLatest } from './dal/database.js';
+import { createKyselyConnection, migrateToLatest } from './dal/database.js';
 import { SettingsRepository } from './dal/repositories/settings_repository.js';
 import { ApiKeyValidator } from './api_key_validator.js';
 
@@ -18,9 +17,7 @@ describe('ApiKeyValidator', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -53,7 +53,12 @@ import { ServoTest } from './models/servo_test.js';
 
 import { fileURLToPath } from 'url';
 
-import { db, migrateToLatest } from './dal/database.js';
+import { initializeDatabase } from './dal/database.js';
+import { Kysely } from 'kysely';
+import { Database } from './dal/types.js';
+import { SystemStatus } from './system_status.js';
+import { writeGuard } from './write_guard.js';
+import { registerSystemStatusRoutes } from './controllers/system_status_controller.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -103,6 +108,9 @@ class ApiServer {
 
   private authHandler!: any;
   private apiKeyValidator!: ReqHandler;
+
+  private db!: Kysely<Database>;
+  private systemStatus = new SystemStatus();
 
   upload!: any;
 
@@ -164,6 +172,9 @@ class ApiServer {
   }
 
   public async Init() {
+    logger.info('Initializing database');
+    this.db = await initializeDatabase(this.systemStatus);
+
     logger.info('Setting up authentication strategy');
     this.setAuthStrategy();
 
@@ -208,7 +219,7 @@ class ApiServer {
           usernameField: 'username',
         },
         async (username: string, password: string, done) => {
-          const repository = new UserRepository(db);
+          const repository = new UserRepository(this.db);
 
           const user = await repository.getByUsername(username);
 
@@ -232,13 +243,6 @@ class ApiServer {
   }
 
   private async configApi(): Promise<void> {
-    try {
-      migrateToLatest(db);
-    } catch (error) {
-      logger.error('Error migrating database', error);
-      process.exit(1);
-    }
-
     const loggerMiddleware = pinoHttp({
       logger: logger,
       autoLogging: true,
@@ -284,6 +288,7 @@ class ApiServer {
     this.app.use(cookieParser());
     this.app.use(Express.static(path.join(__dirname, 'public')));
     this.app.use(passport.initialize());
+    this.app.use('/api', writeGuard(this.systemStatus));
     this.app.use('/api', this.router);
 
     this.app.get('/index.html', (req, res) => {
@@ -315,18 +320,19 @@ class ApiServer {
       algorithms: ['HS256'],
     });
 
-    this.apiKeyValidator = ApiKeyValidator(db);
+    this.apiKeyValidator = ApiKeyValidator(this.db);
   }
 
   private setRoutes(): void {
     registerAuthRoutes(this.router);
-    registerLocationRoutes(this.router, this.authHandler, db);
-    registerScriptRoutes(this.router, this.authHandler, db);
-    registerPlaylistRoutes(this.router, this.authHandler, db);
-    registerRemoteConfigRoutes(this.router, this.authHandler, this.apiKeyValidator, db);
-    registerSettingsRoutes(this.router, this.authHandler, db);
-    registerAudioRoutes(this.router, this.authHandler, db);
-    registerFileRoutes(this.router, this.authHandler, db);
+    registerSystemStatusRoutes(this.router, this.systemStatus);
+    registerLocationRoutes(this.router, this.authHandler, this.db);
+    registerScriptRoutes(this.router, this.authHandler, this.db);
+    registerPlaylistRoutes(this.router, this.authHandler, this.db);
+    registerRemoteConfigRoutes(this.router, this.authHandler, this.apiKeyValidator, this.db);
+    registerSettingsRoutes(this.router, this.authHandler, this.db);
+    registerAudioRoutes(this.router, this.authHandler, this.db);
+    registerFileRoutes(this.router, this.authHandler, this.db);
 
     this.router.get('/check-session', this.authHandler, (req: any, res: any, next: any) => {
       res.status(200);
@@ -443,9 +449,24 @@ class ApiServer {
 
     this.websocket = new Server({ port: this.websocketPort });
 
+    this.systemStatus.subscribe((state) => {
+      this.updateClients({ type: TransmissionType.systemStatus, data: state });
+    });
+
     this.websocket.on('connection', (conn) => {
       const id = uuid_v4();
       this.clients.set(id, conn);
+
+      try {
+        conn.send(
+          JSON.stringify({
+            type: TransmissionType.systemStatus,
+            data: this.systemStatus.getState(),
+          }),
+        );
+      } catch (err) {
+        logger.error(`websocket initial systemStatus send error: ${err}`);
+      }
 
       conn.on('message', (msg) => {
         this.handleWebsocketMessage(msg.toString());
@@ -519,7 +540,7 @@ class ApiServer {
 
       const val = msg as RegistrationResponse;
 
-      const controllerRepo = new ControllerRepository(db);
+      const controllerRepo = new ControllerRepository(this.db);
 
       await controllerRepo.insertControllers(val.registrations);
 
@@ -549,8 +570,8 @@ class ApiServer {
     try {
       const val = msg as PollRepsonse;
 
-      const controlerRepo = new ControllerRepository(db);
-      const locationRepo = new LocationsRepository(db);
+      const controlerRepo = new ControllerRepository(this.db);
+      const locationRepo = new LocationsRepository(this.db);
 
       const controller = await controlerRepo.getControllerByAddress(val.controller.address);
 
@@ -586,7 +607,7 @@ class ApiServer {
     try {
       const val = msg as ConfigSyncResponse;
 
-      const locationRepo = new LocationsRepository(db);
+      const locationRepo = new LocationsRepository(this.db);
 
       const locationId = await locationRepo.getLocationIdByControllerByMac(val.controller.address);
 
@@ -605,8 +626,8 @@ class ApiServer {
     try {
       const val = msg as ConfigSyncResponse;
 
-      const locationRepo = new LocationsRepository(db);
-      const scriptRepo = new ScriptRepository(db);
+      const locationRepo = new LocationsRepository(this.db);
+      const scriptRepo = new ScriptRepository(this.db);
 
       const locId = await locationRepo.getLocationNameByMac(val.controller.address);
 
@@ -662,7 +683,7 @@ class ApiServer {
   private async syncControllerConfig(req: any, res: any, next: any) {
     logger.info('syncing controller config');
 
-    const repo = new LocationsRepository(db);
+    const repo = new LocationsRepository(this.db);
 
     const locations = await repo.loadLocations();
 
@@ -696,8 +717,8 @@ class ApiServer {
 
     const id = req.query.id;
 
-    const scriptRepo = new ScriptRepository(db);
-    const locationsRepo = new LocationsRepository(db);
+    const scriptRepo = new ScriptRepository(this.db);
+    const locationsRepo = new LocationsRepository(this.db);
 
     const cvtr = new ScriptConverter(scriptRepo);
 
@@ -728,8 +749,8 @@ class ApiServer {
     const id = req.query.id;
     logger.info(`running playlist ${id}`);
 
-    const playlistRepo = new PlaylistRepository(db);
-    const locationsRepo = new LocationsRepository(db);
+    const playlistRepo = new PlaylistRepository(this.db);
+    const locationsRepo = new LocationsRepository(this.db);
 
     try {
       const playlist = await playlistRepo.getPlaylist(id);
@@ -769,8 +790,8 @@ class ApiServer {
     const id = req.query.id;
     logger.info(`running script ${id}`);
 
-    const scriptRepo = new ScriptRepository(db);
-    const locationsRepo = new LocationsRepository(db);
+    const scriptRepo = new ScriptRepository(this.db);
+    const locationsRepo = new LocationsRepository(this.db);
 
     const script = await scriptRepo.getScript(id);
     const locations = await locationsRepo.loadLocations();
@@ -797,7 +818,7 @@ class ApiServer {
 
     this.animationQueue.panicStop();
 
-    const ctlRepo = new LocationsRepository(db);
+    const ctlRepo = new LocationsRepository(this.db);
     const locations = await ctlRepo.loadLocations();
     const msg = createScriptRun('panic', locations);
     msg.type = TransmissionType.panic;
@@ -849,13 +870,13 @@ class ApiServer {
   private async directCommand(req: any, res: any, next: any) {
     logger.info('sending direct command');
 
-    const repo = new ControllerRepository(db);
+    const repo = new ControllerRepository(this.db);
     const controller = await repo.getControllerByLocationId(req.body.locationId);
 
     logger.debug(`controller: ${JSON.stringify(controller)}`);
     logger.debug(`req: ${JSON.stringify(req.body)}`);
 
-    const converter = new ScriptConverter(new ScriptRepository(db));
+    const converter = new ScriptConverter(new ScriptRepository(this.db));
     const cmd = await converter.convertCommand(req.body);
 
     this.serialWorker.postMessage({

--- a/astros_api/src/controllers/locations_controller.test.ts
+++ b/astros_api/src/controllers/locations_controller.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../dal/types.js';
-import { migrateToLatest } from '../dal/database.js';
+import { createKyselyConnection, migrateToLatest } from '../dal/database.js';
 import { getLocations } from './locations_controller.js';
 
 function mockRes() {
@@ -16,9 +15,7 @@ describe('Locations Controller', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/controllers/playlist_controller.test.ts
+++ b/astros_api/src/controllers/playlist_controller.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../dal/types.js';
-import { migrateToLatest } from '../dal/database.js';
+import { createKyselyConnection, migrateToLatest } from '../dal/database.js';
 import { getPlaylist, savePlaylist } from './playlist_controller.js';
 import { PlaylistRepository } from '../dal/repositories/playlist_repository.js';
 import { PlaylistType } from '../models/playlists/playlistType.js';
@@ -20,9 +19,7 @@ describe('Playlist Controller', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/controllers/scripts_controller.test.ts
+++ b/astros_api/src/controllers/scripts_controller.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../dal/types.js';
-import { migrateToLatest } from '../dal/database.js';
+import { createKyselyConnection, migrateToLatest } from '../dal/database.js';
 import { deleteScript } from './scripts_controller.js';
 import { ScriptRepository } from '../dal/repositories/script_repository.js';
 import { PlaylistRepository } from '../dal/repositories/playlist_repository.js';
@@ -21,9 +20,7 @@ describe('Scripts Controller', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/controllers/system_status_controller.ts
+++ b/astros_api/src/controllers/system_status_controller.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { SystemStatus } from '../system_status.js';
+
+export function registerSystemStatusRoutes(router: Router, systemStatus: SystemStatus) {
+  router.get('/system/status', (req, res) => {
+    res.status(200).json(systemStatus.getState());
+  });
+}

--- a/astros_api/src/dal/backup.test.ts
+++ b/astros_api/src/dal/backup.test.ts
@@ -142,10 +142,11 @@ describe('backup module', () => {
 
   describe('pruneOldBackups', () => {
     it('keeps the 5 newest backups by mtime, deletes older', () => {
+      const dbPath = path.join(tmpDir, 'database.sqlite3');
       const names = ['v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7'];
       const baseTime = Date.now() - 60_000;
       names.forEach((n, i) => {
-        const p = path.join(tmpDir, `database.sqlite3.backup-${n}`);
+        const p = `${dbPath}.backup-${n}`;
         fs.writeFileSync(p, `data-${n}`);
         const t = (baseTime + i * 1000) / 1000;
         fs.utimesSync(p, t, t);
@@ -154,7 +155,7 @@ describe('backup module', () => {
       // Decoy: a non-backup file should not be touched
       fs.writeFileSync(path.join(tmpDir, 'not-a-backup.txt'), 'keep me');
 
-      pruneOldBackups(tmpDir, 5);
+      pruneOldBackups(dbPath, 5);
 
       const remaining = fs
         .readdirSync(tmpDir)
@@ -172,15 +173,49 @@ describe('backup module', () => {
     });
 
     it('is a no-op when there are fewer backups than the keep count', () => {
-      fs.writeFileSync(path.join(tmpDir, 'database.sqlite3.backup-a'), 'a');
-      fs.writeFileSync(path.join(tmpDir, 'database.sqlite3.backup-b'), 'b');
+      const dbPath = path.join(tmpDir, 'database.sqlite3');
+      fs.writeFileSync(`${dbPath}.backup-a`, 'a');
+      fs.writeFileSync(`${dbPath}.backup-b`, 'b');
 
-      pruneOldBackups(tmpDir, 5);
+      pruneOldBackups(dbPath, 5);
 
       const remaining = fs
         .readdirSync(tmpDir)
         .filter((f) => f.startsWith('database.sqlite3.backup-'));
       expect(remaining.length).toBe(2);
+    });
+
+    it('prunes correctly with a custom dbPath basename (regression: prefix derived from dbPath)', () => {
+      const dbPath = path.join(tmpDir, 'custom.sqlite3');
+      const names = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+      const baseTime = Date.now() - 60_000;
+      names.forEach((n, i) => {
+        const p = `${dbPath}.backup-${n}`;
+        fs.writeFileSync(p, `data-${n}`);
+        const t = (baseTime + i * 1000) / 1000;
+        fs.utimesSync(p, t, t);
+      });
+
+      // Unrelated backup file from a different db basename in the same dir
+      // must be left alone.
+      fs.writeFileSync(path.join(tmpDir, 'database.sqlite3.backup-x'), 'untouched');
+
+      pruneOldBackups(dbPath, 5);
+
+      const customRemaining = fs
+        .readdirSync(tmpDir)
+        .filter((f) => f.startsWith('custom.sqlite3.backup-'))
+        .sort();
+      expect(customRemaining).toEqual([
+        'custom.sqlite3.backup-c',
+        'custom.sqlite3.backup-d',
+        'custom.sqlite3.backup-e',
+        'custom.sqlite3.backup-f',
+        'custom.sqlite3.backup-g',
+      ]);
+
+      // Different-basename backup is not pruned
+      expect(fs.existsSync(path.join(tmpDir, 'database.sqlite3.backup-x'))).toBe(true);
     });
   });
 

--- a/astros_api/src/dal/backup.test.ts
+++ b/astros_api/src/dal/backup.test.ts
@@ -85,7 +85,7 @@ describe('backup module', () => {
       await db.destroy();
     });
 
-    it('returns the most recent migration name by timestamp', async () => {
+    it('returns the latest applied migration in provider order', async () => {
       const db = new Kysely<Database>({
         dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
       });

--- a/astros_api/src/dal/backup.test.ts
+++ b/astros_api/src/dal/backup.test.ts
@@ -14,6 +14,7 @@ import path from 'path';
 import { createKyselyConnection, migrateToLatest } from './database.js';
 import {
   checkPendingMigrations,
+  compareMigrationNames,
   getLastAppliedMigrationName,
   createBackup,
   pruneOldBackups,
@@ -21,7 +22,7 @@ import {
 } from './backup.js';
 
 async function expectedMigrationNames(): Promise<string[]> {
-  return Object.keys(await provider.getMigrations()).sort();
+  return Object.keys(await provider.getMigrations()).sort(compareMigrationNames);
 }
 
 const provider: MigrationProvider = new (class implements MigrationProvider {

--- a/astros_api/src/dal/backup.test.ts
+++ b/astros_api/src/dal/backup.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import SQLite from 'better-sqlite3';
+import { Kysely, Migration, MigrationProvider, SqliteDialect } from 'kysely';
+import {
+  migration_0,
+  migration_1,
+  migration_2,
+  migration_3,
+  migration_4,
+} from './migrations/index.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Database } from './types.js';
+import { migrateToLatest } from './database.js';
+import {
+  checkPendingMigrations,
+  getLastAppliedMigrationName,
+  createBackup,
+  pruneOldBackups,
+  restoreBackup,
+  ALL_MIGRATION_NAMES,
+} from './backup.js';
+
+const provider: MigrationProvider = new (class implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return {
+      '0_initial': migration_0,
+      '1_add_script_evt_id': migration_1,
+      '2_add_script_duration': migration_2,
+      '3_add_playlists': migration_3,
+      '4_add_random_wait': migration_4,
+    };
+  }
+})();
+
+describe('backup module', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astros-backup-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('checkPendingMigrations', () => {
+    it('returns all migrations on a fresh DB with no kysely_migration table', async () => {
+      const db = new Kysely<Database>({
+        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
+      });
+
+      const pending = await checkPendingMigrations(db, provider);
+      expect(pending).toEqual(ALL_MIGRATION_NAMES);
+
+      await db.destroy();
+    });
+
+    it('returns [] on a fully migrated DB', async () => {
+      const db = new Kysely<Database>({
+        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
+      });
+      await migrateToLatest(db);
+
+      const pending = await checkPendingMigrations(db, provider);
+      expect(pending).toEqual([]);
+
+      await db.destroy();
+    });
+  });
+
+  describe('getLastAppliedMigrationName', () => {
+    it('returns null on a DB with no kysely_migration table', async () => {
+      const db = new Kysely<Database>({
+        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
+      });
+
+      const last = await getLastAppliedMigrationName(db, provider);
+      expect(last).toBeNull();
+
+      await db.destroy();
+    });
+
+    it('returns the most recent migration name by timestamp', async () => {
+      const db = new Kysely<Database>({
+        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
+      });
+      await migrateToLatest(db);
+
+      const last = await getLastAppliedMigrationName(db, provider);
+      expect(last).toBe(ALL_MIGRATION_NAMES[ALL_MIGRATION_NAMES.length - 1]);
+
+      await db.destroy();
+    });
+  });
+
+  describe('createBackup', () => {
+    it('writes a backup file with the expected name and matching contents', async () => {
+      const dbPath = path.join(tmpDir, 'database.sqlite3');
+      const sqlite = new SQLite(dbPath);
+      sqlite.prepare('CREATE TABLE t (id INTEGER)').run();
+      const insert = sqlite.prepare('INSERT INTO t VALUES (?)');
+      insert.run(1);
+      insert.run(2);
+      insert.run(3);
+
+      const backupPath = await createBackup(sqlite, dbPath, '4_add_random_wait');
+
+      expect(backupPath).toBe(`${dbPath}.backup-4_add_random_wait`);
+      expect(fs.existsSync(backupPath)).toBe(true);
+
+      const backupSqlite = new SQLite(backupPath, { readonly: true });
+      const rows = backupSqlite.prepare('SELECT id FROM t ORDER BY id').all();
+      expect(rows).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      backupSqlite.close();
+      sqlite.close();
+    });
+
+    it('overwrites a same-version backup file', async () => {
+      const dbPath = path.join(tmpDir, 'database.sqlite3');
+      const sqlite = new SQLite(dbPath);
+      sqlite.prepare('CREATE TABLE t (id INTEGER)').run();
+
+      sqlite.prepare('INSERT INTO t VALUES (?)').run(1);
+      await createBackup(sqlite, dbPath, '4_add_random_wait');
+
+      sqlite.prepare('INSERT INTO t VALUES (?)').run(2);
+      const backupPath = await createBackup(sqlite, dbPath, '4_add_random_wait');
+
+      const backupSqlite = new SQLite(backupPath, { readonly: true });
+      const rows = backupSqlite.prepare('SELECT id FROM t ORDER BY id').all();
+      expect(rows).toEqual([{ id: 1 }, { id: 2 }]);
+
+      const files = fs.readdirSync(tmpDir).filter((f) => f.startsWith('database.sqlite3.backup-'));
+      expect(files).toEqual(['database.sqlite3.backup-4_add_random_wait']);
+
+      backupSqlite.close();
+      sqlite.close();
+    });
+  });
+
+  describe('pruneOldBackups', () => {
+    it('keeps the 5 newest backups by mtime, deletes older', () => {
+      const names = ['v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7'];
+      const baseTime = Date.now() - 60_000;
+      names.forEach((n, i) => {
+        const p = path.join(tmpDir, `database.sqlite3.backup-${n}`);
+        fs.writeFileSync(p, `data-${n}`);
+        const t = (baseTime + i * 1000) / 1000;
+        fs.utimesSync(p, t, t);
+      });
+
+      // Decoy: a non-backup file should not be touched
+      fs.writeFileSync(path.join(tmpDir, 'not-a-backup.txt'), 'keep me');
+
+      pruneOldBackups(tmpDir, 5);
+
+      const remaining = fs
+        .readdirSync(tmpDir)
+        .filter((f) => f.startsWith('database.sqlite3.backup-'))
+        .sort();
+      expect(remaining).toEqual([
+        'database.sqlite3.backup-v3',
+        'database.sqlite3.backup-v4',
+        'database.sqlite3.backup-v5',
+        'database.sqlite3.backup-v6',
+        'database.sqlite3.backup-v7',
+      ]);
+
+      expect(fs.existsSync(path.join(tmpDir, 'not-a-backup.txt'))).toBe(true);
+    });
+
+    it('is a no-op when there are fewer backups than the keep count', () => {
+      fs.writeFileSync(path.join(tmpDir, 'database.sqlite3.backup-a'), 'a');
+      fs.writeFileSync(path.join(tmpDir, 'database.sqlite3.backup-b'), 'b');
+
+      pruneOldBackups(tmpDir, 5);
+
+      const remaining = fs
+        .readdirSync(tmpDir)
+        .filter((f) => f.startsWith('database.sqlite3.backup-'));
+      expect(remaining.length).toBe(2);
+    });
+  });
+
+  describe('restoreBackup', () => {
+    it('copies the backup file over the db path', () => {
+      const dbPath = path.join(tmpDir, 'database.sqlite3');
+      const backupPath = path.join(tmpDir, 'database.sqlite3.backup-x');
+
+      fs.writeFileSync(dbPath, 'corrupt');
+      fs.writeFileSync(backupPath, 'good-data');
+
+      restoreBackup(backupPath, dbPath);
+
+      expect(fs.readFileSync(dbPath, 'utf8')).toBe('good-data');
+    });
+  });
+});

--- a/astros_api/src/dal/backup.test.ts
+++ b/astros_api/src/dal/backup.test.ts
@@ -88,6 +88,44 @@ describe('backup module', () => {
 
       await db.destroy();
     });
+
+    it('orders migrations by numeric prefix, not lexicographically', async () => {
+      // Regression: lexicographic sort places '10_foo' before '2_foo'.
+      // We use a custom provider with mixed single- and double-digit names,
+      // pre-seed the kysely_migration table to mark them all applied, and
+      // assert getLastAppliedMigrationName returns '10_late_addition'.
+      const numericProvider: MigrationProvider = new (class implements MigrationProvider {
+        async getMigrations(): Promise<Record<string, Migration>> {
+          const noop: Migration = {
+            async up() {
+              return;
+            },
+          };
+          return {
+            '0_initial': noop,
+            '2_second': noop,
+            '10_late_addition': noop,
+          };
+        }
+      })();
+
+      const { db, raw } = createKyselyConnection();
+      raw
+        .prepare('CREATE TABLE kysely_migration (name TEXT PRIMARY KEY, timestamp TEXT NOT NULL)')
+        .run();
+      const insertMig = raw.prepare('INSERT INTO kysely_migration VALUES (?, ?)');
+      insertMig.run('0_initial', '2026-01-01T00:00:00.000Z');
+      insertMig.run('2_second', '2026-01-02T00:00:00.000Z');
+      insertMig.run('10_late_addition', '2026-01-03T00:00:00.000Z');
+
+      const last = await getLastAppliedMigrationName(db, numericProvider);
+      expect(last).toBe('10_late_addition');
+
+      const pending = await checkPendingMigrations(db, numericProvider);
+      expect(pending).toEqual([]);
+
+      await db.destroy();
+    });
   });
 
   describe('createBackup', () => {

--- a/astros_api/src/dal/backup.test.ts
+++ b/astros_api/src/dal/backup.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import SQLite from 'better-sqlite3';
-import { Kysely, Migration, MigrationProvider, SqliteDialect } from 'kysely';
+import { Migration, MigrationProvider } from 'kysely';
 import {
   migration_0,
   migration_1,
@@ -11,8 +11,7 @@ import {
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { Database } from './types.js';
-import { migrateToLatest } from './database.js';
+import { createKyselyConnection, migrateToLatest } from './database.js';
 import {
   checkPendingMigrations,
   getLastAppliedMigrationName,
@@ -50,9 +49,7 @@ describe('backup module', () => {
 
   describe('checkPendingMigrations', () => {
     it('returns all migrations on a fresh DB with no kysely_migration table', async () => {
-      const db = new Kysely<Database>({
-        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-      });
+      const { db } = createKyselyConnection();
 
       const pending = await checkPendingMigrations(db, provider);
       expect(pending).toEqual(await expectedMigrationNames());
@@ -61,9 +58,7 @@ describe('backup module', () => {
     });
 
     it('returns [] on a fully migrated DB', async () => {
-      const db = new Kysely<Database>({
-        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-      });
+      const { db } = createKyselyConnection();
       await migrateToLatest(db);
 
       const pending = await checkPendingMigrations(db, provider);
@@ -75,9 +70,7 @@ describe('backup module', () => {
 
   describe('getLastAppliedMigrationName', () => {
     it('returns null on a DB with no kysely_migration table', async () => {
-      const db = new Kysely<Database>({
-        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-      });
+      const { db } = createKyselyConnection();
 
       const last = await getLastAppliedMigrationName(db, provider);
       expect(last).toBeNull();
@@ -86,9 +79,7 @@ describe('backup module', () => {
     });
 
     it('returns the latest applied migration in provider order', async () => {
-      const db = new Kysely<Database>({
-        dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-      });
+      const { db } = createKyselyConnection();
       await migrateToLatest(db);
 
       const last = await getLastAppliedMigrationName(db, provider);

--- a/astros_api/src/dal/backup.test.ts
+++ b/astros_api/src/dal/backup.test.ts
@@ -19,8 +19,11 @@ import {
   createBackup,
   pruneOldBackups,
   restoreBackup,
-  ALL_MIGRATION_NAMES,
 } from './backup.js';
+
+async function expectedMigrationNames(): Promise<string[]> {
+  return Object.keys(await provider.getMigrations()).sort();
+}
 
 const provider: MigrationProvider = new (class implements MigrationProvider {
   async getMigrations(): Promise<Record<string, Migration>> {
@@ -52,7 +55,7 @@ describe('backup module', () => {
       });
 
       const pending = await checkPendingMigrations(db, provider);
-      expect(pending).toEqual(ALL_MIGRATION_NAMES);
+      expect(pending).toEqual(await expectedMigrationNames());
 
       await db.destroy();
     });
@@ -89,7 +92,8 @@ describe('backup module', () => {
       await migrateToLatest(db);
 
       const last = await getLastAppliedMigrationName(db, provider);
-      expect(last).toBe(ALL_MIGRATION_NAMES[ALL_MIGRATION_NAMES.length - 1]);
+      const all = await expectedMigrationNames();
+      expect(last).toBe(all[all.length - 1]);
 
       await db.destroy();
     });

--- a/astros_api/src/dal/backup.ts
+++ b/astros_api/src/dal/backup.ts
@@ -15,9 +15,24 @@ async function migrationTableExists(db: Kysely<Database>): Promise<boolean> {
   return result.rows.length > 0;
 }
 
+// Compare migration names by their leading numeric prefix (`<n>_<slug>`),
+// falling back to lexicographic order on the slug or for non-conforming names.
+// Plain .sort() would put '10_foo' before '2_foo' because '1' < '2'.
+function compareMigrationNames(a: string, b: string): number {
+  const matchA = a.match(/^(\d+)_(.*)$/);
+  const matchB = b.match(/^(\d+)_(.*)$/);
+  if (matchA && matchB) {
+    const numA = parseInt(matchA[1], 10);
+    const numB = parseInt(matchB[1], 10);
+    if (numA !== numB) return numA - numB;
+    return matchA[2].localeCompare(matchB[2]);
+  }
+  return a.localeCompare(b);
+}
+
 async function getProviderMigrationNames(provider: MigrationProvider): Promise<string[]> {
   const map = await provider.getMigrations();
-  return Object.keys(map).sort();
+  return Object.keys(map).sort(compareMigrationNames);
 }
 
 export async function checkPendingMigrations(

--- a/astros_api/src/dal/backup.ts
+++ b/astros_api/src/dal/backup.ts
@@ -1,0 +1,108 @@
+import SQLite from 'better-sqlite3';
+import { Kysely, MigrationProvider, sql } from 'kysely';
+import fs from 'fs';
+import path from 'path';
+import { Database } from './types.js';
+import { logger } from '../logger.js';
+
+export const ALL_MIGRATION_NAMES = [
+  '0_initial',
+  '1_add_script_evt_id',
+  '2_add_script_duration',
+  '3_add_playlists',
+  '4_add_random_wait',
+];
+
+const KYSELY_MIGRATION_TABLE = 'kysely_migration';
+const BACKUP_PREFIX = 'database.sqlite3.backup-';
+
+async function migrationTableExists(db: Kysely<Database>): Promise<boolean> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table' AND name = ${KYSELY_MIGRATION_TABLE}
+  `.execute(db);
+  return result.rows.length > 0;
+}
+
+async function getProviderMigrationNames(provider: MigrationProvider): Promise<string[]> {
+  const map = await provider.getMigrations();
+  return Object.keys(map).sort();
+}
+
+export async function checkPendingMigrations(
+  db: Kysely<Database>,
+  provider: MigrationProvider,
+): Promise<string[]> {
+  const all = await getProviderMigrationNames(provider);
+
+  if (!(await migrationTableExists(db))) {
+    return all;
+  }
+
+  const result = await sql<{ name: string }>`
+    SELECT name FROM ${sql.raw(KYSELY_MIGRATION_TABLE)}
+  `.execute(db);
+  const applied = new Set(result.rows.map((r) => r.name));
+  return all.filter((n) => !applied.has(n));
+}
+
+export async function getLastAppliedMigrationName(
+  db: Kysely<Database>,
+  provider: MigrationProvider,
+): Promise<string | null> {
+  if (!(await migrationTableExists(db))) {
+    return null;
+  }
+
+  const result = await sql<{ name: string }>`
+    SELECT name FROM ${sql.raw(KYSELY_MIGRATION_TABLE)}
+  `.execute(db);
+  if (result.rows.length === 0) return null;
+
+  const all = await getProviderMigrationNames(provider);
+  const applied = new Set(result.rows.map((r) => r.name));
+  for (let i = all.length - 1; i >= 0; i--) {
+    if (applied.has(all[i])) return all[i];
+  }
+  return null;
+}
+
+export async function createBackup(
+  rawSqlite: SQLite.Database,
+  dbPath: string,
+  lastMigrationName: string,
+): Promise<string> {
+  const destPath = `${dbPath}.backup-${lastMigrationName}`;
+
+  if (fs.existsSync(destPath)) {
+    fs.unlinkSync(destPath);
+  }
+  await rawSqlite.backup(destPath);
+  return destPath;
+}
+
+export function pruneOldBackups(appdataDir: string, keep = 5): void {
+  if (!fs.existsSync(appdataDir)) return;
+
+  const entries = fs
+    .readdirSync(appdataDir)
+    .filter((f) => f.startsWith(BACKUP_PREFIX))
+    .map((name) => {
+      const full = path.join(appdataDir, name);
+      const mtimeMs = fs.statSync(full).mtimeMs;
+      return { name, full, mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const stale of entries.slice(keep)) {
+    try {
+      fs.unlinkSync(stale.full);
+    } catch (err) {
+      logger.warn(`Failed to prune backup ${stale.full}: ${err}`);
+    }
+  }
+}
+
+export function restoreBackup(backupPath: string, dbPath: string): void {
+  fs.copyFileSync(backupPath, dbPath);
+}

--- a/astros_api/src/dal/backup.ts
+++ b/astros_api/src/dal/backup.ts
@@ -50,6 +50,8 @@ export async function getLastAppliedMigrationName(
   `.execute(db);
   if (result.rows.length === 0) return null;
 
+  // Provider order is canonical. Kysely's stored timestamp ties at ms resolution
+  // when migrations run in quick succession (e.g. fresh DBs in tests).
   const all = await getProviderMigrationNames(provider);
   const applied = new Set(result.rows.map((r) => r.name));
   for (let i = all.length - 1; i >= 0; i--) {

--- a/astros_api/src/dal/backup.ts
+++ b/astros_api/src/dal/backup.ts
@@ -18,7 +18,8 @@ async function migrationTableExists(db: Kysely<Database>): Promise<boolean> {
 // Compare migration names by their leading numeric prefix (`<n>_<slug>`),
 // falling back to lexicographic order on the slug or for non-conforming names.
 // Plain .sort() would put '10_foo' before '2_foo' because '1' < '2'.
-function compareMigrationNames(a: string, b: string): number {
+// Exported so tests can derive expected ordering without duplicating the rule.
+export function compareMigrationNames(a: string, b: string): number {
   const matchA = a.match(/^(\d+)_(.*)$/);
   const matchB = b.match(/^(\d+)_(.*)$/);
   if (matchA && matchB) {

--- a/astros_api/src/dal/backup.ts
+++ b/astros_api/src/dal/backup.ts
@@ -14,7 +14,6 @@ export const ALL_MIGRATION_NAMES = [
 ];
 
 const KYSELY_MIGRATION_TABLE = 'kysely_migration';
-const BACKUP_PREFIX = 'database.sqlite3.backup-';
 
 async function migrationTableExists(db: Kysely<Database>): Promise<boolean> {
   const result = await sql<{ name: string }>`
@@ -81,14 +80,16 @@ export async function createBackup(
   return destPath;
 }
 
-export function pruneOldBackups(appdataDir: string, keep = 5): void {
-  if (!fs.existsSync(appdataDir)) return;
+export function pruneOldBackups(dbPath: string, keep = 5): void {
+  const dir = path.dirname(dbPath);
+  const prefix = `${path.basename(dbPath)}.backup-`;
+  if (!fs.existsSync(dir)) return;
 
   const entries = fs
-    .readdirSync(appdataDir)
-    .filter((f) => f.startsWith(BACKUP_PREFIX))
+    .readdirSync(dir)
+    .filter((f) => f.startsWith(prefix))
     .map((name) => {
-      const full = path.join(appdataDir, name);
+      const full = path.join(dir, name);
       const mtimeMs = fs.statSync(full).mtimeMs;
       return { name, full, mtimeMs };
     })

--- a/astros_api/src/dal/backup.ts
+++ b/astros_api/src/dal/backup.ts
@@ -5,14 +5,6 @@ import path from 'path';
 import { Database } from './types.js';
 import { logger } from '../logger.js';
 
-export const ALL_MIGRATION_NAMES = [
-  '0_initial',
-  '1_add_script_evt_id',
-  '2_add_script_duration',
-  '3_add_playlists',
-  '4_add_random_wait',
-];
-
 const KYSELY_MIGRATION_TABLE = 'kysely_migration';
 
 async function migrationTableExists(db: Kysely<Database>): Promise<boolean> {

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import SQLite from 'better-sqlite3';
-import { Migration, MigrationProvider } from 'kysely';
+import { Migration, MigrationProvider, sql } from 'kysely';
 import { SystemStatus } from '../system_status.js';
 import {
   initializeDatabase,
@@ -214,13 +214,19 @@ describe('initializeDatabase safety flow', () => {
     });
 
     status = new SystemStatus();
+    let db;
     try {
-      await initializeDatabase(status, { dbPath });
+      db = await initializeDatabase(status, { dbPath });
     } finally {
       spy.mockRestore();
     }
 
     expect(status.isReadOnly()).toBe(true);
     expect(status.getState().reasonCode).toBe('MIGRATION_FAILED_RESTORE_FAILED');
+
+    // Returned connection must be a *fresh* one, not the destroyed handle.
+    // A query against a destroyed Kysely throws; SELECT 1 is the simplest probe.
+    const probe = await sql<{ one: number }>`SELECT 1 AS one`.execute(db);
+    expect(probe.rows).toEqual([{ one: 1 }]);
   });
 });

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import SQLite from 'better-sqlite3';
+import { Migration, MigrationProvider } from 'kysely';
+import { SystemStatus } from '../system_status.js';
+import {
+  initializeDatabase,
+  closeDatabaseForTest,
+  __setMigrationProviderForTest,
+  __resetMigrationProviderForTest,
+} from './database.js';
+import {
+  migration_0,
+  migration_1,
+  migration_2,
+  migration_3,
+  migration_4,
+} from './migrations/index.js';
+
+function buildProvider(extra: Record<string, Migration> = {}): MigrationProvider {
+  return new (class implements MigrationProvider {
+    async getMigrations(): Promise<Record<string, Migration>> {
+      return {
+        '0_initial': migration_0,
+        '1_add_script_evt_id': migration_1,
+        '2_add_script_duration': migration_2,
+        '3_add_playlists': migration_3,
+        '4_add_random_wait': migration_4,
+        ...extra,
+      };
+    }
+  })();
+}
+
+describe('initializeDatabase safety flow', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astros-db-int-'));
+    dbPath = path.join(tmpDir, 'database.sqlite3');
+  });
+
+  afterEach(async () => {
+    await closeDatabaseForTest();
+    __resetMigrationProviderForTest();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('happy path on a fresh DB: takes a backup only after migrations have run at least once', async () => {
+    const status = new SystemStatus();
+    const db = await initializeDatabase(status, { dbPath });
+    expect(db).toBeDefined();
+    expect(status.isReadOnly()).toBe(false);
+
+    // Fresh DB has no last-applied migration before this run, so no backup file is created.
+    const backupFiles = fs
+      .readdirSync(tmpDir)
+      .filter((f) => f.startsWith('database.sqlite3.backup-'));
+    expect(backupFiles).toEqual([]);
+  });
+
+  it('happy path with no pending migrations: no backup taken', async () => {
+    // First run gets it migrated
+    let status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+    await closeDatabaseForTest();
+
+    // Second run — nothing pending
+    status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+    expect(status.isReadOnly()).toBe(false);
+
+    const backupFiles = fs
+      .readdirSync(tmpDir)
+      .filter((f) => f.startsWith('database.sqlite3.backup-'));
+    expect(backupFiles).toEqual([]);
+  });
+
+  it('takes a backup when there is a last-applied migration AND a pending migration', async () => {
+    // First run: migrate to v4
+    let status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+    await closeDatabaseForTest();
+
+    // Inject a 5th migration so we have something pending
+    __setMigrationProviderForTest(
+      buildProvider({
+        '5_safe_addition': {
+          async up(db) {
+            await db.schema.createTable('safe_addition').addColumn('id', 'integer').execute();
+          },
+          async down() {
+            return;
+          },
+        },
+      }),
+    );
+
+    status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+
+    // Backup file named after the previous last-applied migration should exist
+    const backupFiles = fs
+      .readdirSync(tmpDir)
+      .filter((f) => f.startsWith('database.sqlite3.backup-'));
+    expect(backupFiles).toEqual(['database.sqlite3.backup-4_add_random_wait']);
+    expect(status.isReadOnly()).toBe(false);
+  });
+
+  it('failed migration triggers restore from backup; system continues at pre-migration state', async () => {
+    // Migrate to v4 first
+    let status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+    await closeDatabaseForTest();
+
+    // Mark something distinctive in the DB so we can verify restore preserved it.
+    {
+      const sqlite = new SQLite(dbPath);
+      sqlite.prepare('CREATE TABLE marker (note TEXT)').run();
+      sqlite.prepare('INSERT INTO marker VALUES (?)').run('preserve-me');
+      sqlite.close();
+    }
+
+    // Inject a migration that throws
+    __setMigrationProviderForTest(
+      buildProvider({
+        '5_will_fail': {
+          async up() {
+            throw new Error('intentional migration failure');
+          },
+          async down() {
+            return;
+          },
+        },
+      }),
+    );
+
+    status = new SystemStatus();
+    const db = await initializeDatabase(status, { dbPath });
+
+    // Restore should have rolled back to pre-migration state — system is usable, not read-only
+    expect(status.isReadOnly()).toBe(false);
+
+    // Verify our marker survived (proves restore happened)
+    const marker = await db
+      .selectFrom('marker' as never)
+      .select('note' as never)
+      .execute();
+    expect(marker).toEqual([{ note: 'preserve-me' }]);
+  });
+
+  it('backup failure (read-only dir) → enters read-only and skips migrations', async () => {
+    // Migrate baseline first so a last-applied migration exists
+    let status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+    await closeDatabaseForTest();
+
+    // Inject a pending migration so a backup attempt happens
+    __setMigrationProviderForTest(
+      buildProvider({
+        '5_pending': {
+          async up(db) {
+            await db.schema.createTable('pending_table').addColumn('id', 'integer').execute();
+          },
+          async down() {
+            return;
+          },
+        },
+      }),
+    );
+
+    // Make the directory read-only so backup write fails
+    fs.chmodSync(tmpDir, 0o500);
+
+    status = new SystemStatus();
+    try {
+      await initializeDatabase(status, { dbPath });
+    } finally {
+      // Restore perms so afterEach can clean up
+      fs.chmodSync(tmpDir, 0o700);
+    }
+
+    expect(status.isReadOnly()).toBe(true);
+    expect(status.getState().reason).toMatch(/backup failed/i);
+  });
+
+  it('failed migration + failed restore → enters read-only', async () => {
+    // Migrate to v4
+    let status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+    await closeDatabaseForTest();
+
+    // Inject a migration that throws
+    __setMigrationProviderForTest(
+      buildProvider({
+        '5_will_fail': {
+          async up() {
+            throw new Error('intentional migration failure');
+          },
+          async down() {
+            return;
+          },
+        },
+      }),
+    );
+
+    // Spy on copyFileSync to make restore fail. The first copyFileSync call after
+    // a failed migration is the restore attempt.
+    const spy = vi.spyOn(fs, 'copyFileSync').mockImplementation(() => {
+      throw new Error('intentional restore failure');
+    });
+
+    status = new SystemStatus();
+    try {
+      await initializeDatabase(status, { dbPath });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(status.isReadOnly()).toBe(true);
+    expect(status.getState().reason).toMatch(/migration failed.*restore failed/i);
+  });
+});

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -184,7 +184,7 @@ describe('initializeDatabase safety flow', () => {
     }
 
     expect(status.isReadOnly()).toBe(true);
-    expect(status.getState().reason).toMatch(/backup failed/i);
+    expect(status.getState().reasonCode).toBe('BACKUP_FAILED');
   });
 
   it('failed migration + failed restore → enters read-only', async () => {
@@ -221,6 +221,6 @@ describe('initializeDatabase safety flow', () => {
     }
 
     expect(status.isReadOnly()).toBe(true);
-    expect(status.getState().reason).toMatch(/migration failed.*restore failed/i);
+    expect(status.getState().reasonCode).toBe('MIGRATION_FAILED_RESTORE_FAILED');
   });
 });

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -229,4 +229,21 @@ describe('initializeDatabase safety flow', () => {
     const probe = await sql<{ one: number }>`SELECT 1 AS one`.execute(db);
     expect(probe.rows).toEqual([{ one: 1 }]);
   });
+
+  it('initial open failure → enters read-only with STARTUP_OPEN_FAILED and returns a usable in-memory db', async () => {
+    // Create a directory at the dbPath so better-sqlite3 fails to open it
+    // as a database file.
+    const blockingDir = path.join(tmpDir, 'database.sqlite3');
+    fs.mkdirSync(blockingDir);
+
+    const status = new SystemStatus();
+    const db = await initializeDatabase(status, { dbPath: blockingDir });
+
+    expect(status.isReadOnly()).toBe(true);
+    expect(status.getState().reasonCode).toBe('STARTUP_OPEN_FAILED');
+
+    // The returned connection must be functional (an in-memory fallback).
+    const probe = await sql<{ one: number }>`SELECT 1 AS one`.execute(db);
+    expect(probe.rows).toEqual([{ one: 1 }]);
+  });
 });

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -135,7 +135,7 @@ export async function initializeDatabase(
 
   try {
     await migrateToLatest(conn.db);
-    pruneOldBackups(dbDir, 5);
+    pruneOldBackups(dbFile, 5);
     return conn.db;
   } catch (err) {
     logger.error(`Migration failed: ${(err as Error).message}`);

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -67,13 +67,21 @@ interface OpenConnection {
   raw: SQLite.Database;
 }
 
-function openConnection(dbFile: string): OpenConnection {
-  const raw = new SQLite(dbFile);
+// Build a properly-configured Kysely + raw SQLite handle pair. Single source
+// of truth for connection options (PRAGMA foreign_keys = ON) so tests and
+// prod can never diverge. Exported so test setups don't roll their own.
+export function createKyselyConnection(dbPath = ':memory:'): OpenConnection {
+  const raw = new SQLite(dbPath);
   raw.pragma('foreign_keys = ON');
   const db = new Kysely<Database>({ dialect: new SqliteDialect({ database: raw }) });
-  _db = db;
-  _rawSqlite = raw;
   return { db, raw };
+}
+
+function openConnection(dbFile: string): OpenConnection {
+  const conn = createKyselyConnection(dbFile);
+  _db = conn.db;
+  _rawSqlite = conn.raw;
+  return conn;
 }
 
 async function closeConnection(): Promise<void> {
@@ -103,12 +111,9 @@ export async function initializeDatabase(
   const useMemory = !explicitPath && process.env.NODE_ENV?.toLocaleLowerCase() === 'test';
 
   if (useMemory) {
-    const raw = new SQLite(':memory:');
-    const db = new Kysely<Database>({ dialect: new SqliteDialect({ database: raw }) });
-    _db = db;
-    _rawSqlite = raw;
-    await migrateToLatest(db);
-    return db;
+    const conn = openConnection(':memory:');
+    await migrateToLatest(conn.db);
+    return conn.db;
   }
 
   const dbFile =

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -162,12 +162,18 @@ export async function initializeDatabase(
       return conn.db;
     } catch (restoreErr) {
       systemStatus.enterReadOnly('MIGRATION_FAILED_RESTORE_FAILED', restoreErr);
-      // Restore failed; the original connection was already closed.
-      // Best-effort reopen so read-only endpoints still respond.
+      // The original handles were destroyed by closeConnection(). Reopen the
+      // file; if that also fails, fall back to a bare in-memory DB so the
+      // process still comes up and the read-only status endpoint stays
+      // reachable. (The fallback is unmigrated — DB-backed queries will fail,
+      // but /api/system/status doesn't query the DB.)
       try {
         conn = openConnection(dbFile);
-      } catch {
-        // If even reopening fails, fall through with the (now-null) module connection.
+      } catch (reopenErr) {
+        logger.error(
+          `Could not reopen DB after failed restore: ${(reopenErr as Error).message}; falling back to in-memory`,
+        );
+        conn = openConnection(':memory:');
       }
       return conn.db;
     }

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -128,7 +128,7 @@ export async function initializeDatabase(
       backupPath = await createBackup(conn.raw, dbFile, lastApplied);
       logger.info(`Created pre-migration backup at ${backupPath}`);
     } catch (err) {
-      systemStatus.enterReadOnly(`backup failed: ${(err as Error).message}`);
+      systemStatus.enterReadOnly('BACKUP_FAILED', err);
       return conn.db;
     }
   }
@@ -141,9 +141,7 @@ export async function initializeDatabase(
     logger.error(`Migration failed: ${(err as Error).message}`);
 
     if (!backupPath) {
-      systemStatus.enterReadOnly(
-        `migration failed and no backup available: ${(err as Error).message}`,
-      );
+      systemStatus.enterReadOnly('MIGRATION_FAILED_NO_BACKUP', err);
       return conn.db;
     }
 
@@ -154,9 +152,7 @@ export async function initializeDatabase(
       logger.warn(`Restored database from backup ${backupPath} after failed migration`);
       return conn.db;
     } catch (restoreErr) {
-      systemStatus.enterReadOnly(
-        `migration failed and restore failed: ${(restoreErr as Error).message}`,
-      );
+      systemStatus.enterReadOnly('MIGRATION_FAILED_RESTORE_FAILED', restoreErr);
       // Restore failed; the original connection was already closed.
       // Best-effort reopen so read-only endpoints still respond.
       try {

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -122,10 +122,21 @@ export async function initializeDatabase(
   fs.mkdirSync(dbDir, { recursive: true });
   logger.info(`Using database file at ${dbFile}`);
 
-  let conn = openConnection(dbFile);
-
-  const pending = await checkPendingMigrations(conn.db, activeMigrationProvider);
-  const lastApplied = await getLastAppliedMigrationName(conn.db, activeMigrationProvider);
+  let conn: OpenConnection;
+  let pending: string[];
+  let lastApplied: string | null;
+  try {
+    conn = openConnection(dbFile);
+    pending = await checkPendingMigrations(conn.db, activeMigrationProvider);
+    lastApplied = await getLastAppliedMigrationName(conn.db, activeMigrationProvider);
+  } catch (err) {
+    // Initial open or introspection failed (perms, directory-as-file,
+    // corrupted DB, etc.). Degrade to a bare in-memory connection so the
+    // process still comes up and /api/system/status is reachable.
+    logger.error(`Could not open database at startup: ${(err as Error).message}`);
+    systemStatus.enterReadOnly('STARTUP_OPEN_FAILED', err);
+    return openConnection(':memory:').db;
+  }
 
   if (pending.length === 0) {
     return conn.db;

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -76,16 +76,20 @@ function openConnection(dbFile: string): OpenConnection {
   return { db, raw };
 }
 
-function closeConnection(): void {
-  try {
-    _db?.destroy();
-  } catch {
-    // ignore
+async function closeConnection(): Promise<void> {
+  if (_db) {
+    try {
+      await _db.destroy();
+    } catch (err) {
+      logger.warn(`Error destroying Kysely connection: ${(err as Error).message}`);
+    }
   }
-  try {
-    _rawSqlite?.close();
-  } catch {
-    // ignore
+  if (_rawSqlite) {
+    try {
+      _rawSqlite.close();
+    } catch (err) {
+      logger.warn(`Error closing raw sqlite handle: ${(err as Error).message}`);
+    }
   }
   _db = null;
   _rawSqlite = null;
@@ -146,7 +150,7 @@ export async function initializeDatabase(
     }
 
     try {
-      closeConnection();
+      await closeConnection();
       restoreBackup(backupPath, dbFile);
       conn = openConnection(dbFile);
       logger.warn(`Restored database from backup ${backupPath} after failed migration`);
@@ -173,14 +177,7 @@ export function getDb(): Kysely<Database> {
 }
 
 export async function closeDatabaseForTest(): Promise<void> {
-  if (_db) {
-    await _db.destroy();
-  }
-  if (_rawSqlite) {
-    _rawSqlite.close();
-  }
-  _db = null;
-  _rawSqlite = null;
+  await closeConnection();
 }
 
 export function __setMigrationProviderForTest(provider: MigrationProvider): void {

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -21,6 +21,14 @@ import {
   migration_3,
   migration_4,
 } from './migrations/index.js';
+import { SystemStatus } from '../system_status.js';
+import {
+  checkPendingMigrations,
+  createBackup,
+  getLastAppliedMigrationName,
+  pruneOldBackups,
+  restoreBackup,
+} from './backup.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,31 +41,7 @@ export function resolveDatabaseDir(envValue: string | undefined): string {
   return envValue;
 }
 
-const databaseDir = resolveDatabaseDir(process.env.DATABASE_PATH);
-const databaseFile = path.join(databaseDir, 'database.sqlite3');
-
-let dialect = null;
-
-console.log(`NODE_ENV is set to: ${process.env.NODE_ENV}`);
-
-if (process.env.NODE_ENV?.toLocaleLowerCase() === 'test') {
-  console.warn('Using in-memory database for tests');
-  dialect = new SqliteDialect({
-    database: new SQLite(':memory:'),
-  });
-} else {
-  fs.mkdirSync(databaseDir, { recursive: true });
-  console.log(`Using database file at ${databaseFile}`);
-  dialect = new SqliteDialect({
-    database: new SQLite(databaseFile),
-  });
-}
-
-export const db = new Kysely<Database>({
-  dialect,
-});
-
-const migrationProvider = new (class implements MigrationProvider {
+const defaultMigrationProvider: MigrationProvider = new (class implements MigrationProvider {
   async getMigrations(): Promise<Record<string, Migration>> {
     return {
       '0_initial': migration_0,
@@ -69,10 +53,152 @@ const migrationProvider = new (class implements MigrationProvider {
   }
 })();
 
+let activeMigrationProvider: MigrationProvider = defaultMigrationProvider;
+
+let _db: Kysely<Database> | null = null;
+let _rawSqlite: SQLite.Database | null = null;
+
+export interface InitializeDatabaseOptions {
+  dbPath?: string;
+}
+
+interface OpenConnection {
+  db: Kysely<Database>;
+  raw: SQLite.Database;
+}
+
+function openConnection(dbFile: string): OpenConnection {
+  const raw = new SQLite(dbFile);
+  raw.pragma('foreign_keys = ON');
+  const db = new Kysely<Database>({ dialect: new SqliteDialect({ database: raw }) });
+  _db = db;
+  _rawSqlite = raw;
+  return { db, raw };
+}
+
+function closeConnection(): void {
+  try {
+    _db?.destroy();
+  } catch {
+    // ignore
+  }
+  try {
+    _rawSqlite?.close();
+  } catch {
+    // ignore
+  }
+  _db = null;
+  _rawSqlite = null;
+}
+
+export async function initializeDatabase(
+  systemStatus: SystemStatus,
+  options: InitializeDatabaseOptions = {},
+): Promise<Kysely<Database>> {
+  const explicitPath = options.dbPath;
+  const useMemory = !explicitPath && process.env.NODE_ENV?.toLocaleLowerCase() === 'test';
+
+  if (useMemory) {
+    const raw = new SQLite(':memory:');
+    const db = new Kysely<Database>({ dialect: new SqliteDialect({ database: raw }) });
+    _db = db;
+    _rawSqlite = raw;
+    await migrateToLatest(db);
+    return db;
+  }
+
+  const dbFile =
+    explicitPath ?? path.join(resolveDatabaseDir(process.env.DATABASE_PATH), 'database.sqlite3');
+  const dbDir = path.dirname(dbFile);
+  fs.mkdirSync(dbDir, { recursive: true });
+  logger.info(`Using database file at ${dbFile}`);
+
+  let conn = openConnection(dbFile);
+
+  const pending = await checkPendingMigrations(conn.db, activeMigrationProvider);
+  const lastApplied = await getLastAppliedMigrationName(conn.db, activeMigrationProvider);
+
+  if (pending.length === 0) {
+    return conn.db;
+  }
+
+  let backupPath: string | null = null;
+  if (lastApplied) {
+    try {
+      backupPath = await createBackup(conn.raw, dbFile, lastApplied);
+      logger.info(`Created pre-migration backup at ${backupPath}`);
+    } catch (err) {
+      systemStatus.enterReadOnly(`backup failed: ${(err as Error).message}`);
+      return conn.db;
+    }
+  }
+
+  try {
+    await migrateToLatest(conn.db);
+    pruneOldBackups(dbDir, 5);
+    return conn.db;
+  } catch (err) {
+    logger.error(`Migration failed: ${(err as Error).message}`);
+
+    if (!backupPath) {
+      systemStatus.enterReadOnly(
+        `migration failed and no backup available: ${(err as Error).message}`,
+      );
+      return conn.db;
+    }
+
+    try {
+      closeConnection();
+      restoreBackup(backupPath, dbFile);
+      conn = openConnection(dbFile);
+      logger.warn(`Restored database from backup ${backupPath} after failed migration`);
+      return conn.db;
+    } catch (restoreErr) {
+      systemStatus.enterReadOnly(
+        `migration failed and restore failed: ${(restoreErr as Error).message}`,
+      );
+      // Restore failed; the original connection was already closed.
+      // Best-effort reopen so read-only endpoints still respond.
+      try {
+        conn = openConnection(dbFile);
+      } catch {
+        // If even reopening fails, fall through with the (now-null) module connection.
+      }
+      return conn.db;
+    }
+  }
+}
+
+export function getDb(): Kysely<Database> {
+  if (!_db) {
+    throw new Error('Database not initialized — call initializeDatabase() first');
+  }
+  return _db;
+}
+
+export async function closeDatabaseForTest(): Promise<void> {
+  if (_db) {
+    await _db.destroy();
+  }
+  if (_rawSqlite) {
+    _rawSqlite.close();
+  }
+  _db = null;
+  _rawSqlite = null;
+}
+
+export function __setMigrationProviderForTest(provider: MigrationProvider): void {
+  activeMigrationProvider = provider;
+}
+
+export function __resetMigrationProviderForTest(): void {
+  activeMigrationProvider = defaultMigrationProvider;
+}
+
 export async function migrateToLatest(db: Kysely<Database>): Promise<void> {
   const migrator = new Migrator({
     db,
-    provider: migrationProvider,
+    provider: activeMigrationProvider,
   });
 
   const { error, results } = await migrator.migrateToLatest();
@@ -88,6 +214,7 @@ export async function migrateToLatest(db: Kysely<Database>): Promise<void> {
   if (error) {
     logger.error('failed to migrate');
     logger.error(error);
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }
 

--- a/astros_api/src/dal/repositories/audio_file_repository.test.ts
+++ b/astros_api/src/dal/repositories/audio_file_repository.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { AudioFileRepository } from './audio_file_repository.js';
 
 describe('AudioFileRepository', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/dal/repositories/controller_repository.test.ts
+++ b/astros_api/src/dal/repositories/controller_repository.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { ControllerRepository } from './controller_repository.js';
 
 describe('ControllerRepository', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/dal/repositories/locations_repository.test.ts
+++ b/astros_api/src/dal/repositories/locations_repository.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { LocationsRepository } from './locations_repository.js';
 import { ControllerRepository } from './controller_repository.js';
 import { UartModule } from '../../models/control_module/uart/uart_module.js';
@@ -14,9 +13,7 @@ describe('LocationsRepository', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/dal/repositories/module_repositories/gpio_repository.test.ts
+++ b/astros_api/src/dal/repositories/module_repositories/gpio_repository.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
-import { migrateToLatest } from '../../database.js';
+import { Kysely } from 'kysely';
+import { createKyselyConnection, migrateToLatest } from '../../database.js';
 import { Database } from '../../types.js';
 import { getGpioModule, upsertGpioModule } from './gpio_repository.js';
 import { Constants } from '../../../models/index.js';
@@ -12,13 +11,7 @@ describe('GpioRepository', () => {
   const location = Constants.BODY;
 
   beforeEach(async () => {
-    const dialect = new SqliteDialect({
-      database: new SQLite(':memory:'),
-    });
-
-    db = new Kysely<Database>({
-      dialect,
-    });
+    db = createKyselyConnection().db;
 
     await migrateToLatest(db);
   });

--- a/astros_api/src/dal/repositories/module_repositories/i2c_repository.test.ts
+++ b/astros_api/src/dal/repositories/module_repositories/i2c_repository.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../../types.js';
-import { migrateToLatest } from '../../database.js';
+import { createKyselyConnection, migrateToLatest } from '../../database.js';
 import { Constants, I2cModule, ModuleSubType } from '../../../models/index.js';
 import { getI2cModules, upsertI2cModules } from './i2c_repository.js';
 import { v4 as uuid } from 'uuid';
@@ -12,13 +11,7 @@ describe('I2cRepository', () => {
   const location = Constants.BODY;
 
   beforeEach(async () => {
-    const dialect = new SqliteDialect({
-      database: new SQLite(':memory:'),
-    });
-
-    db = new Kysely<Database>({
-      dialect,
-    });
+    db = createKyselyConnection().db;
 
     await migrateToLatest(db);
   });

--- a/astros_api/src/dal/repositories/module_repositories/uart_repository.test.ts
+++ b/astros_api/src/dal/repositories/module_repositories/uart_repository.test.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../../types.js';
-import { migrateToLatest } from '../../database.js';
+import { createKyselyConnection, migrateToLatest } from '../../database.js';
 import {
   Constants,
   UartModule,
@@ -20,13 +19,7 @@ describe('UartRepository', () => {
   const location = Constants.BODY;
 
   beforeEach(async () => {
-    const dialect = new SqliteDialect({
-      database: new SQLite(':memory:'),
-    });
-
-    db = new Kysely<Database>({
-      dialect,
-    });
+    db = createKyselyConnection().db;
 
     await migrateToLatest(db);
   });

--- a/astros_api/src/dal/repositories/playlist_repository.test.ts
+++ b/astros_api/src/dal/repositories/playlist_repository.test.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { PlaylistRepository } from './playlist_repository.js';
 import { Playlist } from '../../models/playlists/playlist.js';
 import { TrackType } from '../../models/playlists/trackType.js';
@@ -19,13 +18,7 @@ describe('Playlist Repository', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    const dialect = new SqliteDialect({
-      database: new SQLite(':memory:'),
-    });
-
-    db = new Kysely<Database>({
-      dialect,
-    });
+    db = createKyselyConnection().db;
 
     await migrateToLatest(db);
   });

--- a/astros_api/src/dal/repositories/remote_config_repository.test.ts
+++ b/astros_api/src/dal/repositories/remote_config_repository.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { RemoteConfigRepository } from './remote_config_repository.js';
 
 describe('RemoteConfigRepository', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/dal/repositories/script_repository.test.ts
+++ b/astros_api/src/dal/repositories/script_repository.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { ScriptRepository } from './script_repository.js';
 import {
   Script,
@@ -39,13 +38,7 @@ describe('Script Repository', () => {
   let locationId: string;
 
   beforeEach(async () => {
-    const dialect = new SqliteDialect({
-      database: new SQLite(':memory:'),
-    });
-
-    db = new Kysely<Database>({
-      dialect,
-    });
+    db = createKyselyConnection().db;
 
     await migrateToLatest(db);
 

--- a/astros_api/src/dal/repositories/settings_repository.test.ts
+++ b/astros_api/src/dal/repositories/settings_repository.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { SettingsRepository } from './settings_repository.js';
 
 describe('SettingsRepository', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/dal/repositories/user_repository.test.ts
+++ b/astros_api/src/dal/repositories/user_repository.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SQLite from 'better-sqlite3';
-import { Kysely, SqliteDialect } from 'kysely';
+import { Kysely } from 'kysely';
 import { Database } from '../types.js';
-import { migrateToLatest } from '../database.js';
+import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { UserRepository } from './user_repository.js';
 import { User } from '../../models/users.js';
 
@@ -10,9 +9,7 @@ describe('UserRepository', () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-    });
+    db = createKyselyConnection().db;
     await migrateToLatest(db);
   });
 

--- a/astros_api/src/models/enums.ts
+++ b/astros_api/src/models/enums.ts
@@ -89,6 +89,7 @@ export enum TransmissionType {
   directCommand,
   formatSD,
   servoTest,
+  systemStatus,
 }
 
 export enum TransmissionStatus {

--- a/astros_api/src/system_status.test.ts
+++ b/astros_api/src/system_status.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SystemStatus } from './system_status.js';
+
+describe('SystemStatus', () => {
+  it('starts not in read-only mode', () => {
+    const status = new SystemStatus();
+    expect(status.isReadOnly()).toBe(false);
+    expect(status.getState()).toEqual({ readOnly: false });
+  });
+
+  it('captures reason and timestamp on enterReadOnly', () => {
+    const status = new SystemStatus();
+    const before = Date.now();
+    status.enterReadOnly('migration failed: bad sql');
+    const after = Date.now();
+
+    const state = status.getState();
+    expect(state.readOnly).toBe(true);
+    expect(state.reason).toBe('migration failed: bad sql');
+    expect(state.enteredAt).toBeDefined();
+    const enteredAtMs = Date.parse(state.enteredAt ?? '');
+    expect(enteredAtMs).toBeGreaterThanOrEqual(before);
+    expect(enteredAtMs).toBeLessThanOrEqual(after);
+  });
+
+  it('isReadOnly returns true once entered', () => {
+    const status = new SystemStatus();
+    status.enterReadOnly('any reason');
+    expect(status.isReadOnly()).toBe(true);
+  });
+
+  it('notifies subscribers on enterReadOnly', () => {
+    const status = new SystemStatus();
+    const cb = vi.fn();
+    status.subscribe(cb);
+
+    status.enterReadOnly('disk full');
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true, reason: 'disk full' }),
+    );
+  });
+
+  it('notifies multiple subscribers', () => {
+    const status = new SystemStatus();
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    status.subscribe(cb1);
+    status.subscribe(cb2);
+
+    status.enterReadOnly('boom');
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe returns an unsubscribe function', () => {
+    const status = new SystemStatus();
+    const cb = vi.fn();
+    const unsubscribe = status.subscribe(cb);
+    unsubscribe();
+
+    status.enterReadOnly('boom');
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('only notifies on the first enterReadOnly (no double-fire)', () => {
+    const status = new SystemStatus();
+    const cb = vi.fn();
+    status.subscribe(cb);
+
+    status.enterReadOnly('first');
+    status.enterReadOnly('second');
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    const state = status.getState();
+    expect(state.reason).toBe('first');
+  });
+
+  it('subscriber errors do not affect other subscribers', () => {
+    const status = new SystemStatus();
+    const failing = vi.fn(() => {
+      throw new Error('subscriber broke');
+    });
+    const ok = vi.fn();
+    status.subscribe(failing);
+    status.subscribe(ok);
+
+    expect(() => status.enterReadOnly('boom')).not.toThrow();
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+});

--- a/astros_api/src/system_status.test.ts
+++ b/astros_api/src/system_status.test.ts
@@ -8,24 +8,37 @@ describe('SystemStatus', () => {
     expect(status.getState()).toEqual({ readOnly: false });
   });
 
-  it('captures reason and timestamp on enterReadOnly', () => {
+  it('captures reasonCode and timestamp on enterReadOnly', () => {
     const status = new SystemStatus();
     const before = Date.now();
-    status.enterReadOnly('migration failed: bad sql');
+    status.enterReadOnly('BACKUP_FAILED');
     const after = Date.now();
 
     const state = status.getState();
     expect(state.readOnly).toBe(true);
-    expect(state.reason).toBe('migration failed: bad sql');
+    expect(state.reasonCode).toBe('BACKUP_FAILED');
     expect(state.enteredAt).toBeDefined();
     const enteredAtMs = Date.parse(state.enteredAt ?? '');
     expect(enteredAtMs).toBeGreaterThanOrEqual(before);
     expect(enteredAtMs).toBeLessThanOrEqual(after);
   });
 
+  it('does not expose the raw error detail on the public state', () => {
+    const status = new SystemStatus();
+    const sensitive = new Error('ENOENT: /home/user/.config/astrosserver/database.sqlite3');
+    status.enterReadOnly('BACKUP_FAILED', sensitive);
+
+    const state = status.getState();
+    expect(state.reasonCode).toBe('BACKUP_FAILED');
+    expect(JSON.stringify(state)).not.toContain('ENOENT');
+    expect(JSON.stringify(state)).not.toContain('astrosserver');
+    expect(state).not.toHaveProperty('reason');
+    expect(state).not.toHaveProperty('detail');
+  });
+
   it('isReadOnly returns true once entered', () => {
     const status = new SystemStatus();
-    status.enterReadOnly('any reason');
+    status.enterReadOnly('MIGRATION_FAILED_NO_BACKUP');
     expect(status.isReadOnly()).toBe(true);
   });
 
@@ -34,10 +47,10 @@ describe('SystemStatus', () => {
     const cb = vi.fn();
     status.subscribe(cb);
 
-    status.enterReadOnly('disk full');
+    status.enterReadOnly('BACKUP_FAILED');
     expect(cb).toHaveBeenCalledTimes(1);
     expect(cb).toHaveBeenCalledWith(
-      expect.objectContaining({ readOnly: true, reason: 'disk full' }),
+      expect.objectContaining({ readOnly: true, reasonCode: 'BACKUP_FAILED' }),
     );
   });
 
@@ -48,7 +61,7 @@ describe('SystemStatus', () => {
     status.subscribe(cb1);
     status.subscribe(cb2);
 
-    status.enterReadOnly('boom');
+    status.enterReadOnly('BACKUP_FAILED');
     expect(cb1).toHaveBeenCalledTimes(1);
     expect(cb2).toHaveBeenCalledTimes(1);
   });
@@ -59,7 +72,7 @@ describe('SystemStatus', () => {
     const unsubscribe = status.subscribe(cb);
     unsubscribe();
 
-    status.enterReadOnly('boom');
+    status.enterReadOnly('BACKUP_FAILED');
     expect(cb).not.toHaveBeenCalled();
   });
 
@@ -68,12 +81,12 @@ describe('SystemStatus', () => {
     const cb = vi.fn();
     status.subscribe(cb);
 
-    status.enterReadOnly('first');
-    status.enterReadOnly('second');
+    status.enterReadOnly('BACKUP_FAILED');
+    status.enterReadOnly('MIGRATION_FAILED_NO_BACKUP');
 
     expect(cb).toHaveBeenCalledTimes(1);
     const state = status.getState();
-    expect(state.reason).toBe('first');
+    expect(state.reasonCode).toBe('BACKUP_FAILED');
   });
 
   it('subscriber errors do not affect other subscribers', () => {
@@ -85,7 +98,7 @@ describe('SystemStatus', () => {
     status.subscribe(failing);
     status.subscribe(ok);
 
-    expect(() => status.enterReadOnly('boom')).not.toThrow();
+    expect(() => status.enterReadOnly('BACKUP_FAILED')).not.toThrow();
     expect(ok).toHaveBeenCalledTimes(1);
   });
 });

--- a/astros_api/src/system_status.ts
+++ b/astros_api/src/system_status.ts
@@ -1,6 +1,7 @@
 import { logger } from './logger.js';
 
 export type ReadOnlyReasonCode =
+  | 'STARTUP_OPEN_FAILED'
   | 'BACKUP_FAILED'
   | 'MIGRATION_FAILED_NO_BACKUP'
   | 'MIGRATION_FAILED_RESTORE_FAILED';

--- a/astros_api/src/system_status.ts
+++ b/astros_api/src/system_status.ts
@@ -1,0 +1,49 @@
+import { logger } from './logger.js';
+
+export interface SystemStatusState {
+  readOnly: boolean;
+  reason?: string;
+  enteredAt?: string;
+}
+
+export type SystemStatusSubscriber = (state: SystemStatusState) => void;
+
+export class SystemStatus {
+  private readOnly = false;
+  private reason: string | undefined;
+  private enteredAt: string | undefined;
+  private subscribers = new Set<SystemStatusSubscriber>();
+
+  isReadOnly(): boolean {
+    return this.readOnly;
+  }
+
+  getState(): SystemStatusState {
+    if (!this.readOnly) return { readOnly: false };
+    return { readOnly: true, reason: this.reason, enteredAt: this.enteredAt };
+  }
+
+  enterReadOnly(reason: string): void {
+    if (this.readOnly) return;
+    this.readOnly = true;
+    this.reason = reason;
+    this.enteredAt = new Date().toISOString();
+    logger.error(`Entering read-only mode: ${reason}`);
+
+    const snapshot = this.getState();
+    for (const cb of this.subscribers) {
+      try {
+        cb(snapshot);
+      } catch (err) {
+        logger.error(`SystemStatus subscriber threw: ${err}`);
+      }
+    }
+  }
+
+  subscribe(cb: SystemStatusSubscriber): () => void {
+    this.subscribers.add(cb);
+    return () => {
+      this.subscribers.delete(cb);
+    };
+  }
+}

--- a/astros_api/src/system_status.ts
+++ b/astros_api/src/system_status.ts
@@ -36,7 +36,7 @@ export class SystemStatus {
     this.reasonCode = code;
     this.enteredAt = new Date().toISOString();
 
-    const detailText = detail instanceof Error ? detail.stack ?? detail.message : String(detail);
+    const detailText = detail instanceof Error ? (detail.stack ?? detail.message) : String(detail);
     logger.error(`Entering read-only mode (${code}): ${detailText}`);
 
     const snapshot = this.getState();

--- a/astros_api/src/system_status.ts
+++ b/astros_api/src/system_status.ts
@@ -1,8 +1,13 @@
 import { logger } from './logger.js';
 
+export type ReadOnlyReasonCode =
+  | 'BACKUP_FAILED'
+  | 'MIGRATION_FAILED_NO_BACKUP'
+  | 'MIGRATION_FAILED_RESTORE_FAILED';
+
 export interface SystemStatusState {
   readOnly: boolean;
-  reason?: string;
+  reasonCode?: ReadOnlyReasonCode;
   enteredAt?: string;
 }
 
@@ -10,7 +15,7 @@ export type SystemStatusSubscriber = (state: SystemStatusState) => void;
 
 export class SystemStatus {
   private readOnly = false;
-  private reason: string | undefined;
+  private reasonCode: ReadOnlyReasonCode | undefined;
   private enteredAt: string | undefined;
   private subscribers = new Set<SystemStatusSubscriber>();
 
@@ -20,15 +25,19 @@ export class SystemStatus {
 
   getState(): SystemStatusState {
     if (!this.readOnly) return { readOnly: false };
-    return { readOnly: true, reason: this.reason, enteredAt: this.enteredAt };
+    return { readOnly: true, reasonCode: this.reasonCode, enteredAt: this.enteredAt };
   }
 
-  enterReadOnly(reason: string): void {
+  // detail (full error message, paths, stack) is logged server-side only.
+  // The public state exposes only the structured code.
+  enterReadOnly(code: ReadOnlyReasonCode, detail?: unknown): void {
     if (this.readOnly) return;
     this.readOnly = true;
-    this.reason = reason;
+    this.reasonCode = code;
     this.enteredAt = new Date().toISOString();
-    logger.error(`Entering read-only mode: ${reason}`);
+
+    const detailText = detail instanceof Error ? detail.stack ?? detail.message : String(detail);
+    logger.error(`Entering read-only mode (${code}): ${detailText}`);
 
     const snapshot = this.getState();
     for (const cb of this.subscribers) {

--- a/astros_api/src/write_guard.test.ts
+++ b/astros_api/src/write_guard.test.ts
@@ -43,22 +43,36 @@ describe('writeGuard', () => {
   });
 
   describe('when in read-only mode', () => {
-    function readOnly(reason = 'test reason'): SystemStatus {
+    function readOnly(code: 'BACKUP_FAILED' = 'BACKUP_FAILED'): SystemStatus {
       const s = new SystemStatus();
-      s.enterReadOnly(reason);
+      s.enterReadOnly(code);
       return s;
     }
 
-    it('blocks POST/PUT/PATCH/DELETE with 503 and includes reason', () => {
-      const status = readOnly('migration failed');
+    it('blocks POST/PUT/PATCH/DELETE with 503 and includes reasonCode', () => {
+      const status = readOnly('BACKUP_FAILED');
       for (const m of ['POST', 'PUT', 'PATCH', 'DELETE']) {
         const { res, next } = call(m, '/scripts', status);
         expect(next).not.toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(503);
         expect(res.json).toHaveBeenCalledWith(
-          expect.objectContaining({ reason: 'migration failed' }),
+          expect.objectContaining({ reasonCode: 'BACKUP_FAILED' }),
         );
       }
+    });
+
+    it('does not leak raw error details into the 503 body', () => {
+      const status = new SystemStatus();
+      status.enterReadOnly(
+        'BACKUP_FAILED',
+        new Error('ENOENT: /home/user/.config/astrosserver/database.sqlite3'),
+      );
+
+      const { res } = call('POST', '/scripts', status);
+      const payload = res.json.mock.calls[0][0];
+      expect(JSON.stringify(payload)).not.toContain('ENOENT');
+      expect(JSON.stringify(payload)).not.toContain('astrosserver');
+      expect(payload).not.toHaveProperty('reason');
     });
 
     it('allows allowlisted POSTs (login, reauth, panicStop, panicClear)', () => {
@@ -79,7 +93,7 @@ describe('writeGuard', () => {
     });
 
     it('blocks the five serial-write GET paths with 503', () => {
-      const status = readOnly('boom');
+      const status = readOnly('BACKUP_FAILED');
       const blockedGets = [
         '/locations/syncconfig',
         '/locations/synccontrollers',
@@ -91,7 +105,9 @@ describe('writeGuard', () => {
         const { res, next } = call('GET', p, status);
         expect(next).not.toHaveBeenCalled();
         expect(res.status).toHaveBeenCalledWith(503);
-        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ reason: 'boom' }));
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({ reasonCode: 'BACKUP_FAILED' }),
+        );
       }
     });
   });

--- a/astros_api/src/write_guard.test.ts
+++ b/astros_api/src/write_guard.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SystemStatus } from './system_status.js';
+import { writeGuard } from './write_guard.js';
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+function call(
+  method: string,
+  path: string,
+  status: SystemStatus,
+): { res: any; next: ReturnType<typeof vi.fn> } {
+  const guard = writeGuard(status);
+  const req: any = { method, path };
+  const res = mockRes();
+  const next = vi.fn();
+  guard(req, res, next);
+  return { res, next };
+}
+
+describe('writeGuard', () => {
+  describe('when not in read-only mode', () => {
+    it('passes through writes', () => {
+      const status = new SystemStatus();
+      for (const m of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+        const { res, next } = call(m, '/scripts', status);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.status).not.toHaveBeenCalled();
+      }
+    });
+
+    it('passes through reads, including the serial-write GETs', () => {
+      const status = new SystemStatus();
+      for (const p of ['/anything', '/locations/syncconfig', '/scripts/upload', '/scripts/run']) {
+        const { next } = call('GET', p, status);
+        expect(next).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe('when in read-only mode', () => {
+    function readOnly(reason = 'test reason'): SystemStatus {
+      const s = new SystemStatus();
+      s.enterReadOnly(reason);
+      return s;
+    }
+
+    it('blocks POST/PUT/PATCH/DELETE with 503 and includes reason', () => {
+      const status = readOnly('migration failed');
+      for (const m of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+        const { res, next } = call(m, '/scripts', status);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(503);
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({ reason: 'migration failed' }),
+        );
+      }
+    });
+
+    it('allows allowlisted POSTs (login, reauth, panicStop, panicClear)', () => {
+      const status = readOnly();
+      for (const p of ['/login', '/reauth', '/panicStop', '/panicClear']) {
+        const { res, next } = call('POST', p, status);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.status).not.toHaveBeenCalled();
+      }
+    });
+
+    it('allows GET requests for safe read paths', () => {
+      const status = readOnly();
+      for (const p of ['/scripts', '/playlists', '/system/status']) {
+        const { next } = call('GET', p, status);
+        expect(next).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('blocks the five serial-write GET paths with 503', () => {
+      const status = readOnly('boom');
+      const blockedGets = [
+        '/locations/syncconfig',
+        '/locations/synccontrollers',
+        '/scripts/upload',
+        '/scripts/run',
+        '/playlists/run',
+      ];
+      for (const p of blockedGets) {
+        const { res, next } = call('GET', p, status);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(503);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ reason: 'boom' }));
+      }
+    });
+  });
+});

--- a/astros_api/src/write_guard.ts
+++ b/astros_api/src/write_guard.ts
@@ -40,7 +40,7 @@ export function writeGuard(systemStatus: SystemStatus): RequestHandler {
       const state = systemStatus.getState();
       res.status(503).json({
         message: 'Server is in read-only mode',
-        reason: state.reason,
+        reasonCode: state.reasonCode,
       });
       return;
     }

--- a/astros_api/src/write_guard.ts
+++ b/astros_api/src/write_guard.ts
@@ -1,0 +1,50 @@
+import { RequestHandler } from 'express';
+import { SystemStatus } from './system_status.js';
+
+const BLOCKED_WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+const ALLOWED_IN_READONLY: Array<{ method: string; path: string }> = [
+  { method: 'POST', path: '/login' },
+  { method: 'POST', path: '/reauth' },
+  { method: 'POST', path: '/panicStop' },
+  { method: 'POST', path: '/panicClear' },
+];
+
+const BLOCKED_GET_PATHS = new Set([
+  '/locations/syncconfig',
+  '/locations/synccontrollers',
+  '/scripts/upload',
+  '/scripts/run',
+  '/playlists/run',
+]);
+
+export function writeGuard(systemStatus: SystemStatus): RequestHandler {
+  return (req, res, next) => {
+    if (!systemStatus.isReadOnly()) {
+      next();
+      return;
+    }
+
+    const allowlisted = ALLOWED_IN_READONLY.some(
+      (entry) => entry.method === req.method && entry.path === req.path,
+    );
+    if (allowlisted) {
+      next();
+      return;
+    }
+
+    const blockedWrite = BLOCKED_WRITE_METHODS.has(req.method);
+    const blockedGet = req.method === 'GET' && BLOCKED_GET_PATHS.has(req.path);
+
+    if (blockedWrite || blockedGet) {
+      const state = systemStatus.getState();
+      res.status(503).json({
+        message: 'Server is in read-only mode',
+        reason: state.reason,
+      });
+      return;
+    }
+
+    next();
+  };
+}


### PR DESCRIPTION
  ## Summary

  Foundational safety infrastructure for the DB Migration Safety Net feature
  (Phase 1 of 3). Phases 2 (schema migrations) and 3 (Vue read-only UI) both
  depend on this.

  Wires up a safe startup flow: detect pending migrations → take a hot SQLite
  backup keyed by last-applied migration → run migrations → on failure, restore
  from backup → on unrecoverable failure, enter in-memory read-only mode.
  Recovery from read-only is a container restart, by design.

  Plan: `.docs/plans/20260410-0807-db-safety-phase1-backup-readonly.md`

  ## What's new

  - **`SystemStatus`** — in-memory singleton with `isReadOnly()`, `enterReadOnly(reason)`,
    `getState()`, `subscribe(cb)`. One-way transition; logs at error level on entry.
  - **`dal/backup.ts`** — `checkPendingMigrations` / `getLastAppliedMigrationName`
    driven by the active `MigrationProvider` (canonical order, no timestamp ties).
    Hot backup via `better-sqlite3`'s `.backup()`. Same-version files overwrite;
    `pruneOldBackups` keeps the 5 newest by mtime.
  - **`writeGuard`** middleware — in read-only mode, blocks `POST/PUT/PATCH/DELETE`
    and the five serial-write `GET`s (`/locations/syncconfig`, `/locations/synccontrollers`,
    `/scripts/upload`, `/scripts/run`, `/playlists/run`). Always allows `/login`,
    `/reauth`, `/panicStop`, `/panicClear`.
  - **`GET /api/system/status`** — public (no auth). Also pushed over WebSocket
    on connect and on every state change.
  - **`dal/database.ts` refactor** — eager `const db` replaced with async
    `initializeDatabase(systemStatus, options?)` + `getDb()`. Sets
    `PRAGMA foreign_keys = ON`. `NODE_ENV=test` still uses `:memory:` by default;
    integration tests pass an explicit `dbPath`. `migrateToLatest` now throws on
    failure so the bootstrap can catch and trigger restore.
  - **`TransmissionType.systemStatus`** — new WebSocket message discriminator.

  ## Failure-mode behavior

  | Failure | Result |
  |---|---|
  | Backup fails (e.g. disk full, perms) | Skip migration; enter read-only |
  | Migration fails, restore succeeds | Server continues at pre-migration version |
  | Migration fails AND restore fails | Enter read-only with combined reason |
  | No prior migration to back up to (fresh DB) | Run migration directly; no backup taken |