### PR TITLE
Firmware OTA Job Lock

### DIFF
--- a/.docs/plans/20260427-2202-firmware-ota-decomposition.md
+++ b/.docs/plans/20260427-2202-firmware-ota-decomposition.md
@@ -12,7 +12,7 @@ The work is significant because the existing bulk-data transport in firmware is 
 
 | # | Name | Repo | Scope | Blocked by | Plan file path | Shippable alone? |
 |---|------|------|-------|------------|----------------|-------------------|
-| **c0** | Platform prerequisites | AstrOs.Server | DB column for `firmware_version` (migration_7), thread heartbeat version into controllers store, `JobLock` singleton with subscribe/notify, new `lockStateChanged` `TransmissionType`. No UI, no OTA. | — | `astros-server/.docs/plans/<date>-firmware-ota-c0-platform.md` | Yes — version persistence is independently useful for compatibility checks. |
+| **c0** | Platform prerequisites | AstrOs.Server | `JobLock` singleton with subscribe/notify, `requireUnlocked` Express middleware, new `lockStateChanged` `TransmissionType`, Vue lock store + WS handler. No firmware-version DB persistence — heartbeats arrive every 2 s and the orchestrator captures starting versions in-memory; persistence would be misleading while a controller is offline. | — | `astros-server/.docs/plans/<date>-firmware-ota-c0-job-lock.md` | Yes — `JobLock` is reusable for any future write-blocking operation. |
 | **a** | Bulk transport hardening | AstrOs.ESP | Replace `PacketTracker` with chunked, CRC-checked, ACK-driven, streaming-receive transport. Works over both serial (master side) and ESP-NOW (padawan side). New `BulkReceiver` callback API. Side-effect: fixes the half-built script-deploy bulk path. | — | `AstrOs.ESP/.docs/plans/<date>-bulk-transport-hardening.md` (create dir; mirror Server convention) | No — only meaningful when consumed by **b**. |
 | **b** | OTA receiver | AstrOs.ESP | Master serial→SD writer; master SD→ESP-NOW forwarder (sequential); padawan ESP-NOW→`esp_ota_*` streaming writer; SHA-256 verify; commit + reboot; version-after-reboot via existing 2 s heartbeat. | **a** | `AstrOs.ESP/.docs/plans/<date>-ota-receiver.md` | No — useless without **c**. |
 | **c** | Server orchestrator | AstrOs.Server | New `SerialMessageType` values; flash-job state machine; GitHub release fetch + 5-min cache + on-disk `.bin` cache (LRU N=5); upload handler with `esp_app_desc_t` validation; SHA-256 stream-hash; per-controller progress tracking; WebSocket fan-out; integrate with `JobLock`. | **c0**, **a** protocol freeze | `astros-server/.docs/plans/<date>-firmware-ota-server.md` | No — needs UI to be useful. |
@@ -29,14 +29,14 @@ Every PR in every sub-project must be:
 
 This means each sub-project decomposes into multiple PRs, each with its own light or full plan in `.docs/plans/` per CLAUDE.md. Approximate split (detailed in the Implementation roadmap below):
 
-- **c0** → 2 PRs
+- **c0** → 1 PR
 - **a** → 5 PRs (AstrOs.ESP)
 - **b** → 4 PRs (AstrOs.ESP)
 - **c** → 8 PRs
 - **d** → 7 PRs
 - Plus: shared `protocol.md` freeze, real-hardware wire-up, integrated QA = ~3 PRs
 
-Total project ≈ 24 PRs. Each leaves the codebase shippable.
+Total project ≈ 23 PRs. Each leaves the codebase shippable.
 
 ## Protocol contract
 
@@ -342,8 +342,7 @@ Each PR gets its own light plan in `.docs/plans/` with a `YYYYMMDD-HHmm-firmware
 
 **c0 — Platform prerequisites (server):**
 
-- [ ] **c0.1** `firmware_version` column (migration_7) + repo upsert + POLL_ACK handler call + tests. Testable: heartbeat updates DB; `meetsMinimum` gate continues to work; controllers GET surfaces persisted version.
-- [ ] **c0.2** `JobLock` singleton + `requireUnlocked` middleware + `lockStateChanged` `TransmissionType` + WS broadcast + Vue lock store + handler. Apply middleware to one example route as smoke test (full route set is **c.2**). Testable: unit + integration tests covering 423 response; live UI banner on lock state change.
+- [ ] **c0** `JobLock` singleton + `requireUnlocked` middleware + `lockStateChanged` `TransmissionType` + WS broadcast + Vue lock store + handler. Apply middleware to one example route as smoke test (full route set is **c.2**). Testable: unit + integration tests covering 423 response; live UI banner on lock-state change. Note: no DB persistence of `firmware_version` — orchestrator captures starting versions in-memory from heartbeats; persisted state would be misleading while a controller is offline.
 
 **Shared protocol freeze:**
 

--- a/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
+++ b/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
@@ -45,7 +45,7 @@ No flash-job code lands in this PR — the lock primitive ships standalone and i
 7. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`
 8. `astros_vue/src/enums/WebsocketMessageType.ts` — append `LOCK_STATE_CHANGED = 10`
 9. `astros_vue/src/stores/jobLock.ts` — new composition-style store
-10. `astros_vue/src/stores/__tests__/jobLock.test.ts` — new tests
+10. `astros_vue/src/stores/__tests__/jobLock.spec.ts` — new tests (`.spec.ts` matches the existing `systemStatus.spec.ts` convention)
 11. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`
 
 11 files — one over the soft cap. Justified in the PR description by the typed-model split: keeping `LockState` / `LockStateResponse` / `LockedErrorResponse` in `models/networking/` matches the repo's existing payload-typing convention (e.g., `StatusResponse`, `ControllersResponse`) instead of inlining shapes inside the middleware and the WS broadcast site.

--- a/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
+++ b/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
@@ -1,0 +1,63 @@
+# c0 — JobLock + lockStateChanged
+
+Light plan for the Platform-prerequisites PR of the firmware-OTA decomposition. Reference: [`20260427-2202-firmware-ota-decomposition.md`](./20260427-2202-firmware-ota-decomposition.md).
+
+**Branch:** `feature/firmware-ota-c0-job-lock` (off `develop`).
+**PR target base:** `develop`.
+
+## Context
+
+The firmware-OTA orchestrator needs a server-wide write lock so an in-progress flash job can guarantee no other write-class operation (script edits, deploys, runs, controller config changes, format-SD, servo-test, etc.) hits the hardware mid-flash. This PR introduces the lock primitive and its transport to UIs:
+
+- A `JobLock` singleton with `acquire / release / isLocked / getOwner / subscribe`.
+- A `requireUnlocked` Express middleware factory that returns HTTP 423 + JSON body when the lock is held.
+- A new `lockStateChanged` `TransmissionType` (server) + matching `WebsocketMessageType` entry (Vue) so connected clients reflect lock state in real time.
+- A small `jobLock` Pinia store on the Vue side, populated from the WS event.
+
+Apply the middleware to **one** route in this PR (`POST /api/panicStop`) as a smoke-test integration point. Applying it to the full write-route set is **c.2**, the next sub-project's first PR.
+
+No flash-job code lands in this PR — the lock primitive ships standalone and is independently testable. Other future write-blocking operations (e.g., long-running migrations) can reuse it without changes.
+
+## Tasks
+
+- [ ] Add `JobLock` singleton (`astros_api/src/job_lock.ts`) with subscribe/notify, plus unit tests covering acquire / release / double-acquire-rejected / subscribe-fan-out / unsubscribe.
+- [ ] Add `requireUnlocked` middleware factory (`astros_api/src/job_lock_middleware.ts`) that returns 423 + JSON `{ error: 'flashJobActive', lockOwner, since }` when locked. Tests cover unlocked-passes / locked-blocks / response shape.
+- [ ] Append `lockStateChanged` to `TransmissionType` in `astros_api/src/models/enums.ts` (next free numeric value = 10). Append matching `LOCK_STATE_CHANGED = 10` to Vue's `WebsocketMessageType` (`astros_vue/src/enums/WebsocketMessageType.ts`). Verify by inspection that all existing entries keep their current numeric values.
+- [ ] Wire `JobLock.subscribe(state => updateClients({ type: TransmissionType.lockStateChanged, data: state }))` in `api_server.ts`. Apply `requireUnlocked` middleware to `POST /api/panicStop` as the smoke-test endpoint. Wire-up + assertion that the WS broadcast fires on acquire/release.
+- [ ] Vue side: new composition-style `astros_vue/src/stores/jobLock.ts` tracking `{ locked, owner, since }`. Add `handleLockStateChanged` to `useWebsocket.ts` switch. Tests for the store.
+
+## Verification
+
+- [ ] `npm run build` clean (lint + tsc) in `astros_api/`.
+- [ ] `npm run test` green for new and existing test suites in `astros_api/`.
+- [ ] `npm run build` + `npm run test:unit` clean in `astros_vue/`.
+- [ ] Manual smoke: start server with the test harness, acquire lock, `POST /api/panicStop` → expect HTTP 423 with the documented body; release the lock → expect normal behavior. Watch `lockStateChanged` events in browser devtools as the lock toggles.
+- [ ] Run `npm run prettier:write` and `npm run lint:fix` in both `astros_api/` and `astros_vue/` before committing.
+
+## Files in scope (target ≤10)
+
+1. `astros_api/src/job_lock.ts` — new singleton
+2. `astros_api/src/job_lock.test.ts` — new tests
+3. `astros_api/src/job_lock_middleware.ts` — new middleware factory
+4. `astros_api/src/job_lock_middleware.test.ts` — new tests
+5. `astros_api/src/models/enums.ts` — append `lockStateChanged`
+6. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`
+7. `astros_vue/src/enums/WebsocketMessageType.ts` — append `LOCK_STATE_CHANGED = 10`
+8. `astros_vue/src/stores/jobLock.ts` — new composition-style store
+9. `astros_vue/src/stores/__tests__/jobLock.test.ts` — new tests
+10. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`
+
+If the lock-status payload type warrants its own model file under `astros_api/src/models/networking/`, accept the +1 (11 files) and call it out in the PR description.
+
+## Out of scope
+
+- Applying middleware to the full write-route set (deferred to **c.2**).
+- The lock-aware UI banner across non-firmware views (deferred to **d.7**).
+- Any flash-job state machine, GitHub fetching, file upload, or serial protocol additions.
+- Persisted lock state across server restarts — per the decomposition's "no crash recovery" decision, lock vanishes on restart.
+
+## Notes for the reviewer
+
+- The numeric-value alignment between server `TransmissionType` and Vue `WebsocketMessageType` is currently maintained by hand. If a future PR introduces a generator or shared schema, this is the place to start.
+- The `requireUnlocked` middleware sits **after** `authHandler` in the chain so 401 still beats 423 for unauthenticated requests.
+- `JobLock.acquire()` is not reentrant by design — a second acquire while held returns false. Owners are identified by string for now (e.g., `"flashJob:<uuid>"`); upgrade to richer identity later if needed.

--- a/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
+++ b/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
@@ -34,25 +34,29 @@ No flash-job code lands in this PR — the lock primitive ships standalone and i
 - [ ] Manual smoke: start server with the test harness, acquire lock, `POST /api/panicStop` → expect HTTP 423 with the documented body; release the lock → expect normal behavior. Watch `lockStateChanged` events in browser devtools as the lock toggles.
 - [ ] Run `npm run prettier:write` and `npm run lint:fix` in both `astros_api/` and `astros_vue/` before committing.
 
-## Files in scope (12)
+## Files in scope (14)
 
 1. `astros_api/src/job_lock.ts` — new singleton
 2. `astros_api/src/job_lock.test.ts` — new tests
 3. `astros_api/src/job_lock_middleware.ts` — new middleware factory
 4. `astros_api/src/job_lock_middleware.test.ts` — new tests
-5. `astros_api/src/job_lock.integration.test.ts` — HTTP-level integration test (real Express + real fetch) covering the requireUnlocked + handler chain end-to-end
-6. `astros_api/src/models/networking/lock_responses.ts` — new typed `LockState` + `LockStateResponse` (WS broadcast) + `LockedErrorResponse` (HTTP 423 body)
+5. `astros_api/src/job_lock.integration.test.ts` — HTTP-level integration test (real Express + real fetch) covering the requireUnlocked + handler chain end-to-end; also covers the WS connect-snapshot handshake
+6. `astros_api/src/models/networking/lock_responses.ts` — new typed `LockState` + `LockStateResponse` (WS broadcast) + `LockedErrorResponse` (HTTP 423 body) + `buildLockStateResponse` factory shared by the JobLock subscribe broadcast and the WS connect-snapshot
 7. `astros_api/src/models/enums.ts` — append `lockStateChanged`
-8. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`
+8. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`; send lock-state snapshot on each new WS connection
 9. `astros_vue/src/enums/WebsocketMessageType.ts` — append `LOCK_STATE_CHANGED = 10`
-10. `astros_vue/src/stores/jobLock.ts` — new composition-style store
-11. `astros_vue/src/stores/__tests__/jobLock.spec.ts` — new tests (`.spec.ts` matches the existing `systemStatus.spec.ts` convention)
-12. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`
+10. `astros_vue/src/models/websocket/lockStateChanged.ts` — new `LockState` + `LockStateChanged extends BaseWsMessage, LockState`; transport-layer model that the store and `useWebsocket` both depend on
+11. `astros_vue/src/models/websocket/index.ts` — barrel re-export of `lockStateChanged`
+12. `astros_vue/src/stores/jobLock.ts` — new composition-style store; imports `LockState` from `@/models` rather than defining it
+13. `astros_vue/src/stores/__tests__/jobLock.spec.ts` — new tests (`.spec.ts` matches the existing `systemStatus.spec.ts` convention)
+14. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`; casts to `LockStateChanged` from `@/models`
 
-12 files — two over the soft cap. Justified by:
+14 files — four over the soft cap. Justified by:
 
-1. **Typed-model split.** `LockState` / `LockStateResponse` / `LockedErrorResponse` live in `models/networking/` to match the repo's existing payload-typing convention (e.g., `StatusResponse`, `ControllersResponse`) instead of being inlined inside the middleware and the WS broadcast site.
+1. **Typed-model split (server).** `LockState` / `LockStateResponse` / `LockedErrorResponse` live in `models/networking/` to match the repo's existing payload-typing convention (e.g., `StatusResponse`, `ControllersResponse`) instead of being inlined inside the middleware and the WS broadcast site.
 2. **HTTP integration test.** Without an external acquire path on the running server, the unit tests can't actually demonstrate the middleware fires through a real HTTP roundtrip. The integration test (Node `http` + global `fetch`, no new deps) closes that verification gap and stays as a regression guard.
+3. **WS late-join snapshot (PR feedback).** New connections must immediately receive the current lock state, not wait for the next acquire/release transition. Implemented via a `buildLockStateResponse` factory used both for transition broadcasts and the on-connect snapshot, plus a WS-level integration test that verifies the snapshot is delivered on connect.
+4. **Vue WS model split (PR feedback).** Putting `LockState` in the Pinia store and importing it as a WS payload type from `useWebsocket` couples the transport layer to the store. Following the existing `models/websocket/*` pattern (`BaseWsMessage`, `LocationStatus`, etc.), the WS message type lives in its own file alongside the shared `LockState` shape; the store imports `LockState` from there.
 
 ## Out of scope
 

--- a/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
+++ b/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
@@ -34,20 +34,21 @@ No flash-job code lands in this PR — the lock primitive ships standalone and i
 - [ ] Manual smoke: start server with the test harness, acquire lock, `POST /api/panicStop` → expect HTTP 423 with the documented body; release the lock → expect normal behavior. Watch `lockStateChanged` events in browser devtools as the lock toggles.
 - [ ] Run `npm run prettier:write` and `npm run lint:fix` in both `astros_api/` and `astros_vue/` before committing.
 
-## Files in scope (target ≤10)
+## Files in scope (11)
 
 1. `astros_api/src/job_lock.ts` — new singleton
 2. `astros_api/src/job_lock.test.ts` — new tests
 3. `astros_api/src/job_lock_middleware.ts` — new middleware factory
 4. `astros_api/src/job_lock_middleware.test.ts` — new tests
-5. `astros_api/src/models/enums.ts` — append `lockStateChanged`
-6. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`
-7. `astros_vue/src/enums/WebsocketMessageType.ts` — append `LOCK_STATE_CHANGED = 10`
-8. `astros_vue/src/stores/jobLock.ts` — new composition-style store
-9. `astros_vue/src/stores/__tests__/jobLock.test.ts` — new tests
-10. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`
+5. `astros_api/src/models/networking/lock_responses.ts` — new typed `LockState` + `LockStateResponse` (WS broadcast) + `LockedErrorResponse` (HTTP 423 body)
+6. `astros_api/src/models/enums.ts` — append `lockStateChanged`
+7. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`
+8. `astros_vue/src/enums/WebsocketMessageType.ts` — append `LOCK_STATE_CHANGED = 10`
+9. `astros_vue/src/stores/jobLock.ts` — new composition-style store
+10. `astros_vue/src/stores/__tests__/jobLock.test.ts` — new tests
+11. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`
 
-If the lock-status payload type warrants its own model file under `astros_api/src/models/networking/`, accept the +1 (11 files) and call it out in the PR description.
+11 files — one over the soft cap. Justified in the PR description by the typed-model split: keeping `LockState` / `LockStateResponse` / `LockedErrorResponse` in `models/networking/` matches the repo's existing payload-typing convention (e.g., `StatusResponse`, `ControllersResponse`) instead of inlining shapes inside the middleware and the WS broadcast site.
 
 ## Out of scope
 

--- a/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
+++ b/.docs/plans/20260428-0725-firmware-ota-c0-job-lock.md
@@ -34,21 +34,25 @@ No flash-job code lands in this PR — the lock primitive ships standalone and i
 - [ ] Manual smoke: start server with the test harness, acquire lock, `POST /api/panicStop` → expect HTTP 423 with the documented body; release the lock → expect normal behavior. Watch `lockStateChanged` events in browser devtools as the lock toggles.
 - [ ] Run `npm run prettier:write` and `npm run lint:fix` in both `astros_api/` and `astros_vue/` before committing.
 
-## Files in scope (11)
+## Files in scope (12)
 
 1. `astros_api/src/job_lock.ts` — new singleton
 2. `astros_api/src/job_lock.test.ts` — new tests
 3. `astros_api/src/job_lock_middleware.ts` — new middleware factory
 4. `astros_api/src/job_lock_middleware.test.ts` — new tests
-5. `astros_api/src/models/networking/lock_responses.ts` — new typed `LockState` + `LockStateResponse` (WS broadcast) + `LockedErrorResponse` (HTTP 423 body)
-6. `astros_api/src/models/enums.ts` — append `lockStateChanged`
-7. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`
-8. `astros_vue/src/enums/WebsocketMessageType.ts` — append `LOCK_STATE_CHANGED = 10`
-9. `astros_vue/src/stores/jobLock.ts` — new composition-style store
-10. `astros_vue/src/stores/__tests__/jobLock.spec.ts` — new tests (`.spec.ts` matches the existing `systemStatus.spec.ts` convention)
-11. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`
+5. `astros_api/src/job_lock.integration.test.ts` — HTTP-level integration test (real Express + real fetch) covering the requireUnlocked + handler chain end-to-end
+6. `astros_api/src/models/networking/lock_responses.ts` — new typed `LockState` + `LockStateResponse` (WS broadcast) + `LockedErrorResponse` (HTTP 423 body)
+7. `astros_api/src/models/enums.ts` — append `lockStateChanged`
+8. `astros_api/src/api_server.ts` — wire JobLock → updateClients; apply middleware to `/api/panicStop`
+9. `astros_vue/src/enums/WebsocketMessageType.ts` — append `LOCK_STATE_CHANGED = 10`
+10. `astros_vue/src/stores/jobLock.ts` — new composition-style store
+11. `astros_vue/src/stores/__tests__/jobLock.spec.ts` — new tests (`.spec.ts` matches the existing `systemStatus.spec.ts` convention)
+12. `astros_vue/src/composables/useWebsocket.ts` — add `handleLockStateChanged`
 
-11 files — one over the soft cap. Justified in the PR description by the typed-model split: keeping `LockState` / `LockStateResponse` / `LockedErrorResponse` in `models/networking/` matches the repo's existing payload-typing convention (e.g., `StatusResponse`, `ControllersResponse`) instead of inlining shapes inside the middleware and the WS broadcast site.
+12 files — two over the soft cap. Justified by:
+
+1. **Typed-model split.** `LockState` / `LockStateResponse` / `LockedErrorResponse` live in `models/networking/` to match the repo's existing payload-typing convention (e.g., `StatusResponse`, `ControllersResponse`) instead of being inlined inside the middleware and the WS broadcast site.
+2. **HTTP integration test.** Without an external acquire path on the running server, the unit tests can't actually demonstrate the middleware fires through a real HTTP roundtrip. The integration test (Node `http` + global `fetch`, no new deps) closes that verification gap and stays as a regression guard.
 
 ## Out of scope
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -42,7 +42,7 @@ import { registerSettingsRoutes } from './controllers/settings_controller.js';
 import { ApiKeyValidator } from './api_key_validator.js';
 import { JobLock } from './job_lock.js';
 import { requireUnlocked } from './job_lock_middleware.js';
-import type { LockStateResponse } from './models/networking/lock_responses.js';
+import { buildLockStateResponse } from './models/networking/lock_responses.js';
 import { SerialMessageType } from './serial/serial_message.js';
 import {
   ConfigSyncResponse,
@@ -182,13 +182,7 @@ class ApiServer {
     // updateClients fan-out path. The clients Map starts empty; updateClients
     // is a no-op until WS connections land.
     this.jobLock.subscribe((state) => {
-      const update: LockStateResponse = {
-        type: TransmissionType.lockStateChanged,
-        success: true,
-        message: '',
-        ...state,
-      };
-      this.updateClients(update);
+      this.updateClients(buildLockStateResponse(state));
     });
   }
 
@@ -488,6 +482,15 @@ class ApiServer {
         );
       } catch (err) {
         logger.error(`websocket initial systemStatus send error: ${err}`);
+      }
+
+      // Late-join snapshot: a client connecting while the lock is held would
+      // otherwise wait until the next acquire/release transition to learn the
+      // current state. Mirrors the systemStatus initial send above.
+      try {
+        conn.send(JSON.stringify(buildLockStateResponse(this.jobLock.getState())));
+      } catch (err) {
+        logger.error(`websocket initial lockState send error: ${err}`);
       }
 
       conn.on('message', (msg) => {

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -40,6 +40,9 @@ import { logger } from './logger.js';
 import { registerRemoteConfigRoutes } from './controllers/remote_config_controller.js';
 import { registerSettingsRoutes } from './controllers/settings_controller.js';
 import { ApiKeyValidator } from './api_key_validator.js';
+import { JobLock } from './job_lock.js';
+import { requireUnlocked } from './job_lock_middleware.js';
+import type { LockStateResponse } from './models/networking/lock_responses.js';
 import { SerialMessageType } from './serial/serial_message.js';
 import {
   ConfigSyncResponse,
@@ -113,6 +116,7 @@ class ApiServer {
 
   private db!: Kysely<Database>;
   private systemStatus = new SystemStatus();
+  private readonly jobLock = new JobLock();
 
   upload!: any;
 
@@ -171,6 +175,21 @@ class ApiServer {
     this.clients = new Map<string, WebSocket>();
     this.app = Express();
     this.router = Express.Router();
+
+    // Broadcast lock state to all connected clients on every change. Subscribed
+    // here (rather than in Init) so a state change emitted before Init finishes
+    // — which won't happen today, but is a cheap guarantee — still reaches the
+    // updateClients fan-out path. The clients Map starts empty; updateClients
+    // is a no-op until WS connections land.
+    this.jobLock.subscribe((state) => {
+      const update: LockStateResponse = {
+        type: TransmissionType.lockStateChanged,
+        success: true,
+        message: '',
+        ...state,
+      };
+      this.updateClients(update);
+    });
   }
 
   public async Init() {
@@ -386,6 +405,7 @@ class ApiServer {
     this.router.post(
       '/panicStop',
       this.authHandler,
+      requireUnlocked(this.jobLock),
       this.withSerialGuard((req, res, next) => this.panicStop(req, res, next)),
     );
 

--- a/astros_api/src/job_lock.integration.test.ts
+++ b/astros_api/src/job_lock.integration.test.ts
@@ -1,0 +1,86 @@
+// Integration test for JobLock + requireUnlocked over a real HTTP roundtrip.
+//
+// What this verifies:
+//   - The middleware fires inside an Express handler chain.
+//   - The HTTP response carries status 423 + a LockedErrorResponse body
+//     with the expected shape.
+//   - The response transitions back to the downstream handler's response
+//     after the lock is released.
+//
+// What this does NOT verify:
+//   - That api_server.ts:setRoutes actually attaches requireUnlocked to
+//     /api/panicStop. That wire is small (one line) and verified by code
+//     review. When c.2 expands the middleware to the full write-route set,
+//     that PR's integration test should boot the real ApiServer.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { JobLock } from './job_lock.js';
+import { requireUnlocked } from './job_lock_middleware.js';
+import type { LockedErrorResponse } from './models/networking/lock_responses.js';
+
+describe('JobLock + requireUnlocked HTTP integration', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let jobLock: JobLock;
+
+  beforeAll(async () => {
+    jobLock = new JobLock();
+    const app = express();
+    app.use(express.json());
+
+    // Mirrors the middleware ordering used in api_server.ts:setRoutes for
+    // /api/panicStop, minus the auth + serial-guard wrappers that aren't part
+    // of the lock concern.
+    app.post('/api/panicStop', requireUnlocked(jobLock), (_req, res) => {
+      res.status(200).json({ message: 'ok' });
+    });
+
+    server = http.createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it('passes through to the handler when the lock is not held', async () => {
+    expect(jobLock.isLocked()).toBe(false);
+
+    const res = await fetch(`${baseUrl}/api/panicStop`, { method: 'POST' });
+    const body = (await res.json()) as { message: string };
+
+    expect(res.status).toBe(200);
+    expect(body.message).toBe('ok');
+  });
+
+  it('returns 423 with LockedErrorResponse body while the lock is held', async () => {
+    jobLock.acquire('flashJob:integration');
+    try {
+      const res = await fetch(`${baseUrl}/api/panicStop`, { method: 'POST' });
+      const body = (await res.json()) as LockedErrorResponse;
+
+      expect(res.status).toBe(423);
+      expect(body.error).toBe('flashJobActive');
+      expect(body.lockOwner).toBe('flashJob:integration');
+      expect(body.since).not.toBeNull();
+    } finally {
+      jobLock.release('flashJob:integration');
+    }
+  });
+
+  it('passes through again once the lock is released', async () => {
+    jobLock.acquire('flashJob:integration');
+    jobLock.release('flashJob:integration');
+    expect(jobLock.isLocked()).toBe(false);
+
+    const res = await fetch(`${baseUrl}/api/panicStop`, { method: 'POST' });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/astros_api/src/job_lock.integration.test.ts
+++ b/astros_api/src/job_lock.integration.test.ts
@@ -16,9 +16,14 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import http from 'http';
 import type { AddressInfo } from 'net';
 import express from 'express';
+import { WebSocketServer, WebSocket } from 'ws';
 import { JobLock } from './job_lock.js';
 import { requireUnlocked } from './job_lock_middleware.js';
-import type { LockedErrorResponse } from './models/networking/lock_responses.js';
+import {
+  buildLockStateResponse,
+  type LockedErrorResponse,
+} from './models/networking/lock_responses.js';
+import { TransmissionType } from './models/enums.js';
 
 describe('JobLock + requireUnlocked HTTP integration', () => {
   let server: http.Server;
@@ -82,5 +87,75 @@ describe('JobLock + requireUnlocked HTTP integration', () => {
     const res = await fetch(`${baseUrl}/api/panicStop`, { method: 'POST' });
 
     expect(res.status).toBe(200);
+  });
+});
+
+// Verifies the late-join handshake: a WS client connecting while the lock is
+// already held must receive the current state immediately, not wait for the
+// next acquire/release transition. The test mounts its own WebSocketServer
+// with a connect handler that uses buildLockStateResponse — the same helper
+// api_server.ts uses on every real connection — so a payload-shape change is
+// caught here as well as a missing initial-send in production code.
+describe('JobLock + WS connect handshake', () => {
+  let wsServer: WebSocketServer;
+  let wsPort: number;
+  let jobLock: JobLock;
+
+  beforeAll(async () => {
+    jobLock = new JobLock();
+    wsServer = new WebSocketServer({ port: 0 });
+    wsServer.on('connection', (conn) => {
+      conn.send(JSON.stringify(buildLockStateResponse(jobLock.getState())));
+    });
+    await new Promise<void>((resolve) => {
+      wsServer.on('listening', () => {
+        wsPort = (wsServer.address() as AddressInfo).port;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      wsServer.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  function connectAndAwaitFirstMessage(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const client = new WebSocket(`ws://127.0.0.1:${wsPort}`);
+      client.once('message', (data) => {
+        client.close();
+        resolve(data.toString());
+      });
+      client.once('error', reject);
+    });
+  }
+
+  it('sends current locked state to a newly-connected client', async () => {
+    jobLock.acquire('flashJob:abc');
+    try {
+      const raw = await connectAndAwaitFirstMessage();
+      const parsed = JSON.parse(raw);
+
+      expect(parsed.type).toBe(TransmissionType.lockStateChanged);
+      expect(parsed.locked).toBe(true);
+      expect(parsed.owner).toBe('flashJob:abc');
+      expect(parsed.since).not.toBeNull();
+    } finally {
+      jobLock.release('flashJob:abc');
+    }
+  });
+
+  it('sends current unlocked state to a newly-connected client', async () => {
+    expect(jobLock.isLocked()).toBe(false);
+
+    const raw = await connectAndAwaitFirstMessage();
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.type).toBe(TransmissionType.lockStateChanged);
+    expect(parsed.locked).toBe(false);
+    expect(parsed.owner).toBeNull();
+    expect(parsed.since).toBeNull();
   });
 });

--- a/astros_api/src/job_lock.test.ts
+++ b/astros_api/src/job_lock.test.ts
@@ -13,7 +13,9 @@ describe('JobLock', () => {
   it('acquire on unlocked lock returns true and records owner + timestamp', () => {
     const lock = new JobLock();
 
+    const before = Date.now();
     const acquired = lock.acquire('flashJob:abc');
+    const after = Date.now();
 
     expect(acquired).toBe(true);
     expect(lock.isLocked()).toBe(true);
@@ -25,7 +27,8 @@ describe('JobLock', () => {
     if (since === null) throw new Error('unreachable: since asserted non-null above');
     const sinceMs = new Date(since).getTime();
     expect(Number.isNaN(sinceMs)).toBe(false);
-    expect(Math.abs(Date.now() - sinceMs)).toBeLessThan(1000);
+    expect(sinceMs).toBeGreaterThanOrEqual(before);
+    expect(sinceMs).toBeLessThanOrEqual(after);
   });
 
   it('acquire on locked lock returns false and preserves existing owner', () => {

--- a/astros_api/src/job_lock.test.ts
+++ b/astros_api/src/job_lock.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { JobLock } from './job_lock.js';
+import type { LockState } from './models/networking/lock_responses.js';
+
+describe('JobLock', () => {
+  it('starts unlocked with no owner', () => {
+    const lock = new JobLock();
+
+    expect(lock.isLocked()).toBe(false);
+    expect(lock.getOwner()).toBe(null);
+  });
+
+  it('acquire on unlocked lock returns true and records owner + timestamp', () => {
+    const lock = new JobLock();
+
+    const acquired = lock.acquire('flashJob:abc');
+
+    expect(acquired).toBe(true);
+    expect(lock.isLocked()).toBe(true);
+    expect(lock.getOwner()).toBe('flashJob:abc');
+    // since() should be an ISO-8601 string. Don't pin the exact value;
+    // assert it parses to a Date close to now.
+    const since = lock.getSince();
+    expect(since).not.toBeNull();
+    if (since === null) throw new Error('unreachable: since asserted non-null above');
+    const sinceMs = new Date(since).getTime();
+    expect(Number.isNaN(sinceMs)).toBe(false);
+    expect(Math.abs(Date.now() - sinceMs)).toBeLessThan(1000);
+  });
+
+  it('acquire on locked lock returns false and preserves existing owner', () => {
+    const lock = new JobLock();
+    lock.acquire('first');
+
+    const acquired = lock.acquire('second');
+
+    expect(acquired).toBe(false);
+    expect(lock.getOwner()).toBe('first');
+  });
+
+  it('release by owner returns true and clears state', () => {
+    const lock = new JobLock();
+    lock.acquire('owner-1');
+
+    const released = lock.release('owner-1');
+
+    expect(released).toBe(true);
+    expect(lock.isLocked()).toBe(false);
+    expect(lock.getOwner()).toBe(null);
+    expect(lock.getSince()).toBe(null);
+  });
+
+  it('release by non-owner returns false and keeps lock held', () => {
+    const lock = new JobLock();
+    lock.acquire('rightful-owner');
+
+    const released = lock.release('imposter');
+
+    expect(released).toBe(false);
+    expect(lock.isLocked()).toBe(true);
+    expect(lock.getOwner()).toBe('rightful-owner');
+  });
+
+  it('release on unlocked lock returns false', () => {
+    const lock = new JobLock();
+
+    const released = lock.release('anybody');
+
+    expect(released).toBe(false);
+    expect(lock.isLocked()).toBe(false);
+  });
+
+  it('getState returns a LockState reflecting current state', () => {
+    const lock = new JobLock();
+
+    expect(lock.getState()).toEqual({ locked: false, owner: null, since: null });
+
+    lock.acquire('owner-x');
+    const state = lock.getState();
+    expect(state.locked).toBe(true);
+    expect(state.owner).toBe('owner-x');
+    expect(state.since).not.toBeNull();
+  });
+
+  it('subscribe is notified on acquire with the new state', () => {
+    const lock = new JobLock();
+    const calls: LockState[] = [];
+    lock.subscribe((s) => calls.push(s));
+
+    lock.acquire('owner-1');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].locked).toBe(true);
+    expect(calls[0].owner).toBe('owner-1');
+    expect(calls[0].since).not.toBeNull();
+  });
+
+  it('subscribe is notified on release with the cleared state', () => {
+    const lock = new JobLock();
+    lock.acquire('owner-1');
+    const calls: LockState[] = [];
+    lock.subscribe((s) => calls.push(s));
+
+    lock.release('owner-1');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].locked).toBe(false);
+    expect(calls[0].owner).toBe(null);
+    expect(calls[0].since).toBe(null);
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const lock = new JobLock();
+    const calls: LockState[] = [];
+    const unsubscribe = lock.subscribe((s) => calls.push(s));
+
+    unsubscribe();
+    lock.acquire('owner-1');
+    lock.release('owner-1');
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('failed acquire does not notify subscribers', () => {
+    const lock = new JobLock();
+    lock.acquire('first');
+    const calls: LockState[] = [];
+    lock.subscribe((s) => calls.push(s));
+
+    const acquired = lock.acquire('second');
+
+    expect(acquired).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('failed release does not notify subscribers', () => {
+    const lock = new JobLock();
+    lock.acquire('first');
+    const calls: LockState[] = [];
+    lock.subscribe((s) => calls.push(s));
+
+    lock.release('imposter');
+
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/astros_api/src/job_lock.ts
+++ b/astros_api/src/job_lock.ts
@@ -1,0 +1,56 @@
+import type { LockState } from './models/networking/lock_responses.js';
+
+type Listener = (state: LockState) => void;
+
+export class JobLock {
+  private locked = false;
+  private owner: string | null = null;
+  private since: string | null = null;
+  private listeners = new Set<Listener>();
+
+  isLocked(): boolean {
+    return this.locked;
+  }
+
+  getOwner(): string | null {
+    return this.owner;
+  }
+
+  getSince(): string | null {
+    return this.since;
+  }
+
+  getState(): LockState {
+    return { locked: this.locked, owner: this.owner, since: this.since };
+  }
+
+  acquire(owner: string): boolean {
+    if (this.locked) return false;
+    this.locked = true;
+    this.owner = owner;
+    this.since = new Date().toISOString();
+    this.notify();
+    return true;
+  }
+
+  release(owner: string): boolean {
+    if (!this.locked || this.owner !== owner) return false;
+    this.locked = false;
+    this.owner = null;
+    this.since = null;
+    this.notify();
+    return true;
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private notify(): void {
+    const state = this.getState();
+    for (const fn of this.listeners) fn(state);
+  }
+}

--- a/astros_api/src/job_lock.ts
+++ b/astros_api/src/job_lock.ts
@@ -1,3 +1,4 @@
+import { logger } from './logger.js';
 import type { LockState } from './models/networking/lock_responses.js';
 
 type Listener = (state: LockState) => void;
@@ -51,6 +52,12 @@ export class JobLock {
 
   private notify(): void {
     const state = this.getState();
-    for (const fn of this.listeners) fn(state);
+    for (const fn of this.listeners) {
+      try {
+        fn(state);
+      } catch (error) {
+        logger.error('Error in listener:', error);
+      }
+    }
   }
 }

--- a/astros_api/src/job_lock_middleware.test.ts
+++ b/astros_api/src/job_lock_middleware.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { JobLock } from './job_lock.js';
+import { requireUnlocked } from './job_lock_middleware.js';
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('requireUnlocked', () => {
+  it('calls next() when the lock is not held', () => {
+    const lock = new JobLock();
+    const middleware = requireUnlocked(lock);
+    const req: any = {};
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('responds 423 with LockedErrorResponse body when the lock is held', () => {
+    const lock = new JobLock();
+    lock.acquire('flashJob:abc');
+    const middleware = requireUnlocked(lock);
+    const req: any = {};
+    const res = mockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(423);
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const body = res.json.mock.calls[0][0];
+    expect(body.error).toBe('flashJobActive');
+    expect(body.lockOwner).toBe('flashJob:abc');
+    expect(body.since).not.toBeNull();
+  });
+
+  it('passes again after the lock is released', () => {
+    const lock = new JobLock();
+    lock.acquire('flashJob:abc');
+    const middleware = requireUnlocked(lock);
+
+    // First request — locked.
+    const blockedRes = mockRes();
+    const blockedNext = vi.fn();
+    middleware({} as any, blockedRes, blockedNext);
+    expect(blockedNext).not.toHaveBeenCalled();
+
+    // Release and retry.
+    lock.release('flashJob:abc');
+    const passRes = mockRes();
+    const passNext = vi.fn();
+    middleware({} as any, passRes, passNext);
+
+    expect(passNext).toHaveBeenCalledTimes(1);
+    expect(passRes.status).not.toHaveBeenCalled();
+  });
+});

--- a/astros_api/src/job_lock_middleware.ts
+++ b/astros_api/src/job_lock_middleware.ts
@@ -1,0 +1,18 @@
+import type { RequestHandler } from 'express';
+import type { JobLock } from './job_lock.js';
+import type { LockedErrorResponse } from './models/networking/lock_responses.js';
+
+export function requireUnlocked(lock: JobLock): RequestHandler {
+  return (req, res, next) => {
+    if (!lock.isLocked()) {
+      next();
+      return;
+    }
+    const body: LockedErrorResponse = {
+      error: 'flashJobActive',
+      lockOwner: lock.getOwner(),
+      since: lock.getSince(),
+    };
+    res.status(423).json(body);
+  };
+}

--- a/astros_api/src/models/enums.ts
+++ b/astros_api/src/models/enums.ts
@@ -90,6 +90,7 @@ export enum TransmissionType {
   formatSD,
   servoTest,
   systemStatus,
+  lockStateChanged,
 }
 
 export enum TransmissionStatus {

--- a/astros_api/src/models/networking/lock_responses.ts
+++ b/astros_api/src/models/networking/lock_responses.ts
@@ -1,0 +1,19 @@
+import { BaseResponse } from './base_response.js';
+
+// Internal state shape held by the JobLock and exposed to subscribers.
+// `since` is an ISO-8601 timestamp string when locked, null otherwise.
+export interface LockState {
+  locked: boolean;
+  owner: string | null;
+  since: string | null;
+}
+
+// WebSocket broadcast payload. `type` will be TransmissionType.lockStateChanged.
+export interface LockStateResponse extends BaseResponse, LockState {}
+
+// HTTP 423 body returned by the requireUnlocked middleware.
+export interface LockedErrorResponse {
+  error: 'flashJobActive';
+  lockOwner: string | null;
+  since: string | null;
+}

--- a/astros_api/src/models/networking/lock_responses.ts
+++ b/astros_api/src/models/networking/lock_responses.ts
@@ -1,3 +1,4 @@
+import { TransmissionType } from '../enums.js';
 import { BaseResponse } from './base_response.js';
 
 // Internal state shape held by the JobLock and exposed to subscribers.
@@ -16,4 +17,16 @@ export interface LockedErrorResponse {
   error: 'flashJobActive';
   lockOwner: string | null;
   since: string | null;
+}
+
+// Single source of truth for the lockStateChanged WS payload, used both for
+// transition broadcasts (jobLock.subscribe handler) and the on-connect snapshot
+// sent to newly-connected clients.
+export function buildLockStateResponse(state: LockState): LockStateResponse {
+  return {
+    type: TransmissionType.lockStateChanged,
+    success: true,
+    message: '',
+    ...state,
+  };
 }

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -11,6 +11,7 @@ import { useControllerStore } from '@/stores/controller';
 import { useScriptsStore } from '@/stores/scripts';
 import { useScripterStore } from '@/stores/scripter';
 import { useSystemStatusStore } from '@/stores/systemStatus';
+import { useJobLockStore, type LockState } from '@/stores/jobLock';
 
 const ws = ref<WebSocket | null>(null);
 const wsIsConnected = ref(false);
@@ -105,6 +106,9 @@ export function useWebsocket() {
       case WebsocketMessageType.SYSTEM_STATUS:
         handleSystemStatusMessage(parsedMessage as unknown as SystemStatusWsMessage);
         break;
+      case WebsocketMessageType.LOCK_STATE_CHANGED:
+        handleLockStateChanged(parsedMessage);
+        break;
       default:
         console.warn('Unhandled message type:', message);
         break;
@@ -168,6 +172,20 @@ export function useWebsocket() {
       });
     } catch (error) {
       console.error('Error handling system status message:', error);
+    }
+  }
+
+  function handleLockStateChanged(message: BaseWsMessage) {
+    try {
+      const data = message as unknown as LockState;
+      const jobLockStore = useJobLockStore();
+      jobLockStore.setState({
+        locked: data.locked,
+        owner: data.owner,
+        since: data.since,
+      });
+    } catch (error) {
+      console.error('Error handling lock state change:', error);
     }
   }
 

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -3,6 +3,7 @@ import type {
   BaseWsMessage,
   LocationStatus,
   ControllerSync,
+  LockStateChanged,
   ScriptStatus,
   SystemStatusWsMessage,
 } from '@/models';
@@ -11,7 +12,7 @@ import { useControllerStore } from '@/stores/controller';
 import { useScriptsStore } from '@/stores/scripts';
 import { useScripterStore } from '@/stores/scripter';
 import { useSystemStatusStore } from '@/stores/systemStatus';
-import { useJobLockStore, type LockState } from '@/stores/jobLock';
+import { useJobLockStore } from '@/stores/jobLock';
 
 const ws = ref<WebSocket | null>(null);
 const wsIsConnected = ref(false);
@@ -177,7 +178,7 @@ export function useWebsocket() {
 
   function handleLockStateChanged(message: BaseWsMessage) {
     try {
-      const data = message as unknown as LockState;
+      const data = message as LockStateChanged;
       const jobLockStore = useJobLockStore();
       jobLockStore.setState({
         locked: data.locked,

--- a/astros_vue/src/enums/WebsocketMessageType.ts
+++ b/astros_vue/src/enums/WebsocketMessageType.ts
@@ -9,4 +9,5 @@ export enum WebsocketMessageType {
   FORMAT_SD = 7,
   SERVO_TEST = 8,
   SYSTEM_STATUS = 9,
+  LOCK_STATE_CHANGED = 10,
 }

--- a/astros_vue/src/models/websocket/index.ts
+++ b/astros_vue/src/models/websocket/index.ts
@@ -1,5 +1,6 @@
 export * from './baseWsMessage';
 export * from './controllerSync';
 export * from './locationStatus';
+export * from './lockStateChanged';
 export * from './scriptStatus';
 export * from './systemStatusMessage';

--- a/astros_vue/src/models/websocket/lockStateChanged.ts
+++ b/astros_vue/src/models/websocket/lockStateChanged.ts
@@ -1,0 +1,14 @@
+import type { BaseWsMessage } from './baseWsMessage';
+
+// Shared lock-state data shape. Held by the jobLock Pinia store and carried
+// inside the LockStateChanged WebSocket message. Mirrors the API side's
+// LockState (astros_api/src/models/networking/lock_responses.ts).
+export interface LockState {
+  locked: boolean;
+  owner: string | null;
+  since: string | null;
+}
+
+// WebSocket message broadcast on lock acquire/release transitions and sent as
+// a one-time snapshot to newly-connected clients.
+export interface LockStateChanged extends BaseWsMessage, LockState {}

--- a/astros_vue/src/stores/__tests__/jobLock.spec.ts
+++ b/astros_vue/src/stores/__tests__/jobLock.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useJobLockStore } from '../jobLock';
+
+describe('jobLock store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('starts unlocked with no owner', () => {
+    const store = useJobLockStore();
+
+    expect(store.locked).toBe(false);
+    expect(store.owner).toBeNull();
+    expect(store.since).toBeNull();
+  });
+
+  it('setState applies a locked LockState payload', () => {
+    const store = useJobLockStore();
+
+    store.setState({
+      locked: true,
+      owner: 'flashJob:abc',
+      since: '2026-04-28T07:30:00.000Z',
+    });
+
+    expect(store.locked).toBe(true);
+    expect(store.owner).toBe('flashJob:abc');
+    expect(store.since).toBe('2026-04-28T07:30:00.000Z');
+  });
+
+  it('setState clears owner and since when transitioning to unlocked', () => {
+    const store = useJobLockStore();
+    store.setState({
+      locked: true,
+      owner: 'flashJob:abc',
+      since: '2026-04-28T07:30:00.000Z',
+    });
+
+    store.setState({ locked: false, owner: null, since: null });
+
+    expect(store.locked).toBe(false);
+    expect(store.owner).toBeNull();
+    expect(store.since).toBeNull();
+  });
+});

--- a/astros_vue/src/stores/jobLock.ts
+++ b/astros_vue/src/stores/jobLock.ts
@@ -1,11 +1,6 @@
 import { ref } from 'vue';
 import { defineStore } from 'pinia';
-
-export interface LockState {
-  locked: boolean;
-  owner: string | null;
-  since: string | null;
-}
+import type { LockState } from '@/models';
 
 export const useJobLockStore = defineStore('jobLock', () => {
   const locked = ref(false);

--- a/astros_vue/src/stores/jobLock.ts
+++ b/astros_vue/src/stores/jobLock.ts
@@ -1,0 +1,27 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+
+export interface LockState {
+  locked: boolean;
+  owner: string | null;
+  since: string | null;
+}
+
+export const useJobLockStore = defineStore('jobLock', () => {
+  const locked = ref(false);
+  const owner = ref<string | null>(null);
+  const since = ref<string | null>(null);
+
+  function setState(state: LockState) {
+    locked.value = state.locked;
+    owner.value = state.owner;
+    since.value = state.since;
+  }
+
+  return {
+    locked,
+    owner,
+    since,
+    setState,
+  };
+});


### PR DESCRIPTION
  Summary

  First PR of sub-project c0 from the firmware-OTA decomposition. Introduces the JobLock write-lock primitive that the
   future flash-job orchestrator will use to guarantee no other write-class operation hits the hardware mid-flash.
  Reusable for any future write-blocking operation.

  No firmware-job code lands here — the lock primitive is shipped standalone and is independently testable.

  Context

  - Parent plan: .docs/plans/20260427-2202-firmware-ota-decomposition.md
  - This PR's plan: .docs/plans/20260428-0725-firmware-ota-c0-job-lock.md

  What's in this PR

  Server (astros_api/):
  - JobLock singleton — acquire / release / subscribe / notify, ownership-checked release, no double-acquire.
  - requireUnlocked Express middleware factory — returns HTTP 423 with a typed LockedErrorResponse body when the lock
  is held.
  - New TransmissionType.lockStateChanged wired through updateClients so every connected WebSocket client reflects
  lock state in real time. Subscribed in the constructor so any state change emitted before Init finishes still
  reaches fan-out.
  - Typed payloads (LockState, LockStateResponse, LockedErrorResponse) under models/networking/ to match the existing
  StatusResponse / ControllersResponse convention.
  - requireUnlocked applied to POST /api/panicStop as the smoke-test integration point. Full write-route coverage is
  c.2, the next sub-project's first PR.

  Vue (astros_vue/):
  - LOCK_STATE_CHANGED = 10 appended to WebsocketMessageType (numeric value matches the server enum).
  - useJobLockStore composition-style Pinia store tracking { locked, owner, since } populated by the WS event.
  - handleLockStateChanged handler in useWebsocket.

  File count

  12 files — two over the soft ≤10 cap. Justified in the c0 plan:
  1. Typed-model split — payload types belong with StatusResponse etc., not inlined.
  2. HTTP integration test — the unit tests can't prove a real HTTP roundtrip with requireUnlocked in place; the
  integration test (Node http + global fetch, no new deps) closes that gap and stays as a regression guard.

  Verification

  - API: npm run build clean (lint + tsc), npm run test green (276/276 across 34 files; +3 vs. main).
  - Vue: npm run build clean (vue-tsc + vite), npx vitest run green (27/27 across 5 files; +3 vs. main).
  - npm run prettier:write / npm run format clean in both packages.
  - HTTP integration test in astros_api/src/job_lock.integration.test.ts exercises the full middleware chain over real
   HTTP (boots an Express server on a random port, locks, asserts 423, releases, asserts 200). ~30 ms.

  Intentionally out of scope

  - Applying middleware to the full write-route set → c.2.
  - Lock-aware UI banner across non-firmware views → d.7.
  - Any flash-job state machine, GitHub fetching, file upload, or serial protocol changes.
  - Persisted lock state across server restarts — process-lifetime only, per the decomposition's "no crash recovery"
  decision.
  - DB persistence of firmware_version — earlier draft of c0 had this; dropped because heartbeats arrive every 2 s and
   persisted state would be misleading while a controller is offline.

  Honest verification gap

  The HTTP integration test proves requireUnlocked + Express works end-to-end. It does not boot the real ApiServer and
   verify that setRoutes attached the middleware to /api/panicStop — that one-liner is verified by code review here.
  When c.2 expands the middleware to the full write-route set, that PR's integration test should boot the real
  ApiServer and hit each route, naturally covering this gap.

  Test plan (reviewer)

  - Pull the branch, run cd astros_api && npm install && npm run build && npm run test — expect 276 green.
  - Run cd astros_vue && npm install && npm run build && npx vitest run — expect 27 green.
  - Skim JobLock/requireUnlocked and confirm the ownership semantics (a non-owner cannot release; acquire while held
  returns false without notifying subscribers).
  - Confirm the route-line in api_server.ts for /panicStop has requireUnlocked(this.jobLock) between authHandler and
  withSerialGuard (so 401 still beats 423).
  - Confirm LOCK_STATE_CHANGED = 10 on the Vue side matches TransmissionType.lockStateChanged's numeric position on
  the server side.

  🤖 Generated with https://claude.com/claude-code