### PR TITLE
astros write button

### DIFF
--- a/astros_vue/src/components/common/AstrosWriteButton.stories.ts
+++ b/astros_vue/src/components/common/AstrosWriteButton.stories.ts
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { createPinia, setActivePinia } from 'pinia';
+import AstrosWriteButton from './AstrosWriteButton.vue';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+
+const meta = {
+  title: 'Components/Common/AstrosWriteButton',
+  component: AstrosWriteButton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AstrosWriteButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Each story owns its Pinia instance so readOnly state doesn't bleed.
+
+export const Default: Story = {
+  render: () => ({
+    components: { AstrosWriteButton },
+    setup() {
+      setActivePinia(createPinia());
+      return {};
+    },
+    template: `
+      <AstrosWriteButton class="btn btn-primary w-32">
+        Save
+      </AstrosWriteButton>
+    `,
+  }),
+};
+
+export const ReadOnly: Story = {
+  render: () => ({
+    components: { AstrosWriteButton },
+    setup() {
+      setActivePinia(createPinia());
+      useSystemStatusStore().setStatus({
+        readOnly: true,
+        reasonCode: 'BACKUP_FAILED',
+      });
+      return {};
+    },
+    template: `
+      <div class="p-8">
+        <AstrosWriteButton class="btn btn-primary w-32">
+          Save
+        </AstrosWriteButton>
+      </div>
+    `,
+  }),
+};
+
+export const DisabledByCaller: Story = {
+  render: () => ({
+    components: { AstrosWriteButton },
+    setup() {
+      setActivePinia(createPinia());
+      return {};
+    },
+    template: `
+      <AstrosWriteButton :disabled="true" class="btn btn-primary w-32">
+        Save (loading)
+      </AstrosWriteButton>
+    `,
+  }),
+};
+
+export const WithIconAndText: Story = {
+  render: () => ({
+    components: { AstrosWriteButton },
+    setup() {
+      setActivePinia(createPinia());
+      return {};
+    },
+    template: `
+      <AstrosWriteButton class="btn btn-primary">
+        <span>💾</span>
+        <span>Save</span>
+      </AstrosWriteButton>
+    `,
+  }),
+};

--- a/astros_vue/src/components/common/AstrosWriteButton.vue
+++ b/astros_vue/src/components/common/AstrosWriteButton.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+
+interface Props {
+  // Optional caller-supplied disabled state (loading, validation, etc.).
+  // ORed with the system read-only state so callers don't lose capability
+  // vs. the hand-rolled inline pattern this component replaces.
+  disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), { disabled: false });
+
+const { t } = useI18n();
+const systemStatusStore = useSystemStatusStore();
+
+const isReadOnlyDisabled = computed(() => systemStatusStore.readOnly);
+const isDisabled = computed(() => props.disabled || isReadOnlyDisabled.value);
+
+// Route every other attribute (class, data-testid, type, aria-*) onto the
+// inner button rather than the wrapper div. Without this, Vue would default
+// to setting them on the root element of the template — which is the tooltip
+// wrapper, not the button.
+defineOptions({ inheritAttrs: false });
+</script>
+
+<template>
+  <div
+    :class="isReadOnlyDisabled ? 'tooltip' : ''"
+    :data-tip="t('systemStatus.readOnly.disabled')"
+  >
+    <button
+      v-bind="$attrs"
+      :disabled="isDisabled"
+    >
+      <slot />
+    </button>
+  </div>
+</template>

--- a/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
+++ b/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createI18n } from 'vue-i18n';
+import enUS from '@/locales/enUS.json';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
+import { useSystemStatusStore } from '@/stores/systemStatus';
+
+function createTestI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'enUS',
+    fallbackLocale: 'enUS',
+    messages: { enUS },
+  });
+}
+
+function mountButton(
+  opts: {
+    attrs?: Record<string, unknown>;
+    props?: Record<string, unknown>;
+    slot?: string;
+  } = {},
+) {
+  return mount(AstrosWriteButton, {
+    attrs: opts.attrs,
+    props: opts.props,
+    slots: { default: opts.slot ?? 'Save' },
+    global: { plugins: [createTestI18n()] },
+  });
+}
+
+describe('AstrosWriteButton', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders slot content as the button label', () => {
+    const wrapper = mountButton({ slot: 'Custom Label' });
+    expect(wrapper.find('button').text()).toBe('Custom Label');
+  });
+
+  it('is enabled when readOnly is false and no disabled prop', () => {
+    const wrapper = mountButton();
+    const button = wrapper.find('button');
+    expect(button.attributes('disabled')).toBeUndefined();
+  });
+
+  it('is disabled when systemStatus.readOnly is true', async () => {
+    const store = useSystemStatusStore();
+    store.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+
+    const wrapper = mountButton();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+  });
+
+  it('is disabled when caller passes disabled prop true even if readOnly is false', () => {
+    const wrapper = mountButton({ props: { disabled: true } });
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+  });
+
+  it('applies the tooltip class to the wrapper only when readOnly is true', async () => {
+    // Not read-only: no tooltip class.
+    let wrapper = mountButton();
+    expect(wrapper.find('div').classes()).not.toContain('tooltip');
+
+    // Read-only: tooltip class present.
+    setActivePinia(createPinia());
+    useSystemStatusStore().setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    wrapper = mountButton();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('div').classes()).toContain('tooltip');
+  });
+
+  it('forwards data-testid onto the inner button (not the wrapper)', () => {
+    const wrapper = mountButton({ attrs: { 'data-testid': 'save-button' } });
+    const button = wrapper.find('button');
+    expect(button.attributes('data-testid')).toBe('save-button');
+    // Wrapper div should NOT carry the testid.
+    expect(wrapper.find('div').attributes('data-testid')).toBeUndefined();
+  });
+
+  it('forwards class onto the inner button (not the wrapper)', () => {
+    const wrapper = mountButton({ attrs: { class: 'btn btn-primary w-24' } });
+    const button = wrapper.find('button');
+    expect(button.classes()).toContain('btn');
+    expect(button.classes()).toContain('btn-primary');
+    expect(button.classes()).toContain('w-24');
+  });
+
+  it('emits click events from the underlying button when enabled', async () => {
+    const wrapper = mountButton();
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.emitted('click')).toBeTruthy();
+    expect(wrapper.emitted('click')).toHaveLength(1);
+  });
+
+  it('does not emit click when the button is disabled by readOnly', async () => {
+    useSystemStatusStore().setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    const wrapper = mountButton();
+    await wrapper.vm.$nextTick();
+    await wrapper.find('button').trigger('click');
+    // Browsers suppress click on disabled buttons; jsdom respects this too.
+    expect(wrapper.emitted('click')).toBeUndefined();
+  });
+});

--- a/astros_vue/src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue
+++ b/astros_vue/src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue
@@ -6,8 +6,8 @@ import { PlaylistType } from '@/enums/playlists/playlistType';
 import { v4 as uuid } from 'uuid';
 import AstrosPlaylistSettings from './AstrosPlaylistSettings.vue';
 import AstrosPlaylistTrack from './AstrosPlaylistTrack.vue';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import { usePlaylistsStore } from '@/stores/playlists';
-import { useSystemStatusStore } from '@/stores/systemStatus';
 import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { AstrosConfirmModal, AstrosHtmlModal } from '@/components/modals';
@@ -21,7 +21,6 @@ const { success, error } = useToast();
 const route = useRoute();
 const router = useRouter();
 const playlistStore = usePlaylistsStore();
-const systemStatusStore = useSystemStatusStore();
 const { selectedPlaylist } = storeToRefs(playlistStore);
 const playlist = computed(() => selectedPlaylist.value!);
 
@@ -242,19 +241,13 @@ async function save() {
     <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0">
       <h1 class="text-2xl font-bold">{{ $t('playlist_editor_view.title') }}</h1>
       <div class="grow"></div>
-      <div
-        :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-        :data-tip="$t('systemStatus.readOnly.disabled')"
+      <AstrosWriteButton
+        data-testid="save_module_settings"
+        class="btn btn-primary w-24"
+        @click="save"
       >
-        <button
-          data-testid="save_module_settings"
-          class="btn btn-primary w-24"
-          :disabled="systemStatusStore.readOnly"
-          @click="save"
-        >
-          {{ $t('playlist_editor_view.save') }}
-        </button>
-      </div>
+        {{ $t('playlist_editor_view.save') }}
+      </AstrosWriteButton>
     </div>
     <div class="min-h-0 flex-1 flex">
       <div class="grow"></div>

--- a/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
+++ b/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import AstrosRemoteButton from './AstrosRemoteButton.vue';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import type { RemoteControlPage } from '@/models/remoteControl/remoteControlPage';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import { useScriptsStore } from '@/stores/scripts';
 import { usePlaylistsStore } from '@/stores/playlists';
 import { useRemoteControlStore } from '@/stores/remoteControl';
-import { useSystemStatusStore } from '@/stores/systemStatus';
 import { useToast } from '@/composables/useToast';
 import { useI18n } from 'vue-i18n';
 
@@ -20,7 +20,6 @@ interface SelectionItem {
 const scriptStore = useScriptsStore();
 const playlistStore = usePlaylistsStore();
 const remoteControlStore = useRemoteControlStore();
-const systemStatusStore = useSystemStatusStore();
 const { success, error } = useToast();
 
 const pageNumber = ref(1);
@@ -106,19 +105,13 @@ const buttonNumbers = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const;
     <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0">
       <h1 class="text-2xl font-bold">{{ $t('remote_view.title') }}</h1>
       <div class="grow"></div>
-      <div
-        :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-        :data-tip="$t('systemStatus.readOnly.disabled')"
+      <AstrosWriteButton
+        data-testid="save_module_settings"
+        class="btn btn-primary w-24"
+        @click="saveConfig"
       >
-        <button
-          data-testid="save_module_settings"
-          class="btn btn-primary w-24"
-          :disabled="systemStatusStore.readOnly"
-          @click="saveConfig"
-        >
-          {{ $t('remote_view.save') }}
-        </button>
-      </div>
+        {{ $t('remote_view.save') }}
+      </AstrosWriteButton>
     </div>
 
     <!-- Page Navigation -->

--- a/astros_vue/src/views/ModulesView.vue
+++ b/astros_vue/src/views/ModulesView.vue
@@ -3,7 +3,6 @@ import { ref, computed } from 'vue';
 import type { AddModuleEvent, RemoveModuleEvent, ServoTestEvent } from '@/models/events';
 import { useLocationStore } from '@/stores/location';
 import { useControllerStore } from '@/stores/controller';
-import { useSystemStatusStore } from '@/stores/systemStatus';
 import { Location, ModalType, ControllerStatus } from '@/enums';
 import { useModuleManagement } from '@/composables/useModuleManagement';
 import {
@@ -16,6 +15,7 @@ import {
   AstrosAddModuleModal,
   AstrosServoTestModal,
 } from '@/components';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import apiService from '@/api/apiService';
 import { SYNC_CONFIG } from '@/api/endpoints';
 import { useToast } from '@/composables/useToast';
@@ -37,7 +37,6 @@ const openAccordion = ref<string | null>(null);
 
 const locationStore = useLocationStore();
 const controllerStore = useControllerStore();
-const systemStatusStore = useSystemStatusStore();
 
 const { success, error } = useToast();
 
@@ -151,31 +150,19 @@ function controllerSelectChanged(location: string) {
         <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0 mb-4">
           <h1 class="text-2xl font-bold">{{ $t('module_view.modules') }}</h1>
           <div class="grow"></div>
-          <div
-            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-            :data-tip="$t('systemStatus.readOnly.disabled')"
+          <AstrosWriteButton
+            data-testid="save_module_settings"
+            class="btn btn-primary w-24"
+            @click="saveModuleSettings"
           >
-            <button
-              data-testid="save_module_settings"
-              class="btn btn-primary w-24"
-              :disabled="systemStatusStore.readOnly"
-              @click="saveModuleSettings"
-            >
-              {{ $t('module_view.save') }}
-            </button>
-          </div>
-          <div
-            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-            :data-tip="$t('systemStatus.readOnly.disabled')"
+            {{ $t('module_view.save') }}
+          </AstrosWriteButton>
+          <AstrosWriteButton
+            class="btn btn-primary w-24"
+            @click="syncModuleSettings"
           >
-            <button
-              class="btn btn-primary w-24"
-              :disabled="systemStatusStore.readOnly"
-              @click="syncModuleSettings"
-            >
-              {{ $t('module_view.sync') }}
-            </button>
-          </div>
+            {{ $t('module_view.sync') }}
+          </AstrosWriteButton>
         </div>
 
         <!-- Module Accordions -->

--- a/astros_vue/src/views/PlaylistsView.vue
+++ b/astros_vue/src/views/PlaylistsView.vue
@@ -1,19 +1,18 @@
 <script setup lang="ts">
 import { useToast } from '@/composables/useToast';
 import { usePlaylistsStore } from '@/stores/playlists';
-import { useSystemStatusStore } from '@/stores/systemStatus';
 import { ref, onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { AstrosLayout, AstrosPlaylistRow } from '@/components';
 import AstrosFieldFilter from '@/components/common/fields/AstrosFieldFilter.vue';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 
 const router = useRouter();
 const { t } = useI18n();
 const { success, error } = useToast();
 
 const playlistStore = usePlaylistsStore();
-const systemStatusStore = useSystemStatusStore();
 
 const showDeleteModal = ref(false);
 const deletePlaylistId = ref('');
@@ -101,20 +100,14 @@ const editPlaylist = (id: string) => {
             v-model="filterText"
           />
         </div>
-        <div
-          :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-          :data-tip="$t('systemStatus.readOnly.disabled')"
+        <AstrosWriteButton
+          data-testid="save_module_settings"
+          class="btn btn-primary w-24"
+          aria-label="$t('playlists_view.new')"
+          @click="newPlaylist"
         >
-          <button
-            data-testid="save_module_settings"
-            class="btn btn-primary w-24"
-            aria-label="$t('playlists_view.new')"
-            :disabled="systemStatusStore.readOnly"
-            @click="newPlaylist"
-          >
-            {{ $t('playlists_view.new') }}
-          </button>
-        </div>
+          {{ $t('playlists_view.new') }}
+        </AstrosWriteButton>
       </div>
       <div class="flex flex-row flex-nowrap">
         <div class="grow"></div>
@@ -155,18 +148,12 @@ const editPlaylist = (id: string) => {
             {{ $t('playlists_view.delete_confirm', { name: deletePlaylistName }) }}
           </p>
           <div class="modal-action">
-            <div
-              :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-              :data-tip="$t('systemStatus.readOnly.disabled')"
+            <AstrosWriteButton
+              class="btn btn-error"
+              @click="confirmDelete"
             >
-              <button
-                class="btn btn-error"
-                :disabled="systemStatusStore.readOnly"
-                @click="confirmDelete"
-              >
-                {{ $t('delete') }}
-              </button>
-            </div>
+              {{ $t('delete') }}
+            </AstrosWriteButton>
             <button
               class="btn"
               @click="closeDeleteModal"

--- a/astros_vue/src/views/ScripterView.vue
+++ b/astros_vue/src/views/ScripterView.vue
@@ -2,7 +2,6 @@
 import { onMounted, ref, useTemplateRef } from 'vue';
 import { ModalMode, ModalType, ScriptChannelType } from '@/enums';
 import { useScripterStore } from '@/stores/scripter';
-import { useSystemStatusStore } from '@/stores/systemStatus';
 import { useRoute, onBeforeRouteLeave } from 'vue-router';
 import {
   AstrosLayout,
@@ -26,6 +25,7 @@ import { useToast } from '@/composables/useToast';
 import { useI18n } from 'vue-i18n';
 import { v4 as uuid } from 'uuid';
 import AstrosChannelSwapModal from '@/components/modals/scripter/AstrosChannelSwapModal.vue';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import apiService from '@/api/apiService';
 import { SCRIPTS_TEST_CHANNEL } from '@/api/endpoints';
 
@@ -44,7 +44,6 @@ const channelTestValue = ref<ChannelTestValue | null>(null);
 
 const route = useRoute();
 const scripterStore = useScripterStore();
-const systemStatusStore = useSystemStatusStore();
 
 const { eventTypeToModalType, getDefaultScriptEvent } = useScriptEvents();
 
@@ -385,30 +384,18 @@ onMounted(async () => {
               :aria-label="$t('description')"
             />
           </div>
-          <div
-            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-            :data-tip="$t('systemStatus.readOnly.disabled')"
+          <AstrosWriteButton
+            class="btn w-24 btn-primary"
+            @click="saveScript"
           >
-            <button
-              class="btn w-24 btn-primary"
-              :disabled="systemStatusStore.readOnly"
-              @click="saveScript"
-            >
-              {{ $t('save') }}
-            </button>
-          </div>
-          <div
-            :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-            :data-tip="$t('systemStatus.readOnly.disabled')"
+            {{ $t('save') }}
+          </AstrosWriteButton>
+          <AstrosWriteButton
+            class="btn w-24 btn-primary"
+            @click="scriptTest"
           >
-            <button
-              class="btn w-24 btn-primary"
-              :disabled="systemStatusStore.readOnly"
-              @click="scriptTest"
-            >
-              {{ $t('test') }}
-            </button>
-          </div>
+            {{ $t('test') }}
+          </AstrosWriteButton>
         </div>
       </div>
       <AstrosPixiView

--- a/astros_vue/src/views/ScriptsView.vue
+++ b/astros_vue/src/views/ScriptsView.vue
@@ -4,9 +4,9 @@ import { useRouter } from 'vue-router';
 import { AstrosLayout, AstrosScriptRow } from '@/components';
 import { useToast } from '@/composables/useToast';
 import { useScriptsStore } from '@/stores/scripts';
-import { useSystemStatusStore } from '@/stores/systemStatus';
 import { UploadStatus, Location } from '@/enums';
 import AstrosFieldFilter from '@/components/common/fields/AstrosFieldFilter.vue';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import { useI18n } from 'vue-i18n';
 
 const router = useRouter();
@@ -14,7 +14,6 @@ const { t } = useI18n();
 const { success, error } = useToast();
 
 const scriptStore = useScriptsStore();
-const systemStatusStore = useSystemStatusStore();
 
 const showDeleteModal = ref(false);
 const deleteScriptId = ref('');
@@ -126,19 +125,13 @@ const editScript = (id: string) => {
             v-model="filterText"
           />
         </div>
-        <div
-          :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-          :data-tip="$t('systemStatus.readOnly.disabled')"
+        <AstrosWriteButton
+          data-testid="save_module_settings"
+          class="btn btn-primary w-24"
+          @click="newScript"
         >
-          <button
-            data-testid="save_module_settings"
-            class="btn btn-primary w-24"
-            :disabled="systemStatusStore.readOnly"
-            @click="newScript"
-          >
-            {{ $t('scripts_view.new') }}
-          </button>
-        </div>
+          {{ $t('scripts_view.new') }}
+        </AstrosWriteButton>
       </div>
       <div class="flex flex-row flex-nowrap">
         <div class="grow"></div>
@@ -194,18 +187,12 @@ const editScript = (id: string) => {
             </template>
           </p>
           <div class="modal-action">
-            <div
-              :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-              :data-tip="$t('systemStatus.readOnly.disabled')"
+            <AstrosWriteButton
+              class="btn btn-error"
+              @click="confirmDelete"
             >
-              <button
-                class="btn btn-error"
-                :disabled="systemStatusStore.readOnly"
-                @click="confirmDelete"
-              >
-                {{ $t('delete') }}
-              </button>
-            </div>
+              {{ $t('delete') }}
+            </AstrosWriteButton>
             <button
               class="btn"
               @click="closeDeleteModal"

--- a/astros_vue/src/views/UtilityView.vue
+++ b/astros_vue/src/views/UtilityView.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { AstrosLayout } from '@/components';
+import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import apiService from '@/api/apiService';
 import type { ControllerModule } from '@/models';
 import { useI18n } from 'vue-i18n';
-import { useSystemStatusStore } from '@/stores/systemStatus';
-
-const systemStatusStore = useSystemStatusStore();
 
 interface SelectedControllerModule extends ControllerModule {
   selected: boolean;
@@ -143,19 +141,13 @@ const closeAlert = () => {
                 {{ apiKey }}
               </div>
               <div class="float-right">
-                <div
-                  :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-                  :data-tip="$t('systemStatus.readOnly.disabled')"
+                <AstrosWriteButton
+                  class="btn btn-primary w-35 px-5 py-0.75"
+                  aria-label="$t('generate')"
+                  @click="generateApiKey"
                 >
-                  <button
-                    class="btn btn-primary w-35 px-5 py-0.75"
-                    aria-label="$t('generate')"
-                    :disabled="systemStatusStore.readOnly"
-                    @click="generateApiKey"
-                  >
-                    {{ $t('generate') }}
-                  </button>
-                </div>
+                  {{ $t('generate') }}
+                </AstrosWriteButton>
               </div>
             </div>
           </div>
@@ -166,19 +158,13 @@ const closeAlert = () => {
             <div class="flex flex-row flex-nowrap">
               <div class="grow"></div>
               <div class="float-right">
-                <div
-                  :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-                  :data-tip="$t('systemStatus.readOnly.disabled')"
+                <AstrosWriteButton
+                  class="btn btn-primary w-35 px-5 py-0.75"
+                  aria-label="$t('format')"
+                  @click="openFormatModal"
                 >
-                  <button
-                    class="btn btn-primary w-35 px-5 py-0.75"
-                    aria-label="$t('format')"
-                    :disabled="systemStatusStore.readOnly"
-                    @click="openFormatModal"
-                  >
-                    {{ $t('format') }}
-                  </button>
-                </div>
+                  {{ $t('format') }}
+                </AstrosWriteButton>
               </div>
             </div>
           </div>
@@ -228,18 +214,12 @@ const closeAlert = () => {
             </div>
           </div>
           <div class="modal-action">
-            <div
-              :class="systemStatusStore.readOnly ? 'tooltip' : ''"
-              :data-tip="$t('systemStatus.readOnly.disabled')"
+            <AstrosWriteButton
+              class="btn btn-primary"
+              @click="confirmFormat"
             >
-              <button
-                class="btn btn-primary"
-                :disabled="systemStatusStore.readOnly"
-                @click="confirmFormat"
-              >
-                {{ $t('ok') }}
-              </button>
-            </div>
+              {{ $t('ok') }}
+            </AstrosWriteButton>
             <button
               class="btn"
               @click="closeFormatModal"


### PR DESCRIPTION
  ## Summary

  Follow-up cleanup to PR #61 (Phase 3). The Phase 3 work introduced a
  read-only-disable + DaisyUI tooltip pattern at 12 button call sites
  across 7 files, each with its own `useSystemStatusStore` import and
  ~6 lines of wrapper markup. This PR extracts the pattern into a
  shared `<AstrosWriteButton>` component.

  Net change: **-86 lines** (12 inline wrappers + 7 store imports/consts
  removed; ~12 component usages added).

  ## What's in this PR

  ### Commit 1 — `8ef7694` add component + tests + story

  `src/components/common/AstrosWriteButton.vue` — thin wrapper that
  internally reads the `systemStatus` store, renders the DaisyUI tooltip
  wrapper with the localized disabled hint, and renders a `<button>`
  with disabled state ORed with any caller-supplied `disabled` prop.
  `inheritAttrs: false` + `v-bind="$attrs"` routes
  `class`/`data-testid`/`type`/`aria-*` onto the inner button rather
  than the wrapper div.

  ```vue
  <AstrosWriteButton
    data-testid="save_module_settings"
    class="btn btn-primary w-24"
    @click="saveModuleSettings"
  >
    {{ $t('module_view.save') }}
  </AstrosWriteButton>

  Optional disabled prop ORs with read-only — keeps capability parity
  with the inline pattern (none of the existing call sites use it
  today, but it's there for future loading/validation guards).

  Nine tests cover slot rendering, enabled/disabled per readOnly +
  caller prop, tooltip class only when readOnly, $attrs forwarding
  for both data-testid and class onto the inner button (not the
  wrapper), click emission when enabled, and click suppression when
  disabled. Storybook covers Default, ReadOnly, DisabledByCaller, and
  WithIconAndText.

  Commit 2 — 17b0906 replace inline pattern at all 12 call sites

  Files touched (drops the per-file useSystemStatusStore import +
  const declaration too — none of the views read the store for
  anything else):

  - src/views/ModulesView.vue (Save, Sync)
  - src/views/ScriptsView.vue (New, modal Delete)
  - src/views/PlaylistsView.vue (New, modal Delete)
  - src/views/ScripterView.vue (Save, Test)
  - src/views/UtilityView.vue (Generate, Format, modal OK)
  - src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue (Save)
  - src/components/remoteControl/AstrosRemoteControl.vue (Save)

  No behavior change. Disabled-state logic, tooltip rendering, and the
  i18n key are identical — they just live in one component now.

  Test plan

  - npx vitest run — 24/24 passing (9 new AstrosWriteButton +
  15 from prior phases).
  - npx vue-tsc --noEmit — clean.
  - npm run lint — clean.
  - npx prettier --write 'src/**/*.{vue,ts,json}' — clean.
  - Manual: in dev mode, force read-only (per
  .docs/qa/system-readonly-mode.md), confirm every Save / New /
  Delete-confirm / Generate / Format / Sync / Test button is
  grayed out and shows the tooltip on hover. Recovery clears them
  all.

  Notes

  - After this lands, the systemStatus store has exactly two consumers
  in src/: AstrosWriteButton.vue (button-disable + tooltip) and
  SystemStatusBanner.vue (visibility check). No more per-view
  imports.
  - A more general <ReadOnlyGuard> slot wrapper for non-button
  write-intent UI (selects, inputs, anchors) is still YAGNI — none
  exist today. If/when one shows up, that's a separate component.