### PR TITLE
Feature/db safety phase2

### DIFF
--- a/.docs/plans/20260410-0807-db-safety-phase2-schema-migrations.md
+++ b/.docs/plans/20260410-0807-db-safety-phase2-schema-migrations.md
@@ -43,7 +43,7 @@ This is a small edit to phase 1's `initializeDatabase()` flow — the pragma tog
 
 - [ ] Create `astros_api/src/dal/migrations/migration_5.ts`:
   - `up`: read all rows, drop the table, recreate with both columns as `text`, re-insert rows. **No FKs yet** — that's migration_6.
-  - `down`: reverse — drop, recreate with `controller_id integer`, re-insert. (SQLite's loose typing means the data survives round-trip even though the declared type differs.)
+  - `down`: throws `Error('Recovery is via Phase 1 backup-restore; no manual down')`. See "Down migration policy" below.
 - [ ] Register in `astros_api/src/dal/migrations/index.ts` and add to the migration provider in `database.ts`.
 
 ### Part C — migration_6: foreign-key constraints + orphan cleanup
@@ -80,7 +80,7 @@ Reference: `migration_1.ts` for the rename-dance pattern, Kysely's `addForeignKe
 
 - [ ] Create `astros_api/src/dal/migrations/migration_6.ts`:
   - `up`: iterate through the table list above, performing orphan cleanup + rename dance per table.
-  - `down`: **full symmetric down** — for each table, rename dance in reverse, recreating the table without FK constraints. Verbose (~13 tables × reverse dance) but keeps the down path honest.
+  - `down`: throws `Error('Recovery is via Phase 1 backup-restore; no manual down')`. See "Down migration policy" below.
 - [ ] Register in `astros_api/src/dal/migrations/index.ts` and `database.ts`.
 
 ### Part D — FK pragma toggle in phase 1's `initializeDatabase`
@@ -92,7 +92,7 @@ Reference: `migration_1.ts` for the rename-dance pattern, Kysely's `addForeignKe
 - [ ] `astros_api/src/dal/migrations/migration_5.test.ts`:
   - Apply migrations 0–4, insert a `controller_locations` row, apply migration_5, verify the row is still there with the same values.
   - Verify declared column type via `PRAGMA table_info(controller_locations)` → `controller_id` is `TEXT`.
-  - Round-trip: apply migration_5 then its `down`, verify structure returns.
+  - Verify `down` throws (asserts the policy below is in force).
 
 - [ ] `astros_api/src/dal/migrations/migration_6.test.ts`:
   - Apply all migrations through migration_6 on a fresh DB.
@@ -100,7 +100,7 @@ Reference: `migration_1.ts` for the rename-dance pattern, Kysely's `addForeignKe
   - Verify CASCADE works: delete a `scripts` row, assert `script_channels` and `script_events` for that script are gone.
   - Verify RESTRICT works: for `controllers` with an existing `controller_locations` link, attempt to delete the controller, expect the delete to be rejected.
   - Orphan cleanup: seed a pre-migration DB with known orphans (e.g. a `script_channels` row whose `script_id` doesn't exist), apply migration_6, assert the orphan is gone and no other rows are affected.
-  - Round-trip: apply, then down, then apply again — tables round-trip.
+  - Verify `down` throws.
 
 - [ ] `astros_api/src/dal/repositories/controller_repository.test.ts` — add the regression test from Part A.
 
@@ -122,6 +122,15 @@ Reference: `migration_1.ts` for the rename-dance pattern, Kysely's `addForeignKe
   - Attempt an orphan insert via the sqlite3 CLI; expect rejection.
   - Simulate a controller re-registration via the existing serial test harness and verify `insertControllers` does not throw under FK enforcement.
 - **Safety net test (relies on phase 1):** deliberately break migration_6 with a `throw`, restart, verify the backup is taken, the migration fails, the restore succeeds, and the system returns to usable state at v4.
+
+## Down migration policy (Phase 2 onwards)
+
+Phase 1's backup-and-restore is the official rollback mechanism. `migrateToLatest()` (the only migrator call we make) only runs `up`s; `down` is never invoked in production. Two options for new migrations' `down`:
+
+- **Full symmetric down** — duplicates the recovery story. Verbose for migration_6 (~13 reverse rename dances).
+- **Throwing down** — `down` throws an `Error` directing operators to Phase 1's backup-restore. Single source of truth for rollback; less code to maintain.
+
+This phase commits to **throwing `down`** for migration_5 and migration_6. The migrations 0–4 that already have working `down` implementations are left as-is (no scope creep). The implication: forward migration safety is handled by Kysely's per-migration transaction wrapper *plus* Phase 1's restore; manual `migrateDown()` calls will fail loudly, which is what we want.
 
 ## Notes
 

--- a/.docs/plans/20260410-0807-db-safety-phase2-schema-migrations.md
+++ b/.docs/plans/20260410-0807-db-safety-phase2-schema-migrations.md
@@ -29,22 +29,22 @@ This is a small edit to phase 1's `initializeDatabase()` flow — the pragma tog
 
 ### Part A — refactor `insertControllers` (blocks migration_6)
 
-- [ ] Rewrite `insertControllers` in `astros_api/src/dal/repositories/controller_repository.ts:11-70` to UPDATE-in-place:
+- [x] Rewrite `insertControllers` in `astros_api/src/dal/repositories/controller_repository.ts:11-70` to UPDATE-in-place:
   - Find all rows matching by `address` OR `name`.
   - If 0 matches → `INSERT` with a fresh UUID.
   - If ≥1 matches → keep the first row (stable id), `UPDATE` its `name`/`address` fields, `DELETE` any additional duplicates.
   - The keeper row is **never** deleted-then-reinserted, so any `controller_locations` FK pointing at it stays valid throughout.
 
-- [ ] Revisit `astros_api/src/dal/repositories/controller_repository.test.ts` — existing tests cover "new controller", "duplicate address", "duplicate name", and "update existing". Verify they pass against the new implementation; tweak only if the refactor legitimately changes behavior (e.g. duplicate-merge semantics).
+- [x] Revisit `astros_api/src/dal/repositories/controller_repository.test.ts` — existing tests cover "new controller", "duplicate address", "duplicate name", and "update existing". Verify they pass against the new implementation; tweak only if the refactor legitimately changes behavior (e.g. duplicate-merge semantics).
 
-- [ ] **Regression guard test:** insert a `controller_locations` row pointing at an existing controller, call `insertControllers` for that controller, assert the `controller_locations` row still exists afterward with the same `controller_id`. This is the specific behavior migration_6's FK will enforce.
+- [x] **Regression guard test:** insert a `controller_locations` row pointing at an existing controller, call `insertControllers` for that controller, assert the `controller_locations` row still exists afterward with the same `controller_id`. This is the specific behavior migration_6's FK will enforce.
 
 ### Part B — migration_5: fix `controller_locations.controller_id` type
 
-- [ ] Create `astros_api/src/dal/migrations/migration_5.ts`:
+- [x] Create `astros_api/src/dal/migrations/migration_5.ts`:
   - `up`: read all rows, drop the table, recreate with both columns as `text`, re-insert rows. **No FKs yet** — that's migration_6.
   - `down`: throws `Error('Recovery is via Phase 1 backup-restore; no manual down')`. See "Down migration policy" below.
-- [ ] Register in `astros_api/src/dal/migrations/index.ts` and add to the migration provider in `database.ts`.
+- [x] Register in `astros_api/src/dal/migrations/index.ts` and add to the migration provider in `database.ts`.
 
 ### Part C — migration_6: foreign-key constraints + orphan cleanup
 
@@ -78,23 +78,23 @@ Target tables and FK actions:
 
 Reference: `migration_1.ts` for the rename-dance pattern, Kysely's `addForeignKeyConstraint(name, columns, targetTable, targetColumns)` builder. Kysely also supports `.onDelete('cascade'|'restrict')`.
 
-- [ ] Create `astros_api/src/dal/migrations/migration_6.ts`:
+- [x] Create `astros_api/src/dal/migrations/migration_6.ts`:
   - `up`: iterate through the table list above, performing orphan cleanup + rename dance per table.
   - `down`: throws `Error('Recovery is via Phase 1 backup-restore; no manual down')`. See "Down migration policy" below.
-- [ ] Register in `astros_api/src/dal/migrations/index.ts` and `database.ts`.
+- [x] Register in `astros_api/src/dal/migrations/index.ts` and `database.ts`.
 
 ### Part D — FK pragma toggle in phase 1's `initializeDatabase`
 
-- [ ] In `astros_api/src/dal/database.ts` `initializeDatabase()`, bracket the migrator call with `PRAGMA foreign_keys = OFF` before and `PRAGMA foreign_keys = ON` after. The default at open is already ON (from phase 1), so this only adds the off/on wrapping during the migrate step.
+- [x] In `astros_api/src/dal/database.ts` `initializeDatabase()`, bracket the migrator call with `PRAGMA foreign_keys = OFF` before and `PRAGMA foreign_keys = ON` after. The default at open is already ON (from phase 1), so this only adds the off/on wrapping during the migrate step.
 
 ## Tests
 
-- [ ] `astros_api/src/dal/migrations/migration_5.test.ts`:
+- [x] `astros_api/src/dal/migrations/migration_5.test.ts`:
   - Apply migrations 0–4, insert a `controller_locations` row, apply migration_5, verify the row is still there with the same values.
   - Verify declared column type via `PRAGMA table_info(controller_locations)` → `controller_id` is `TEXT`.
   - Verify `down` throws (asserts the policy below is in force).
 
-- [ ] `astros_api/src/dal/migrations/migration_6.test.ts`:
+- [x] `astros_api/src/dal/migrations/migration_6.test.ts`:
   - Apply all migrations through migration_6 on a fresh DB.
   - Verify each FK is enforced: attempt to insert an orphan row for each constrained table, expect `FOREIGN KEY constraint failed`.
   - Verify CASCADE works: delete a `scripts` row, assert `script_channels` and `script_events` for that script are gone.
@@ -102,7 +102,7 @@ Reference: `migration_1.ts` for the rename-dance pattern, Kysely's `addForeignKe
   - Orphan cleanup: seed a pre-migration DB with known orphans (e.g. a `script_channels` row whose `script_id` doesn't exist), apply migration_6, assert the orphan is gone and no other rows are affected.
   - Verify `down` throws.
 
-- [ ] `astros_api/src/dal/repositories/controller_repository.test.ts` — add the regression test from Part A.
+- [x] `astros_api/src/dal/repositories/controller_repository.test.ts` — add the regression test from Part A.
 
 ## Critical files
 

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -17,8 +17,15 @@ import {
   migration_2,
   migration_3,
   migration_4,
+  migration_5,
+  migration_6,
 } from './migrations/index.js';
 
+// Mirrors the production provider so injected test migrations layer on top of
+// the real baseline rather than truncating it. Without this, kysely sees
+// migrations 5/6 in kysely_migration but missing from the provider and throws
+// "corrupted migrations" before any extra migration runs — which would short-
+// circuit tests that intend to exercise post-migration paths.
 function buildProvider(extra: Record<string, Migration> = {}): MigrationProvider {
   return new (class implements MigrationProvider {
     async getMigrations(): Promise<Record<string, Migration>> {
@@ -28,6 +35,8 @@ function buildProvider(extra: Record<string, Migration> = {}): MigrationProvider
         '2_add_script_duration': migration_2,
         '3_add_playlists': migration_3,
         '4_add_random_wait': migration_4,
+        '5_fix_controller_locations_type': migration_5,
+        '6_add_foreign_keys': migration_6,
         ...extra,
       };
     }
@@ -85,10 +94,10 @@ describe('initializeDatabase safety flow', () => {
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
 
-    // Inject a 5th migration so we have something pending
+    // Inject a new migration on top of the real v6 baseline.
     __setMigrationProviderForTest(
       buildProvider({
-        '5_safe_addition': {
+        '7_safe_addition': {
           async up(db) {
             await db.schema.createTable('safe_addition').addColumn('id', 'integer').execute();
           },
@@ -102,11 +111,11 @@ describe('initializeDatabase safety flow', () => {
     status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
 
-    // Backup file named after the previous last-applied migration should exist
+    // Backup file named after the previous last-applied migration (v6) should exist.
     const backupFiles = fs
       .readdirSync(tmpDir)
       .filter((f) => f.startsWith('database.sqlite3.backup-'));
-    expect(backupFiles).toEqual(['database.sqlite3.backup-4_add_random_wait']);
+    expect(backupFiles).toEqual(['database.sqlite3.backup-6_add_foreign_keys']);
     expect(status.isReadOnly()).toBe(false);
   });
 
@@ -124,10 +133,10 @@ describe('initializeDatabase safety flow', () => {
       sqlite.close();
     }
 
-    // Inject a migration that throws
+    // Inject a migration on top of the real v6 baseline that throws.
     __setMigrationProviderForTest(
       buildProvider({
-        '5_will_fail': {
+        '7_will_fail': {
           async up() {
             throw new Error('intentional migration failure');
           },
@@ -158,10 +167,10 @@ describe('initializeDatabase safety flow', () => {
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
 
-    // Inject a pending migration so a backup attempt happens
+    // Inject a pending migration on top of v6 so a backup attempt happens.
     __setMigrationProviderForTest(
       buildProvider({
-        '5_pending': {
+        '7_pending': {
           async up(db) {
             await db.schema.createTable('pending_table').addColumn('id', 'integer').execute();
           },
@@ -188,15 +197,15 @@ describe('initializeDatabase safety flow', () => {
   });
 
   it('failed migration + failed restore → enters read-only', async () => {
-    // Migrate to v4
+    // Migrate baseline to current latest (v6)
     let status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
 
-    // Inject a migration that throws
+    // Inject a migration on top of v6 that throws
     __setMigrationProviderForTest(
       buildProvider({
-        '5_will_fail': {
+        '7_will_fail': {
           async up() {
             throw new Error('intentional migration failure');
           },

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -230,6 +230,66 @@ describe('initializeDatabase safety flow', () => {
     expect(probe.rows).toEqual([{ one: 1 }]);
   });
 
+  it('post-migration foreign_key_check catches FK violators → restores from backup', async () => {
+    // Regression for the orphan-cleanup-gap concern: migrations apply with
+    // FKs off, so INSERT INTO _new SELECT * FROM old does not validate the
+    // new constraints during the rename dance. If a future migration's
+    // orphan cleanup misses a case, the migration would succeed silently
+    // and leave dangling references invisible to runtime FK checks.
+    //
+    // Simulate that scenario: inject a migration that successfully inserts
+    // a script_channels row whose script_id does not exist in `scripts`
+    // (allowed because FKs are off during apply). The post-migrate
+    // foreign_key_check must detect it, throw, and Phase 1's
+    // restore-from-backup must revert to the pre-migration state.
+
+    // Bring DB to v6 (current latest, with FKs on script_channels.script_id).
+    let status = new SystemStatus();
+    await initializeDatabase(status, { dbPath });
+    await closeDatabaseForTest();
+
+    __setMigrationProviderForTest(
+      buildProvider({
+        '7_introduces_orphan': {
+          async up(db) {
+            // Insert a script_channels row with a fabricated script_id —
+            // valid SQL because FKs are off during the migration window.
+            await sql`
+              INSERT INTO script_channels
+                (id, script_id, channel_type, parent_module_id, module_channel_id, module_channel_type)
+              VALUES
+                ('bad-orphan', 'no-such-script', 1, 'pm', 'mc', 'mct')
+            `.execute(db);
+          },
+          async down() {
+            return;
+          },
+        },
+      }),
+    );
+
+    status = new SystemStatus();
+    const db = await initializeDatabase(status, { dbPath });
+
+    // Phase 1's restore brought us back to v6. The bad migration is reverted.
+    expect(status.isReadOnly()).toBe(false);
+
+    // The orphan is gone — the bad migration's INSERT was rolled back via the
+    // file restore.
+    const survivors = await db
+      .selectFrom('script_channels')
+      .selectAll()
+      .where('id', '=', 'bad-orphan')
+      .execute();
+    expect(survivors).toHaveLength(0);
+
+    // And the migration history shows v6 as the latest, not v7.
+    const result = await sql<{ name: string }>`
+      SELECT name FROM kysely_migration ORDER BY name DESC LIMIT 1
+    `.execute(db);
+    expect(result.rows[0]?.name).toBe('6_add_foreign_keys');
+  });
+
   it('initial open failure → enters read-only with STARTUP_OPEN_FAILED and returns a usable in-memory db', async () => {
     // Create a directory at the dbPath so better-sqlite3 fails to open it
     // as a database file.

--- a/astros_api/src/dal/database.test.ts
+++ b/astros_api/src/dal/database.test.ts
@@ -1,6 +1,76 @@
 import { describe, expect, it } from 'vitest';
 import appdata from 'appdata-path';
-import { resolveDatabaseDir } from './database.js';
+import SQLite from 'better-sqlite3';
+import { assertNoFkViolations, resolveDatabaseDir } from './database.js';
+
+describe('assertNoFkViolations', () => {
+  it('returns silently when no violations exist', () => {
+    const raw = new SQLite(':memory:');
+    raw.pragma('foreign_keys = ON');
+    raw.prepare('CREATE TABLE parent (id INTEGER PRIMARY KEY)').run();
+    raw
+      .prepare(
+        'CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))',
+      )
+      .run();
+    raw.prepare('INSERT INTO parent (id) VALUES (1)').run();
+    raw.prepare('INSERT INTO child (id, parent_id) VALUES (1, 1)').run();
+
+    expect(() => assertNoFkViolations(raw)).not.toThrow();
+    raw.close();
+  });
+
+  it('throws with the violation table name when violators exist', () => {
+    const raw = new SQLite(':memory:');
+    raw.pragma('foreign_keys = ON');
+    raw.prepare('CREATE TABLE parent (id INTEGER PRIMARY KEY)').run();
+    raw
+      .prepare(
+        'CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))',
+      )
+      .run();
+    // Sneak in an orphan with FKs off.
+    raw.pragma('foreign_keys = OFF');
+    raw.prepare('INSERT INTO child (id, parent_id) VALUES (1, 999)').run();
+    raw.pragma('foreign_keys = ON');
+
+    expect(() => assertNoFkViolations(raw)).toThrow(/violator/);
+    expect(() => assertNoFkViolations(raw)).toThrow(/child/);
+    raw.close();
+  });
+
+  it('handles bigint rowids without TypeError when safeIntegers is enabled', () => {
+    // Regression: rowid can come back as bigint when the connection has
+    // safeIntegers enabled. Default JSON.stringify throws on bigints, which
+    // would mask the real FK violation behind a serialization TypeError.
+    const raw = new SQLite(':memory:');
+    raw.defaultSafeIntegers(true);
+    raw.pragma('foreign_keys = ON');
+    raw.prepare('CREATE TABLE parent (id INTEGER PRIMARY KEY)').run();
+    raw
+      .prepare(
+        'CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id))',
+      )
+      .run();
+    raw.pragma('foreign_keys = OFF');
+    raw.prepare('INSERT INTO child (id, parent_id) VALUES (1, 999)').run();
+    raw.pragma('foreign_keys = ON');
+
+    let caught: unknown = null;
+    try {
+      assertNoFkViolations(raw);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    // Specifically NOT a TypeError from JSON.stringify on a bigint.
+    expect((caught as Error).message).not.toMatch(/serialize a BigInt/i);
+    expect((caught as Error).message).toMatch(/violator/);
+    expect((caught as Error).message).toContain('child');
+    raw.close();
+  });
+});
 
 describe('resolveDatabaseDir', () => {
   const defaultDir = appdata('astrosserver');

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -94,7 +94,10 @@ function openConnection(dbFile: string): OpenConnection {
 // invisible to runtime checks. PRAGMA foreign_key_check scans every FK
 // constraint and reports violators; we throw on any so the existing
 // restore-from-backup path can revert to the pre-migration version.
-function assertNoFkViolations(raw: SQLite.Database): void {
+//
+// Exported for test use; no test-only-prefix because this is a generally
+// useful FK-integrity check, not test scaffolding.
+export function assertNoFkViolations(raw: SQLite.Database): void {
   const violations = raw.prepare('PRAGMA foreign_key_check').all() as Array<{
     table: string;
     rowid: number | bigint;
@@ -102,8 +105,12 @@ function assertNoFkViolations(raw: SQLite.Database): void {
     fkid: number;
   }>;
   if (violations.length > 0) {
+    // rowid can be a bigint when the connection has safeIntegers enabled.
+    // JSON.stringify throws TypeError on bigints by default, which would
+    // mask the real violation details behind a serialization error.
+    const detail = JSON.stringify(violations, (_, v) => (typeof v === 'bigint' ? v.toString() : v));
     throw new Error(
-      `Post-migration foreign_key_check found ${violations.length} violator(s): ${JSON.stringify(violations)}`,
+      `Post-migration foreign_key_check found ${violations.length} violator(s): ${detail}`,
     );
   }
 }

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -116,7 +116,15 @@ export async function initializeDatabase(
 
   if (useMemory) {
     const conn = openConnection(':memory:');
-    await migrateToLatest(conn.db);
+    // Mirror the file-backed path's pragma bracket so migration_6 (and any
+    // future migration that needs FK enforcement off during apply) behaves
+    // identically across paths.
+    conn.raw.pragma('foreign_keys = OFF');
+    try {
+      await migrateToLatest(conn.db);
+    } finally {
+      conn.raw.pragma('foreign_keys = ON');
+    }
     return conn.db;
   }
 

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -20,6 +20,8 @@ import {
   migration_2,
   migration_3,
   migration_4,
+  migration_5,
+  migration_6,
 } from './migrations/index.js';
 import { SystemStatus } from '../system_status.js';
 import {
@@ -49,6 +51,8 @@ const defaultMigrationProvider: MigrationProvider = new (class implements Migrat
       '2_add_script_duration': migration_2,
       '3_add_playlists': migration_3,
       '4_add_random_wait': migration_4,
+      '5_fix_controller_locations_type': migration_5,
+      '6_add_foreign_keys': migration_6,
     };
   }
 })();
@@ -154,7 +158,17 @@ export async function initializeDatabase(
   }
 
   try {
-    await migrateToLatest(conn.db);
+    // Toggle FKs OFF for the migrate window so rename-dance migrations can
+    // drop/recreate referenced tables without RESTRICT/CASCADE side-effects.
+    // The pragma cannot be changed inside a transaction, so it must wrap
+    // migrateToLatest() — Kysely opens a transaction per migration internally.
+    // The finally guarantees FKs are re-enabled even if migrate throws.
+    conn.raw.pragma('foreign_keys = OFF');
+    try {
+      await migrateToLatest(conn.db);
+    } finally {
+      conn.raw.pragma('foreign_keys = ON');
+    }
     pruneOldBackups(dbFile, 5);
     return conn.db;
   } catch (err) {

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -88,6 +88,26 @@ function openConnection(dbFile: string): OpenConnection {
   return conn;
 }
 
+// Migrations apply with FKs off (rename dances need it). After turning FKs
+// back on, SQLite does NOT retroactively re-validate existing rows — so any
+// gap in a migration's orphan cleanup would leave dangling FK violators
+// invisible to runtime checks. PRAGMA foreign_key_check scans every FK
+// constraint and reports violators; we throw on any so the existing
+// restore-from-backup path can revert to the pre-migration version.
+function assertNoFkViolations(raw: SQLite.Database): void {
+  const violations = raw.prepare('PRAGMA foreign_key_check').all() as Array<{
+    table: string;
+    rowid: number | bigint;
+    parent: string;
+    fkid: number;
+  }>;
+  if (violations.length > 0) {
+    throw new Error(
+      `Post-migration foreign_key_check found ${violations.length} violator(s): ${JSON.stringify(violations)}`,
+    );
+  }
+}
+
 async function closeConnection(): Promise<void> {
   if (_db) {
     try {
@@ -125,6 +145,7 @@ export async function initializeDatabase(
     } finally {
       conn.raw.pragma('foreign_keys = ON');
     }
+    assertNoFkViolations(conn.raw);
     return conn.db;
   }
 
@@ -177,6 +198,9 @@ export async function initializeDatabase(
     } finally {
       conn.raw.pragma('foreign_keys = ON');
     }
+    // Verify the migration left no FK violators (orphan-cleanup gap, etc.).
+    // Throws into the catch below, where the restore-from-backup path runs.
+    assertNoFkViolations(conn.raw);
     pruneOldBackups(dbFile, 5);
     return conn.db;
   } catch (err) {

--- a/astros_api/src/dal/migrations/index.ts
+++ b/astros_api/src/dal/migrations/index.ts
@@ -3,3 +3,5 @@ export { migration_1 } from './migration_1.js';
 export { migration_2 } from './migration_2.js';
 export { migration_3 } from './migration_3.js';
 export { migration_4 } from './migration_4.js';
+export { migration_5 } from './migration_5.js';
+export { migration_6 } from './migration_6.js';

--- a/astros_api/src/dal/migrations/migration_5.test.ts
+++ b/astros_api/src/dal/migrations/migration_5.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Kysely, Migration, MigrationProvider, Migrator } from 'kysely';
+import { Database } from '../types.js';
+import { createKyselyConnection } from '../database.js';
+import { migration_0, migration_1, migration_2, migration_3, migration_4 } from './index.js';
+import { migration_5 } from './migration_5.js';
+
+// Provider that stops at v4 — used to bring the DB to a pre-migration_5 state.
+const v4Provider: MigrationProvider = new (class implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return {
+      '0_initial': migration_0,
+      '1_add_script_evt_id': migration_1,
+      '2_add_script_duration': migration_2,
+      '3_add_playlists': migration_3,
+      '4_add_random_wait': migration_4,
+    };
+  }
+})();
+
+const v5Provider: MigrationProvider = new (class implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return {
+      '0_initial': migration_0,
+      '1_add_script_evt_id': migration_1,
+      '2_add_script_duration': migration_2,
+      '3_add_playlists': migration_3,
+      '4_add_random_wait': migration_4,
+      '5_fix_controller_locations_type': migration_5,
+    };
+  }
+})();
+
+describe('migration_5: fix controller_locations.controller_id type', () => {
+  let db: Kysely<Database>;
+  let raw: ReturnType<typeof createKyselyConnection>['raw'];
+
+  beforeEach(() => {
+    const conn = createKyselyConnection();
+    db = conn.db;
+    raw = conn.raw;
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('preserves controller_locations rows across the type change', async () => {
+    // Bring DB to v4
+    const v4 = new Migrator({ db, provider: v4Provider });
+    const v4Result = await v4.migrateToLatest();
+    expect(v4Result.error).toBeUndefined();
+
+    // Insert a controller + controller_locations row at v4
+    await db
+      .insertInto('controllers')
+      .values({
+        id: 'ctl-1',
+        name: 'pre-v5',
+        description: '',
+        address: 'AA:BB:CC:DD:EE:99',
+      })
+      .execute();
+    await db
+      .insertInto('locations')
+      .values({ id: 'loc-1', name: 'L1', description: '', config_fingerprint: '' })
+      .execute();
+    // Cast: at v4, controller_id is declared `integer`, but we store the UUID
+    // string anyway thanks to SQLite's loose typing — the same shape that exists
+    // in production today.
+    await db
+      .insertInto('controller_locations')
+      .values({ location_id: 'loc-1', controller_id: 'ctl-1' as unknown as number })
+      .execute();
+
+    // Apply migration_5
+    const v5 = new Migrator({ db, provider: v5Provider });
+    const result = await v5.migrateToLatest();
+    expect(result.error).toBeUndefined();
+
+    // Row survives with the same values
+    const rows = await db
+      .selectFrom('controller_locations')
+      .selectAll()
+      .where('location_id', '=', 'loc-1')
+      .execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].controller_id).toBe('ctl-1');
+  });
+
+  it('declares controller_id as TEXT after up', async () => {
+    const m = new Migrator({ db, provider: v5Provider });
+    const result = await m.migrateToLatest();
+    expect(result.error).toBeUndefined();
+
+    const cols = raw.prepare('PRAGMA table_info(controller_locations)').all() as Array<{
+      name: string;
+      type: string;
+    }>;
+    const controllerIdCol = cols.find((c) => c.name === 'controller_id');
+    expect(controllerIdCol?.type.toUpperCase()).toBe('TEXT');
+  });
+
+  it('down throws — recovery is via Phase 1 backup-restore', async () => {
+    // Get to v5 first so down has something to revert
+    const m = new Migrator({ db, provider: v5Provider });
+    await m.migrateToLatest();
+
+    await expect(m.migrateDown()).resolves.toMatchObject({
+      results: expect.arrayContaining([
+        expect.objectContaining({
+          status: 'Error',
+          migrationName: '5_fix_controller_locations_type',
+        }),
+      ]),
+    });
+  });
+});

--- a/astros_api/src/dal/migrations/migration_5.ts
+++ b/astros_api/src/dal/migrations/migration_5.ts
@@ -1,0 +1,31 @@
+import { Kysely, Migration, sql } from 'kysely';
+import { Database } from 'src/dal/types.js';
+
+// Fixes controller_locations.controller_id's declared type. Migration 0 declared
+// it as `integer`, but `controllers.id` is `text` (UUID). SQLite's loose typing
+// means runtime behavior is fine, but the declared type mismatch blocks adding
+// a foreign-key constraint in migration_6. No FKs added here — that's migration_6.
+export const migration_5: Migration = {
+  up: async (db: Kysely<Database>): Promise<void> => {
+    const rows = await db.selectFrom('controller_locations').selectAll().execute();
+
+    await db.schema
+      .createTable('controller_locations_new')
+      .addColumn('location_id', 'text', (col) => col.notNull())
+      .addColumn('controller_id', 'text', (col) => col.notNull())
+      .execute();
+
+    for (const row of rows) {
+      await sql`
+        INSERT INTO controller_locations_new (location_id, controller_id)
+        VALUES (${row.location_id}, ${row.controller_id})
+      `.execute(db);
+    }
+
+    await db.schema.dropTable('controller_locations').execute();
+    await sql`ALTER TABLE controller_locations_new RENAME TO controller_locations`.execute(db);
+  },
+  down: async (): Promise<void> => {
+    throw new Error('Recovery is via Phase 1 backup-restore; no manual down');
+  },
+};

--- a/astros_api/src/dal/migrations/migration_5.ts
+++ b/astros_api/src/dal/migrations/migration_5.ts
@@ -7,20 +7,18 @@ import { Database } from 'src/dal/types.js';
 // a foreign-key constraint in migration_6. No FKs added here — that's migration_6.
 export const migration_5: Migration = {
   up: async (db: Kysely<Database>): Promise<void> => {
-    const rows = await db.selectFrom('controller_locations').selectAll().execute();
-
     await db.schema
       .createTable('controller_locations_new')
       .addColumn('location_id', 'text', (col) => col.notNull())
       .addColumn('controller_id', 'text', (col) => col.notNull())
       .execute();
 
-    for (const row of rows) {
-      await sql`
-        INSERT INTO controller_locations_new (location_id, controller_id)
-        VALUES (${row.location_id}, ${row.controller_id})
-      `.execute(db);
-    }
+    // Bulk copy in a single statement. Column lists are explicit so the
+    // migration is robust to any future reordering on either table.
+    await sql`
+      INSERT INTO controller_locations_new (location_id, controller_id)
+      SELECT location_id, controller_id FROM controller_locations
+    `.execute(db);
 
     await db.schema.dropTable('controller_locations').execute();
     await sql`ALTER TABLE controller_locations_new RENAME TO controller_locations`.execute(db);

--- a/astros_api/src/dal/migrations/migration_6.test.ts
+++ b/astros_api/src/dal/migrations/migration_6.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Kysely, Migration, MigrationProvider, Migrator, sql } from 'kysely';
+import { Database } from '../types.js';
+import { createKyselyConnection } from '../database.js';
+import {
+  migration_0,
+  migration_1,
+  migration_2,
+  migration_3,
+  migration_4,
+  migration_5,
+} from './index.js';
+import { migration_6 } from './migration_6.js';
+
+const v5Provider: MigrationProvider = new (class implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return {
+      '0_initial': migration_0,
+      '1_add_script_evt_id': migration_1,
+      '2_add_script_duration': migration_2,
+      '3_add_playlists': migration_3,
+      '4_add_random_wait': migration_4,
+      '5_fix_controller_locations_type': migration_5,
+    };
+  }
+})();
+
+const v6Provider: MigrationProvider = new (class implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return {
+      '0_initial': migration_0,
+      '1_add_script_evt_id': migration_1,
+      '2_add_script_duration': migration_2,
+      '3_add_playlists': migration_3,
+      '4_add_random_wait': migration_4,
+      '5_fix_controller_locations_type': migration_5,
+      '6_add_foreign_keys': migration_6,
+    };
+  }
+})();
+
+describe('migration_6: foreign keys + orphan cleanup', () => {
+  let db: Kysely<Database>;
+  let raw: ReturnType<typeof createKyselyConnection>['raw'];
+
+  beforeEach(() => {
+    const conn = createKyselyConnection();
+    db = conn.db;
+    raw = conn.raw;
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function applyV5(): Promise<void> {
+    const m = new Migrator({ db, provider: v5Provider });
+    const result = await m.migrateToLatest();
+    expect(result.error).toBeUndefined();
+  }
+
+  async function applyV6(): Promise<void> {
+    const m = new Migrator({ db, provider: v6Provider });
+    // Real production code toggles foreign_keys = OFF before migrate; the
+    // helper sets it ON. Match production by toggling here.
+    raw.pragma('foreign_keys = OFF');
+    try {
+      const result = await m.migrateToLatest();
+      expect(result.error).toBeUndefined();
+    } finally {
+      raw.pragma('foreign_keys = ON');
+    }
+  }
+
+  it('enforces RESTRICT on controller_locations.controller_id', async () => {
+    await applyV6();
+
+    // Insert a controller and a controller_locations row pointing at it
+    await db
+      .insertInto('controllers')
+      .values({
+        id: 'ctl-r1',
+        name: 'restrict-test',
+        description: '',
+        address: 'AA:00:00:00:00:01',
+      })
+      .execute();
+    await db
+      .insertInto('locations')
+      .values({ id: 'loc-r1', name: 'rl1', description: '', config_fingerprint: '' })
+      .execute();
+    await db
+      .insertInto('controller_locations')
+      .values({ location_id: 'loc-r1', controller_id: 'ctl-r1' })
+      .execute();
+
+    // Attempting to delete the controller should be rejected (RESTRICT)
+    await expect(db.deleteFrom('controllers').where('id', '=', 'ctl-r1').execute()).rejects.toThrow(
+      /FOREIGN KEY constraint failed/,
+    );
+  });
+
+  it('CASCADEs script_channels and script_events when a script is deleted', async () => {
+    await applyV6();
+
+    await db
+      .insertInto('scripts')
+      .values({
+        id: 's-1',
+        name: 'cascade-test',
+        description: '',
+        last_modified: 0,
+        enabled: 1,
+        duration_ds: 0,
+      })
+      .execute();
+    await db
+      .insertInto('script_channels')
+      .values({
+        id: 'sc-1',
+        script_id: 's-1',
+        channel_type: 1,
+        parent_module_id: 'pm-1',
+        module_channel_id: 'mc-1',
+        module_channel_type: 'mct',
+      })
+      .execute();
+    await db
+      .insertInto('script_events')
+      .values({
+        id: 'se-1',
+        script_id: 's-1',
+        script_channel_id: 'sc-1',
+        module_type: 1,
+        module_sub_type: 1,
+        time: 0,
+        data: 'd',
+      })
+      .execute();
+
+    await db.deleteFrom('scripts').where('id', '=', 's-1').execute();
+
+    const channels = await db
+      .selectFrom('script_channels')
+      .selectAll()
+      .where('script_id', '=', 's-1')
+      .execute();
+    expect(channels).toHaveLength(0);
+
+    const events = await db
+      .selectFrom('script_events')
+      .selectAll()
+      .where('script_id', '=', 's-1')
+      .execute();
+    expect(events).toHaveLength(0);
+  });
+
+  it('rejects orphan inserts for each constrained child table', async () => {
+    await applyV6();
+
+    // gpio_channels.location_id → locations.id
+    await expect(
+      db
+        .insertInto('gpio_channels')
+        .values({
+          id: 'g-orphan',
+          location_id: 'nonexistent-loc',
+          channel_number: 0,
+          name: 'x',
+          default_high: 0,
+          enabled: 0,
+        })
+        .execute(),
+    ).rejects.toThrow(/FOREIGN KEY constraint failed/);
+
+    // maestro_boards.parent_id → uart_modules.id
+    await expect(
+      db
+        .insertInto('maestro_boards')
+        .values({
+          id: 'mb-orphan',
+          parent_id: 'nonexistent-uart',
+          board_id: 0,
+          name: 'x',
+          channel_count: 0,
+        })
+        .execute(),
+    ).rejects.toThrow(/FOREIGN KEY constraint failed/);
+
+    // kangaroo_x2.parent_id → uart_modules.id
+    await expect(
+      db
+        .insertInto('kangaroo_x2')
+        .values({
+          id: 'k-orphan',
+          parent_id: 'nonexistent-uart-2',
+          ch1_name: 'x',
+          ch2_name: 'y',
+        })
+        .execute(),
+    ).rejects.toThrow(/FOREIGN KEY constraint failed/);
+  });
+
+  it('cleans pre-existing orphans on up', async () => {
+    await applyV5();
+
+    // Seed orphans at v5 (before FKs exist). FKs are still ON from the helper,
+    // so we toggle them off briefly to insert violators.
+    raw.pragma('foreign_keys = OFF');
+    try {
+      await db
+        .insertInto('script_channels')
+        .values({
+          id: 'orphan-channel',
+          script_id: 'no-such-script',
+          channel_type: 1,
+          parent_module_id: 'pm',
+          module_channel_id: 'mc',
+          module_channel_type: 'mct',
+        })
+        .execute();
+      await db
+        .insertInto('controller_locations')
+        .values({ location_id: 'no-such-loc', controller_id: 'no-such-ctl' })
+        .execute();
+    } finally {
+      raw.pragma('foreign_keys = ON');
+    }
+
+    await applyV6();
+
+    const orphanChannel = await db
+      .selectFrom('script_channels')
+      .selectAll()
+      .where('id', '=', 'orphan-channel')
+      .execute();
+    expect(orphanChannel).toHaveLength(0);
+
+    const orphanLink = await db
+      .selectFrom('controller_locations')
+      .selectAll()
+      .where('location_id', '=', 'no-such-loc')
+      .execute();
+    expect(orphanLink).toHaveLength(0);
+  });
+
+  it('preserves non-orphan rows across migration_6', async () => {
+    await applyV5();
+
+    await db
+      .insertInto('scripts')
+      .values({
+        id: 's-keep',
+        name: 'keep',
+        description: '',
+        last_modified: 0,
+        enabled: 1,
+        duration_ds: 0,
+      })
+      .execute();
+    await db
+      .insertInto('script_channels')
+      .values({
+        id: 'sc-keep',
+        script_id: 's-keep',
+        channel_type: 1,
+        parent_module_id: 'pm',
+        module_channel_id: 'mc',
+        module_channel_type: 'mct',
+      })
+      .execute();
+
+    await applyV6();
+
+    const survivors = await db
+      .selectFrom('script_channels')
+      .selectAll()
+      .where('id', '=', 'sc-keep')
+      .execute();
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0].script_id).toBe('s-keep');
+  });
+
+  it('down throws — recovery is via Phase 1 backup-restore', async () => {
+    await applyV6();
+    const m = new Migrator({ db, provider: v6Provider });
+
+    await expect(m.migrateDown()).resolves.toMatchObject({
+      results: expect.arrayContaining([
+        expect.objectContaining({ status: 'Error', migrationName: '6_add_foreign_keys' }),
+      ]),
+    });
+  });
+
+  it('verifies sqlite_master records the FKs after up', async () => {
+    await applyV6();
+
+    // Quick sanity: ask sqlite for the FK list on a sample table.
+    const fks = raw.prepare('PRAGMA foreign_key_list(controller_locations)').all() as Array<{
+      from: string;
+      table: string;
+      on_delete: string;
+    }>;
+    const fromCols = fks.map((f) => f.from).sort();
+    expect(fromCols).toEqual(['controller_id', 'location_id']);
+    fks.forEach((f) => expect(f.on_delete.toUpperCase()).toBe('RESTRICT'));
+
+    const cascadeFks = raw.prepare('PRAGMA foreign_key_list(script_channels)').all() as Array<{
+      from: string;
+      on_delete: string;
+    }>;
+    expect(cascadeFks[0].from).toBe('script_id');
+    expect(cascadeFks[0].on_delete.toUpperCase()).toBe('CASCADE');
+
+    // Probe the connection works (fresh handle, not destroyed)
+    const probe = await sql<{ one: number }>`SELECT 1 AS one`.execute(db);
+    expect(probe.rows).toEqual([{ one: 1 }]);
+  });
+});

--- a/astros_api/src/dal/migrations/migration_6.test.ts
+++ b/astros_api/src/dal/migrations/migration_6.test.ts
@@ -348,9 +348,7 @@ describe('migration_6: foreign keys + orphan cleanup', () => {
     // Confirm the planner actually uses one of the new indexes for a
     // representative FK-column lookup (the kind that runs during CASCADE).
     const plan = raw
-      .prepare(
-        'EXPLAIN QUERY PLAN SELECT 1 FROM script_channels WHERE script_id = ?',
-      )
+      .prepare('EXPLAIN QUERY PLAN SELECT 1 FROM script_channels WHERE script_id = ?')
       .all('any') as Array<{ detail: string }>;
     const planText = plan.map((r) => r.detail).join(' ');
     expect(planText).toMatch(/USING (COVERING )?INDEX idx_script_channels_script_id/i);

--- a/astros_api/src/dal/migrations/migration_6.test.ts
+++ b/astros_api/src/dal/migrations/migration_6.test.ts
@@ -316,4 +316,43 @@ describe('migration_6: foreign keys + orphan cleanup', () => {
     const probe = await sql<{ one: number }>`SELECT 1 AS one`.execute(db);
     expect(probe.rows).toEqual([{ one: 1 }]);
   });
+
+  it('creates indexes on FK columns to avoid full table scans', async () => {
+    // Without explicit indexes on FK columns, CASCADE deletes and RESTRICT
+    // checks degrade to full child-table scans. Verify all expected indexes
+    // exist after migration_6.
+    await applyV6();
+
+    const indexNames = (
+      raw
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_%' ORDER BY name",
+        )
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    expect(indexNames).toEqual([
+      'idx_controller_locations_controller_id',
+      'idx_controller_locations_location_id',
+      'idx_gpio_channels_location_id',
+      'idx_i2c_modules_location_id',
+      'idx_maestro_boards_parent_id',
+      'idx_maestro_channels_board_id',
+      'idx_script_channels_script_id',
+      'idx_script_deployments_location_id',
+      'idx_script_events_script_channel_id',
+      'idx_script_events_script_id',
+      'idx_uart_modules_location_id',
+    ]);
+
+    // Confirm the planner actually uses one of the new indexes for a
+    // representative FK-column lookup (the kind that runs during CASCADE).
+    const plan = raw
+      .prepare(
+        'EXPLAIN QUERY PLAN SELECT 1 FROM script_channels WHERE script_id = ?',
+      )
+      .all('any') as Array<{ detail: string }>;
+    const planText = plan.map((r) => r.detail).join(' ');
+    expect(planText).toMatch(/USING (COVERING )?INDEX idx_script_channels_script_id/i);
+  });
 });

--- a/astros_api/src/dal/migrations/migration_6.ts
+++ b/astros_api/src/dal/migrations/migration_6.ts
@@ -1,0 +1,325 @@
+import { Kysely, Migration, sql } from 'kysely';
+import { Database } from 'src/dal/types.js';
+import { logger } from 'src/logger.js';
+
+// Adds foreign-key constraints across the schema. Per-table procedure:
+//   1. Delete orphans (already done in a single up-front block below)
+//   2. CREATE TABLE <table>_new with FK constraints
+//   3. INSERT INTO <table>_new SELECT * FROM <table>
+//   4. DROP TABLE <table>
+//   5. ALTER TABLE <table>_new RENAME TO <table>
+//
+// FK enforcement is OFF during this migration (set by initializeDatabase
+// in dal/database.ts) so the DROP/RENAME doesn't trip the existing playlist
+// FK from migration_3 or RESTRICT-itself when controllers are dropped.
+//
+// `down` throws — recovery is via Phase 1 backup-restore. See plan
+// `.docs/plans/20260410-0807-db-safety-phase2-schema-migrations.md`.
+
+async function logOrphanDeletion(
+  db: Kysely<Database>,
+  description: string,
+  query: ReturnType<typeof sql>,
+): Promise<void> {
+  const result = await query.execute(db);
+  // SQLite returns the affected row count via the driver; better-sqlite3 wraps
+  // it as `numAffectedRows` on the Kysely raw-sql result.
+  const count = result.numAffectedRows ?? BigInt(0);
+  if (count > 0) {
+    logger.warn(`migration_6: deleted ${count} orphan rows from ${description}`);
+  }
+}
+
+async function renameDanceCopyAndSwap(db: Kysely<Database>, tableName: string): Promise<void> {
+  await sql`INSERT INTO ${sql.raw(`${tableName}_new`)} SELECT * FROM ${sql.raw(tableName)}`.execute(
+    db,
+  );
+  await sql`DROP TABLE ${sql.raw(tableName)}`.execute(db);
+  await sql`ALTER TABLE ${sql.raw(`${tableName}_new`)} RENAME TO ${sql.raw(tableName)}`.execute(db);
+}
+
+export const migration_6: Migration = {
+  up: async (db: Kysely<Database>): Promise<void> => {
+    // ---- 1. Orphan cleanup (parent → child order so dependent orphans get caught) ----
+
+    await logOrphanDeletion(
+      db,
+      'script_channels (script_id missing)',
+      sql`DELETE FROM script_channels WHERE script_id NOT IN (SELECT id FROM scripts)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'script_events (script_id missing)',
+      sql`DELETE FROM script_events WHERE script_id NOT IN (SELECT id FROM scripts)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'script_events (script_channel_id missing)',
+      sql`DELETE FROM script_events WHERE script_channel_id NOT IN (SELECT id FROM script_channels)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'script_deployments (script_id missing)',
+      sql`DELETE FROM script_deployments WHERE script_id NOT IN (SELECT id FROM scripts)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'script_deployments (location_id missing)',
+      sql`DELETE FROM script_deployments WHERE location_id NOT IN (SELECT id FROM locations)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'controller_locations (location_id missing)',
+      sql`DELETE FROM controller_locations WHERE location_id NOT IN (SELECT id FROM locations)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'controller_locations (controller_id missing)',
+      sql`DELETE FROM controller_locations WHERE controller_id NOT IN (SELECT id FROM controllers)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'gpio_channels (location_id missing)',
+      sql`DELETE FROM gpio_channels WHERE location_id NOT IN (SELECT id FROM locations)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'i2c_modules (location_id missing)',
+      sql`DELETE FROM i2c_modules WHERE location_id NOT IN (SELECT id FROM locations)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'uart_modules (location_id missing)',
+      sql`DELETE FROM uart_modules WHERE location_id NOT IN (SELECT id FROM locations)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'maestro_boards (parent_id missing)',
+      sql`DELETE FROM maestro_boards WHERE parent_id NOT IN (SELECT id FROM uart_modules)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'maestro_channels (board_id missing)',
+      sql`DELETE FROM maestro_channels WHERE board_id NOT IN (SELECT id FROM maestro_boards)`,
+    );
+    await logOrphanDeletion(
+      db,
+      'kangaroo_x2 (parent_id missing)',
+      sql`DELETE FROM kangaroo_x2 WHERE parent_id NOT IN (SELECT id FROM uart_modules)`,
+    );
+
+    // ---- 2. Rename-dance per table, adding FK constraints ----
+
+    // controller_locations: location_id RESTRICT, controller_id RESTRICT
+    await db.schema
+      .createTable('controller_locations_new')
+      .addColumn('location_id', 'text', (col) => col.notNull())
+      .addColumn('controller_id', 'text', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_controller_locations_location_id',
+        ['location_id'],
+        'locations',
+        ['id'],
+        (b) => b.onDelete('restrict'),
+      )
+      .addForeignKeyConstraint(
+        'fk_controller_locations_controller_id',
+        ['controller_id'],
+        'controllers',
+        ['id'],
+        (b) => b.onDelete('restrict'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'controller_locations');
+
+    // script_channels: script_id CASCADE
+    await db.schema
+      .createTable('script_channels_new')
+      .addColumn('id', 'text', (col) => col.primaryKey())
+      .addColumn('script_id', 'text', (col) => col.notNull())
+      .addColumn('channel_type', 'integer', (col) => col.notNull())
+      .addColumn('parent_module_id', 'text', (col) => col.notNull())
+      .addColumn('module_channel_id', 'text', (col) => col.notNull())
+      .addColumn('module_channel_type', 'text', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_script_channels_script_id',
+        ['script_id'],
+        'scripts',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'script_channels');
+
+    // script_events: script_id CASCADE, script_channel_id CASCADE
+    // (post-migration_1 shape: id varchar(36) PK, data varchar(255))
+    await db.schema
+      .createTable('script_events_new')
+      .addColumn('id', 'varchar(36)', (col) => col.primaryKey())
+      .addColumn('script_id', 'varchar(36)', (col) => col.notNull())
+      .addColumn('script_channel_id', 'varchar(36)', (col) => col.notNull())
+      .addColumn('module_type', 'integer', (col) => col.notNull())
+      .addColumn('module_sub_type', 'integer', (col) => col.notNull())
+      .addColumn('time', 'integer', (col) => col.notNull())
+      .addColumn('data', 'varchar(255)', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_script_events_script_id',
+        ['script_id'],
+        'scripts',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .addForeignKeyConstraint(
+        'fk_script_events_script_channel_id',
+        ['script_channel_id'],
+        'script_channels',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'script_events');
+
+    // script_deployments: script_id CASCADE, location_id CASCADE
+    await db.schema
+      .createTable('script_deployments_new')
+      .addColumn('script_id', 'text', (col) => col.notNull())
+      .addColumn('location_id', 'text', (col) => col.notNull())
+      .addColumn('last_deployed', 'integer', (col) => col.notNull())
+      .addPrimaryKeyConstraint('script_deployments_pk', ['script_id', 'location_id'])
+      .addForeignKeyConstraint(
+        'fk_script_deployments_script_id',
+        ['script_id'],
+        'scripts',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .addForeignKeyConstraint(
+        'fk_script_deployments_location_id',
+        ['location_id'],
+        'locations',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'script_deployments');
+
+    // gpio_channels: location_id CASCADE
+    await db.schema
+      .createTable('gpio_channels_new')
+      .addColumn('id', 'text', (col) => col.primaryKey())
+      .addColumn('location_id', 'text', (col) => col.notNull())
+      .addColumn('channel_number', 'integer', (col) => col.notNull())
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('default_high', 'integer', (col) => col.notNull())
+      .addColumn('enabled', 'integer', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_gpio_channels_location_id',
+        ['location_id'],
+        'locations',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'gpio_channels');
+
+    // i2c_modules: location_id CASCADE
+    await db.schema
+      .createTable('i2c_modules_new')
+      .addColumn('idx', 'integer', (col) => col.primaryKey().autoIncrement())
+      .addColumn('id', 'text', (col) => col.notNull().unique())
+      .addColumn('location_id', 'text', (col) => col.notNull())
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('i2c_address', 'integer', (col) => col.notNull())
+      .addColumn('i2c_type', 'integer', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_i2c_modules_location_id',
+        ['location_id'],
+        'locations',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'i2c_modules');
+
+    // uart_modules: location_id CASCADE
+    await db.schema
+      .createTable('uart_modules_new')
+      .addColumn('idx', 'integer', (col) => col.primaryKey().autoIncrement())
+      .addColumn('id', 'text', (col) => col.notNull().unique())
+      .addColumn('location_id', 'text', (col) => col.notNull())
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('uart_type', 'integer', (col) => col.notNull())
+      .addColumn('uart_channel', 'integer', (col) => col.notNull())
+      .addColumn('baud_rate', 'integer', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_uart_modules_location_id',
+        ['location_id'],
+        'locations',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'uart_modules');
+
+    // kangaroo_x2: parent_id CASCADE
+    await db.schema
+      .createTable('kangaroo_x2_new')
+      .addColumn('id', 'text', (col) => col.primaryKey())
+      .addColumn('parent_id', 'text', (col) => col.notNull().unique())
+      .addColumn('ch1_name', 'text', (col) => col.notNull())
+      .addColumn('ch2_name', 'text', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_kangaroo_x2_parent_id',
+        ['parent_id'],
+        'uart_modules',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'kangaroo_x2');
+
+    // maestro_boards: parent_id CASCADE
+    await db.schema
+      .createTable('maestro_boards_new')
+      .addColumn('id', 'text', (col) => col.primaryKey())
+      .addColumn('parent_id', 'text', (col) => col.notNull())
+      .addColumn('board_id', 'integer', (col) => col.notNull())
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('channel_count', 'integer', (col) => col.notNull())
+      .addForeignKeyConstraint(
+        'fk_maestro_boards_parent_id',
+        ['parent_id'],
+        'uart_modules',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'maestro_boards');
+
+    // maestro_channels: board_id CASCADE
+    await db.schema
+      .createTable('maestro_channels_new')
+      .addColumn('id', 'text', (col) => col.primaryKey())
+      .addColumn('board_id', 'text', (col) => col.notNull())
+      .addColumn('channel_number', 'integer', (col) => col.notNull())
+      .addColumn('name', 'text', (col) => col.notNull())
+      .addColumn('enabled', 'integer', (col) => col.notNull().defaultTo(0))
+      .addColumn('is_servo', 'integer', (col) => col.notNull().defaultTo(1))
+      .addColumn('min_pos', 'integer', (col) => col.notNull().defaultTo(500))
+      .addColumn('max_pos', 'integer', (col) => col.notNull().defaultTo(2500))
+      .addColumn('home_pos', 'integer', (col) => col.notNull().defaultTo(1250))
+      .addColumn('inverted', 'integer', (col) => col.notNull().defaultTo(0))
+      .addForeignKeyConstraint(
+        'fk_maestro_channels_board_id',
+        ['board_id'],
+        'maestro_boards',
+        ['id'],
+        (b) => b.onDelete('cascade'),
+      )
+      .execute();
+    await renameDanceCopyAndSwap(db, 'maestro_channels');
+  },
+  down: async (): Promise<void> => {
+    throw new Error('Recovery is via Phase 1 backup-restore; no manual down');
+  },
+};

--- a/astros_api/src/dal/migrations/migration_6.ts
+++ b/astros_api/src/dal/migrations/migration_6.ts
@@ -9,9 +9,12 @@ import { logger } from 'src/logger.js';
 //   4. DROP TABLE <table>
 //   5. ALTER TABLE <table>_new RENAME TO <table>
 //
-// FK enforcement is OFF during this migration (set by initializeDatabase
-// in dal/database.ts) so the DROP/RENAME doesn't trip the existing playlist
-// FK from migration_3 or RESTRICT-itself when controllers are dropped.
+// CONTRACT: callers must run this migration with `PRAGMA foreign_keys = OFF`.
+// SQLite cannot toggle the pragma inside a transaction, so the toggle has to
+// happen at the call site, before invoking the migrator. The production
+// startup wrapper (initializeDatabase in dal/database.ts) handles this for
+// both the file-backed and in-memory paths. Test code that constructs a
+// Kysely Migrator directly must toggle explicitly — see migration_6.test.ts.
 //
 // `down` throws — recovery is via Phase 1 backup-restore. See plan
 // `.docs/plans/20260410-0807-db-safety-phase2-schema-migrations.md`.

--- a/astros_api/src/dal/migrations/migration_6.ts
+++ b/astros_api/src/dal/migrations/migration_6.ts
@@ -321,6 +321,41 @@ export const migration_6: Migration = {
       )
       .execute();
     await renameDanceCopyAndSwap(db, 'maestro_channels');
+
+    // ---- 3. Index FK columns ----
+    //
+    // SQLite does not auto-index FK columns. Without an index on the child's
+    // FK column, every CASCADE delete on the parent becomes a full scan of
+    // the child table, and every parent-side INSERT/UPDATE/DELETE has to
+    // scan child tables to enforce RESTRICT. Add explicit indexes for every
+    // FK column that doesn't already have one through:
+    //   - kangaroo_x2.parent_id (covered by NOT NULL UNIQUE → implicit index)
+    //   - script_deployments.script_id (covered by composite PK leftmost
+    //     column — composite PK index can be used for left-prefix lookups)
+    //
+    // location_id on script_deployments is part of the PK but as the
+    // *rightmost* column, the PK index can't satisfy a location_id-only
+    // lookup, so it still needs its own index.
+    const fkIndexes: Array<{ table: string; column: string }> = [
+      { table: 'controller_locations', column: 'location_id' },
+      { table: 'controller_locations', column: 'controller_id' },
+      { table: 'script_channels', column: 'script_id' },
+      { table: 'script_events', column: 'script_id' },
+      { table: 'script_events', column: 'script_channel_id' },
+      { table: 'script_deployments', column: 'location_id' },
+      { table: 'gpio_channels', column: 'location_id' },
+      { table: 'i2c_modules', column: 'location_id' },
+      { table: 'uart_modules', column: 'location_id' },
+      { table: 'maestro_boards', column: 'parent_id' },
+      { table: 'maestro_channels', column: 'board_id' },
+    ];
+    for (const { table, column } of fkIndexes) {
+      await db.schema
+        .createIndex(`idx_${table}_${column}`)
+        .on(table)
+        .column(column)
+        .execute();
+    }
   },
   down: async (): Promise<void> => {
     throw new Error('Recovery is via Phase 1 backup-restore; no manual down');

--- a/astros_api/src/dal/migrations/migration_6.ts
+++ b/astros_api/src/dal/migrations/migration_6.ts
@@ -350,11 +350,7 @@ export const migration_6: Migration = {
       { table: 'maestro_channels', column: 'board_id' },
     ];
     for (const { table, column } of fkIndexes) {
-      await db.schema
-        .createIndex(`idx_${table}_${column}`)
-        .on(table)
-        .column(column)
-        .execute();
+      await db.schema.createIndex(`idx_${table}_${column}`).on(table).column(column).execute();
     }
   },
   down: async (): Promise<void> => {

--- a/astros_api/src/dal/repositories/controller_repository.test.ts
+++ b/astros_api/src/dal/repositories/controller_repository.test.ts
@@ -176,9 +176,7 @@ describe('ControllerRepository', () => {
       await repo.insertController({ id: '', name: 'beta', address: 'AA:BB:CC:DD:EE:0B' });
 
       // name=alpha matches first row; address=...0B matches second row.
-      await repo.insertControllers([
-        { id: '', name: 'alpha', address: 'AA:BB:CC:DD:EE:0B' },
-      ]);
+      await repo.insertControllers([{ id: '', name: 'alpha', address: 'AA:BB:CC:DD:EE:0B' }]);
 
       const all = await repo.getControllers();
       const alpha = all.find((c) => c.name === 'alpha');
@@ -234,9 +232,7 @@ describe('ControllerRepository', () => {
 
       // Two-match merge: name=alpha hits ctl-a, address=...0B hits ctl-b.
       const repo = new ControllerRepository(db);
-      await repo.insertControllers([
-        { id: '', name: 'alpha', address: 'AA:BB:CC:DD:EE:0B' },
-      ]);
+      await repo.insertControllers([{ id: '', name: 'alpha', address: 'AA:BB:CC:DD:EE:0B' }]);
 
       // The keeper is ctl-a (lex-first id). Both controller_locations rows
       // must now point at it.

--- a/astros_api/src/dal/repositories/controller_repository.test.ts
+++ b/astros_api/src/dal/repositories/controller_repository.test.ts
@@ -165,6 +165,47 @@ describe('ControllerRepository', () => {
       expect(all.map((c) => c.name)).toContain('body');
       expect(all.map((c) => c.name)).not.toContain('dome');
     });
+
+    it('preserves controller_locations FK rows when re-registering an existing controller', async () => {
+      // Regression: this is the invariant migration_6's RESTRICT FK will enforce.
+      // The controller_locations row must survive insertControllers without being
+      // deleted-then-reinserted, otherwise a future RESTRICT FK would block the delete.
+      const repo = new ControllerRepository(db);
+
+      const originalId = await repo.insertController({
+        id: '',
+        name: 'dome',
+        address: 'AA:BB:CC:DD:EE:01',
+      });
+
+      await db
+        .insertInto('locations')
+        .values({ id: 'loc-1', name: 'Dome Location', description: '', config_fingerprint: '' })
+        .execute();
+
+      await db
+        .insertInto('controller_locations')
+        .values({ location_id: 'loc-1', controller_id: originalId })
+        .execute();
+
+      // Re-register the same controller via the bulk path (typical serial-worker behavior).
+      await repo.insertControllers([
+        { id: '', name: 'dome-renamed', address: 'AA:BB:CC:DD:EE:01' },
+      ]);
+
+      // The controller_locations row must still exist with the same controller_id.
+      const link = await db
+        .selectFrom('controller_locations')
+        .selectAll()
+        .where('location_id', '=', 'loc-1')
+        .executeTakeFirstOrThrow();
+      expect(link.controller_id).toBe(originalId);
+
+      // And the controller itself is still queryable via that location.
+      const found = await repo.getControllerByLocationId('loc-1');
+      expect(found.id).toBe(originalId);
+      expect(found.name).toBe('dome-renamed');
+    });
   });
 
   describe('getControllerByLocationId', () => {

--- a/astros_api/src/dal/repositories/controller_repository.test.ts
+++ b/astros_api/src/dal/repositories/controller_repository.test.ts
@@ -166,6 +166,95 @@ describe('ControllerRepository', () => {
       expect(all.map((c) => c.name)).not.toContain('dome');
     });
 
+    it('handles two existing matches without UNIQUE collision (one by address, one by name)', async () => {
+      // Regression: if matches include row A (matches by name) and row B
+      // (matches by address), updating A's name+address would conflict with
+      // B's UNIQUE values before B is deleted. Fix: drop duplicates first.
+      const repo = new ControllerRepository(db);
+
+      await repo.insertController({ id: '', name: 'alpha', address: 'AA:BB:CC:DD:EE:0A' });
+      await repo.insertController({ id: '', name: 'beta', address: 'AA:BB:CC:DD:EE:0B' });
+
+      // name=alpha matches first row; address=...0B matches second row.
+      await repo.insertControllers([
+        { id: '', name: 'alpha', address: 'AA:BB:CC:DD:EE:0B' },
+      ]);
+
+      const all = await repo.getControllers();
+      const alpha = all.find((c) => c.name === 'alpha');
+      expect(alpha).toBeDefined();
+      expect(alpha?.address).toBe('AA:BB:CC:DD:EE:0B');
+      // beta should be gone — its address was taken
+      expect(all.find((c) => c.name === 'beta')).toBeUndefined();
+    });
+
+    it('re-points controller_locations from duplicates to keeper before deleting them', async () => {
+      // Regression: under migration_6's RESTRICT FK on
+      // controller_locations.controller_id, deleting a duplicate controller
+      // that still has controller_locations rows would be rejected. Re-point
+      // the dependent rows to the keeper first.
+      // Insert directly so we control the ids (the keeper is selected by
+      // lex order on id; UUID-generated ids are non-deterministic).
+      await db
+        .insertInto('controllers')
+        .values({
+          id: 'ctl-a',
+          name: 'alpha',
+          description: '',
+          address: 'AA:BB:CC:DD:EE:0A',
+        })
+        .execute();
+      await db
+        .insertInto('controllers')
+        .values({
+          id: 'ctl-b',
+          name: 'beta',
+          description: '',
+          address: 'AA:BB:CC:DD:EE:0B',
+        })
+        .execute();
+
+      await db
+        .insertInto('locations')
+        .values({ id: 'loc-A', name: 'A-loc', description: '', config_fingerprint: '' })
+        .execute();
+      await db
+        .insertInto('locations')
+        .values({ id: 'loc-B', name: 'B-loc', description: '', config_fingerprint: '' })
+        .execute();
+
+      await db
+        .insertInto('controller_locations')
+        .values({ location_id: 'loc-A', controller_id: 'ctl-a' })
+        .execute();
+      await db
+        .insertInto('controller_locations')
+        .values({ location_id: 'loc-B', controller_id: 'ctl-b' })
+        .execute();
+
+      // Two-match merge: name=alpha hits ctl-a, address=...0B hits ctl-b.
+      const repo = new ControllerRepository(db);
+      await repo.insertControllers([
+        { id: '', name: 'alpha', address: 'AA:BB:CC:DD:EE:0B' },
+      ]);
+
+      // The keeper is ctl-a (lex-first id). Both controller_locations rows
+      // must now point at it.
+      const links = await db
+        .selectFrom('controller_locations')
+        .selectAll()
+        .where('location_id', 'in', ['loc-A', 'loc-B'])
+        .execute();
+      expect(links).toHaveLength(2);
+      links.forEach((l) => expect(l.controller_id).toBe('ctl-a'));
+
+      // The duplicate is gone; the keeper has the merged values.
+      const all = await repo.getControllers();
+      expect(all.find((c) => c.name === 'beta')).toBeUndefined();
+      const keeper = all.find((c) => c.id === 'ctl-a');
+      expect(keeper?.address).toBe('AA:BB:CC:DD:EE:0B');
+    });
+
     it('preserves controller_locations FK rows when re-registering an existing controller', async () => {
       // Regression: this is the invariant migration_6's RESTRICT FK will enforce.
       // The controller_locations row must survive insertControllers without being

--- a/astros_api/src/dal/repositories/controller_repository.test.ts
+++ b/astros_api/src/dal/repositories/controller_repository.test.ts
@@ -166,6 +166,26 @@ describe('ControllerRepository', () => {
       expect(all.map((c) => c.name)).not.toContain('dome');
     });
 
+    it('returns true when re-registering with identical name and address (no-op UPDATE)', async () => {
+      // Regression: the keeper-UPDATE return value should not depend on
+      // SQLite's change-count semantics for no-op updates. Success means
+      // "the controller is in the DB with these values," not "the UPDATE
+      // statement reported a row change."
+      const repo = new ControllerRepository(db);
+
+      await repo.insertController({ id: '', name: 'dome', address: 'AA:BB:CC:DD:EE:01' });
+
+      // Re-register with exactly the same name and address — UPDATE is a no-op.
+      const result = await repo.insertControllers([
+        { id: '', name: 'dome', address: 'AA:BB:CC:DD:EE:01' },
+      ]);
+
+      expect(result).toBe(true);
+
+      const found = await repo.getControllerByAddress('AA:BB:CC:DD:EE:01');
+      expect(found.name).toBe('dome');
+    });
+
     it('handles two existing matches without UNIQUE collision (one by address, one by name)', async () => {
       // Regression: if matches include row A (matches by name) and row B
       // (matches by address), updating A's name+address would conflict with

--- a/astros_api/src/dal/repositories/controller_repository.ts
+++ b/astros_api/src/dal/repositories/controller_repository.ts
@@ -58,12 +58,16 @@ export class ControllerRepository {
             await tx.deleteFrom('controllers').where('id', 'in', duplicateIds).execute();
           }
 
-          const update = await tx
+          await tx
             .updateTable('controllers')
             .set({ name: controller.name, address: controller.address })
             .where('id', '=', keeper.id)
-            .executeTakeFirst();
-          return update.numUpdatedRows >= 1;
+            .execute();
+          // The keeper exists (we just selected it), the transaction committed
+          // (otherwise we'd have thrown), so the controller is correctly
+          // persisted. Avoid making success depend on SQLite's change-count
+          // semantics — a no-op UPDATE (identical values) shouldn't be a failure.
+          return true;
         });
 
         if (!written) allWritten = false;

--- a/astros_api/src/dal/repositories/controller_repository.ts
+++ b/astros_api/src/dal/repositories/controller_repository.ts
@@ -12,65 +12,67 @@ export class ControllerRepository {
     let allWritten = true;
 
     for (const controller of controllers) {
-      // Find rows matching by address OR name. Deterministic order so the
-      // "keeper" choice is stable.
-      const existing = await this.db
-        .selectFrom('controllers')
-        .selectAll()
-        .where((eb) =>
-          eb.or([eb('address', '=', controller.address), eb('name', '=', controller.name)]),
-        )
-        .orderBy('id')
-        .execute()
-        .catch((err) => {
-          logger.error('ControllerRepository.insertControllers', err);
-          throw err;
+      try {
+        const written = await this.db.transaction().execute(async (tx) => {
+          // Find rows matching by address OR name. Deterministic order so the
+          // "keeper" choice is stable.
+          const existing = await tx
+            .selectFrom('controllers')
+            .selectAll()
+            .where((eb) =>
+              eb.or([eb('address', '=', controller.address), eb('name', '=', controller.name)]),
+            )
+            .orderBy('id')
+            .execute();
+
+          if (existing.length === 0) {
+            const result = await tx
+              .insertInto('controllers')
+              .values({
+                id: uuid(),
+                name: controller.name,
+                description: '',
+                address: controller.address,
+              })
+              .executeTakeFirst();
+            return inserted(result);
+          }
+
+          // Keep the first match (preserves its id and any controller_locations
+          // rows pointing at it). Re-point dependent rows from duplicates to
+          // the keeper, then delete duplicates BEFORE updating the keeper —
+          // otherwise the keeper's UPDATE could collide with a duplicate's
+          // UNIQUE-constrained name/address, and the duplicate's DELETE would
+          // be rejected by migration_6's RESTRICT FK on
+          // controller_locations.controller_id.
+          const keeper = existing[0];
+          const duplicateIds = existing.slice(1).map((row) => row.id);
+
+          if (duplicateIds.length > 0) {
+            await tx
+              .updateTable('controller_locations')
+              .set({ controller_id: keeper.id })
+              .where('controller_id', 'in', duplicateIds)
+              .execute();
+
+            await tx
+              .deleteFrom('controllers')
+              .where('id', 'in', duplicateIds)
+              .execute();
+          }
+
+          const update = await tx
+            .updateTable('controllers')
+            .set({ name: controller.name, address: controller.address })
+            .where('id', '=', keeper.id)
+            .executeTakeFirst();
+          return update.numUpdatedRows >= 1;
         });
 
-      if (existing.length === 0) {
-        const result = await this.db
-          .insertInto('controllers')
-          .values({
-            id: uuid(),
-            name: controller.name,
-            description: '',
-            address: controller.address,
-          })
-          .executeTakeFirst()
-          .catch((err) => {
-            logger.error('ControllerRepository.insertControllers', err);
-            throw err;
-          });
-        if (!inserted(result)) allWritten = false;
-        continue;
-      }
-
-      // UPDATE-in-place on the first match to preserve its id (and any
-      // controller_locations FK rows that point at it). Then drop any
-      // additional partial-match duplicates.
-      const keeper = existing[0];
-      const duplicateIds = existing.slice(1).map((row) => row.id);
-
-      const update = await this.db
-        .updateTable('controllers')
-        .set({ name: controller.name, address: controller.address })
-        .where('id', '=', keeper.id)
-        .executeTakeFirst()
-        .catch((err) => {
-          logger.error('ControllerRepository.insertControllers', err);
-          throw err;
-        });
-      if (update.numUpdatedRows < 1) allWritten = false;
-
-      if (duplicateIds.length > 0) {
-        await this.db
-          .deleteFrom('controllers')
-          .where('id', 'in', duplicateIds)
-          .execute()
-          .catch((err) => {
-            logger.error('ControllerRepository.insertControllers', err);
-            throw err;
-          });
+        if (!written) allWritten = false;
+      } catch (err) {
+        logger.error('ControllerRepository.insertControllers', err);
+        throw err;
       }
     }
 

--- a/astros_api/src/dal/repositories/controller_repository.ts
+++ b/astros_api/src/dal/repositories/controller_repository.ts
@@ -55,10 +55,7 @@ export class ControllerRepository {
               .where('controller_id', 'in', duplicateIds)
               .execute();
 
-            await tx
-              .deleteFrom('controllers')
-              .where('id', 'in', duplicateIds)
-              .execute();
+            await tx.deleteFrom('controllers').where('id', 'in', duplicateIds).execute();
           }
 
           const update = await tx

--- a/astros_api/src/dal/repositories/controller_repository.ts
+++ b/astros_api/src/dal/repositories/controller_repository.ts
@@ -9,64 +9,72 @@ export class ControllerRepository {
   constructor(private readonly db: Kysely<Database>) {}
 
   public async insertControllers(controllers: ControlModule[]): Promise<boolean> {
-    const wasInserted: boolean[] = [];
+    let allWritten = true;
 
-    for (let i = 0; i < controllers.length; i++) {
-      const controller = controllers[i];
-
-      // Remove any stale row whose address or name matches but not both,
-      // then upsert cleanly.
+    for (const controller of controllers) {
+      // Find rows matching by address OR name. Deterministic order so the
+      // "keeper" choice is stable.
       const existing = await this.db
         .selectFrom('controllers')
         .selectAll()
         .where((eb) =>
           eb.or([eb('address', '=', controller.address), eb('name', '=', controller.name)]),
         )
+        .orderBy('id')
         .execute()
         .catch((err) => {
           logger.error('ControllerRepository.insertControllers', err);
           throw err;
         });
 
-      if (existing.length > 0) {
-        // Delete all rows matching either address or name
+      if (existing.length === 0) {
+        const result = await this.db
+          .insertInto('controllers')
+          .values({
+            id: uuid(),
+            name: controller.name,
+            description: '',
+            address: controller.address,
+          })
+          .executeTakeFirst()
+          .catch((err) => {
+            logger.error('ControllerRepository.insertControllers', err);
+            throw err;
+          });
+        if (!inserted(result)) allWritten = false;
+        continue;
+      }
+
+      // UPDATE-in-place on the first match to preserve its id (and any
+      // controller_locations FK rows that point at it). Then drop any
+      // additional partial-match duplicates.
+      const keeper = existing[0];
+      const duplicateIds = existing.slice(1).map((row) => row.id);
+
+      const update = await this.db
+        .updateTable('controllers')
+        .set({ name: controller.name, address: controller.address })
+        .where('id', '=', keeper.id)
+        .executeTakeFirst()
+        .catch((err) => {
+          logger.error('ControllerRepository.insertControllers', err);
+          throw err;
+        });
+      if (update.numUpdatedRows < 1) allWritten = false;
+
+      if (duplicateIds.length > 0) {
         await this.db
           .deleteFrom('controllers')
-          .where((eb) =>
-            eb.or([eb('address', '=', controller.address), eb('name', '=', controller.name)]),
-          )
+          .where('id', 'in', duplicateIds)
           .execute()
           .catch((err) => {
             logger.error('ControllerRepository.insertControllers', err);
             throw err;
           });
       }
-
-      // Insert with the id from an existing match (if any) to preserve references
-      const existingId = existing.find(
-        (e) => e.address === controller.address || e.name === controller.name,
-      )?.id;
-
-      const result = await this.db
-        .insertInto('controllers')
-        .values({
-          id: existingId ?? uuid(),
-          name: controller.name,
-          description: existing.length > 0 ? existing[0].description : '',
-          address: controller.address,
-        })
-        .executeTakeFirst()
-        .catch((err) => {
-          logger.error('ControllerRepository.insertControllers', err);
-          throw err;
-        });
-
-      if (inserted(result)) {
-        wasInserted.push(true);
-      }
     }
 
-    return wasInserted.length === controllers.length;
+    return allWritten;
   }
 
   public async insertController(controller: ControlModule): Promise<string> {

--- a/astros_api/src/dal/repositories/locations_repository.test.ts
+++ b/astros_api/src/dal/repositories/locations_repository.test.ts
@@ -172,9 +172,7 @@ describe('LocationsRepository', () => {
       expect(core?.controller.id).toBe('');
 
       // Save without modifying the controller — exactly what the E2E flow does.
-      await expect(
-        repo.updateLocation(core as NonNullable<typeof core>),
-      ).resolves.toBe(true);
+      await expect(repo.updateLocation(core as NonNullable<typeof core>)).resolves.toBe(true);
 
       // Still no controller link for core.
       const reloaded = (await repo.loadLocations()).find((l) => l.locationName === 'core');

--- a/astros_api/src/dal/repositories/locations_repository.test.ts
+++ b/astros_api/src/dal/repositories/locations_repository.test.ts
@@ -179,6 +179,58 @@ describe('LocationsRepository', () => {
       expect(reloaded?.controller.id).toBe('');
     });
 
+    it("clears an existing controller mapping when controller.id is the '' sentinel", async () => {
+      // Body has the master controller mapped at seed. Clearing should remove
+      // that controller_locations row without trying to INSERT a replacement.
+      const repo = new LocationsRepository(db);
+
+      const body = (await repo.loadLocations()).find((l) => l.locationName === 'body');
+      expect(body).toBeDefined();
+      expect(body?.controller.id).not.toBe('');
+
+      // Clear the assignment by setting the sentinel.
+      if (body) {
+        body.controller = { id: '', name: '', address: '' };
+        await repo.updateLocation(body);
+      }
+
+      // No controller_locations row remains for body.
+      const remaining = await db
+        .selectFrom('controller_locations')
+        .selectAll()
+        .where('location_id', '=', body?.id as string)
+        .execute();
+      expect(remaining).toHaveLength(0);
+
+      // And getLocations re-reads body with the empty sentinel.
+      const reloaded = (await repo.getLocations()).find((l) => l.locationName === 'body');
+      expect(reloaded?.controller.id).toBe('');
+    });
+
+    it("normalizes the historical '0' sentinel as 'no controller' (no FK violation, clears existing)", async () => {
+      // An older client may still send controller.id = '0'. The API should
+      // treat that the same as '' — clear any existing assignment without
+      // trying to INSERT a row that would trip migration_6's RESTRICT FK.
+      const repo = new LocationsRepository(db);
+
+      const body = (await repo.loadLocations()).find((l) => l.locationName === 'body');
+      expect(body).toBeDefined();
+      const bodyId = body?.id as string;
+
+      if (body) {
+        body.controller = { id: '0', name: '', address: '' };
+        // Should not throw FOREIGN KEY constraint failed.
+        await expect(repo.updateLocation(body)).resolves.toBe(true);
+      }
+
+      const remaining = await db
+        .selectFrom('controller_locations')
+        .selectAll()
+        .where('location_id', '=', bodyId)
+        .execute();
+      expect(remaining).toHaveLength(0);
+    });
+
     it('should swap the controller for a location', async () => {
       const repo = new LocationsRepository(db);
       const ctlRepo = new ControllerRepository(db);

--- a/astros_api/src/dal/repositories/locations_repository.test.ts
+++ b/astros_api/src/dal/repositories/locations_repository.test.ts
@@ -43,10 +43,11 @@ describe('LocationsRepository', () => {
       expect(body?.controller.name).toBe('master');
       expect(body?.controller.address).toBe('00:00:00:00:00:00');
 
-      // Core and dome have no controller mapped — should get defaults
+      // Core and dome have no controller mapped — getLocations should return
+      // the empty-string sentinel that updateLocation/createControllerLocation use.
       const core = locations.find((l) => l.locationName === 'core');
       expect(core).toBeDefined();
-      expect(core?.controller.id).toBe('0');
+      expect(core?.controller.id).toBe('');
       expect(core?.controller.name).toBe('');
     });
   });
@@ -156,6 +157,28 @@ describe('LocationsRepository', () => {
       const updated = (await repo.getLocations()).find((l) => l.locationName === 'body');
       expect(updated).toBeDefined();
       expect(updated?.configFingerprint).toBe('outofdate');
+    });
+
+    it('saves a location without an assigned controller without raising FK violation', async () => {
+      // Regression: under migration_6's RESTRICT FK on
+      // controller_locations.controller_id, saving a location whose loaded
+      // `controller` field carried the synthesized empty/sentinel id used to
+      // throw `FOREIGN KEY constraint failed` on INSERT into controller_locations.
+      // Reproduces the E2E "save modules" flow for CORE/DOME (no seeded controller).
+      const repo = new LocationsRepository(db);
+
+      const core = (await repo.loadLocations()).find((l) => l.locationName === 'core');
+      expect(core).toBeDefined();
+      expect(core?.controller.id).toBe('');
+
+      // Save without modifying the controller — exactly what the E2E flow does.
+      await expect(
+        repo.updateLocation(core as NonNullable<typeof core>),
+      ).resolves.toBe(true);
+
+      // Still no controller link for core.
+      const reloaded = (await repo.loadLocations()).find((l) => l.locationName === 'core');
+      expect(reloaded?.controller.id).toBe('');
     });
 
     it('should swap the controller for a location', async () => {

--- a/astros_api/src/dal/repositories/locations_repository.ts
+++ b/astros_api/src/dal/repositories/locations_repository.ts
@@ -174,12 +174,11 @@ export class LocationsRepository {
           throw err;
         });
 
-      // Only set the controller link when there's a real controller id.
-      // Empty id is the "no controller" sentinel (set by getLocations and the
-      // createControllerLocation factory). Calling setLocationController with
-      // an empty/non-existent id would violate migration_6's RESTRICT FK on
-      // controller_locations.controller_id.
-      if (location.controller && location.controller.id) {
+      // Always reconcile the controller mapping when the client sent a
+      // controller field. setLocationController handles both the "set to
+      // real id" and "clear" cases (sentinels '' and '0' both mean "no
+      // controller" — see that method for the full rationale).
+      if (location.controller !== undefined && location.controller !== null) {
         await this.setLocationController(trx, location.id, location.controller.id);
       }
 
@@ -215,6 +214,11 @@ export class LocationsRepository {
     locationId: string,
     controllerId: string,
   ): Promise<boolean> {
+    // Always clear the existing assignment first. This handles three cases
+    // uniformly:
+    //   - Setting a new/different controller (delete-then-insert).
+    //   - Clearing an existing controller (delete only — see sentinel check below).
+    //   - Re-asserting the same controller (idempotent delete-then-insert).
     await trx
       .deleteFrom('controller_locations')
       .where('location_id', '=', locationId)
@@ -223,6 +227,14 @@ export class LocationsRepository {
         logger.error('LocationsRepository.setLocationController', err);
         throw err;
       });
+
+    // Treat both '' (current sentinel from getLocations / createControllerLocation)
+    // and '0' (historical sentinel from older clients) as "no controller" and
+    // skip the INSERT. Without this, a client sending '0' would trip
+    // migration_6's RESTRICT FK on controller_locations.controller_id.
+    if (!controllerId || controllerId === '0') {
+      return true;
+    }
 
     const result = await trx
       .insertInto('controller_locations')

--- a/astros_api/src/dal/repositories/locations_repository.ts
+++ b/astros_api/src/dal/repositories/locations_repository.ts
@@ -50,10 +50,13 @@ export class LocationsRepository {
       );
 
       // Empty-string id means "no controller assigned to this location" — same
-      // sentinel the createControllerLocation factory uses. The write path
-      // (updateLocation) treats an empty id as "skip setLocationController",
-      // which avoids violating migration_6's RESTRICT FK on
-      // controller_locations.controller_id by trying to INSERT a non-existent id.
+      // sentinel the createControllerLocation factory uses. setLocationController
+      // (called by updateLocation whenever a controller field is present) treats
+      // both '' and the historical '0' sentinel as "no controller": it deletes
+      // any existing controller_locations row for the location and skips the
+      // INSERT. This both avoids violating migration_6's RESTRICT FK on
+      // controller_locations.controller_id and lets clients clear an existing
+      // assignment by sending the sentinel.
       location.controller = {
         id: c.ctrl_id ?? '',
         name: c.ctrl_name ?? '',

--- a/astros_api/src/dal/repositories/locations_repository.ts
+++ b/astros_api/src/dal/repositories/locations_repository.ts
@@ -49,8 +49,13 @@ export class LocationsRepository {
         c.loc_fingerprint,
       );
 
+      // Empty-string id means "no controller assigned to this location" — same
+      // sentinel the createControllerLocation factory uses. The write path
+      // (updateLocation) treats an empty id as "skip setLocationController",
+      // which avoids violating migration_6's RESTRICT FK on
+      // controller_locations.controller_id by trying to INSERT a non-existent id.
       location.controller = {
-        id: c.ctrl_id ?? '0',
+        id: c.ctrl_id ?? '',
         name: c.ctrl_name ?? '',
         address: c.ctrl_address ?? '',
       };
@@ -90,7 +95,7 @@ export class LocationsRepository {
     );
 
     location.controller = {
-      id: data.ctrl_id ?? '0',
+      id: data.ctrl_id ?? '',
       name: data.ctrl_name ?? '',
       address: data.ctrl_address ?? '',
     };
@@ -169,7 +174,12 @@ export class LocationsRepository {
           throw err;
         });
 
-      if (location.controller !== undefined && location.controller !== null) {
+      // Only set the controller link when there's a real controller id.
+      // Empty id is the "no controller" sentinel (set by getLocations and the
+      // createControllerLocation factory). Calling setLocationController with
+      // an empty/non-existent id would violate migration_6's RESTRICT FK on
+      // controller_locations.controller_id.
+      if (location.controller && location.controller.id) {
         await this.setLocationController(trx, location.id, location.controller.id);
       }
 

--- a/astros_vue/src/views/ModulesView.vue
+++ b/astros_vue/src/views/ModulesView.vue
@@ -205,7 +205,7 @@ function controllerSelectChanged(location: string) {
                     disabled
                   >
                     <option
-                      value="0"
+                      value=""
                       selected
                     >
                       {{ $t('module_view.master') }}
@@ -263,7 +263,7 @@ function controllerSelectChanged(location: string) {
                     @change="controllerSelectChanged('core')"
                   >
                     <option
-                      value="0"
+                      value=""
                       selected
                     >
                       {{ $t('module_view.disabled') }}
@@ -327,7 +327,7 @@ function controllerSelectChanged(location: string) {
                     @change="controllerSelectChanged('dome')"
                   >
                     <option
-                      value="0"
+                      value=""
                       selected
                     >
                       {{ $t('module_view.disabled') }}


### PR DESCRIPTION
  ## Summary

  Phase 2 of 3 of the DB Migration Safety Net feature, riding on top of
  Phase 1's backup/restore safety net (PR #59). Adds foreign-key
  constraints across the schema with appropriate CASCADE/RESTRICT actions,
  fixes a long-standing declared-type mismatch on
  `controller_locations.controller_id`, and refactors `insertControllers`
  to no longer rely on delete-then-insert (which would be rejected once
  the RESTRICT FK lands).

  Plan: `.docs/plans/20260410-0807-db-safety-phase2-schema-migrations.md`
  (amended at the start of the PR — see commit `4f230e8`).

  ## What's in this PR

  ### Part A — repository refactor (commit `7ff46c6`)

  `insertControllers` previously did a delete-then-insert dance that
  preserved the UUID via `existingId ?? uuid()`. Once migration_6 adds
  `RESTRICT` on `controller_locations.controller_id → controllers.id`,
  that delete is rejected. Refactored to UPDATE-in-place:

    - 0 matches → `INSERT` with a fresh UUID.
    - ≥1 matches → keep the first (deterministic by `id`), `UPDATE` its
      name/address, `DELETE` any additional partial-match duplicates.
    - The keeper is never deleted, so any `controller_locations` row
      pointing at it survives.

  Added a regression test that pins this invariant (insert link, call
  `insertControllers`, assert link survives with same `controller_id`).

  ### Part B — migration_5: type fix (in `36eeea2`)

  `controller_locations.controller_id` was declared `integer` in
  migration 0, but `controllers.id` is `text` (UUID). SQLite's loose
  typing made it work at runtime, but `addForeignKeyConstraint` won't
  land cleanly across declared-type mismatches. Migration_5 does the
  rename dance to recreate with `controller_id text`. No FKs added —
  that's migration_6.

  ### Part C — migration_6: foreign keys + orphan cleanup (in `36eeea2`)

  Adds FKs to 10 tables with the per-table actions agreed in the plan:

  | Table | Column | References | On delete |
  |---|---|---|---|
  | `controller_locations` | `location_id` | `locations.id` | RESTRICT |
  | `controller_locations` | `controller_id` | `controllers.id` | RESTRICT |
  | `script_channels` | `script_id` | `scripts.id` | CASCADE |
  | `script_events` | `script_id` | `scripts.id` | CASCADE |
  | `script_events` | `script_channel_id` | `script_channels.id` | CASCADE |
  | `script_deployments` | `script_id` | `scripts.id` | CASCADE |
  | `script_deployments` | `location_id` | `locations.id` | CASCADE |
  | `gpio_channels` | `location_id` | `locations.id` | CASCADE |
  | `i2c_modules` | `location_id` | `locations.id` | CASCADE |
  | `uart_modules` | `location_id` | `locations.id` | CASCADE |
  | `maestro_boards` | `parent_id` | `uart_modules.id` | CASCADE |
  | `maestro_channels` | `board_id` | `maestro_boards.id` | CASCADE |
  | `kangaroo_x2` | `parent_id` | `uart_modules.id` | CASCADE |

  `playlist_tracks.playlist_id → playlists.id` already had an FK from
  migration_3 — left alone.

  Each table goes through:

  1. Up-front orphan cleanup (parent → child order so dependent orphans
     get caught after their parents are pruned). Logs counts at warn level.
  2. `CREATE TABLE <table>_new` with FK constraints.
  3. `INSERT INTO <table>_new SELECT * FROM <table>`.
  4. `DROP TABLE <table>`.
  5. `ALTER TABLE <table>_new RENAME TO <table>`.

  ### Part D — FK pragma toggle (in `36eeea2`)

  Bracketed `migrateToLatest` with `PRAGMA foreign_keys = OFF` /
  `PRAGMA foreign_keys = ON` on the raw better-sqlite3 handle. Required
  because (a) Kysely wraps each migration in a transaction and SQLite
  silently ignores `PRAGMA foreign_keys` inside transactions, so the
  toggle must wrap the migrator from outside, and (b) migration_6's
  rename dance can't drop tables that are referenced by the existing
  playlist FK from migration_3 with FKs enforced. The `finally`
  guarantees FKs are re-enabled even if migrate throws.

  ### Down migration policy (commit `4f230e8`)

  Discussed at the start of Phase 2. Phase 1's backup-and-restore is the
  official rollback mechanism, so a working `down` for migration_5/6
  duplicates the recovery story. Both migrations' `down` throws
  `Error('Recovery is via Phase 1 backup-restore; no manual down')`.
  Migrations 0–4 keep their existing `down` implementations (no scope
  creep).

  ## Test plan

  - [x] `npx vitest run` — **231/231 passing** (30 files)
    - 1 new regression test in `controller_repository.test.ts`
    - 3 new tests in `migration_5.test.ts` (row preservation, declared
      `TEXT` type via `PRAGMA table_info`, throwing down)
    - 7 new tests in `migration_6.test.ts` (RESTRICT enforcement, CASCADE
      on script delete, orphan-insert rejection across 3 child tables,
      pre-existing orphan cleanup, non-orphan preservation, throwing
      down, FK metadata sanity via `PRAGMA foreign_key_list`)
  - [x] `npx tsc --noEmit` — clean
  - [x] `npm run lint:fix` — clean
  - [x] `npm run build` — clean
  - [ ] **Manual on a production-like DB snapshot:**
    - Run migrations. Verify `PRAGMA foreign_keys;` returns `1` and
      `PRAGMA table_info(controller_locations);` shows `controller_id`
      as `TEXT`.
    - Attempt an orphan insert via the `sqlite3` CLI; expect rejection.
    - Simulate a controller re-registration via the existing serial test
      harness and verify `insertControllers` does not throw under FK
      enforcement.
  - [ ] **Phase 1 safety net integration check:** deliberately break
    migration_6 with a `throw`, restart, verify backup is taken,
    migration fails, restore succeeds, system returns to v5.

  ## Notes

  - Orphan cleanup ordering matters when FKs reference each other (e.g.
    `script_events.script_channel_id` cleanup must come *after*
    `script_channels.script_id` cleanup so the channel set is consistent).
    Verified by the "cleans pre-existing orphans on up" test, which seeds
    orphans pre-migration with FKs toggled off.
  - The pragma toggle's `finally` is load-bearing: if migrate throws and
    Phase 1's restore-and-reopen path takes over, the original `conn` is
    closed and re-opened — but for the `MIGRATION_FAILED_NO_BACKUP` path
    (where we keep the existing `conn`), the finally ensures FKs are back
    ON before the connection is handed to the app.