### PR TITLE
DB Safety Phase 3 - Read Only Mode

### DIFF
--- a/.docs/plans/20260410-0807-db-safety-phase1-backup-readonly.md
+++ b/.docs/plans/20260410-0807-db-safety-phase1-backup-readonly.md
@@ -26,7 +26,7 @@ Wire up a safe startup flow: detect pending migrations → take a hot backup →
 - **Guard rule:** in read-only mode, block any `POST/PUT/PATCH/DELETE` AND the five serial-write GETs (`/locations/syncconfig`, `/locations/synccontrollers`, `/scripts/upload`, `/scripts/run`, `/playlists/run`), **except** the allowlist: `POST /login`, `POST /reauth`, `POST /panicStop`, `POST /panicClear`.
 - **Status exposure:** new `GET /api/system/status` endpoint (no auth). WebSocket pushes a `SYSTEM_STATUS` message on connect and whenever the state changes.
 - **Backup failure = enter read-only**, migrations skipped.
-- **Migration failure → restore backup.** Restore success = server continues at pre-migration version. Restore failure = enter read-only.
+- **Migration failure → restore backup.** Restore success = server enters read-only with `MIGRATION_FAILED_RESTORED` (see Phase 3 amendment, 2026-04-26: silent recovery hid migration failures from operators and risked schema-drift writes against the rolled-back version). Restore failure = enter read-only with `MIGRATION_FAILED_RESTORE_FAILED`.
 - **Do not add a "clear read-only mode" endpoint.** Recovery path is a container restart.
 
 ## Required `database.ts` refactor

--- a/.docs/plans/20260410-0807-db-safety-phase3-vue-readonly-ui.md
+++ b/.docs/plans/20260410-0807-db-safety-phase3-vue-readonly-ui.md
@@ -21,10 +21,12 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
   ```
 
 - [ ] Create `astros_vue/src/stores/systemStatus.ts`:
-  - Pinia store with `readOnly: Ref<boolean>`, `reason: Ref<string | null>`, `enteredAt: Ref<string | null>`.
+  - Pinia store with `readOnly: Ref<boolean>`, `reasonCode: Ref<ReadOnlyReasonCode | null>`, `enteredAt: Ref<string | null>`.
+  - `ReadOnlyReasonCode` is the same string-union type as the API:
+    `'STARTUP_OPEN_FAILED' | 'BACKUP_FAILED' | 'MIGRATION_FAILED_NO_BACKUP' | 'MIGRATION_FAILED_RESTORE_FAILED'`.
   - `fetchStatus()` — GET `/system/status`, updates refs.
   - `setStatus(state)` — used by WebSocket message handler and by the API interceptor.
-  - Expose `readOnly`, `reason`, `enteredAt`, `fetchStatus`, `setStatus`.
+  - Expose `readOnly`, `reasonCode`, `enteredAt`, `fetchStatus`, `setStatus`.
 
 - [ ] Update `astros_vue/src/composables/useWebsocket.ts` (or wherever `handleMessage` dispatches) to handle `SYSTEM_STATUS` messages and forward them to `systemStatusStore.setStatus()`. Add the new type to the existing discriminator.
 
@@ -41,11 +43,13 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
     >
       <span class="font-bold">{{ $t('systemStatus.readOnly.title') }}</span>
       <span>
-        {{ systemStatusStore.reason || $t('systemStatus.readOnly.unknownReason') }}
+        {{ $t(`systemStatus.reasonCode.${systemStatusStore.reasonCode || 'UNKNOWN'}`) }}
       </span>
     </div>
   </template>
   ```
+  - Map the API's structured `reasonCode` to a human-readable, localized
+    string at render time. Unknown codes fall back to `UNKNOWN`.
   - DaisyUI `alert-warning` matches existing toast patterns.
   - `role="status"` + `aria-live="polite"` for screen readers (per CLAUDE.md a11y rules).
   - Full-width, `rounded-none` so it reads as chrome, not a card.
@@ -53,8 +57,8 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
 
 - [ ] Mount `SystemStatusBanner` at the top of `astros_vue/src/components/common/layout/AstrosLayout.vue`, above the navbar. It should push content down when visible without layout jank.
 
-- [ ] Update `astros_vue/src/api/apiService.ts` axios response interceptor to detect `503` responses that carry a read-only payload (`{ reason: '...' }` shape from `write_guard.ts`):
-  - Call `systemStatusStore.setStatus({ readOnly: true, reason })`.
+- [ ] Update `astros_vue/src/api/apiService.ts` axios response interceptor to detect `503` responses that carry a read-only payload (`{ message, reasonCode }` shape from `write_guard.ts`):
+  - Call `systemStatusStore.setStatus({ readOnly: true, reasonCode })`.
   - Surface a toast: `useToast().warning(t('systemStatus.readOnly.requestBlocked'))`.
   - Reject the promise so the calling code sees the failure and can bail out cleanly.
 
@@ -75,14 +79,20 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
   "systemStatus": {
     "readOnly": {
       "title": "Read-only mode",
-      "unknownReason": "The database is currently unavailable for writes.",
       "disabled": "This action is disabled while the system is in read-only mode.",
       "requestBlocked": "The server is in read-only mode. Your change was not saved."
+    },
+    "reasonCode": {
+      "STARTUP_OPEN_FAILED": "The database could not be opened at startup. The server is running on a temporary in-memory database with no data.",
+      "BACKUP_FAILED": "A pre-migration backup could not be written. The schema upgrade was skipped.",
+      "MIGRATION_FAILED_NO_BACKUP": "A schema migration failed and there was no prior backup to restore from. The database may be in a partially-migrated state.",
+      "MIGRATION_FAILED_RESTORE_FAILED": "A schema migration failed and the automatic restore also failed. Manual recovery is required.",
+      "UNKNOWN": "The database is currently unavailable for writes."
     }
   }
   ```
 
-- [ ] Write a Storybook story for `SystemStatusBanner` showing the hidden and visible states (default + short reason + long reason variants).
+- [ ] Write a Storybook story for `SystemStatusBanner` showing the hidden state and visible variants for each `reasonCode` (plus the `UNKNOWN` fallback).
 
 ## Tests
 
@@ -93,8 +103,8 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
   - `setStatus` correctly handles partial payloads.
 - [ ] `astros_vue/src/components/common/__tests__/SystemStatusBanner.spec.ts`:
   - Renders nothing when `readOnly === false`.
-  - Renders alert with reason when `readOnly === true`.
-  - Renders fallback i18n string when reason is null.
+  - Renders alert with the localized reasonCode message when `readOnly === true`.
+  - Renders fallback (`UNKNOWN`) i18n string when `reasonCode` is null or unrecognized.
   - Has `role="status"` and `aria-live="polite"` attributes.
 - [ ] Integration/snapshot: verify `AstrosLayout` mounts the banner above the navbar.
 
@@ -108,7 +118,7 @@ Create `docs/qa/system-readonly-mode.md`:
 1. Force read-only mode. Verify the banner appears within ≤1s via WebSocket push.
 2. Refresh the page. Verify banner still appears (from `fetchStatus` on mount).
 3. Navigate to Scripts view. Verify all save/delete/copy buttons are disabled with tooltip.
-4. Attempt to save a script via direct API call (devtools). Verify 503 response with `reason` field and a toast surfaces.
+4. Attempt to save a script via direct API call (devtools). Verify 503 response with `reasonCode` field and a toast surfaces.
 5. Log out, log back in. Verify login works and banner reappears after login.
 6. Verify `POST /panicStop` still succeeds (Utility view panic button).
 7. Verify `GET /settings/logs` still works (log download).
@@ -134,6 +144,26 @@ Create `docs/qa/system-readonly-mode.md`:
 - `cd astros_vue && npx vue-tsc --noEmit` — clean.
 - `cd astros_vue && npx eslint src/...` on modified files — clean.
 - Manual QA: follow the plan in `docs/qa/system-readonly-mode.md`.
+
+## Plan amendment (Phase 3 startup, 2026-04-26)
+
+The plan was authored before Phase 1 went through PR review. During that
+review, the API's read-only payload was sanitized: the free-form
+`reason: string` (which would have leaked filesystem paths and SQL
+fragments to an unauthenticated `/api/system/status` endpoint) was replaced
+with `reasonCode: ReadOnlyReasonCode` — a discriminated string union
+(`STARTUP_OPEN_FAILED | BACKUP_FAILED | MIGRATION_FAILED_NO_BACKUP |
+MIGRATION_FAILED_RESTORE_FAILED`). Full error details are logged
+server-side only.
+
+This amendment updates Phase 3 to consume the structured code:
+
+  - Store holds `reasonCode`, not `reason`.
+  - Banner template renders `$t(\`systemStatus.reasonCode.${code || 'UNKNOWN'}\`)`.
+  - 503 interceptor reads `reasonCode` from the response body.
+  - i18n keys are reorganized into `systemStatus.reasonCode.*` (one per
+    code, plus `UNKNOWN` fallback) and `systemStatus.readOnly.*` (UI
+    strings: title, disabled tooltip, request-blocked toast).
 
 ## Notes
 

--- a/.docs/plans/20260410-0807-db-safety-phase3-vue-readonly-ui.md
+++ b/.docs/plans/20260410-0807-db-safety-phase3-vue-readonly-ui.md
@@ -15,12 +15,12 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
 
 ## Tasks
 
-- [ ] Add `SYSTEM_STATUS` endpoint to `astros_vue/src/api/endpoints.ts`:
+- [x] Add `SYSTEM_STATUS` endpoint to `astros_vue/src/api/endpoints.ts`:
   ```typescript
   export const SYSTEM_STATUS = '/system/status';
   ```
 
-- [ ] Create `astros_vue/src/stores/systemStatus.ts`:
+- [x] Create `astros_vue/src/stores/systemStatus.ts`:
   - Pinia store with `readOnly: Ref<boolean>`, `reasonCode: Ref<ReadOnlyReasonCode | null>`, `enteredAt: Ref<string | null>`.
   - `ReadOnlyReasonCode` is the same string-union type as the API:
     `'STARTUP_OPEN_FAILED' | 'BACKUP_FAILED' | 'MIGRATION_FAILED_NO_BACKUP' | 'MIGRATION_FAILED_RESTORE_FAILED'`.
@@ -28,11 +28,11 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
   - `setStatus(state)` — used by WebSocket message handler and by the API interceptor.
   - Expose `readOnly`, `reasonCode`, `enteredAt`, `fetchStatus`, `setStatus`.
 
-- [ ] Update `astros_vue/src/composables/useWebsocket.ts` (or wherever `handleMessage` dispatches) to handle `SYSTEM_STATUS` messages and forward them to `systemStatusStore.setStatus()`. Add the new type to the existing discriminator.
+- [x] Update `astros_vue/src/composables/useWebsocket.ts` (or wherever `handleMessage` dispatches) to handle `SYSTEM_STATUS` messages and forward them to `systemStatusStore.setStatus()`. Add the new type to the existing discriminator.
 
-- [ ] Update `astros_vue/src/App.vue` mount hook to call `systemStatusStore.fetchStatus()` once before the WebSocket connects. (The WebSocket will also push initial state on connect — this is belt-and-braces for the window between HTTP load and WS handshake.)
+- [x] Update `astros_vue/src/App.vue` mount hook to call `systemStatusStore.fetchStatus()` once before the WebSocket connects. (The WebSocket will also push initial state on connect — this is belt-and-braces for the window between HTTP load and WS handshake.)
 
-- [ ] Create `astros_vue/src/components/common/SystemStatusBanner.vue`:
+- [x] Create `astros_vue/src/components/common/SystemStatusBanner.vue`:
   ```vue
   <template>
     <div
@@ -55,14 +55,14 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
   - Full-width, `rounded-none` so it reads as chrome, not a card.
   - **Persistent — no dismiss button.** When the banner goes away, the mode really ended (via a container restart).
 
-- [ ] Mount `SystemStatusBanner` at the top of `astros_vue/src/components/common/layout/AstrosLayout.vue`, above the navbar. It should push content down when visible without layout jank.
+- [x] Mount `SystemStatusBanner` at the top of `astros_vue/src/components/common/layout/AstrosLayout.vue`, above the navbar. It should push content down when visible without layout jank.
 
-- [ ] Update `astros_vue/src/api/apiService.ts` axios response interceptor to detect `503` responses that carry a read-only payload (`{ message, reasonCode }` shape from `write_guard.ts`):
+- [x] Update `astros_vue/src/api/apiService.ts` axios response interceptor to detect `503` responses that carry a read-only payload (`{ message, reasonCode }` shape from `write_guard.ts`):
   - Call `systemStatusStore.setStatus({ readOnly: true, reasonCode })`.
   - Surface a toast: `useToast().warning(t('systemStatus.readOnly.requestBlocked'))`.
   - Reject the promise so the calling code sees the failure and can bail out cleanly.
 
-- [ ] Disable write-intent buttons in primary views when `systemStatusStore.readOnly === true`:
+- [x] Disable write-intent buttons in primary views when `systemStatusStore.readOnly === true`:
   - Scripts view (save, delete, copy)
   - Scripter view (save)
   - Playlists view (save, delete, copy, run)
@@ -74,7 +74,7 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
 
   **Pattern:** view imports `useSystemStatusStore`, destructures `readOnly`, binds to button `:disabled="readOnly"`. Add `:title="readOnly ? $t('systemStatus.readOnly.disabled') : ''"` for tooltip.
 
-- [ ] Add i18n keys to `astros_vue/src/locales/enUS.json`:
+- [x] Add i18n keys to `astros_vue/src/locales/enUS.json`:
   ```json
   "systemStatus": {
     "readOnly": {
@@ -92,21 +92,21 @@ A persistent read-only banner at the top of the app, disabled save/delete contro
   }
   ```
 
-- [ ] Write a Storybook story for `SystemStatusBanner` showing the hidden state and visible variants for each `reasonCode` (plus the `UNKNOWN` fallback).
+- [x] Write a Storybook story for `SystemStatusBanner` showing the hidden state and visible variants for each `reasonCode` (plus the `UNKNOWN` fallback).
 
 ## Tests
 
-- [ ] `astros_vue/src/stores/__tests__/systemStatus.spec.ts`:
+- [x] `astros_vue/src/stores/__tests__/systemStatus.spec.ts`:
   - Store state transitions (default → read-only → default on setStatus).
   - `fetchStatus` success updates refs correctly.
   - `fetchStatus` failure leaves refs at previous state, does not throw.
   - `setStatus` correctly handles partial payloads.
-- [ ] `astros_vue/src/components/common/__tests__/SystemStatusBanner.spec.ts`:
+- [x] `astros_vue/src/components/common/__tests__/SystemStatusBanner.spec.ts`:
   - Renders nothing when `readOnly === false`.
   - Renders alert with the localized reasonCode message when `readOnly === true`.
   - Renders fallback (`UNKNOWN`) i18n string when `reasonCode` is null or unrecognized.
   - Has `role="status"` and `aria-live="polite"` attributes.
-- [ ] Integration/snapshot: verify `AstrosLayout` mounts the banner above the navbar.
+- [x] Integration/snapshot: verify `AstrosLayout` mounts the banner above the navbar.
 
 ## QA test plan
 
@@ -164,6 +164,28 @@ This amendment updates Phase 3 to consume the structured code:
   - i18n keys are reorganized into `systemStatus.reasonCode.*` (one per
     code, plus `UNKNOWN` fallback) and `systemStatus.readOnly.*` (UI
     strings: title, disabled tooltip, request-blocked toast).
+
+## Plan amendment 2: restore-success now enters read-only (2026-04-26)
+
+Reviewing Phase 1's "locked" design call ("restore success = server
+continues at pre-migration version") flagged a real issue: silent
+recovery hid migration failures from operators, and writes against the
+rolled-back schema could compound the underlying problem before the
+fixed migration shipped. Phase 2's FK enforcement work made this
+hazard concrete — a migration could fail because of orphans, restore
+could roll back, and operators would never know to investigate.
+
+Add a new `MIGRATION_FAILED_RESTORED` reason code:
+
+  - DB is at a known-good prior version (restore worked).
+  - System enters read-only anyway. Operators see the banner and know
+    to investigate before redeploying.
+  - Distinct from `MIGRATION_FAILED_RESTORE_FAILED` (DB possibly
+    broken) and `MIGRATION_FAILED_NO_BACKUP` (DB possibly partial).
+
+Touches API (`system_status.ts`, `database.ts`, integration test) and
+Vue (store union, banner allowlist, i18n, story, banner test) — all
+in this PR.
 
 ## Notes
 

--- a/.docs/qa/system-readonly-mode.md
+++ b/.docs/qa/system-readonly-mode.md
@@ -1,0 +1,125 @@
+# System read-only mode QA
+
+Tests for the Phase 3 Vue UI when the AstrOs.Server enters read-only mode (Phase 1's safety net). Run after merging Phase 3.
+
+## Preconditions
+
+- AstrOs.Server stopped between scenarios so each starts from a known state.
+- Working `~/.config/astrosserver/database.sqlite3` file from a healthy run (so we have something to back up).
+- Vue app running: `cd astros_vue && npm run dev`. Browser at `http://localhost:5173`.
+- Devtools open with the Network tab visible.
+- Login credentials handy.
+
+## Forcing read-only mode
+
+Three reliable ways to put the server into read-only mode for testing. Pick whichever matches the scenario:
+
+1. **`STARTUP_OPEN_FAILED`** — point `DATABASE_PATH` at a directory:
+   ```bash
+   mkdir -p /tmp/astros-readonly-test/database.sqlite3
+   DATABASE_PATH=/tmp/astros-readonly-test npm run start
+   ```
+   `better-sqlite3` rejects opening a directory as a database file; the server boots in read-only mode with the in-memory fallback.
+
+2. **`BACKUP_FAILED`** — drop write permissions on the dbDir before starting:
+   ```bash
+   chmod 0500 ~/.config/astrosserver
+   # add an unapplied migration to force a backup attempt (see git-stash a quick stub or temporarily edit migrations/index.ts)
+   npm run start
+   # restore perms after: chmod 0700 ~/.config/astrosserver
+   ```
+
+3. **`MIGRATION_FAILED_RESTORED`** — inject a migration that throws but leave the backup mechanism intact. The system rolls back to the prior version and enters read-only with this code so operators are forced to notice and investigate. Easiest from the integration tests (`database.integration.test.ts`).
+
+4. **`MIGRATION_FAILED_RESTORE_FAILED`** — inject a migration that throws *and* mock `fs.copyFileSync` to throw too. Mostly observable via tests, not manual QA.
+
+For most cases, scenario 1 is fastest.
+
+## Test cases
+
+### 1. Banner appears via WebSocket push (≤1s)
+
+1. Start the server in read-only mode (scenario 1 above).
+2. With the Vue app already loaded and a fresh login, observe the page.
+3. **Pass:** within ≤1s of the WebSocket reconnect, the yellow banner appears at the top of the page reading "Read-only mode" + the localized reason for `STARTUP_OPEN_FAILED`.
+4. **Fail:** banner doesn't appear, or shows the raw i18n key path (`systemStatus.reasonCode.STARTUP_OPEN_FAILED`).
+
+### 2. Banner persists across page refresh
+
+1. With the server still in read-only mode, hit `Ctrl+R` to refresh the browser.
+2. **Pass:** the banner reappears immediately on first paint (from `fetchStatus` on mount, before WebSocket reconnect).
+3. **Fail:** banner disappears for >100ms after refresh.
+
+### 3. Write-intent buttons disabled across views
+
+For each view below, navigate to it and confirm:
+
+- The disabled buttons are visually disabled (grayed out) and cannot be clicked.
+- Hovering the disabled button shows the tooltip "This action is disabled while the system is in read-only mode."
+
+| View | Disabled buttons |
+|---|---|
+| Modules | Save, Sync |
+| Scripts | New (top), Delete (in delete-confirmation modal) |
+| Scripter | Save, Test |
+| Playlists | New (top), Delete (in delete-confirmation modal) |
+| Playlist Editor (open one) | Save |
+| Utility | Generate (API key), Format (SD), Format-confirm (modal) |
+
+**Must remain enabled:**
+
+- Login button on AuthView (user must still be able to log in).
+- Logout button in the sidebar.
+- Download Logs button in Utility (read action).
+- Any panicStop / panicClear button (server allowlists these for read-only mode).
+- Filter inputs, navigation, accordion toggles, modal close/cancel buttons.
+
+### 4. Direct-API write returns 503 + toast
+
+1. Open browser devtools → Console.
+2. Paste:
+   ```js
+   fetch('/api/scripts/12345', { method: 'DELETE', headers: { 'Authorization': 'Bearer ' + localStorage.jwt_token } }).then(r => r.json().then(b => console.log(r.status, b)))
+   ```
+3. **Pass:** logs `503 { message: "Server is in read-only mode", reasonCode: "..." }`. A yellow toast appears reading "The server is in read-only mode. Your change was not saved."
+4. **Fail:** any 5xx that isn't 503, or no toast appears, or the response is missing the `reasonCode` field.
+
+### 5. Login still works
+
+1. Click "Logout".
+2. Verify the auth page loads with the banner still visible.
+3. Log back in.
+4. **Pass:** login succeeds, banner reappears immediately on the post-login route.
+5. **Fail:** login button is disabled, or login fails with a 503.
+
+### 6. Panic stop still works
+
+1. Navigate to Utility.
+2. Click `Panic Stop`.
+3. **Pass:** request succeeds (200), audible/visual confirmation that the panic was processed.
+4. **Fail:** 503 response — meaning the API allowlist is broken.
+
+### 7. Recovery (banner clears after fix)
+
+1. Stop the server.
+2. Remove the forced-failure (e.g. `rmdir /tmp/astros-readonly-test/database.sqlite3` and unset `DATABASE_PATH`).
+3. Restart the server.
+4. **Pass:** within ≤1s of the WebSocket reconnect, the banner disappears. All previously-disabled buttons are re-enabled.
+5. **Fail:** banner persists, or buttons stay disabled.
+
+### 8. Unknown reasonCode fallback
+
+The Vue app's allowlist of known reasonCodes is hardcoded. If a future server adds a new code before the client catches up, the banner should fall back to "The database is currently unavailable for writes." rather than rendering the raw key.
+
+To force this scenario: temporarily edit `src/composables/useWebsocket.ts`'s `handleSystemStatusMessage` to set `reasonCode: 'NOT_A_REAL_CODE' as ReadOnlyReasonCode` instead of using the wire payload. Refresh.
+
+**Pass:** banner reads "The database is currently unavailable for writes." (the UNKNOWN fallback).
+**Fail:** banner reads "systemStatus.reasonCode.NOT_A_REAL_CODE" (raw key leaked).
+
+## Storybook spot-check
+
+Run `cd astros_vue && npm run storybook`. Navigate to "Components / Common / SystemStatusBanner". Verify each story renders without console errors:
+
+- `Hidden` — no banner visible, only the placeholder text.
+- `StartupOpenFailed`, `BackupFailed`, `MigrationFailedNoBackup`, `MigrationFailedRestored`, `MigrationFailedRestoreFailed` — each shows the banner with the corresponding localized message.
+- `UnknownReasonCode`, `NoReasonCode` — both show the UNKNOWN fallback.

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -119,8 +119,8 @@ describe('initializeDatabase safety flow', () => {
     expect(status.isReadOnly()).toBe(false);
   });
 
-  it('failed migration triggers restore from backup; system continues at pre-migration state', async () => {
-    // Migrate to v4 first
+  it('failed migration triggers restore from backup AND enters read-only with MIGRATION_FAILED_RESTORED', async () => {
+    // Migrate baseline to v6 first
     let status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
@@ -150,10 +150,15 @@ describe('initializeDatabase safety flow', () => {
     status = new SystemStatus();
     const db = await initializeDatabase(status, { dbPath });
 
-    // Restore should have rolled back to pre-migration state — system is usable, not read-only
-    expect(status.isReadOnly()).toBe(false);
+    // Restore brought the file back to v6, but a migration still failed —
+    // the system enters read-only with MIGRATION_FAILED_RESTORED so operators
+    // notice and investigate before redeploying. Writes against the rolled-
+    // back schema while the migration is broken could compound the problem.
+    expect(status.isReadOnly()).toBe(true);
+    expect(status.getState().reasonCode).toBe('MIGRATION_FAILED_RESTORED');
 
-    // Verify our marker survived (proves restore happened)
+    // Verify our marker survived (proves restore happened) — read-only does
+    // not affect SELECTs.
     const marker = await db
       .selectFrom('marker' as never)
       .select('note' as never)
@@ -280,8 +285,11 @@ describe('initializeDatabase safety flow', () => {
     status = new SystemStatus();
     const db = await initializeDatabase(status, { dbPath });
 
-    // Phase 1's restore brought us back to v6. The bad migration is reverted.
-    expect(status.isReadOnly()).toBe(false);
+    // Restore brought us back to v6 AND the system enters read-only with
+    // MIGRATION_FAILED_RESTORED so operators notice — the same end-state as
+    // any other migration failure that successfully recovered.
+    expect(status.isReadOnly()).toBe(true);
+    expect(status.getState().reasonCode).toBe('MIGRATION_FAILED_RESTORED');
 
     // The orphan is gone — the bad migration's INSERT was rolled back via the
     // file restore.

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -223,6 +223,12 @@ export async function initializeDatabase(
       restoreBackup(backupPath, dbFile);
       conn = openConnection(dbFile);
       logger.warn(`Restored database from backup ${backupPath} after failed migration`);
+      // Restore succeeded — DB is at a known-good prior version. Enter read-only
+      // anyway: a migration failed, and silently coming back up "as if nothing
+      // happened" hides that from operators and risks letting writes against the
+      // older schema compound the underlying problem before a fix ships.
+      // Recovery is still a container restart with a fixed migration.
+      systemStatus.enterReadOnly('MIGRATION_FAILED_RESTORED', err);
       return conn.db;
     } catch (restoreErr) {
       systemStatus.enterReadOnly('MIGRATION_FAILED_RESTORE_FAILED', restoreErr);

--- a/astros_api/src/system_status.ts
+++ b/astros_api/src/system_status.ts
@@ -4,6 +4,7 @@ export type ReadOnlyReasonCode =
   | 'STARTUP_OPEN_FAILED'
   | 'BACKUP_FAILED'
   | 'MIGRATION_FAILED_NO_BACKUP'
+  | 'MIGRATION_FAILED_RESTORED'
   | 'MIGRATION_FAILED_RESTORE_FAILED';
 
 export interface SystemStatusState {

--- a/astros_vue/src/App.vue
+++ b/astros_vue/src/App.vue
@@ -3,9 +3,17 @@ import { onMounted, onUnmounted } from 'vue';
 import { RouterView } from 'vue-router';
 import { useWebsocket } from './composables/useWebsocket';
 import AstrosToastContainer from './components/common/AstrosToastContainer.vue';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 
 const { wsConnect, wsDisconnect } = useWebsocket();
+const systemStatusStore = useSystemStatusStore();
+
 onMounted(() => {
+  // Belt-and-braces: WebSocket pushes initial state on connect, but until the
+  // handshake completes there's a window where the user could see write-intent
+  // controls enabled when the server is in read-only mode. Fetch once up-front
+  // so the banner and disabled-button bindings are correct from the first paint.
+  systemStatusStore.fetchStatus();
   wsConnect();
 });
 

--- a/astros_vue/src/api/apiService.ts
+++ b/astros_vue/src/api/apiService.ts
@@ -1,10 +1,10 @@
-import axios, { type AxiosError } from 'axios';
+import axios from 'axios';
 import router from '@/router';
-import i18n from '@/i18n';
-import { useToast } from '@/composables/useToast';
-import { useSystemStatusStore, type ReadOnlyReasonCode } from '@/stores/systemStatus';
 
-const apiClient = axios.create({
+// Exported so app-level wiring (main.ts) can attach additional interceptors
+// after Pinia is created — keeps this module dependency-free of stores and
+// avoids the circular-dep trap (apiService → store → apiService).
+export const apiClient = axios.create({
   baseURL: import.meta.env.BACKEND_API || 'http://localhost:3000',
   headers: {
     'Content-Type': 'application/json',
@@ -25,20 +25,13 @@ apiClient.interceptors.request.use(
   },
 );
 
-// Recognize a 503 read-only response by its body shape: { message, reasonCode }
-// per write_guard.ts on the API. Treating "any 503 with a reasonCode field"
-// as the signal keeps us robust if a future server adds 503s for unrelated
-// reasons without that envelope.
-function readOnlyReasonCodeFrom(error: AxiosError): ReadOnlyReasonCode | null {
-  if (error.response?.status !== 503) return null;
-  const body = error.response.data as { reasonCode?: string } | undefined;
-  return (body?.reasonCode as ReadOnlyReasonCode | undefined) ?? null;
-}
-
-// Add response interceptor to handle 401 + 503 read-only
+// Add response interceptor to handle 401 errors. The 503 read-only handler
+// lives in `@/api/readOnlyInterceptor` and is installed from main.ts after
+// Pinia is created — installing it here would require importing the store,
+// which itself imports apiService, creating a circular module dependency.
 apiClient.interceptors.response.use(
   (response) => response,
-  (error: AxiosError) => {
+  (error) => {
     if (error.response?.status === 401) {
       // Clear token on auth failure
       localStorage.removeItem('jwt_token');
@@ -46,30 +39,7 @@ apiClient.interceptors.response.use(
       if (router.currentRoute.value.path !== '/auth') {
         router.push('/auth');
       }
-      return Promise.reject(error);
     }
-
-    const reasonCode = readOnlyReasonCodeFrom(error);
-    if (reasonCode !== null) {
-      // Sync local state with the server's view of itself — the WebSocket
-      // push would catch up eventually, but updating here makes the banner
-      // and disabled-button bindings flip immediately.
-      try {
-        const systemStatusStore = useSystemStatusStore();
-        systemStatusStore.setStatus({ readOnly: true, reasonCode });
-      } catch (storeErr) {
-        // Pinia not initialized (e.g., setup-time error); state will catch
-        // up via the WebSocket push on next handshake.
-        console.warn('Could not update systemStatus store from 503:', storeErr);
-      }
-
-      try {
-        useToast().warning(i18n.global.t('systemStatus.readOnly.requestBlocked'));
-      } catch (toastErr) {
-        console.warn('Could not surface read-only toast:', toastErr);
-      }
-    }
-
     return Promise.reject(error);
   },
 );

--- a/astros_vue/src/api/apiService.ts
+++ b/astros_vue/src/api/apiService.ts
@@ -1,5 +1,8 @@
-import axios from 'axios';
+import axios, { type AxiosError } from 'axios';
 import router from '@/router';
+import i18n from '@/i18n';
+import { useToast } from '@/composables/useToast';
+import { useSystemStatusStore, type ReadOnlyReasonCode } from '@/stores/systemStatus';
 
 const apiClient = axios.create({
   baseURL: import.meta.env.BACKEND_API || 'http://localhost:3000',
@@ -22,10 +25,20 @@ apiClient.interceptors.request.use(
   },
 );
 
-// Add response interceptor to handle 401 errors
+// Recognize a 503 read-only response by its body shape: { message, reasonCode }
+// per write_guard.ts on the API. Treating "any 503 with a reasonCode field"
+// as the signal keeps us robust if a future server adds 503s for unrelated
+// reasons without that envelope.
+function readOnlyReasonCodeFrom(error: AxiosError): ReadOnlyReasonCode | null {
+  if (error.response?.status !== 503) return null;
+  const body = error.response.data as { reasonCode?: string } | undefined;
+  return (body?.reasonCode as ReadOnlyReasonCode | undefined) ?? null;
+}
+
+// Add response interceptor to handle 401 + 503 read-only
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
+  (error: AxiosError) => {
     if (error.response?.status === 401) {
       // Clear token on auth failure
       localStorage.removeItem('jwt_token');
@@ -33,7 +46,30 @@ apiClient.interceptors.response.use(
       if (router.currentRoute.value.path !== '/auth') {
         router.push('/auth');
       }
+      return Promise.reject(error);
     }
+
+    const reasonCode = readOnlyReasonCodeFrom(error);
+    if (reasonCode !== null) {
+      // Sync local state with the server's view of itself — the WebSocket
+      // push would catch up eventually, but updating here makes the banner
+      // and disabled-button bindings flip immediately.
+      try {
+        const systemStatusStore = useSystemStatusStore();
+        systemStatusStore.setStatus({ readOnly: true, reasonCode });
+      } catch (storeErr) {
+        // Pinia not initialized (e.g., setup-time error); state will catch
+        // up via the WebSocket push on next handshake.
+        console.warn('Could not update systemStatus store from 503:', storeErr);
+      }
+
+      try {
+        useToast().warning(i18n.global.t('systemStatus.readOnly.requestBlocked'));
+      } catch (toastErr) {
+        console.warn('Could not surface read-only toast:', toastErr);
+      }
+    }
+
     return Promise.reject(error);
   },
 );

--- a/astros_vue/src/api/endpoints.ts
+++ b/astros_vue/src/api/endpoints.ts
@@ -25,3 +25,5 @@ export const PLAYLISTS_COPY = 'api/playlists/copy';
 export const PLAYLISTS_RUN = 'api/playlists/run';
 
 export const REMOTE_CONFIG = 'api/remoteConfig';
+
+export const SYSTEM_STATUS = 'api/system/status';

--- a/astros_vue/src/api/readOnlyInterceptor.ts
+++ b/astros_vue/src/api/readOnlyInterceptor.ts
@@ -1,0 +1,48 @@
+import type { AxiosError } from 'axios';
+import { apiClient } from '@/api/apiService';
+import i18n from '@/i18n';
+import { useToast } from '@/composables/useToast';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+import type { ReadOnlyReasonCode } from '@/types/systemStatus';
+
+// Recognize a 503 read-only response by its body shape: { message, reasonCode }
+// per write_guard.ts on the API. Treating "any 503 with a reasonCode field"
+// as the signal keeps us robust if a future server adds 503s for unrelated
+// reasons without that envelope.
+function readOnlyReasonCodeFrom(error: AxiosError): ReadOnlyReasonCode | null {
+  if (error.response?.status !== 503) return null;
+  const body = error.response.data as { reasonCode?: string } | undefined;
+  return (body?.reasonCode as ReadOnlyReasonCode | undefined) ?? null;
+}
+
+// Installs an axios response interceptor that detects the API's read-only
+// 503s, mirrors the state into the systemStatus store, and surfaces a toast.
+//
+// MUST be called from main.ts AFTER `app.use(createPinia())`. Calling
+// useSystemStatusStore() before Pinia is active throws.
+export function installReadOnlyInterceptor(): void {
+  apiClient.interceptors.response.use(
+    (response) => response,
+    (error: AxiosError) => {
+      const reasonCode = readOnlyReasonCodeFrom(error);
+      if (reasonCode !== null) {
+        // Sync local state with the server's view of itself — the WebSocket
+        // push would catch up eventually, but updating here makes the banner
+        // and disabled-button bindings flip immediately.
+        try {
+          useSystemStatusStore().setStatus({ readOnly: true, reasonCode });
+        } catch (storeErr) {
+          console.warn('Could not update systemStatus store from 503:', storeErr);
+        }
+
+        try {
+          useToast().warning(i18n.global.t('systemStatus.readOnly.requestBlocked'));
+        } catch (toastErr) {
+          console.warn('Could not surface read-only toast:', toastErr);
+        }
+      }
+
+      return Promise.reject(error);
+    },
+  );
+}

--- a/astros_vue/src/components/common/SystemStatusBanner.stories.ts
+++ b/astros_vue/src/components/common/SystemStatusBanner.stories.ts
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { createPinia, setActivePinia } from 'pinia';
 import SystemStatusBanner from './SystemStatusBanner.vue';
-import { useSystemStatusStore, type ReadOnlyReasonCode } from '@/stores/systemStatus';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+import type { ReadOnlyReasonCode } from '@/types/systemStatus';
 
 const meta = {
   title: 'Components/Common/SystemStatusBanner',

--- a/astros_vue/src/components/common/SystemStatusBanner.stories.ts
+++ b/astros_vue/src/components/common/SystemStatusBanner.stories.ts
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { createPinia, setActivePinia } from 'pinia';
+import SystemStatusBanner from './SystemStatusBanner.vue';
+import { useSystemStatusStore, type ReadOnlyReasonCode } from '@/stores/systemStatus';
+
+const meta = {
+  title: 'Components/Common/SystemStatusBanner',
+  component: SystemStatusBanner,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SystemStatusBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function makeStory(reasonCode: ReadOnlyReasonCode | null | 'NOT_A_REAL_CODE'): Story {
+  return {
+    render: () => ({
+      components: { SystemStatusBanner },
+      setup() {
+        // Each story owns its Pinia instance so the readOnly state doesn't
+        // bleed between stories in the same Storybook session.
+        setActivePinia(createPinia());
+        const store = useSystemStatusStore();
+        store.setStatus({
+          readOnly: true,
+          reasonCode: reasonCode as ReadOnlyReasonCode | null | undefined,
+        });
+        return {};
+      },
+      template: '<SystemStatusBanner />',
+    }),
+  };
+}
+
+export const Hidden: Story = {
+  render: () => ({
+    components: { SystemStatusBanner },
+    setup() {
+      setActivePinia(createPinia());
+      // Default state — readOnly=false; banner should render nothing.
+      return {};
+    },
+    template:
+      '<div class="p-4 text-sm">Banner is hidden when readOnly=false. Nothing renders below this line.</div><SystemStatusBanner />',
+  }),
+};
+
+export const StartupOpenFailed = makeStory('STARTUP_OPEN_FAILED');
+export const BackupFailed = makeStory('BACKUP_FAILED');
+export const MigrationFailedNoBackup = makeStory('MIGRATION_FAILED_NO_BACKUP');
+export const MigrationFailedRestored = makeStory('MIGRATION_FAILED_RESTORED');
+export const MigrationFailedRestoreFailed = makeStory('MIGRATION_FAILED_RESTORE_FAILED');
+
+// Future-proofing: simulates a server reasonCode the client doesn't recognize.
+// The banner should still render with the UNKNOWN fallback message instead of
+// leaking the raw key path.
+export const UnknownReasonCode = makeStory('NOT_A_REAL_CODE');
+
+// Explicitly null: e.g. read-only set without a code.
+export const NoReasonCode = makeStory(null);

--- a/astros_vue/src/components/common/SystemStatusBanner.vue
+++ b/astros_vue/src/components/common/SystemStatusBanner.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useSystemStatusStore, type ReadOnlyReasonCode } from '@/stores/systemStatus';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+import type { ReadOnlyReasonCode } from '@/types/systemStatus';
 
 const { t } = useI18n();
 const systemStatusStore = useSystemStatusStore();

--- a/astros_vue/src/components/common/SystemStatusBanner.vue
+++ b/astros_vue/src/components/common/SystemStatusBanner.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useSystemStatusStore, type ReadOnlyReasonCode } from '@/stores/systemStatus';
+
+const { t } = useI18n();
+const systemStatusStore = useSystemStatusStore();
+
+// Allowlist of codes the client knows how to localize. Anything else (including
+// null and codes added on the server before the client catches up) falls back
+// to UNKNOWN so we never leak a raw i18n key path to the operator.
+const KNOWN_CODES: readonly ReadOnlyReasonCode[] = [
+  'STARTUP_OPEN_FAILED',
+  'BACKUP_FAILED',
+  'MIGRATION_FAILED_NO_BACKUP',
+  'MIGRATION_FAILED_RESTORED',
+  'MIGRATION_FAILED_RESTORE_FAILED',
+];
+
+const reasonMessage = computed(() => {
+  const code = systemStatusStore.reasonCode;
+  if (code && KNOWN_CODES.includes(code)) {
+    return t(`systemStatus.reasonCode.${code}`);
+  }
+  return t('systemStatus.reasonCode.UNKNOWN');
+});
+</script>
+
+<template>
+  <div
+    v-if="systemStatusStore.readOnly"
+    class="alert alert-warning rounded-none"
+    role="status"
+    aria-live="polite"
+  >
+    <span class="font-bold">{{ $t('systemStatus.readOnly.title') }}</span>
+    <span>{{ reasonMessage }}</span>
+  </div>
+</template>

--- a/astros_vue/src/components/common/__tests__/SystemStatusBanner.spec.ts
+++ b/astros_vue/src/components/common/__tests__/SystemStatusBanner.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createI18n } from 'vue-i18n';
+import enUS from '@/locales/enUS.json';
+import SystemStatusBanner from '@/components/common/SystemStatusBanner.vue';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+
+function createTestI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'enUS',
+    fallbackLocale: 'enUS',
+    messages: { enUS },
+  });
+}
+
+function mountBanner() {
+  return mount(SystemStatusBanner, {
+    global: {
+      plugins: [createTestI18n()],
+    },
+  });
+}
+
+describe('SystemStatusBanner', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders nothing when not in read-only mode', () => {
+    const wrapper = mountBanner();
+    expect(wrapper.find('[role="status"]').exists()).toBe(false);
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('renders the alert with the localized reasonCode message in read-only mode', async () => {
+    const store = useSystemStatusStore();
+    store.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+
+    const wrapper = mountBanner();
+    await wrapper.vm.$nextTick();
+
+    const alert = wrapper.find('[role="status"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text()).toContain('Read-only mode');
+    expect(alert.text()).toContain('pre-migration backup could not be written');
+  });
+
+  it('renders the recovered-after-failure message for MIGRATION_FAILED_RESTORED', async () => {
+    const store = useSystemStatusStore();
+    store.setStatus({ readOnly: true, reasonCode: 'MIGRATION_FAILED_RESTORED' });
+
+    const wrapper = mountBanner();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('Investigate the failed migration before redeploying');
+  });
+
+  it('falls back to UNKNOWN message when reasonCode is null', async () => {
+    const store = useSystemStatusStore();
+    // Force a state where readOnly is true but no reasonCode is set.
+    store.setStatus({ readOnly: true });
+
+    const wrapper = mountBanner();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('currently unavailable for writes');
+  });
+
+  it('falls back to UNKNOWN message for unrecognized reasonCode', async () => {
+    const store = useSystemStatusStore();
+    // Cast through unknown to simulate a future server reason code the
+    // current client doesn't know about.
+    store.setStatus({
+      readOnly: true,
+      reasonCode: 'NOT_A_REAL_CODE' as unknown as 'STARTUP_OPEN_FAILED',
+    });
+
+    const wrapper = mountBanner();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('currently unavailable for writes');
+  });
+
+  it('exposes role=status and aria-live=polite for screen readers', async () => {
+    const store = useSystemStatusStore();
+    store.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+
+    const wrapper = mountBanner();
+    await wrapper.vm.$nextTick();
+
+    const alert = wrapper.find('[role="status"]');
+    expect(alert.attributes('aria-live')).toBe('polite');
+  });
+});

--- a/astros_vue/src/components/common/layout/AstrosLayout.vue
+++ b/astros_vue/src/components/common/layout/AstrosLayout.vue
@@ -2,6 +2,7 @@
 import router from '@/router';
 import apiService from '@/api/apiService';
 import { ref, watch } from 'vue';
+import SystemStatusBanner from '@/components/common/SystemStatusBanner.vue';
 
 const props = defineProps({
   isSidebarOpen: {
@@ -44,6 +45,7 @@ function logout() {
       aria-controls="sidebar-menu"
     />
     <div class="drawer-content">
+      <SystemStatusBanner />
       <div class="navbar bg-base-100 shadow-sm">
         <div class="flex-none pl-2 flex items-center">
           <label

--- a/astros_vue/src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue
+++ b/astros_vue/src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue
@@ -242,15 +242,19 @@ async function save() {
     <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0">
       <h1 class="text-2xl font-bold">{{ $t('playlist_editor_view.title') }}</h1>
       <div class="grow"></div>
-      <button
-        data-testid="save_module_settings"
-        class="btn btn-primary w-24"
-        :disabled="systemStatusStore.readOnly"
-        :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-        @click="save"
+      <div
+        :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+        :data-tip="$t('systemStatus.readOnly.disabled')"
       >
-        {{ $t('playlist_editor_view.save') }}
-      </button>
+        <button
+          data-testid="save_module_settings"
+          class="btn btn-primary w-24"
+          :disabled="systemStatusStore.readOnly"
+          @click="save"
+        >
+          {{ $t('playlist_editor_view.save') }}
+        </button>
+      </div>
     </div>
     <div class="min-h-0 flex-1 flex">
       <div class="grow"></div>

--- a/astros_vue/src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue
+++ b/astros_vue/src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue
@@ -7,6 +7,7 @@ import { v4 as uuid } from 'uuid';
 import AstrosPlaylistSettings from './AstrosPlaylistSettings.vue';
 import AstrosPlaylistTrack from './AstrosPlaylistTrack.vue';
 import { usePlaylistsStore } from '@/stores/playlists';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { AstrosConfirmModal, AstrosHtmlModal } from '@/components/modals';
@@ -20,6 +21,7 @@ const { success, error } = useToast();
 const route = useRoute();
 const router = useRouter();
 const playlistStore = usePlaylistsStore();
+const systemStatusStore = useSystemStatusStore();
 const { selectedPlaylist } = storeToRefs(playlistStore);
 const playlist = computed(() => selectedPlaylist.value!);
 
@@ -243,6 +245,8 @@ async function save() {
       <button
         data-testid="save_module_settings"
         class="btn btn-primary w-24"
+        :disabled="systemStatusStore.readOnly"
+        :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
         @click="save"
       >
         {{ $t('playlist_editor_view.save') }}

--- a/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
+++ b/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
@@ -6,6 +6,7 @@ import type { PageButton } from '@/models/remoteControl/pageButton';
 import { useScriptsStore } from '@/stores/scripts';
 import { usePlaylistsStore } from '@/stores/playlists';
 import { useRemoteControlStore } from '@/stores/remoteControl';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 import { useToast } from '@/composables/useToast';
 import { useI18n } from 'vue-i18n';
 
@@ -19,6 +20,7 @@ interface SelectionItem {
 const scriptStore = useScriptsStore();
 const playlistStore = usePlaylistsStore();
 const remoteControlStore = useRemoteControlStore();
+const systemStatusStore = useSystemStatusStore();
 const { success, error } = useToast();
 
 const pageNumber = ref(1);
@@ -107,6 +109,8 @@ const buttonNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
       <button
         data-testid="save_module_settings"
         class="btn btn-primary w-24"
+        :disabled="systemStatusStore.readOnly"
+        :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
         @click="saveConfig"
       >
         {{ $t('remote_view.save') }}

--- a/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
+++ b/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
@@ -106,15 +106,19 @@ const buttonNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
     <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0">
       <h1 class="text-2xl font-bold">{{ $t('remote_view.title') }}</h1>
       <div class="grow"></div>
-      <button
-        data-testid="save_module_settings"
-        class="btn btn-primary w-24"
-        :disabled="systemStatusStore.readOnly"
-        :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-        @click="saveConfig"
+      <div
+        :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+        :data-tip="$t('systemStatus.readOnly.disabled')"
       >
-        {{ $t('remote_view.save') }}
-      </button>
+        <button
+          data-testid="save_module_settings"
+          class="btn btn-primary w-24"
+          :disabled="systemStatusStore.readOnly"
+          @click="saveConfig"
+        >
+          {{ $t('remote_view.save') }}
+        </button>
+      </div>
     </div>
 
     <!-- Page Navigation -->

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -1,9 +1,16 @@
 import { ref } from 'vue';
-import type { BaseWsMessage, LocationStatus, ControllerSync, ScriptStatus } from '@/models';
+import type {
+  BaseWsMessage,
+  LocationStatus,
+  ControllerSync,
+  ScriptStatus,
+  SystemStatusWsMessage,
+} from '@/models';
 import { WebsocketMessageType, Location, ControllerStatus } from '@/enums';
 import { useControllerStore } from '@/stores/controller';
 import { useScriptsStore } from '@/stores/scripts';
 import { useScripterStore } from '@/stores/scripter';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 
 const ws = ref<WebSocket | null>(null);
 const wsIsConnected = ref(false);
@@ -95,6 +102,9 @@ export function useWebsocket() {
       case WebsocketMessageType.SCRIPT:
         handleScriptMessage(parsedMessage);
         break;
+      case WebsocketMessageType.SYSTEM_STATUS:
+        handleSystemStatusMessage(parsedMessage as unknown as SystemStatusWsMessage);
+        break;
       default:
         console.warn('Unhandled message type:', message);
         break;
@@ -136,6 +146,19 @@ export function useWebsocket() {
       }
     } catch (error) {
       console.error('Error handling status message:', error);
+    }
+  }
+
+  function handleSystemStatusMessage(message: SystemStatusWsMessage) {
+    try {
+      const systemStatusStore = useSystemStatusStore();
+      systemStatusStore.setStatus({
+        readOnly: message.data.readOnly,
+        reasonCode: message.data.reasonCode ?? null,
+        enteredAt: message.data.enteredAt ?? null,
+      });
+    } catch (error) {
+      console.error('Error handling system status message:', error);
     }
   }
 

--- a/astros_vue/src/enums/WebsocketMessageType.ts
+++ b/astros_vue/src/enums/WebsocketMessageType.ts
@@ -8,4 +8,5 @@ export enum WebsocketMessageType {
   DIRECT_COMMAND = 6,
   FORMAT_SD = 7,
   SERVO_TEST = 8,
+  SYSTEM_STATUS = 9,
 }

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -357,5 +357,20 @@
     "help_shufflewithdelayandrepeat": "Similar to Shuffle With Delay, but once all tracks have been played, it reshuffles and starts again. This type is always interruptible.",
     "sequential_nested_confirm_title": "Remove Nested Playlists",
     "sequential_nested_warning": "Sequential playlists cannot contain nested playlists. {count} track will be removed. | Sequential playlists cannot contain nested playlists. {count} tracks will be removed."
+  },
+  "systemStatus": {
+    "readOnly": {
+      "title": "Read-only mode",
+      "disabled": "This action is disabled while the system is in read-only mode.",
+      "requestBlocked": "The server is in read-only mode. Your change was not saved."
+    },
+    "reasonCode": {
+      "STARTUP_OPEN_FAILED": "The database could not be opened at startup. The server is running on a temporary in-memory database with no data.",
+      "BACKUP_FAILED": "A pre-migration backup could not be written. The schema upgrade was skipped.",
+      "MIGRATION_FAILED_NO_BACKUP": "A schema migration failed and there was no prior backup to restore from. The database may be in a partially-migrated state.",
+      "MIGRATION_FAILED_RESTORED": "A schema migration failed but the database was successfully rolled back to the previous version. Investigate the failed migration before redeploying.",
+      "MIGRATION_FAILED_RESTORE_FAILED": "A schema migration failed and the automatic restore also failed. Manual recovery is required.",
+      "UNKNOWN": "The database is currently unavailable for writes."
+    }
   }
 }

--- a/astros_vue/src/main.ts
+++ b/astros_vue/src/main.ts
@@ -21,6 +21,7 @@ import { MdDraghandle } from 'oh-vue-icons/icons/md';
 import App from './App.vue';
 import router from './router';
 import i18n from './i18n';
+import { installReadOnlyInterceptor } from '@/api/readOnlyInterceptor';
 
 addIcons(
   IoCloudUpload,
@@ -45,5 +46,11 @@ app.use(i18n);
 app.component('v-icon', OhVueIcon);
 app.use(createPinia());
 app.use(router);
+
+// Install the 503 read-only-mode response interceptor *after* Pinia is
+// active. This keeps apiService.ts free of any store import and breaks
+// what would otherwise be a circular module dependency
+// (apiService → store → apiService).
+installReadOnlyInterceptor();
 
 app.mount('#app');

--- a/astros_vue/src/models/websocket/index.ts
+++ b/astros_vue/src/models/websocket/index.ts
@@ -2,3 +2,4 @@ export * from './baseWsMessage';
 export * from './controllerSync';
 export * from './locationStatus';
 export * from './scriptStatus';
+export * from './systemStatusMessage';

--- a/astros_vue/src/models/websocket/systemStatusMessage.ts
+++ b/astros_vue/src/models/websocket/systemStatusMessage.ts
@@ -1,0 +1,16 @@
+import type { WebsocketMessageType } from '@/enums/WebsocketMessageType';
+import type { ReadOnlyReasonCode } from '@/stores/systemStatus';
+
+// The server's systemStatus broadcast (api_server.ts) sends
+//   { type: TransmissionType.systemStatus, data: state }
+// where `state` is the public read-only state object — no `success`/`message`
+// envelope, unlike the other WS messages. Modeled here as a standalone shape
+// rather than extending BaseWsMessage to keep that asymmetry honest.
+export interface SystemStatusWsMessage {
+  type: WebsocketMessageType.SYSTEM_STATUS;
+  data: {
+    readOnly: boolean;
+    reasonCode?: ReadOnlyReasonCode | null;
+    enteredAt?: string | null;
+  };
+}

--- a/astros_vue/src/models/websocket/systemStatusMessage.ts
+++ b/astros_vue/src/models/websocket/systemStatusMessage.ts
@@ -1,5 +1,5 @@
 import type { WebsocketMessageType } from '@/enums/WebsocketMessageType';
-import type { ReadOnlyReasonCode } from '@/stores/systemStatus';
+import type { ReadOnlyReasonCode } from '@/types/systemStatus';
 
 // The server's systemStatus broadcast (api_server.ts) sends
 //   { type: TransmissionType.systemStatus, data: state }

--- a/astros_vue/src/stores/__tests__/systemStatus.spec.ts
+++ b/astros_vue/src/stores/__tests__/systemStatus.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+vi.mock('@/api/apiService', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import apiService from '@/api/apiService';
+import { useSystemStatusStore } from '../systemStatus';
+
+const apiGet = apiService.get as ReturnType<typeof vi.fn>;
+
+describe('systemStatus store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    apiGet.mockReset();
+  });
+
+  it('starts with default not-read-only state', () => {
+    const store = useSystemStatusStore();
+    expect(store.readOnly).toBe(false);
+    expect(store.reasonCode).toBeNull();
+    expect(store.enteredAt).toBeNull();
+  });
+
+  describe('setStatus', () => {
+    it('transitions to read-only with reasonCode and enteredAt', () => {
+      const store = useSystemStatusStore();
+
+      store.setStatus({
+        readOnly: true,
+        reasonCode: 'BACKUP_FAILED',
+        enteredAt: '2026-04-26T00:00:00.000Z',
+      });
+
+      expect(store.readOnly).toBe(true);
+      expect(store.reasonCode).toBe('BACKUP_FAILED');
+      expect(store.enteredAt).toBe('2026-04-26T00:00:00.000Z');
+    });
+
+    it('transitions back to not-read-only and clears reasonCode/enteredAt', () => {
+      const store = useSystemStatusStore();
+      store.setStatus({
+        readOnly: true,
+        reasonCode: 'BACKUP_FAILED',
+        enteredAt: '2026-04-26T00:00:00.000Z',
+      });
+
+      store.setStatus({ readOnly: false });
+
+      expect(store.readOnly).toBe(false);
+      expect(store.reasonCode).toBeNull();
+      expect(store.enteredAt).toBeNull();
+    });
+
+    it('handles partial payloads without enteredAt', () => {
+      const store = useSystemStatusStore();
+
+      store.setStatus({ readOnly: true, reasonCode: 'STARTUP_OPEN_FAILED' });
+
+      expect(store.readOnly).toBe(true);
+      expect(store.reasonCode).toBe('STARTUP_OPEN_FAILED');
+      expect(store.enteredAt).toBeNull();
+    });
+
+    it('coerces missing reasonCode to null even when readOnly is true', () => {
+      const store = useSystemStatusStore();
+      store.setStatus({ readOnly: true });
+      expect(store.reasonCode).toBeNull();
+    });
+  });
+
+  describe('fetchStatus', () => {
+    it('updates state from a successful GET response', async () => {
+      apiGet.mockResolvedValueOnce({
+        readOnly: true,
+        reasonCode: 'MIGRATION_FAILED_NO_BACKUP',
+        enteredAt: '2026-04-26T00:00:00.000Z',
+      });
+
+      const store = useSystemStatusStore();
+      await store.fetchStatus();
+
+      expect(apiGet).toHaveBeenCalledWith('api/system/status');
+      expect(store.readOnly).toBe(true);
+      expect(store.reasonCode).toBe('MIGRATION_FAILED_NO_BACKUP');
+      expect(store.enteredAt).toBe('2026-04-26T00:00:00.000Z');
+    });
+
+    it('updates state from a not-read-only GET response', async () => {
+      apiGet.mockResolvedValueOnce({ readOnly: false });
+
+      const store = useSystemStatusStore();
+      // Pre-seed with a prior read-only state so we can verify it gets cleared
+      store.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+
+      await store.fetchStatus();
+
+      expect(store.readOnly).toBe(false);
+      expect(store.reasonCode).toBeNull();
+    });
+
+    it('leaves state unchanged on fetch failure (does not throw)', async () => {
+      apiGet.mockRejectedValueOnce(new Error('network'));
+
+      const store = useSystemStatusStore();
+      store.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+
+      await expect(store.fetchStatus()).resolves.toBeUndefined();
+
+      expect(store.readOnly).toBe(true);
+      expect(store.reasonCode).toBe('BACKUP_FAILED');
+    });
+  });
+});

--- a/astros_vue/src/stores/systemStatus.ts
+++ b/astros_vue/src/stores/systemStatus.ts
@@ -2,19 +2,7 @@ import { ref } from 'vue';
 import { defineStore } from 'pinia';
 import apiService from '@/api/apiService';
 import { SYSTEM_STATUS } from '@/api/endpoints';
-
-export type ReadOnlyReasonCode =
-  | 'STARTUP_OPEN_FAILED'
-  | 'BACKUP_FAILED'
-  | 'MIGRATION_FAILED_NO_BACKUP'
-  | 'MIGRATION_FAILED_RESTORED'
-  | 'MIGRATION_FAILED_RESTORE_FAILED';
-
-export interface SystemStatusPayload {
-  readOnly: boolean;
-  reasonCode?: ReadOnlyReasonCode | null;
-  enteredAt?: string | null;
-}
+import type { ReadOnlyReasonCode, SystemStatusPayload } from '@/types/systemStatus';
 
 export const useSystemStatusStore = defineStore('systemStatus', () => {
   const readOnly = ref(false);

--- a/astros_vue/src/stores/systemStatus.ts
+++ b/astros_vue/src/stores/systemStatus.ts
@@ -1,0 +1,55 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+import apiService from '@/api/apiService';
+import { SYSTEM_STATUS } from '@/api/endpoints';
+
+export type ReadOnlyReasonCode =
+  | 'STARTUP_OPEN_FAILED'
+  | 'BACKUP_FAILED'
+  | 'MIGRATION_FAILED_NO_BACKUP'
+  | 'MIGRATION_FAILED_RESTORED'
+  | 'MIGRATION_FAILED_RESTORE_FAILED';
+
+export interface SystemStatusPayload {
+  readOnly: boolean;
+  reasonCode?: ReadOnlyReasonCode | null;
+  enteredAt?: string | null;
+}
+
+export const useSystemStatusStore = defineStore('systemStatus', () => {
+  const readOnly = ref(false);
+  const reasonCode = ref<ReadOnlyReasonCode | null>(null);
+  const enteredAt = ref<string | null>(null);
+
+  function setStatus(state: SystemStatusPayload) {
+    readOnly.value = state.readOnly;
+    if (state.readOnly) {
+      reasonCode.value = state.reasonCode ?? null;
+      enteredAt.value = state.enteredAt ?? null;
+    } else {
+      reasonCode.value = null;
+      enteredAt.value = null;
+    }
+  }
+
+  async function fetchStatus(): Promise<void> {
+    try {
+      const response = (await apiService.get(SYSTEM_STATUS)) as SystemStatusPayload;
+      setStatus(response);
+    } catch (error) {
+      // Leave state unchanged. The /api/system/status endpoint is unauthenticated
+      // and on a healthy system always responds; a network error here is
+      // transient and another fetch (or the WebSocket push on connect) will
+      // bring us back up to date.
+      console.warn('systemStatus.fetchStatus failed', error);
+    }
+  }
+
+  return {
+    readOnly,
+    reasonCode,
+    enteredAt,
+    setStatus,
+    fetchStatus,
+  };
+});

--- a/astros_vue/src/types/systemStatus.ts
+++ b/astros_vue/src/types/systemStatus.ts
@@ -1,0 +1,16 @@
+// Wire-protocol types shared between the Pinia store, the axios layer, and the
+// WebSocket dispatcher. Lives in `types/` so neither the store nor the api
+// service has to import from each other to share these shapes.
+
+export type ReadOnlyReasonCode =
+  | 'STARTUP_OPEN_FAILED'
+  | 'BACKUP_FAILED'
+  | 'MIGRATION_FAILED_NO_BACKUP'
+  | 'MIGRATION_FAILED_RESTORED'
+  | 'MIGRATION_FAILED_RESTORE_FAILED';
+
+export interface SystemStatusPayload {
+  readOnly: boolean;
+  reasonCode?: ReadOnlyReasonCode | null;
+  enteredAt?: string | null;
+}

--- a/astros_vue/src/views/ModulesView.vue
+++ b/astros_vue/src/views/ModulesView.vue
@@ -151,23 +151,31 @@ function controllerSelectChanged(location: string) {
         <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0 mb-4">
           <h1 class="text-2xl font-bold">{{ $t('module_view.modules') }}</h1>
           <div class="grow"></div>
-          <button
-            data-testid="save_module_settings"
-            class="btn btn-primary w-24"
-            :disabled="systemStatusStore.readOnly"
-            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-            @click="saveModuleSettings"
+          <div
+            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+            :data-tip="$t('systemStatus.readOnly.disabled')"
           >
-            {{ $t('module_view.save') }}
-          </button>
-          <button
-            class="btn btn-primary w-24"
-            :disabled="systemStatusStore.readOnly"
-            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-            @click="syncModuleSettings"
+            <button
+              data-testid="save_module_settings"
+              class="btn btn-primary w-24"
+              :disabled="systemStatusStore.readOnly"
+              @click="saveModuleSettings"
+            >
+              {{ $t('module_view.save') }}
+            </button>
+          </div>
+          <div
+            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+            :data-tip="$t('systemStatus.readOnly.disabled')"
           >
-            {{ $t('module_view.sync') }}
-          </button>
+            <button
+              class="btn btn-primary w-24"
+              :disabled="systemStatusStore.readOnly"
+              @click="syncModuleSettings"
+            >
+              {{ $t('module_view.sync') }}
+            </button>
+          </div>
         </div>
 
         <!-- Module Accordions -->

--- a/astros_vue/src/views/ModulesView.vue
+++ b/astros_vue/src/views/ModulesView.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue';
 import type { AddModuleEvent, RemoveModuleEvent, ServoTestEvent } from '@/models/events';
 import { useLocationStore } from '@/stores/location';
 import { useControllerStore } from '@/stores/controller';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 import { Location, ModalType, ControllerStatus } from '@/enums';
 import { useModuleManagement } from '@/composables/useModuleManagement';
 import {
@@ -36,6 +37,7 @@ const openAccordion = ref<string | null>(null);
 
 const locationStore = useLocationStore();
 const controllerStore = useControllerStore();
+const systemStatusStore = useSystemStatusStore();
 
 const { success, error } = useToast();
 
@@ -152,12 +154,16 @@ function controllerSelectChanged(location: string) {
           <button
             data-testid="save_module_settings"
             class="btn btn-primary w-24"
+            :disabled="systemStatusStore.readOnly"
+            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
             @click="saveModuleSettings"
           >
             {{ $t('module_view.save') }}
           </button>
           <button
             class="btn btn-primary w-24"
+            :disabled="systemStatusStore.readOnly"
+            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
             @click="syncModuleSettings"
           >
             {{ $t('module_view.sync') }}

--- a/astros_vue/src/views/PlaylistsView.vue
+++ b/astros_vue/src/views/PlaylistsView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useToast } from '@/composables/useToast';
 import { usePlaylistsStore } from '@/stores/playlists';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 import { ref, onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
@@ -12,6 +13,7 @@ const { t } = useI18n();
 const { success, error } = useToast();
 
 const playlistStore = usePlaylistsStore();
+const systemStatusStore = useSystemStatusStore();
 
 const showDeleteModal = ref(false);
 const deletePlaylistId = ref('');
@@ -103,6 +105,8 @@ const editPlaylist = (id: string) => {
           data-testid="save_module_settings"
           class="btn btn-primary w-24"
           aria-label="$t('playlists_view.new')"
+          :disabled="systemStatusStore.readOnly"
+          :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
           @click="newPlaylist"
         >
           {{ $t('playlists_view.new') }}
@@ -149,6 +153,8 @@ const editPlaylist = (id: string) => {
           <div class="modal-action">
             <button
               class="btn btn-error"
+              :disabled="systemStatusStore.readOnly"
+              :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
               @click="confirmDelete"
             >
               {{ $t('delete') }}

--- a/astros_vue/src/views/PlaylistsView.vue
+++ b/astros_vue/src/views/PlaylistsView.vue
@@ -101,16 +101,20 @@ const editPlaylist = (id: string) => {
             v-model="filterText"
           />
         </div>
-        <button
-          data-testid="save_module_settings"
-          class="btn btn-primary w-24"
-          aria-label="$t('playlists_view.new')"
-          :disabled="systemStatusStore.readOnly"
-          :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-          @click="newPlaylist"
+        <div
+          :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+          :data-tip="$t('systemStatus.readOnly.disabled')"
         >
-          {{ $t('playlists_view.new') }}
-        </button>
+          <button
+            data-testid="save_module_settings"
+            class="btn btn-primary w-24"
+            aria-label="$t('playlists_view.new')"
+            :disabled="systemStatusStore.readOnly"
+            @click="newPlaylist"
+          >
+            {{ $t('playlists_view.new') }}
+          </button>
+        </div>
       </div>
       <div class="flex flex-row flex-nowrap">
         <div class="grow"></div>
@@ -151,14 +155,18 @@ const editPlaylist = (id: string) => {
             {{ $t('playlists_view.delete_confirm', { name: deletePlaylistName }) }}
           </p>
           <div class="modal-action">
-            <button
-              class="btn btn-error"
-              :disabled="systemStatusStore.readOnly"
-              :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-              @click="confirmDelete"
+            <div
+              :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+              :data-tip="$t('systemStatus.readOnly.disabled')"
             >
-              {{ $t('delete') }}
-            </button>
+              <button
+                class="btn btn-error"
+                :disabled="systemStatusStore.readOnly"
+                @click="confirmDelete"
+              >
+                {{ $t('delete') }}
+              </button>
+            </div>
             <button
               class="btn"
               @click="closeDeleteModal"

--- a/astros_vue/src/views/ScripterView.vue
+++ b/astros_vue/src/views/ScripterView.vue
@@ -2,6 +2,7 @@
 import { onMounted, ref, useTemplateRef } from 'vue';
 import { ModalMode, ModalType, ScriptChannelType } from '@/enums';
 import { useScripterStore } from '@/stores/scripter';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 import { useRoute, onBeforeRouteLeave } from 'vue-router';
 import {
   AstrosLayout,
@@ -43,6 +44,7 @@ const channelTestValue = ref<ChannelTestValue | null>(null);
 
 const route = useRoute();
 const scripterStore = useScripterStore();
+const systemStatusStore = useSystemStatusStore();
 
 const { eventTypeToModalType, getDefaultScriptEvent } = useScriptEvents();
 
@@ -385,12 +387,16 @@ onMounted(async () => {
           </div>
           <button
             class="btn w-24 btn-primary"
+            :disabled="systemStatusStore.readOnly"
+            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
             @click="saveScript"
           >
             {{ $t('save') }}
           </button>
           <button
             class="btn w-24 btn-primary"
+            :disabled="systemStatusStore.readOnly"
+            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
             @click="scriptTest"
           >
             {{ $t('test') }}

--- a/astros_vue/src/views/ScripterView.vue
+++ b/astros_vue/src/views/ScripterView.vue
@@ -385,22 +385,30 @@ onMounted(async () => {
               :aria-label="$t('description')"
             />
           </div>
-          <button
-            class="btn w-24 btn-primary"
-            :disabled="systemStatusStore.readOnly"
-            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-            @click="saveScript"
+          <div
+            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+            :data-tip="$t('systemStatus.readOnly.disabled')"
           >
-            {{ $t('save') }}
-          </button>
-          <button
-            class="btn w-24 btn-primary"
-            :disabled="systemStatusStore.readOnly"
-            :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-            @click="scriptTest"
+            <button
+              class="btn w-24 btn-primary"
+              :disabled="systemStatusStore.readOnly"
+              @click="saveScript"
+            >
+              {{ $t('save') }}
+            </button>
+          </div>
+          <div
+            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+            :data-tip="$t('systemStatus.readOnly.disabled')"
           >
-            {{ $t('test') }}
-          </button>
+            <button
+              class="btn w-24 btn-primary"
+              :disabled="systemStatusStore.readOnly"
+              @click="scriptTest"
+            >
+              {{ $t('test') }}
+            </button>
+          </div>
         </div>
       </div>
       <AstrosPixiView

--- a/astros_vue/src/views/ScriptsView.vue
+++ b/astros_vue/src/views/ScriptsView.vue
@@ -126,15 +126,19 @@ const editScript = (id: string) => {
             v-model="filterText"
           />
         </div>
-        <button
-          data-testid="save_module_settings"
-          class="btn btn-primary w-24"
-          :disabled="systemStatusStore.readOnly"
-          :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-          @click="newScript"
+        <div
+          :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+          :data-tip="$t('systemStatus.readOnly.disabled')"
         >
-          {{ $t('scripts_view.new') }}
-        </button>
+          <button
+            data-testid="save_module_settings"
+            class="btn btn-primary w-24"
+            :disabled="systemStatusStore.readOnly"
+            @click="newScript"
+          >
+            {{ $t('scripts_view.new') }}
+          </button>
+        </div>
       </div>
       <div class="flex flex-row flex-nowrap">
         <div class="grow"></div>
@@ -190,14 +194,18 @@ const editScript = (id: string) => {
             </template>
           </p>
           <div class="modal-action">
-            <button
-              class="btn btn-error"
-              :disabled="systemStatusStore.readOnly"
-              :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-              @click="confirmDelete"
+            <div
+              :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+              :data-tip="$t('systemStatus.readOnly.disabled')"
             >
-              {{ $t('delete') }}
-            </button>
+              <button
+                class="btn btn-error"
+                :disabled="systemStatusStore.readOnly"
+                @click="confirmDelete"
+              >
+                {{ $t('delete') }}
+              </button>
+            </div>
             <button
               class="btn"
               @click="closeDeleteModal"

--- a/astros_vue/src/views/ScriptsView.vue
+++ b/astros_vue/src/views/ScriptsView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router';
 import { AstrosLayout, AstrosScriptRow } from '@/components';
 import { useToast } from '@/composables/useToast';
 import { useScriptsStore } from '@/stores/scripts';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 import { UploadStatus, Location } from '@/enums';
 import AstrosFieldFilter from '@/components/common/fields/AstrosFieldFilter.vue';
 import { useI18n } from 'vue-i18n';
@@ -13,6 +14,7 @@ const { t } = useI18n();
 const { success, error } = useToast();
 
 const scriptStore = useScriptsStore();
+const systemStatusStore = useSystemStatusStore();
 
 const showDeleteModal = ref(false);
 const deleteScriptId = ref('');
@@ -127,6 +129,8 @@ const editScript = (id: string) => {
         <button
           data-testid="save_module_settings"
           class="btn btn-primary w-24"
+          :disabled="systemStatusStore.readOnly"
+          :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
           @click="newScript"
         >
           {{ $t('scripts_view.new') }}
@@ -188,6 +192,8 @@ const editScript = (id: string) => {
           <div class="modal-action">
             <button
               class="btn btn-error"
+              :disabled="systemStatusStore.readOnly"
+              :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
               @click="confirmDelete"
             >
               {{ $t('delete') }}

--- a/astros_vue/src/views/UtilityView.vue
+++ b/astros_vue/src/views/UtilityView.vue
@@ -143,15 +143,19 @@ const closeAlert = () => {
                 {{ apiKey }}
               </div>
               <div class="float-right">
-                <button
-                  class="btn btn-primary w-35 px-5 py-0.75"
-                  aria-label="$t('generate')"
-                  :disabled="systemStatusStore.readOnly"
-                  :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-                  @click="generateApiKey"
+                <div
+                  :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+                  :data-tip="$t('systemStatus.readOnly.disabled')"
                 >
-                  {{ $t('generate') }}
-                </button>
+                  <button
+                    class="btn btn-primary w-35 px-5 py-0.75"
+                    aria-label="$t('generate')"
+                    :disabled="systemStatusStore.readOnly"
+                    @click="generateApiKey"
+                  >
+                    {{ $t('generate') }}
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -162,15 +166,19 @@ const closeAlert = () => {
             <div class="flex flex-row flex-nowrap">
               <div class="grow"></div>
               <div class="float-right">
-                <button
-                  class="btn btn-primary w-35 px-5 py-0.75"
-                  aria-label="$t('format')"
-                  :disabled="systemStatusStore.readOnly"
-                  :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-                  @click="openFormatModal"
+                <div
+                  :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+                  :data-tip="$t('systemStatus.readOnly.disabled')"
                 >
-                  {{ $t('format') }}
-                </button>
+                  <button
+                    class="btn btn-primary w-35 px-5 py-0.75"
+                    aria-label="$t('format')"
+                    :disabled="systemStatusStore.readOnly"
+                    @click="openFormatModal"
+                  >
+                    {{ $t('format') }}
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -220,14 +228,18 @@ const closeAlert = () => {
             </div>
           </div>
           <div class="modal-action">
-            <button
-              class="btn btn-primary"
-              :disabled="systemStatusStore.readOnly"
-              :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
-              @click="confirmFormat"
+            <div
+              :class="systemStatusStore.readOnly ? 'tooltip' : ''"
+              :data-tip="$t('systemStatus.readOnly.disabled')"
             >
-              {{ $t('ok') }}
-            </button>
+              <button
+                class="btn btn-primary"
+                :disabled="systemStatusStore.readOnly"
+                @click="confirmFormat"
+              >
+                {{ $t('ok') }}
+              </button>
+            </div>
             <button
               class="btn"
               @click="closeFormatModal"

--- a/astros_vue/src/views/UtilityView.vue
+++ b/astros_vue/src/views/UtilityView.vue
@@ -4,6 +4,9 @@ import { AstrosLayout } from '@/components';
 import apiService from '@/api/apiService';
 import type { ControllerModule } from '@/models';
 import { useI18n } from 'vue-i18n';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+
+const systemStatusStore = useSystemStatusStore();
 
 interface SelectedControllerModule extends ControllerModule {
   selected: boolean;
@@ -143,6 +146,8 @@ const closeAlert = () => {
                 <button
                   class="btn btn-primary w-35 px-5 py-0.75"
                   aria-label="$t('generate')"
+                  :disabled="systemStatusStore.readOnly"
+                  :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
                   @click="generateApiKey"
                 >
                   {{ $t('generate') }}
@@ -160,6 +165,8 @@ const closeAlert = () => {
                 <button
                   class="btn btn-primary w-35 px-5 py-0.75"
                   aria-label="$t('format')"
+                  :disabled="systemStatusStore.readOnly"
+                  :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
                   @click="openFormatModal"
                 >
                   {{ $t('format') }}
@@ -215,6 +222,8 @@ const closeAlert = () => {
           <div class="modal-action">
             <button
               class="btn btn-primary"
+              :disabled="systemStatusStore.readOnly"
+              :title="systemStatusStore.readOnly ? $t('systemStatus.readOnly.disabled') : ''"
               @click="confirmFormat"
             >
               {{ $t('ok') }}


### PR DESCRIPTION
## Summary

  Phase 3 of 3 of the DB Migration Safety Net feature, building on the
  Phase 1 backend (`/api/system/status` + WebSocket push + 503 writeGuard)
  and the Phase 2 schema migrations + FK enforcement.

  This phase makes the read-only state visible to operators and disables
  write-intent controls across the Vue frontend. It also closes a
  design-call gap that surfaced during review of Phase 1's "locked"
  decision.

  Plans:
  - `.docs/plans/20260410-0807-db-safety-phase3-vue-readonly-ui.md`
    (with two amendments inline at the end documenting the API-shape
    reasonCode change and the restore-success-enters-readonly change)

  ## What's in this PR

  ### Design-call change (cross-phase, commits `ea6963c` + `3495fa3`)

  Phase 1 originally said "restore success = server continues at
  pre-migration version." Re-evaluating: silent recovery hid migration
  failures from operators, and writes against the rolled-back schema
  risked compounding the underlying problem before a fix shipped.

  Added a new reasonCode `MIGRATION_FAILED_RESTORED`:

    - DB is at a known-good prior version (restore worked).
    - System enters read-only anyway. Operators see the banner, know to
      investigate before redeploying.
    - Distinct from `MIGRATION_FAILED_RESTORE_FAILED` (DB possibly
      broken) and `MIGRATION_FAILED_NO_BACKUP` (DB possibly partial).

  Updated the integration tests that asserted the old "system continues
  normally" behavior to assert the new read-only state.

  ### Vue infrastructure (`24e36cc`)

    - **`stores/systemStatus.ts`** (Pinia): `readOnly`, `reasonCode` (string
      union mirroring API), `enteredAt` refs. `fetchStatus()` reads
      `/api/system/status`; `setStatus()` invoked by WebSocket dispatcher
      and 503 interceptor. Fetch failure is non-throwing.
    - **`composables/useWebsocket.ts`**: dispatches `SYSTEM_STATUS`
      messages. New `SystemStatusWsMessage` model (the server payload
      has `{ type, data }` without the `success`/`message` envelope of
      other messages — modeled explicitly to keep the asymmetry honest).
    - **`App.vue`**: fetch status on mount before WebSocket connect.
      Belt-and-braces for the window between HTTP load and WS handshake.
    - **`enums/WebsocketMessageType.ts`**: `SYSTEM_STATUS = 9` mirrors
      Phase 1's API enum.
    - **i18n** (`enUS.json`): `systemStatus.reasonCode.*` (one per code +
      `UNKNOWN` fallback) and `systemStatus.readOnly.*` (UI strings).

  ### Banner + 503 interceptor (`f3fd991`)

    - **`SystemStatusBanner.vue`**: yellow alert at top of layout when
      `readOnly`. Maps reasonCode → localized message via explicit
      `KNOWN_CODES` allowlist + `UNKNOWN` fallback so unknown codes
      don't leak the raw key path. `role="status"` + `aria-live="polite"`.
    - Mounted above the navbar in `AstrosLayout.vue`.
    - **`apiService.ts`** response interceptor: detects `503` with
      `reasonCode` body shape (per `write_guard.ts`), syncs the store
      immediately, surfaces a warning toast, then rejects.

  ### Disable write-intent buttons (`5fdd61e`)

  | View | Disabled buttons |
  |---|---|
  | Modules | Save, Sync |
  | Scripts | New, Delete-confirm |
  | Scripter | Save, Test |
  | Playlists | New, Delete-confirm |
  | PlaylistEditor | Save |
  | Utility | Generate (API key), Format (SD), Format-confirm |

  Explicitly NOT disabled: Login, Logout, Download Logs, panicStop /
  panicClear (server allowlists these), filters, modal close/cancel,
  navigation, accordion toggles.

  ### QA plan (`217c0a4`)

  `.docs/qa/system-readonly-mode.md` — eight test cases covering banner
  appearance, persistence, button state, 503 toast, login/panic still
  working, recovery, and the unknown-reasonCode fallback. Plus three
  documented ways to force each reasonCode locally.

  ## Test plan

  - [x] **API**: `npx vitest run` — **242/242 passing**. The two affected
    tests (`failed migration triggers restore` and the
    `foreign_key_check` regression) now correctly assert read-only state
    with the new reasonCode rather than "system continues normally."
  - [x] **Vue**: `npx vitest run` — **15/15 passing**:
    - 8 systemStatus store transitions
    - 6 SystemStatusBanner render variants (hidden, four known codes
      incl. `MIGRATION_FAILED_RESTORED`, null/unknown fallbacks, a11y
      attrs)
    - 1 pre-existing utility test
  - [x] `npx tsc --noEmit` (API) — clean
  - [x] `npx vue-tsc --noEmit` (Vue) — clean
  - [x] `npm run lint:fix` (both) — clean
  - [x] `npm run prettier:write` (both) — clean
  - [ ] **Manual QA**: follow `.docs/qa/system-readonly-mode.md`. Critical
    path: scenarios 1, 2, 3, 4 (devtools 503 probe), 6 (panic still works),
    7 (recovery).

  ## Notes

  - Per CLAUDE.md i18n rule: zero hardcoded user-facing strings — every
    banner message, tooltip, and toast routes through `enUS.json`.
  - The banner is chrome — it doesn't block interaction with the rest of
    the UI. Only buttons explicitly bound to `readOnly` are disabled.
  - Future-proof: `KNOWN_CODES` allowlist + `UNKNOWN` fallback means
    the client can ship before the API adds new reasonCodes without
    leaking raw keys to operators.