### PR TITLE
Firmware OTA Message Types

### DIFF
--- a/.docs/plans/20260428-2043-firmware-ota-c-1-fw-message-types.md
+++ b/.docs/plans/20260428-2043-firmware-ota-c-1-fw-message-types.md
@@ -1,0 +1,56 @@
+# c.1 — FW_\* SerialMessageType extensions + serializers
+
+Light plan for the first server-orchestrator PR of the firmware-OTA decomposition. Builds on the now-frozen [`.docs/protocol.md`](../protocol.md) contract.
+
+**Branch:** `feature/firmware-ota-c-1-fw-message-types` (off `develop`).
+**PR target base:** `develop`.
+**References:** [decomposition plan](./20260427-2202-firmware-ota-decomposition.md), [protocol contract](../protocol.md).
+
+## Context
+
+Implements the server-side wire layer for the cross-repo OTA protocol: extends `SerialMessageType` and validator strings with the 11 reserved `FW_*` values (30–40), adds 4 outgoing-message generators, adds 7 incoming-message handlers, and ships round-trip tests in both directions.
+
+Stays within the existing serial-protocol patterns (`MessageGenerator.generateMessage` switch dispatch, `MessageHandler` per-type methods, `MessageHelper.ValidationMap` lookup, `SerialWorkerResponseType` for inbound). No flash-job state machine, no orchestration logic — those land in c.6. No `api_server.ts` dispatch wiring for the new handlers — that also lands in c.6. This PR ships the *capability*; c.6 wires it into a flow.
+
+## Tasks
+
+- [ ] **Foundation.** Extend `SerialMessageType` (values 30–40) and `SerialMsgConst` validator strings in `serial_message.ts` to match `.docs/protocol.md` § A. Extend `MessageHelper.ValidationMap` with the 11 new mappings. Add `MessageTimeouts` entries for the 4 outgoing types (`FW_TRANSFER_BEGIN` 5000 ms; `FW_CHUNK` 1500 ms per the protocol contract; `FW_TRANSFER_END` 5000 ms; `FW_DEPLOY_BEGIN` 5000 ms).
+- [ ] **Typed payloads.** New `astros_api/src/models/firmware/firmware_messages.ts` consolidating typed interfaces for all 11 message payloads. Each interface mirrors the field layout from `.docs/protocol.md`: `FwTransferBegin`, `FwTransferBeginAck`, `FwChunk`, `FwChunkAck`, `FwChunkNak`, `FwTransferEnd`, `FwTransferEndAck`, `FwDeployBegin`, `FwProgress`, `FwDeployDone`, `FwBackpressure`. Stage enum included (matching protocol).
+- [ ] **Outgoing generators.** Add `generateFwTransferBegin`, `generateFwChunk`, `generateFwTransferEnd`, `generateFwDeployBegin` to `MessageGenerator`, plus four new cases in the `generateMessage` switch. Each generator returns the existing `MessageGeneratorResponse` shape (msg + controllers + metaData=transferId).
+- [ ] **Incoming handlers.** Add `handleFwTransferBeginAck`, `handleFwChunkAck`, `handleFwChunkNak`, `handleFwTransferEndAck`, `handleFwProgress`, `handleFwDeployDone`, `handleFwBackpressure` to `MessageHandler`. Each parses the wire payload (US/RS-separated per protocol) into a typed response.
+- [ ] **Inbound response types.** Extend `SerialWorkerResponseType` with `FW_TRANSFER_BEGIN_ACK`, `FW_CHUNK_ACK`, `FW_CHUNK_NAK`, `FW_TRANSFER_END_ACK`, `FW_PROGRESS`, `FW_DEPLOY_DONE`, `FW_BACKPRESSURE`. Add response interfaces extending `ISerialWorkerResponse` for each.
+- [ ] **Tests.** Round-trip tests in `message_generator.test.ts` and `message_handler.test.ts`: build payload → generate string → parse string → assert parsed payload matches original. Cover happy path for each of the 11 types plus malformed-input rejection for the 7 handlers.
+
+## Verification
+
+- [ ] `npm run build` clean (lint + tsc) in `astros_api/`.
+- [ ] `npm run test` green for all serial-related test files. Each round-trip test demonstrates the generator's output is parseable by the corresponding handler.
+- [ ] `npm run prettier:write` and `npm run lint:fix` clean.
+- [ ] Visual cross-check: enum integer values 30–40 match `.docs/protocol.md` § "Reserved enum ranges". Validator strings match table A names exactly (`FW_TRANSFER_BEGIN`, etc.).
+
+## Files in scope (8)
+
+1. `astros_api/src/serial/serial_message.ts` — extend `SerialMessageType` + `SerialMsgConst`
+2. `astros_api/src/serial/message_helper.ts` — extend `ValidationMap` + `MessageTimeouts`
+3. `astros_api/src/serial/serial_worker_response.ts` — extend enum + add 7 response interfaces
+4. `astros_api/src/serial/message_generator.ts` — add 4 generators + switch cases
+5. `astros_api/src/serial/message_handler.ts` — add 7 handlers
+6. `astros_api/src/serial/message_generator.test.ts` — generator + round-trip tests
+7. `astros_api/src/serial/message_handler.test.ts` — handler + round-trip tests
+8. `astros_api/src/models/firmware/firmware_messages.ts` — new directory + consolidated typed payload interfaces (server-side counterpart to `.docs/protocol.md` § A)
+
+8 files — within the soft cap. The typed-payloads consolidation into one file (instead of one-file-per-message) is a deliberate choice: the 11 interfaces are tightly coupled by the protocol and easier to read together than scattered across 11 files.
+
+## Out of scope
+
+- No `api_server.ts` dispatch wiring for the new handlers — c.6 will route inbound `FW_*` ack/nak/progress messages to the flash-job orchestrator.
+- No flash-job state machine, GitHub fetching, file upload, on-disk cache — those are c.3 through c.8.
+- No actual hardware integration — round-trip tests verify only the wire layer.
+- No protocol amendments — if implementation reveals a gap in `.docs/protocol.md`, that gets a separate cross-repo amendment commit (paired with AstrOs.ESP) before this PR merges.
+
+## Notes for the reviewer
+
+- Both copies of `.docs/protocol.md` (this repo + AstrOs.ESP) are the source of truth for enum numbers and field layouts. Cross-check against table A there.
+- `FW_PROGRESS` is unsolicited (master → server, no preceding request); the generator pattern doesn't apply. Only the handler exists in this PR.
+- `FW_CHUNK` uses base64 encoding for binary payload because the line-delimited framing (`\n` terminator) breaks on raw binary. Decoded chunk size is 4096 bytes; encoded ≈ 5500 bytes per `FW_CHUNK` line.
+- The `metaData` field on `MessageGeneratorResponse` carries `transferId` for outgoing FW_* messages, mirroring the existing pattern for `scriptId` on `RUN_SCRIPT` / `DEPLOY_SCRIPT`. c.6 will consume this for state tracking.

--- a/.docs/protocol.md
+++ b/.docs/protocol.md
@@ -1,0 +1,203 @@
+# AstrOs Firmware-OTA Protocol Contract
+
+This document is checked into both **AstrOs.Server** and **AstrOs.ESP** at the same content. Any change must be made in both repos at the same commit; sub-projects code against this file. Do not let the two copies drift.
+
+It covers the two cross-repo wire surfaces:
+
+- **A.** Server ↔ Master ESP, over serial.
+- **B.** Master ESP ↔ Padawan ESPs, over ESP-NOW.
+
+The Server ↔ Vue WebSocket contract (`flashJobStarted`, `flashControllerUpdate`, etc.) lives in AstrOs.Server only; see `.docs/plans/20260427-2202-firmware-ota-decomposition.md` § "Server ↔ Vue".
+
+## Reserved enum ranges
+
+| Range | Owner | Notes |
+|---|---|---|
+| `SerialMessageType` 30–40 | This contract | `FW_*` messages, table A below. Last existing entry on Server: `SERVO_TEST_ACK = 22`; gap 23–29 reserved for in-flight non-OTA additions. |
+| `AstrOsPacketType OTA_*` block | This contract | New packet types listed in table B below. Append to the existing enum; do not renumber existing entries. |
+
+When extending either enum, **append** — never reorder existing entries. Both repos must update their copy of this file in lockstep.
+
+## Shared values
+
+| Item | Value | Notes |
+|---|---|---|
+| Image hash | SHA-256, hex-encoded as 64 lowercase chars | Computed by server over the full `.bin`; verified at master (after SD landing) and at each padawan (after `esp_ota_end`). |
+| Frame CRC | CRC-16/CCITT-FALSE (poly `0x1021`, init `0xFFFF`) | Per ESP-NOW data frame, over `[transfer-id .. payload bytes]`. ESP-IDF: `esp_crc16_le`. |
+| Serial chunk size | 4096 bytes (decoded) | Base64-encoded in the wire form, ≈ 5.5 KB per `FW_CHUNK` line at 115200 baud (~0.5 s transit). |
+| ESP-NOW chunk size | 128 bytes | Per `OTA_DATA` frame; 1.2 MB image ≈ 9400 frames per padawan. |
+| Serial sliding window | 16 frames | Inflight bytes ≈ 64 KB. |
+| ESP-NOW sliding window | 8 frames | Inflight bytes ≈ 1 KB. |
+
+## Stage enum (shared)
+
+Master emits these in `FW_PROGRESS.stage` (table A). Server forwards them to the UI via `flashControllerUpdate`. Both sides must agree on the spelling.
+
+```
+QUEUED | UPLOADING_TO_MASTER | SENDING | VERIFYING | REBOOTING | VERSION_CONFIRMED | FAILED
+```
+
+## A. Server ↔ Master (serial)
+
+Existing framing is unchanged: `[type(int)][RS][validator-string][RS][msg-id][GS][payload]\n` with `RS=0x1E`, `US=0x1F`, `GS=0x1D`. Chunk payloads are base64-encoded because the line-delimited framing breaks on raw binary.
+
+### Message types
+
+| Value | Name | Direction | Purpose |
+|---|---|---|---|
+| 30 | `FW_TRANSFER_BEGIN` | server → master | Announce job: targets, total size, expected SHA-256, chunk size. |
+| 31 | `FW_TRANSFER_BEGIN_ACK` | master → server | Ready or reject (e.g. SD full). |
+| 32 | `FW_CHUNK` | server → master | One frame of base64-encoded bytes with seq + CRC-16. |
+| 33 | `FW_CHUNK_ACK` | master → server | Cumulative ACK with `next-expected-seq` and `window-remaining`. |
+| 34 | `FW_CHUNK_NAK` | master → server | Bad CRC / out-of-order, with `last-good-seq`. |
+| 35 | `FW_TRANSFER_END` | server → master | End-of-stream + final SHA-256. |
+| 36 | `FW_TRANSFER_END_ACK` | master → server | `OK` / `HASH_MISMATCH` / `IO_ERROR` + computed hash. |
+| 37 | `FW_DEPLOY_BEGIN` | server → master | Push staged SD copy to listed controllers, in given order. |
+| 38 | `FW_PROGRESS` | master → server (unsolicited) | Per-controller, per-stage update. |
+| 39 | `FW_DEPLOY_DONE` | master → server | All targets attempted; final per-controller report. |
+| 40 | `FW_BACKPRESSURE` | master → server | Pause / resume sender. |
+
+### Payload field layouts
+
+`US` separates fields; `RS` separates repeated groups.
+
+```
+FW_TRANSFER_BEGIN:    transfer-id<US>total-size<US>sha256-hex<US>chunk-size<US>target-list
+                      target-list = controllerId[RS]controllerId[RS]...
+                                    "master" included means master self-flashes last
+FW_CHUNK:             transfer-id<US>seq<US>payload-len<US>base64-bytes<US>crc16-hex
+FW_CHUNK_ACK:         transfer-id<US>highest-contiguous-seq<US>next-expected-seq<US>window-remaining
+FW_CHUNK_NAK:         transfer-id<US>last-good-seq<US>reason-code   // CRC|SIZE|OUT_OF_ORDER|FLASH_FULL
+FW_TRANSFER_END:      transfer-id<US>total-chunks<US>final-sha256-hex
+FW_TRANSFER_END_ACK:  transfer-id<US>OK|HASH_MISMATCH|IO_ERROR<US>computed-sha256-hex
+FW_DEPLOY_BEGIN:      transfer-id<US>order-list   // ordered ids, padawans first, master last
+FW_PROGRESS:          transfer-id<US>controller-id<US>stage<US>bytes-sent<US>total-bytes<US>detail
+                      stage value: see "Stage enum" above
+FW_DEPLOY_DONE:       transfer-id<US>per-controller-result-list
+                      result = controllerId<US>OK|FAILED<US>finalVersion<US>errorOrEmpty (RS-separated)
+FW_BACKPRESSURE:      transfer-id<US>PAUSE|RESUME<US>reason
+```
+
+### Timing
+
+- Per-frame ACK timeout: **1500 ms**, up to 3 retries.
+- Whole-transfer watchdog: **5 minutes**.
+
+### Happy path (Body + Core + Dome all selected)
+
+```
+Server                                Master
+  |--FW_TRANSFER_BEGIN------------------>|     (open SD file)
+  |<-FW_TRANSFER_BEGIN_ACK----------------|
+  |--FW_CHUNK seq=0..N (sliding window)-->|     (write to SD, update streaming SHA)
+  |<-FW_CHUNK_ACK ...---------------------|
+  |--FW_TRANSFER_END--------------------->|     (verify SD hash)
+  |<-FW_TRANSFER_END_ACK OK---------------|
+  |--FW_DEPLOY_BEGIN order=core,dome,master->|
+  |<-FW_PROGRESS core SENDING...----------|
+  |<-FW_PROGRESS core VERIFYING-----------|
+  |<-FW_PROGRESS core REBOOTING-----------|
+  |<-FW_PROGRESS core VERSION_CONFIRMED---|     (master saw new version in heartbeat)
+  |<-FW_PROGRESS dome ...same sequence----|
+  |<-FW_PROGRESS master REBOOTING---------|     (master flashes self last)
+  |<-FW_DEPLOY_DONE all=OK----------------|     (sent BEFORE master commits + reboots)
+  |<-(silence ~8s while master reboots)---|
+  |<-(POLL_ACK heartbeat: master version=target)
+                                                Server holds the JobLock until this heartbeat.
+```
+
+### Failure modes
+
+- CRC fail → `FW_CHUNK_NAK` with `last-good-seq` → server resumes from N+1.
+- Hash mismatch at end → `FW_TRANSFER_END_ACK HASH_MISMATCH` → server retries the whole transfer once, then fails the job.
+- SD full → `FW_TRANSFER_BEGIN_ACK` rejects → fail job fast.
+- Padawan unreachable / reboot timeout → master moves to next padawan, marks the failed one in `FW_DEPLOY_DONE`. ("Continue past failures" decision.)
+
+## B. Master ↔ Padawan (ESP-NOW)
+
+Constraint: 250-byte ESP-NOW frame. Existing per-frame overhead leaves ≈150 bytes usable after CRC + seq fields. Frames are **binary packed structs**, not US/RS-delimited — every byte matters.
+
+### Message types
+
+| Name | Direction | Purpose |
+|---|---|---|
+| `OTA_BEGIN` | master → padawan | Announce: transfer-id, total size, SHA-256, chunk-size. |
+| `OTA_BEGIN_ACK` / `OTA_BEGIN_NAK` | padawan → master | `esp_ota_begin` succeeded / no free OTA slot. |
+| `OTA_DATA` | master → padawan | One chunk: transfer-id, seq, len, CRC-16, payload. |
+| `OTA_DATA_ACK` / `OTA_DATA_NAK` | padawan → master | Per-frame ACK with `next-expected-seq`, `window-remaining`. |
+| `OTA_END` | master → padawan | End-of-stream + final SHA-256. |
+| `OTA_END_ACK` | padawan → master | `OK` / `HASH_MISMATCH` / `WRITE_ERROR` + computed hash. |
+| `OTA_COMMIT` | master → padawan | `esp_ota_set_boot_partition` + reboot. |
+| `OTA_COMMIT_ACK` | padawan → master | About to reboot. (No post-reboot message; heartbeat carries the new version.) |
+
+### Frame layouts
+
+Binary, fixed-offset, little-endian unless noted:
+
+```
+OTA_BEGIN payload (≈40 bytes):
+  uint8  transfer-id
+  uint32 total-size
+  uint16 chunk-size            // recommend 128 bytes per OTA_DATA
+  uint32 total-chunks
+  uint8[32] sha256-expected
+  uint8  flags                 // bit0=enable-psram-buffer; rest reserved
+
+OTA_DATA payload (≈148 bytes):
+  uint8  transfer-id
+  uint32 seq
+  uint16 payload-len
+  uint16 crc16-ccitt           // poly 0x1021, init 0xFFFF; over [transfer-id..payload]
+  uint8  payload[chunk-size]
+
+OTA_DATA_ACK / OTA_DATA_NAK:
+  uint8  transfer-id
+  uint32 highest-contiguous-seq
+  uint32 next-expected-seq
+  uint8  window-remaining      // backpressure
+  uint8  reason-code           // 0 on ACK; CRC|WRITE|OUT_OF_ORDER|HEAP on NAK
+
+OTA_END payload:                { uint8 transfer-id; uint32 total-chunks-sent; uint8[32] sha256-final; }
+OTA_END_ACK payload:            { uint8 transfer-id; uint8 status; uint8[32] sha256-computed; }
+OTA_COMMIT payload:             { uint8 transfer-id; }
+OTA_COMMIT_ACK payload:         { uint8 transfer-id; uint8 rebooting; }   // rebooting = 1
+```
+
+### Timing
+
+- Per-frame ACK timeout: **400 ms**, up to 3 retries.
+- `OTA_BEGIN_ACK` timeout: **2 s** (padawan may erase a partition).
+- `OTA_END_ACK` timeout: **5 s** (full SHA-256 over 1.2 MB on ESP32 ≈ 1–3 s).
+- Inter-padawan idle: **0 ms**.
+- Post-`OTA_COMMIT` heartbeat poll: master polls padawan's heartbeat for `version === target` for **up to 15 s** before declaring `VERSION_CONFIRMED` or `FAILED detail=reboot_timeout`.
+
+### Happy path (one padawan)
+
+```
+Master                                 Padawan
+  |--OTA_BEGIN--------------------------->|   esp_ota_begin(inactive_part)
+  |<-OTA_BEGIN_ACK------------------------|
+  |--OTA_DATA seq=0..7------------------->|   esp_ota_write each
+  |<-OTA_DATA_ACK next=8 win=8------------|
+  |     ... (sliding window) ...          |
+  |--OTA_END------------------------------>|   esp_ota_end + sha256 verify
+  |<-OTA_END_ACK OK------------------------|
+  |--OTA_COMMIT---------------------------->|   esp_ota_set_boot_partition
+  |<-OTA_COMMIT_ACK rebooting=1-------------|
+  |  (silent: padawan reboots)              |
+  |<-(POLL_ACK heartbeat: version=target)---|
+  master records VERSION_CONFIRMED, moves to next padawan
+```
+
+### Failure modes
+
+- v1: abort the failing padawan and move on. Wire format leaves room for resume-from-seq-N (`next-expected-seq` field) but it is not implemented in v1.
+- `OTA_END_ACK HASH_MISMATCH`: padawan refuses the commit; partition stays bootable on the previous image.
+- Reboot watchdog: padawan boots into new firmware, must call `esp_ota_mark_app_valid_cancel_rollback` on first successful POLL_ACK back to master. Otherwise the bootloader auto-rolls back on next boot.
+
+## How to amend this document
+
+1. Edit the file in **both** repos in coordinated commits or PRs that reference each other.
+2. When extending either enum, **append** new values — never reorder existing entries.
+3. Note the cross-repo commit hash in the PR description so reviewers can verify the two copies match.
+4. Sub-project plans that reference enum names from this file must be reviewed for compatibility.

--- a/.docs/protocol.md
+++ b/.docs/protocol.md
@@ -65,6 +65,9 @@ Existing framing is unchanged: `[type(int)][RS][validator-string][RS][msg-id][GS
 FW_TRANSFER_BEGIN:    transfer-id<US>total-size<US>sha256-hex<US>chunk-size<US>target-list
                       target-list = controllerId[RS]controllerId[RS]...
                                     "master" included means master self-flashes last
+FW_TRANSFER_BEGIN_ACK: transfer-id<US>status
+                      status = "OK" on success; otherwise a snake_case rejection
+                      code (e.g., "sd_full", "busy", "unsupported_version")
 FW_CHUNK:             transfer-id<US>seq<US>payload-len<US>base64-bytes<US>crc16-hex
 FW_CHUNK_ACK:         transfer-id<US>highest-contiguous-seq<US>next-expected-seq<US>window-remaining
 FW_CHUNK_NAK:         transfer-id<US>last-good-seq<US>reason-code   // CRC|SIZE|OUT_OF_ORDER|FLASH_FULL

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -47,7 +47,7 @@ import { SerialMessageType } from './serial/serial_message.js';
 import {
   ConfigSyncResponse,
   ISerialWorkerResponse,
-  PollRepsonse,
+  PollResponse,
   RegistrationResponse,
   SerialWorkerResponseType,
 } from './serial/serial_worker_response.js';
@@ -593,7 +593,7 @@ class ApiServer {
 
   async handlePollResponse(msg: ISerialWorkerResponse) {
     try {
-      const val = msg as PollRepsonse;
+      const val = msg as PollResponse;
 
       const controlerRepo = new ControllerRepository(this.db);
       const locationRepo = new LocationsRepository(this.db);

--- a/astros_api/src/models/firmware/firmware_messages.ts
+++ b/astros_api/src/models/firmware/firmware_messages.ts
@@ -67,7 +67,11 @@ export interface FwChunkAck {
   windowRemaining: number;
 }
 
-export type FwChunkNakReason = 'CRC' | 'SIZE' | 'OUT_OF_ORDER' | 'FLASH_FULL';
+// Single source of truth for the FW_CHUNK_NAK reason codes. The runtime check
+// in MessageHandler derives its lookup set from this same tuple, so adding a
+// new reason here automatically extends both the type and the validator.
+export const FW_CHUNK_NAK_REASONS = ['CRC', 'SIZE', 'OUT_OF_ORDER', 'FLASH_FULL'] as const;
+export type FwChunkNakReason = (typeof FW_CHUNK_NAK_REASONS)[number];
 
 export interface FwChunkNak {
   transferId: string;
@@ -75,7 +79,8 @@ export interface FwChunkNak {
   reasonCode: FwChunkNakReason;
 }
 
-export type FwTransferEndStatus = 'OK' | 'HASH_MISMATCH' | 'IO_ERROR';
+export const FW_TRANSFER_END_STATUSES = ['OK', 'HASH_MISMATCH', 'IO_ERROR'] as const;
+export type FwTransferEndStatus = (typeof FW_TRANSFER_END_STATUSES)[number];
 
 export interface FwTransferEndAck {
   transferId: string;
@@ -104,7 +109,8 @@ export interface FwDeployDone {
   results: FwDeployDoneResult[];
 }
 
-export type FwBackpressureAction = 'PAUSE' | 'RESUME';
+export const FW_BACKPRESSURE_ACTIONS = ['PAUSE', 'RESUME'] as const;
+export type FwBackpressureAction = (typeof FW_BACKPRESSURE_ACTIONS)[number];
 
 export interface FwBackpressure {
   transferId: string;

--- a/astros_api/src/models/firmware/firmware_messages.ts
+++ b/astros_api/src/models/firmware/firmware_messages.ts
@@ -1,0 +1,113 @@
+// Typed payload interfaces for the firmware OTA wire protocol.
+// Mirrors the field layouts in .docs/protocol.md § A. The two copies of
+// .docs/protocol.md (this repo + AstrOs.ESP) are the source of truth;
+// any change here must be made in lockstep with both.
+
+// ---------------------------------------------------------------------------
+// Stage enum (shared with .docs/protocol.md "Stage enum"). Master emits these
+// in FW_PROGRESS.stage; server forwards them to the UI.
+// ---------------------------------------------------------------------------
+
+export enum FwStage {
+  Queued = 'QUEUED',
+  UploadingToMaster = 'UPLOADING_TO_MASTER',
+  Sending = 'SENDING',
+  Verifying = 'VERIFYING',
+  Rebooting = 'REBOOTING',
+  VersionConfirmed = 'VERSION_CONFIRMED',
+  Failed = 'FAILED',
+}
+
+// ---------------------------------------------------------------------------
+// Server → master (outgoing). Consumed by MessageGenerator.
+// ---------------------------------------------------------------------------
+
+export interface FwTransferBegin {
+  transferId: string;
+  totalSize: number;
+  sha256Hex: string; // 64 lowercase hex chars
+  chunkSize: number; // decoded bytes per FW_CHUNK
+  targets: string[]; // controller IDs; "master" included means self-flash last
+}
+
+export interface FwChunk {
+  transferId: string;
+  seq: number;
+  payloadLen: number;
+  base64Bytes: string;
+  crc16Hex: string;
+}
+
+export interface FwTransferEnd {
+  transferId: string;
+  totalChunks: number;
+  finalSha256Hex: string;
+}
+
+export interface FwDeployBegin {
+  transferId: string;
+  order: string[]; // ordered controller IDs; padawans first, master last
+}
+
+// ---------------------------------------------------------------------------
+// Master → server (incoming). Produced by MessageHandler.
+// ---------------------------------------------------------------------------
+
+export interface FwTransferBeginAck {
+  transferId: string;
+  // "ready" or a rejection reason like "sd_full". Open-ended string per
+  // protocol.md so future reasons can be added without enum churn.
+  status: string;
+}
+
+export interface FwChunkAck {
+  transferId: string;
+  highestContiguousSeq: number;
+  nextExpectedSeq: number;
+  windowRemaining: number;
+}
+
+export type FwChunkNakReason = 'CRC' | 'SIZE' | 'OUT_OF_ORDER' | 'FLASH_FULL';
+
+export interface FwChunkNak {
+  transferId: string;
+  lastGoodSeq: number;
+  reasonCode: FwChunkNakReason;
+}
+
+export type FwTransferEndStatus = 'OK' | 'HASH_MISMATCH' | 'IO_ERROR';
+
+export interface FwTransferEndAck {
+  transferId: string;
+  status: FwTransferEndStatus;
+  computedSha256Hex: string;
+}
+
+export interface FwProgress {
+  transferId: string;
+  controllerId: string;
+  stage: FwStage;
+  bytesSent: number;
+  totalBytes: number;
+  detail: string;
+}
+
+export interface FwDeployDoneResult {
+  controllerId: string;
+  outcome: 'OK' | 'FAILED';
+  finalVersion: string;
+  error: string; // empty string when outcome === 'OK'
+}
+
+export interface FwDeployDone {
+  transferId: string;
+  results: FwDeployDoneResult[];
+}
+
+export type FwBackpressureAction = 'PAUSE' | 'RESUME';
+
+export interface FwBackpressure {
+  transferId: string;
+  action: FwBackpressureAction;
+  reason: string;
+}

--- a/astros_api/src/models/firmware/firmware_messages.ts
+++ b/astros_api/src/models/firmware/firmware_messages.ts
@@ -55,7 +55,7 @@ export interface FwDeployBegin {
 
 export interface FwTransferBeginAck {
   transferId: string;
-  // "ready" or a rejection reason like "sd_full". Open-ended string per
+  // "OK" or a rejection reason like "sd_full". Open-ended string per
   // protocol.md so future reasons can be added without enum churn.
   status: string;
 }

--- a/astros_api/src/models/firmware/firmware_messages.ts
+++ b/astros_api/src/models/firmware/firmware_messages.ts
@@ -4,6 +4,15 @@
 // any change here must be made in lockstep with both.
 
 // ---------------------------------------------------------------------------
+// Protocol numeric constants. Single source of truth for runtime range checks.
+// ---------------------------------------------------------------------------
+
+// Maximum sliding-window size on the serial transport (server↔master), per
+// .docs/protocol.md "Shared values". FW_CHUNK_ACK.windowRemaining must lie in
+// [0, FW_SERIAL_SLIDING_WINDOW]; larger values indicate a malformed frame.
+export const FW_SERIAL_SLIDING_WINDOW = 16;
+
+// ---------------------------------------------------------------------------
 // Stage enum (shared with .docs/protocol.md "Stage enum"). Master emits these
 // in FW_PROGRESS.stage; server forwards them to the UI.
 // ---------------------------------------------------------------------------

--- a/astros_api/src/serial/message_generator.test.ts
+++ b/astros_api/src/serial/message_generator.test.ts
@@ -2,6 +2,12 @@ import { expect, describe, it } from 'vitest';
 import { MessageGenerator } from './message_generator.js';
 import { MessageHelper } from './message_helper.js';
 import { SerialMessageType } from './serial_message.js';
+import type {
+  FwTransferBegin,
+  FwChunk,
+  FwTransferEnd,
+  FwDeployBegin,
+} from '../models/firmware/firmware_messages.js';
 import { createConfigSync } from '../models/config/config_sync.js';
 import { createScriptRun } from '../models/scripts/script_run.js';
 import { createScriptUpload } from '../models/scripts/script_upload.js';
@@ -165,6 +171,87 @@ describe('Message Generator Tests', () => {
         `${addr2}${US}${ctrlName2}${US}5@1|0|1|0;1@${idx2}:1:9600@1:1:1:800:2000:1400:0|2:1:0:500:2500:1500:1` +
         RS +
         `${addr3}${US}${ctrlName3}${US}5@1|0|1|0;1@${idx3}:1:9600@1:1:1:800:2000:1400:0|2:1:0:500:2500:1500:1\n`,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Firmware OTA outgoing messages (.docs/protocol.md § A).
+  // -------------------------------------------------------------------------
+
+  it('generate FW_TRANSFER_BEGIN serializes transferId + size + hash + chunk-size + targets', () => {
+    const generator = new MessageGenerator();
+    const payload: FwTransferBegin = {
+      transferId: 'xfer-1',
+      totalSize: 1234567,
+      sha256Hex: 'a'.repeat(64),
+      chunkSize: 4096,
+      targets: ['core', 'dome', 'master'],
+    };
+
+    const message = generator.generateMessage(
+      SerialMessageType.FW_TRANSFER_BEGIN,
+      'msg-1',
+      payload,
+    );
+
+    expect(message.controllers).toEqual(['core', 'dome', 'master']);
+    expect(message.metaData).toBe('xfer-1');
+    expect(message.msg).toBe(
+      `30${RS}FW_TRANSFER_BEGIN${RS}msg-1${GS}` +
+        `xfer-1${US}1234567${US}${'a'.repeat(64)}${US}4096${US}` +
+        `core${RS}dome${RS}master\n`,
+    );
+  });
+
+  it('generate FW_CHUNK serializes seq + len + base64 + crc', () => {
+    const generator = new MessageGenerator();
+    const payload: FwChunk = {
+      transferId: 'xfer-1',
+      seq: 42,
+      payloadLen: 128,
+      base64Bytes: 'aGVsbG8gd29ybGQ=',
+      crc16Hex: 'beef',
+    };
+
+    const message = generator.generateMessage(SerialMessageType.FW_CHUNK, 'msg-2', payload);
+
+    expect(message.metaData).toBe('xfer-1');
+    expect(message.controllers).toEqual([]);
+    expect(message.msg).toBe(
+      `32${RS}FW_CHUNK${RS}msg-2${GS}xfer-1${US}42${US}128${US}aGVsbG8gd29ybGQ=${US}beef\n`,
+    );
+  });
+
+  it('generate FW_TRANSFER_END serializes total-chunks + final-hash', () => {
+    const generator = new MessageGenerator();
+    const payload: FwTransferEnd = {
+      transferId: 'xfer-1',
+      totalChunks: 9376,
+      finalSha256Hex: 'b'.repeat(64),
+    };
+
+    const message = generator.generateMessage(SerialMessageType.FW_TRANSFER_END, 'msg-3', payload);
+
+    expect(message.metaData).toBe('xfer-1');
+    expect(message.controllers).toEqual([]);
+    expect(message.msg).toBe(
+      `35${RS}FW_TRANSFER_END${RS}msg-3${GS}xfer-1${US}9376${US}${'b'.repeat(64)}\n`,
+    );
+  });
+
+  it('generate FW_DEPLOY_BEGIN serializes ordered controller list', () => {
+    const generator = new MessageGenerator();
+    const payload: FwDeployBegin = {
+      transferId: 'xfer-1',
+      order: ['core', 'dome', 'master'],
+    };
+
+    const message = generator.generateMessage(SerialMessageType.FW_DEPLOY_BEGIN, 'msg-4', payload);
+
+    expect(message.metaData).toBe('xfer-1');
+    expect(message.controllers).toEqual(['core', 'dome', 'master']);
+    expect(message.msg).toBe(
+      `37${RS}FW_DEPLOY_BEGIN${RS}msg-4${GS}xfer-1${US}core${RS}dome${RS}master\n`,
     );
   });
 });

--- a/astros_api/src/serial/message_generator.ts
+++ b/astros_api/src/serial/message_generator.ts
@@ -9,6 +9,12 @@ import { ScriptUpload } from 'src/models/scripts/script_upload.js';
 import { ScriptRun } from 'src/models/scripts/script_run.js';
 import { ServoTest } from 'src/models/servo_test.js';
 import { MaestroModule } from 'src/models/index.js';
+import type {
+  FwTransferBegin,
+  FwChunk,
+  FwTransferEnd,
+  FwDeployBegin,
+} from 'src/models/firmware/firmware_messages.js';
 
 export enum EspModuleType {
   NONE = 0,
@@ -52,6 +58,18 @@ export class MessageGenerator {
         break;
       case SerialMessageType.SERVO_TEST:
         result = this.generateServoTestCommand(header, data);
+        break;
+      case SerialMessageType.FW_TRANSFER_BEGIN:
+        result = this.generateFwTransferBegin(header, data);
+        break;
+      case SerialMessageType.FW_CHUNK:
+        result = this.generateFwChunk(header, data);
+        break;
+      case SerialMessageType.FW_TRANSFER_END:
+        result = this.generateFwTransferEnd(header, data);
+        break;
+      case SerialMessageType.FW_DEPLOY_BEGIN:
+        result = this.generateFwDeployBegin(header, data);
         break;
       default:
         logger.error(`Unknown message type: ${type}`);
@@ -314,6 +332,50 @@ export class MessageGenerator {
     return new MessageGeneratorResponse(`${header}${MessageHelper.MessageEOL}`, [
       '00:00:00:00:00:00',
     ]);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Firmware OTA outgoing messages — see .docs/protocol.md § A.
+  // ---------------------------------------------------------------------------
+
+  generateFwTransferBegin(header: string, data: FwTransferBegin): MessageGeneratorResponse {
+    const payload = [
+      data.transferId,
+      String(data.totalSize),
+      data.sha256Hex,
+      String(data.chunkSize),
+      data.targets.join(this.RS),
+    ].join(this.US);
+
+    const msg = `${header}${this.GS}${payload}${MessageHelper.MessageEOL}`;
+    return new MessageGeneratorResponse(msg, [...data.targets], data.transferId);
+  }
+
+  generateFwChunk(header: string, data: FwChunk): MessageGeneratorResponse {
+    const payload = [
+      data.transferId,
+      String(data.seq),
+      String(data.payloadLen),
+      data.base64Bytes,
+      data.crc16Hex,
+    ].join(this.US);
+
+    const msg = `${header}${this.GS}${payload}${MessageHelper.MessageEOL}`;
+    return new MessageGeneratorResponse(msg, [], data.transferId);
+  }
+
+  generateFwTransferEnd(header: string, data: FwTransferEnd): MessageGeneratorResponse {
+    const payload = [data.transferId, String(data.totalChunks), data.finalSha256Hex].join(this.US);
+
+    const msg = `${header}${this.GS}${payload}${MessageHelper.MessageEOL}`;
+    return new MessageGeneratorResponse(msg, [], data.transferId);
+  }
+
+  generateFwDeployBegin(header: string, data: FwDeployBegin): MessageGeneratorResponse {
+    const payload = [data.transferId, data.order.join(this.RS)].join(this.US);
+
+    const msg = `${header}${this.GS}${payload}${MessageHelper.MessageEOL}`;
+    return new MessageGeneratorResponse(msg, [...data.order], data.transferId);
   }
 
   generateFormatSD(header: string, data: any) {

--- a/astros_api/src/serial/message_handler.test.ts
+++ b/astros_api/src/serial/message_handler.test.ts
@@ -3,6 +3,7 @@ import { MessageHandler } from './message_handler.js';
 import { MessageHelper } from './message_helper.js';
 import { SerialMessageType } from './serial_message.js';
 import { SerialWorkerResponseType } from './serial_worker_response.js';
+import { FwStage } from '../models/firmware/firmware_messages.js';
 
 const RS = MessageHelper.RS;
 const GS = MessageHelper.GS;
@@ -310,5 +311,155 @@ describe('Serial Message Handler Tests', () => {
     expect(response.registrations.length).toBe(1);
     expect(response.registrations[0].name).toBe('name1');
     expect(response.registrations[0].address).toBe('mac1');
+  });
+
+  // -------------------------------------------------------------------------
+  // Firmware OTA incoming messages (.docs/protocol.md § A).
+  // -------------------------------------------------------------------------
+
+  it('handle FW_TRANSFER_BEGIN_ACK parses transferId + status', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}OK`;
+
+    const response = handler.handleFwTransferBeginAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK);
+    expect(response.payload).toEqual({ transferId: 'xfer-1', status: 'OK' });
+  });
+
+  it('handle FW_TRANSFER_BEGIN_ACK preserves rejection codes verbatim', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}sd_full`;
+
+    const response = handler.handleFwTransferBeginAck(payload);
+
+    expect(response.payload.status).toBe('sd_full');
+  });
+
+  it('handle FW_CHUNK_ACK parses cumulative ack window state', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}99${US}100${US}8`;
+
+    const response = handler.handleFwChunkAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.FW_CHUNK_ACK);
+    expect(response.payload).toEqual({
+      transferId: 'xfer-1',
+      highestContiguousSeq: 99,
+      nextExpectedSeq: 100,
+      windowRemaining: 8,
+    });
+  });
+
+  it('handle FW_CHUNK_NAK parses last-good-seq + reason', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}42${US}CRC`;
+
+    const response = handler.handleFwChunkNak(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.FW_CHUNK_NAK);
+    expect(response.payload).toEqual({
+      transferId: 'xfer-1',
+      lastGoodSeq: 42,
+      reasonCode: 'CRC',
+    });
+  });
+
+  it('handle FW_CHUNK_NAK rejects unknown reason codes', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}42${US}NONSENSE`;
+
+    const response = handler.handleFwChunkNak(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
+  it('handle FW_TRANSFER_END_ACK parses status + computed hash', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}OK${US}${'a'.repeat(64)}`;
+
+    const response = handler.handleFwTransferEndAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.FW_TRANSFER_END_ACK);
+    expect(response.payload).toEqual({
+      transferId: 'xfer-1',
+      status: 'OK',
+      computedSha256Hex: 'a'.repeat(64),
+    });
+  });
+
+  it('handle FW_TRANSFER_END_ACK preserves HASH_MISMATCH status', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}HASH_MISMATCH${US}${'b'.repeat(64)}`;
+
+    const response = handler.handleFwTransferEndAck(payload);
+
+    expect(response.payload.status).toBe('HASH_MISMATCH');
+  });
+
+  it('handle FW_PROGRESS parses controller stage update', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}core${US}SENDING${US}524288${US}1234567${US}ok`;
+
+    const response = handler.handleFwProgress(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.FW_PROGRESS);
+    expect(response.payload).toEqual({
+      transferId: 'xfer-1',
+      controllerId: 'core',
+      stage: FwStage.Sending,
+      bytesSent: 524288,
+      totalBytes: 1234567,
+      detail: 'ok',
+    });
+  });
+
+  it('handle FW_PROGRESS rejects unknown stage values', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}core${US}NONSENSE${US}0${US}0${US}`;
+
+    const response = handler.handleFwProgress(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
+  it('handle FW_DEPLOY_DONE parses per-controller results', () => {
+    const handler = new MessageHandler();
+    const payload =
+      `xfer-1${US}` +
+      `core${US}OK${US}1.4.0${US}${RS}` +
+      `dome${US}FAILED${US}1.3.2${US}reboot_timeout`;
+
+    const response = handler.handleFwDeployDone(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.FW_DEPLOY_DONE);
+    expect(response.payload.transferId).toBe('xfer-1');
+    expect(response.payload.results).toEqual([
+      { controllerId: 'core', outcome: 'OK', finalVersion: '1.4.0', error: '' },
+      { controllerId: 'dome', outcome: 'FAILED', finalVersion: '1.3.2', error: 'reboot_timeout' },
+    ]);
+  });
+
+  it('handle FW_BACKPRESSURE parses pause/resume + reason', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}PAUSE${US}sd_writing`;
+
+    const response = handler.handleFwBackpressure(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.FW_BACKPRESSURE);
+    expect(response.payload).toEqual({
+      transferId: 'xfer-1',
+      action: 'PAUSE',
+      reason: 'sd_writing',
+    });
+  });
+
+  it('handle FW_BACKPRESSURE rejects unknown action values', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}NONSENSE${US}reason`;
+
+    const response = handler.handleFwBackpressure(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
   });
 });

--- a/astros_api/src/serial/message_handler.test.ts
+++ b/astros_api/src/serial/message_handler.test.ts
@@ -351,6 +351,30 @@ describe('Serial Message Handler Tests', () => {
     });
   });
 
+  it('handle FW_CHUNK_ACK rejects numeric fields with trailing garbage', () => {
+    const handler = new MessageHandler();
+    // parseInt would silently truncate '99junk' to 99; the strict validator
+    // must reject the frame entirely so a malformed ack cannot poison
+    // downstream window-tracking state.
+    const payload = `xfer-1${US}99junk${US}100${US}8`;
+
+    const response = handler.handleFwChunkAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
+  it('handle FW_CHUNK_ACK rejects windowRemaining outside the configured sliding window', () => {
+    const handler = new MessageHandler();
+    // Per .docs/protocol.md the serial sliding window is 16 frames; any
+    // larger value is malformed and must be rejected so the orchestrator
+    // can't end up sending more in-flight chunks than the contract allows.
+    const payload = `xfer-1${US}99${US}100${US}17`;
+
+    const response = handler.handleFwChunkAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
   it('handle FW_CHUNK_NAK parses last-good-seq + reason', () => {
     const handler = new MessageHandler();
     const payload = `xfer-1${US}42${US}CRC`;
@@ -368,6 +392,15 @@ describe('Serial Message Handler Tests', () => {
   it('handle FW_CHUNK_NAK rejects unknown reason codes', () => {
     const handler = new MessageHandler();
     const payload = `xfer-1${US}42${US}NONSENSE`;
+
+    const response = handler.handleFwChunkNak(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
+  it('handle FW_CHUNK_NAK rejects lastGoodSeq with trailing garbage', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}42junk${US}CRC`;
 
     const response = handler.handleFwChunkNak(payload);
 
@@ -417,6 +450,15 @@ describe('Serial Message Handler Tests', () => {
   it('handle FW_PROGRESS rejects unknown stage values', () => {
     const handler = new MessageHandler();
     const payload = `xfer-1${US}core${US}NONSENSE${US}0${US}0${US}`;
+
+    const response = handler.handleFwProgress(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
+  it('handle FW_PROGRESS rejects byte counts with trailing garbage', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}core${US}SENDING${US}1024junk${US}1234567${US}ok`;
 
     const response = handler.handleFwProgress(payload);
 

--- a/astros_api/src/serial/message_handler.test.ts
+++ b/astros_api/src/serial/message_handler.test.ts
@@ -430,6 +430,38 @@ describe('Serial Message Handler Tests', () => {
     expect(response.payload.status).toBe('HASH_MISMATCH');
   });
 
+  it('handle FW_TRANSFER_END_ACK rejects hashes with wrong length', () => {
+    const handler = new MessageHandler();
+    // 63 chars (one short). A sloppy parser would still pass this through and
+    // every later byte-comparison against the server's reference hash would
+    // appear as a hash mismatch, hiding the wire-format corruption.
+    const payload = `xfer-1${US}OK${US}${'a'.repeat(63)}`;
+
+    const response = handler.handleFwTransferEndAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
+  it('handle FW_TRANSFER_END_ACK rejects hashes with non-hex characters', () => {
+    const handler = new MessageHandler();
+    const payload = `xfer-1${US}OK${US}${'g'.repeat(64)}`;
+
+    const response = handler.handleFwTransferEndAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
+  it('handle FW_TRANSFER_END_ACK rejects uppercase hex (contract requires lowercase)', () => {
+    const handler = new MessageHandler();
+    // Lowercase-only matters for byte-equality against crypto.createHash
+    // output, which is always lowercase.
+    const payload = `xfer-1${US}OK${US}${'A'.repeat(64)}`;
+
+    const response = handler.handleFwTransferEndAck(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
   it('handle FW_PROGRESS parses controller stage update', () => {
     const handler = new MessageHandler();
     const payload = `xfer-1${US}core${US}SENDING${US}524288${US}1234567${US}ok`;

--- a/astros_api/src/serial/message_handler.test.ts
+++ b/astros_api/src/serial/message_handler.test.ts
@@ -440,6 +440,17 @@ describe('Serial Message Handler Tests', () => {
     ]);
   });
 
+  it('handle FW_DEPLOY_DONE rejects an OK result that carries a non-empty error', () => {
+    const handler = new MessageHandler();
+    // OK + non-empty error violates the per-result invariant in protocol.md
+    // ("errorOrEmpty"); accepting it would produce inconsistent UI state.
+    const payload = `xfer-1${US}core${US}OK${US}1.4.0${US}stale_data`;
+
+    const response = handler.handleFwDeployDone(payload);
+
+    expect(response.type).toBe(SerialWorkerResponseType.UNKNOWN);
+  });
+
   it('handle FW_BACKPRESSURE parses pause/resume + reason', () => {
     const handler = new MessageHandler();
     const payload = `xfer-1${US}PAUSE${US}sd_writing`;

--- a/astros_api/src/serial/message_handler.ts
+++ b/astros_api/src/serial/message_handler.ts
@@ -21,6 +21,7 @@ import type { ControlModule } from 'src/models/index.js';
 import {
   FW_BACKPRESSURE_ACTIONS,
   FW_CHUNK_NAK_REASONS,
+  FW_SERIAL_SLIDING_WINDOW,
   FW_TRANSFER_END_STATUSES,
   FwStage,
   type FwBackpressureAction,
@@ -212,11 +213,19 @@ export class MessageHandler {
       return response;
     }
 
-    const highest = parseInt(parts[1], 10);
-    const next = parseInt(parts[2], 10);
-    const window = parseInt(parts[3], 10);
-    if (Number.isNaN(highest) || Number.isNaN(next) || Number.isNaN(window)) {
-      logger.error(`FW_CHUNK_ACK has non-numeric fields: ${msg}`);
+    const highest = MessageHelper.parseUint(parts[1]);
+    const next = MessageHelper.parseUint(parts[2]);
+    const window = MessageHelper.parseUint(parts[3]);
+    if (highest === null || next === null || window === null) {
+      logger.error(`FW_CHUNK_ACK has non-numeric or malformed fields: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    if (window > FW_SERIAL_SLIDING_WINDOW) {
+      logger.error(
+        `FW_CHUNK_ACK windowRemaining ${window} exceeds configured sliding window ${FW_SERIAL_SLIDING_WINDOW}: ${msg}`,
+      );
       response.type = SerialWorkerResponseType.UNKNOWN;
       return response;
     }
@@ -242,9 +251,9 @@ export class MessageHandler {
       return response;
     }
 
-    const lastGoodSeq = parseInt(parts[1], 10);
-    if (Number.isNaN(lastGoodSeq)) {
-      logger.error(`FW_CHUNK_NAK lastGoodSeq is not numeric: ${msg}`);
+    const lastGoodSeq = MessageHelper.parseUint(parts[1]);
+    if (lastGoodSeq === null) {
+      logger.error(`FW_CHUNK_NAK lastGoodSeq is not a valid unsigned integer: ${msg}`);
       response.type = SerialWorkerResponseType.UNKNOWN;
       return response;
     }
@@ -306,10 +315,10 @@ export class MessageHandler {
       return response;
     }
 
-    const bytesSent = parseInt(parts[3], 10);
-    const totalBytes = parseInt(parts[4], 10);
-    if (Number.isNaN(bytesSent) || Number.isNaN(totalBytes)) {
-      logger.error(`FW_PROGRESS has non-numeric byte counts: ${msg}`);
+    const bytesSent = MessageHelper.parseUint(parts[3]);
+    const totalBytes = MessageHelper.parseUint(parts[4]);
+    if (bytesSent === null || totalBytes === null) {
+      logger.error(`FW_PROGRESS has non-numeric or malformed byte counts: ${msg}`);
       response.type = SerialWorkerResponseType.UNKNOWN;
       return response;
     }

--- a/astros_api/src/serial/message_handler.ts
+++ b/astros_api/src/serial/message_handler.ts
@@ -362,11 +362,21 @@ export class MessageHandler {
         return response;
       }
 
+      const error = fields[3];
+      // Cross-field invariant from protocol.md: an OK outcome must have an
+      // empty error. Accepting OK + non-empty error would produce contradictory
+      // downstream state (e.g., a green pill with an error tooltip).
+      if (outcome === 'OK' && error !== '') {
+        logger.error(`FW_DEPLOY_DONE OK result has non-empty error: ${error}`);
+        response.type = SerialWorkerResponseType.UNKNOWN;
+        return response;
+      }
+
       results.push({
         controllerId: fields[0],
         outcome,
         finalVersion: fields[2],
-        error: fields[3],
+        error,
       });
     }
 

--- a/astros_api/src/serial/message_handler.ts
+++ b/astros_api/src/serial/message_handler.ts
@@ -15,6 +15,7 @@ import type {
   RegistrationResponse,
   ScriptDeployResponse,
   ScriptRunResponse,
+  UnknownSerialResponse,
 } from './serial_worker_response.js';
 import type { SerialMsgValidationResult } from './serial_message.js';
 import type { ControlModule } from 'src/models/index.js';
@@ -185,32 +186,24 @@ export class MessageHandler {
   // Firmware OTA incoming messages — see .docs/protocol.md § A.
   // ---------------------------------------------------------------------------
 
-  handleFwTransferBeginAck(msg: string): FwTransferBeginAckResponse {
-    const response = {
-      type: SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK,
-    } as FwTransferBeginAckResponse;
-
+  handleFwTransferBeginAck(msg: string): FwTransferBeginAckResponse | UnknownSerialResponse {
     const parts = msg.split(MessageHelper.US);
     if (parts.length !== 2) {
       logger.error(`Invalid FW_TRANSFER_BEGIN_ACK: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
-    response.payload = { transferId: parts[0], status: parts[1] };
-    return response;
+    return {
+      type: SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK,
+      payload: { transferId: parts[0], status: parts[1] },
+    };
   }
 
-  handleFwChunkAck(msg: string): FwChunkAckResponse {
-    const response = {
-      type: SerialWorkerResponseType.FW_CHUNK_ACK,
-    } as FwChunkAckResponse;
-
+  handleFwChunkAck(msg: string): FwChunkAckResponse | UnknownSerialResponse {
     const parts = msg.split(MessageHelper.US);
     if (parts.length !== 4) {
       logger.error(`Invalid FW_CHUNK_ACK: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const highest = MessageHelper.parseUint(parts[1]);
@@ -218,74 +211,63 @@ export class MessageHandler {
     const window = MessageHelper.parseUint(parts[3]);
     if (highest === null || next === null || window === null) {
       logger.error(`FW_CHUNK_ACK has non-numeric or malformed fields: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     if (window > FW_SERIAL_SLIDING_WINDOW) {
       logger.error(
         `FW_CHUNK_ACK windowRemaining ${window} exceeds configured sliding window ${FW_SERIAL_SLIDING_WINDOW}: ${msg}`,
       );
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
-    response.payload = {
-      transferId: parts[0],
-      highestContiguousSeq: highest,
-      nextExpectedSeq: next,
-      windowRemaining: window,
+    return {
+      type: SerialWorkerResponseType.FW_CHUNK_ACK,
+      payload: {
+        transferId: parts[0],
+        highestContiguousSeq: highest,
+        nextExpectedSeq: next,
+        windowRemaining: window,
+      },
     };
-    return response;
   }
 
-  handleFwChunkNak(msg: string): FwChunkNakResponse {
-    const response = {
-      type: SerialWorkerResponseType.FW_CHUNK_NAK,
-    } as FwChunkNakResponse;
-
+  handleFwChunkNak(msg: string): FwChunkNakResponse | UnknownSerialResponse {
     const parts = msg.split(MessageHelper.US);
     if (parts.length !== 3) {
       logger.error(`Invalid FW_CHUNK_NAK: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const lastGoodSeq = MessageHelper.parseUint(parts[1]);
     if (lastGoodSeq === null) {
       logger.error(`FW_CHUNK_NAK lastGoodSeq is not a valid unsigned integer: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const reason = parts[2] as FwChunkNakReason;
     if (!FW_CHUNK_NAK_REASON_SET.has(reason)) {
       logger.error(`FW_CHUNK_NAK has unknown reason: ${parts[2]}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
-    response.payload = { transferId: parts[0], lastGoodSeq, reasonCode: reason };
-    return response;
+    return {
+      type: SerialWorkerResponseType.FW_CHUNK_NAK,
+      payload: { transferId: parts[0], lastGoodSeq, reasonCode: reason },
+    };
   }
 
-  handleFwTransferEndAck(msg: string): FwTransferEndAckResponse {
-    const response = {
-      type: SerialWorkerResponseType.FW_TRANSFER_END_ACK,
-    } as FwTransferEndAckResponse;
-
+  handleFwTransferEndAck(msg: string): FwTransferEndAckResponse | UnknownSerialResponse {
     const parts = msg.split(MessageHelper.US);
     if (parts.length !== 3) {
       logger.error(`Invalid FW_TRANSFER_END_ACK: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const status = parts[1] as FwTransferEndStatus;
     if (!FW_TRANSFER_END_STATUS_SET.has(status)) {
       logger.error(`FW_TRANSFER_END_ACK has unknown status: ${parts[1]}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const computedSha256Hex = MessageHelper.parseSha256Hex(parts[2]);
@@ -293,61 +275,49 @@ export class MessageHandler {
       logger.error(
         `FW_TRANSFER_END_ACK has malformed sha256 (expected 64 lowercase hex chars): ${parts[2]}`,
       );
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
-    response.payload = {
-      transferId: parts[0],
-      status,
-      computedSha256Hex,
+    return {
+      type: SerialWorkerResponseType.FW_TRANSFER_END_ACK,
+      payload: { transferId: parts[0], status, computedSha256Hex },
     };
-    return response;
   }
 
-  handleFwProgress(msg: string): FwProgressResponse {
-    const response = {
-      type: SerialWorkerResponseType.FW_PROGRESS,
-    } as FwProgressResponse;
-
+  handleFwProgress(msg: string): FwProgressResponse | UnknownSerialResponse {
     const parts = msg.split(MessageHelper.US);
     if (parts.length !== 6) {
       logger.error(`Invalid FW_PROGRESS: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const stage = parts[2] as FwStage;
     if (!FW_STAGE_VALUES.has(stage)) {
       logger.error(`FW_PROGRESS has unknown stage: ${parts[2]}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const bytesSent = MessageHelper.parseUint(parts[3]);
     const totalBytes = MessageHelper.parseUint(parts[4]);
     if (bytesSent === null || totalBytes === null) {
       logger.error(`FW_PROGRESS has non-numeric or malformed byte counts: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
-    response.payload = {
-      transferId: parts[0],
-      controllerId: parts[1],
-      stage,
-      bytesSent,
-      totalBytes,
-      detail: parts[5],
+    return {
+      type: SerialWorkerResponseType.FW_PROGRESS,
+      payload: {
+        transferId: parts[0],
+        controllerId: parts[1],
+        stage,
+        bytesSent,
+        totalBytes,
+        detail: parts[5],
+      },
     };
-    return response;
   }
 
-  handleFwDeployDone(msg: string): FwDeployDoneResponse {
-    const response = {
-      type: SerialWorkerResponseType.FW_DEPLOY_DONE,
-    } as FwDeployDoneResponse;
-
+  handleFwDeployDone(msg: string): FwDeployDoneResponse | UnknownSerialResponse {
     // Wire format: transfer-id<US>result_1<RS>result_2<RS>...
     // where result = controllerId<US>outcome<US>finalVersion<US>error
     // We split only on the first US to keep the result list intact, then split
@@ -355,8 +325,7 @@ export class MessageHandler {
     const firstUs = msg.indexOf(MessageHelper.US);
     if (firstUs < 0) {
       logger.error(`Invalid FW_DEPLOY_DONE (no transferId separator): ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const transferId = msg.substring(0, firstUs);
@@ -368,15 +337,13 @@ export class MessageHandler {
       const fields = resultStr.split(MessageHelper.US);
       if (fields.length !== 4) {
         logger.error(`Invalid FW_DEPLOY_DONE result: ${resultStr}`);
-        response.type = SerialWorkerResponseType.UNKNOWN;
-        return response;
+        return { type: SerialWorkerResponseType.UNKNOWN };
       }
 
       const outcome = fields[1];
       if (outcome !== 'OK' && outcome !== 'FAILED') {
         logger.error(`FW_DEPLOY_DONE has unknown outcome: ${outcome}`);
-        response.type = SerialWorkerResponseType.UNKNOWN;
-        return response;
+        return { type: SerialWorkerResponseType.UNKNOWN };
       }
 
       const error = fields[3];
@@ -385,8 +352,7 @@ export class MessageHandler {
       // downstream state (e.g., a green pill with an error tooltip).
       if (outcome === 'OK' && error !== '') {
         logger.error(`FW_DEPLOY_DONE OK result has non-empty error: ${error}`);
-        response.type = SerialWorkerResponseType.UNKNOWN;
-        return response;
+        return { type: SerialWorkerResponseType.UNKNOWN };
       }
 
       results.push({
@@ -397,31 +363,29 @@ export class MessageHandler {
       });
     }
 
-    response.payload = { transferId, results };
-    return response;
+    return {
+      type: SerialWorkerResponseType.FW_DEPLOY_DONE,
+      payload: { transferId, results },
+    };
   }
 
-  handleFwBackpressure(msg: string): FwBackpressureResponse {
-    const response = {
-      type: SerialWorkerResponseType.FW_BACKPRESSURE,
-    } as FwBackpressureResponse;
-
+  handleFwBackpressure(msg: string): FwBackpressureResponse | UnknownSerialResponse {
     const parts = msg.split(MessageHelper.US);
     if (parts.length !== 3) {
       logger.error(`Invalid FW_BACKPRESSURE: ${msg}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
     const action = parts[1] as FwBackpressureAction;
     if (!FW_BACKPRESSURE_ACTION_SET.has(action)) {
       logger.error(`FW_BACKPRESSURE has unknown action: ${parts[1]}`);
-      response.type = SerialWorkerResponseType.UNKNOWN;
-      return response;
+      return { type: SerialWorkerResponseType.UNKNOWN };
     }
 
-    response.payload = { transferId: parts[0], action, reason: parts[2] };
-    return response;
+    return {
+      type: SerialWorkerResponseType.FW_BACKPRESSURE,
+      payload: { transferId: parts[0], action, reason: parts[2] },
+    };
   }
 
   handleRunScriptAckNak(type: SerialMessageType, msg: string): ScriptRunResponse {

--- a/astros_api/src/serial/message_handler.ts
+++ b/astros_api/src/serial/message_handler.ts
@@ -288,10 +288,19 @@ export class MessageHandler {
       return response;
     }
 
+    const computedSha256Hex = MessageHelper.parseSha256Hex(parts[2]);
+    if (computedSha256Hex === null) {
+      logger.error(
+        `FW_TRANSFER_END_ACK has malformed sha256 (expected 64 lowercase hex chars): ${parts[2]}`,
+      );
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
     response.payload = {
       transferId: parts[0],
       status,
-      computedSha256Hex: parts[2],
+      computedSha256Hex,
     };
     return response;
   }

--- a/astros_api/src/serial/message_handler.ts
+++ b/astros_api/src/serial/message_handler.ts
@@ -19,6 +19,9 @@ import type {
 import type { SerialMsgValidationResult } from './serial_message.js';
 import type { ControlModule } from 'src/models/index.js';
 import {
+  FW_BACKPRESSURE_ACTIONS,
+  FW_CHUNK_NAK_REASONS,
+  FW_TRANSFER_END_STATUSES,
   FwStage,
   type FwBackpressureAction,
   type FwChunkNakReason,
@@ -26,21 +29,17 @@ import {
   type FwTransferEndStatus,
 } from 'src/models/firmware/firmware_messages.js';
 
-const FW_CHUNK_NAK_REASONS: ReadonlySet<FwChunkNakReason> = new Set([
-  'CRC',
-  'SIZE',
-  'OUT_OF_ORDER',
-  'FLASH_FULL',
-]);
-
-const FW_TRANSFER_END_STATUSES: ReadonlySet<FwTransferEndStatus> = new Set([
-  'OK',
-  'HASH_MISMATCH',
-  'IO_ERROR',
-]);
-
-const FW_BACKPRESSURE_ACTIONS: ReadonlySet<FwBackpressureAction> = new Set(['PAUSE', 'RESUME']);
-
+// Runtime validation sets — derived directly from the const tuples in
+// firmware_messages.ts so the type and runtime checks share a single source.
+// Adding a new value to e.g. FW_CHUNK_NAK_REASONS automatically extends both
+// FwChunkNakReason and FW_CHUNK_NAK_REASON_SET below.
+const FW_CHUNK_NAK_REASON_SET: ReadonlySet<FwChunkNakReason> = new Set(FW_CHUNK_NAK_REASONS);
+const FW_TRANSFER_END_STATUS_SET: ReadonlySet<FwTransferEndStatus> = new Set(
+  FW_TRANSFER_END_STATUSES,
+);
+const FW_BACKPRESSURE_ACTION_SET: ReadonlySet<FwBackpressureAction> = new Set(
+  FW_BACKPRESSURE_ACTIONS,
+);
 const FW_STAGE_VALUES: ReadonlySet<FwStage> = new Set(Object.values(FwStage));
 
 //|--type--|--validation--|---msg Id---|---------------payload-------------|
@@ -251,7 +250,7 @@ export class MessageHandler {
     }
 
     const reason = parts[2] as FwChunkNakReason;
-    if (!FW_CHUNK_NAK_REASONS.has(reason)) {
+    if (!FW_CHUNK_NAK_REASON_SET.has(reason)) {
       logger.error(`FW_CHUNK_NAK has unknown reason: ${parts[2]}`);
       response.type = SerialWorkerResponseType.UNKNOWN;
       return response;
@@ -274,7 +273,7 @@ export class MessageHandler {
     }
 
     const status = parts[1] as FwTransferEndStatus;
-    if (!FW_TRANSFER_END_STATUSES.has(status)) {
+    if (!FW_TRANSFER_END_STATUS_SET.has(status)) {
       logger.error(`FW_TRANSFER_END_ACK has unknown status: ${parts[1]}`);
       response.type = SerialWorkerResponseType.UNKNOWN;
       return response;
@@ -397,7 +396,7 @@ export class MessageHandler {
     }
 
     const action = parts[1] as FwBackpressureAction;
-    if (!FW_BACKPRESSURE_ACTIONS.has(action)) {
+    if (!FW_BACKPRESSURE_ACTION_SET.has(action)) {
       logger.error(`FW_BACKPRESSURE has unknown action: ${parts[1]}`);
       response.type = SerialWorkerResponseType.UNKNOWN;
       return response;

--- a/astros_api/src/serial/message_handler.ts
+++ b/astros_api/src/serial/message_handler.ts
@@ -4,6 +4,13 @@ import { MessageHelper } from './message_helper.js';
 import { SerialWorkerResponseType } from './serial_worker_response.js';
 import type {
   ConfigSyncResponse,
+  FwBackpressureResponse,
+  FwChunkAckResponse,
+  FwChunkNakResponse,
+  FwDeployDoneResponse,
+  FwProgressResponse,
+  FwTransferBeginAckResponse,
+  FwTransferEndAckResponse,
   PollRepsonse,
   RegistrationResponse,
   ScriptDeployResponse,
@@ -11,6 +18,30 @@ import type {
 } from './serial_worker_response.js';
 import type { SerialMsgValidationResult } from './serial_message.js';
 import type { ControlModule } from 'src/models/index.js';
+import {
+  FwStage,
+  type FwBackpressureAction,
+  type FwChunkNakReason,
+  type FwDeployDoneResult,
+  type FwTransferEndStatus,
+} from 'src/models/firmware/firmware_messages.js';
+
+const FW_CHUNK_NAK_REASONS: ReadonlySet<FwChunkNakReason> = new Set([
+  'CRC',
+  'SIZE',
+  'OUT_OF_ORDER',
+  'FLASH_FULL',
+]);
+
+const FW_TRANSFER_END_STATUSES: ReadonlySet<FwTransferEndStatus> = new Set([
+  'OK',
+  'HASH_MISMATCH',
+  'IO_ERROR',
+]);
+
+const FW_BACKPRESSURE_ACTIONS: ReadonlySet<FwBackpressureAction> = new Set(['PAUSE', 'RESUME']);
+
+const FW_STAGE_VALUES: ReadonlySet<FwStage> = new Set(Object.values(FwStage));
 
 //|--type--|--validation--|---msg Id---|---------------payload-------------|
 //|--int---RS---string----RS--string---GS--val--US--val--RS--val--US--val--|
@@ -147,6 +178,222 @@ export class MessageHandler {
     const module: ControlModule = { id: '', name: parts[1], address: parts[0] };
     response.controller = module;
 
+    return response;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Firmware OTA incoming messages — see .docs/protocol.md § A.
+  // ---------------------------------------------------------------------------
+
+  handleFwTransferBeginAck(msg: string): FwTransferBeginAckResponse {
+    const response = {
+      type: SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK,
+    } as FwTransferBeginAckResponse;
+
+    const parts = msg.split(MessageHelper.US);
+    if (parts.length !== 2) {
+      logger.error(`Invalid FW_TRANSFER_BEGIN_ACK: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    response.payload = { transferId: parts[0], status: parts[1] };
+    return response;
+  }
+
+  handleFwChunkAck(msg: string): FwChunkAckResponse {
+    const response = {
+      type: SerialWorkerResponseType.FW_CHUNK_ACK,
+    } as FwChunkAckResponse;
+
+    const parts = msg.split(MessageHelper.US);
+    if (parts.length !== 4) {
+      logger.error(`Invalid FW_CHUNK_ACK: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const highest = parseInt(parts[1], 10);
+    const next = parseInt(parts[2], 10);
+    const window = parseInt(parts[3], 10);
+    if (Number.isNaN(highest) || Number.isNaN(next) || Number.isNaN(window)) {
+      logger.error(`FW_CHUNK_ACK has non-numeric fields: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    response.payload = {
+      transferId: parts[0],
+      highestContiguousSeq: highest,
+      nextExpectedSeq: next,
+      windowRemaining: window,
+    };
+    return response;
+  }
+
+  handleFwChunkNak(msg: string): FwChunkNakResponse {
+    const response = {
+      type: SerialWorkerResponseType.FW_CHUNK_NAK,
+    } as FwChunkNakResponse;
+
+    const parts = msg.split(MessageHelper.US);
+    if (parts.length !== 3) {
+      logger.error(`Invalid FW_CHUNK_NAK: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const lastGoodSeq = parseInt(parts[1], 10);
+    if (Number.isNaN(lastGoodSeq)) {
+      logger.error(`FW_CHUNK_NAK lastGoodSeq is not numeric: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const reason = parts[2] as FwChunkNakReason;
+    if (!FW_CHUNK_NAK_REASONS.has(reason)) {
+      logger.error(`FW_CHUNK_NAK has unknown reason: ${parts[2]}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    response.payload = { transferId: parts[0], lastGoodSeq, reasonCode: reason };
+    return response;
+  }
+
+  handleFwTransferEndAck(msg: string): FwTransferEndAckResponse {
+    const response = {
+      type: SerialWorkerResponseType.FW_TRANSFER_END_ACK,
+    } as FwTransferEndAckResponse;
+
+    const parts = msg.split(MessageHelper.US);
+    if (parts.length !== 3) {
+      logger.error(`Invalid FW_TRANSFER_END_ACK: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const status = parts[1] as FwTransferEndStatus;
+    if (!FW_TRANSFER_END_STATUSES.has(status)) {
+      logger.error(`FW_TRANSFER_END_ACK has unknown status: ${parts[1]}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    response.payload = {
+      transferId: parts[0],
+      status,
+      computedSha256Hex: parts[2],
+    };
+    return response;
+  }
+
+  handleFwProgress(msg: string): FwProgressResponse {
+    const response = {
+      type: SerialWorkerResponseType.FW_PROGRESS,
+    } as FwProgressResponse;
+
+    const parts = msg.split(MessageHelper.US);
+    if (parts.length !== 6) {
+      logger.error(`Invalid FW_PROGRESS: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const stage = parts[2] as FwStage;
+    if (!FW_STAGE_VALUES.has(stage)) {
+      logger.error(`FW_PROGRESS has unknown stage: ${parts[2]}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const bytesSent = parseInt(parts[3], 10);
+    const totalBytes = parseInt(parts[4], 10);
+    if (Number.isNaN(bytesSent) || Number.isNaN(totalBytes)) {
+      logger.error(`FW_PROGRESS has non-numeric byte counts: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    response.payload = {
+      transferId: parts[0],
+      controllerId: parts[1],
+      stage,
+      bytesSent,
+      totalBytes,
+      detail: parts[5],
+    };
+    return response;
+  }
+
+  handleFwDeployDone(msg: string): FwDeployDoneResponse {
+    const response = {
+      type: SerialWorkerResponseType.FW_DEPLOY_DONE,
+    } as FwDeployDoneResponse;
+
+    // Wire format: transfer-id<US>result_1<RS>result_2<RS>...
+    // where result = controllerId<US>outcome<US>finalVersion<US>error
+    // We split only on the first US to keep the result list intact, then split
+    // the result list on RS, then split each result on US.
+    const firstUs = msg.indexOf(MessageHelper.US);
+    if (firstUs < 0) {
+      logger.error(`Invalid FW_DEPLOY_DONE (no transferId separator): ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const transferId = msg.substring(0, firstUs);
+    const resultListStr = msg.substring(firstUs + 1);
+    const resultStrs = resultListStr.split(MessageHelper.RS);
+    const results: FwDeployDoneResult[] = [];
+
+    for (const resultStr of resultStrs) {
+      const fields = resultStr.split(MessageHelper.US);
+      if (fields.length !== 4) {
+        logger.error(`Invalid FW_DEPLOY_DONE result: ${resultStr}`);
+        response.type = SerialWorkerResponseType.UNKNOWN;
+        return response;
+      }
+
+      const outcome = fields[1];
+      if (outcome !== 'OK' && outcome !== 'FAILED') {
+        logger.error(`FW_DEPLOY_DONE has unknown outcome: ${outcome}`);
+        response.type = SerialWorkerResponseType.UNKNOWN;
+        return response;
+      }
+
+      results.push({
+        controllerId: fields[0],
+        outcome,
+        finalVersion: fields[2],
+        error: fields[3],
+      });
+    }
+
+    response.payload = { transferId, results };
+    return response;
+  }
+
+  handleFwBackpressure(msg: string): FwBackpressureResponse {
+    const response = {
+      type: SerialWorkerResponseType.FW_BACKPRESSURE,
+    } as FwBackpressureResponse;
+
+    const parts = msg.split(MessageHelper.US);
+    if (parts.length !== 3) {
+      logger.error(`Invalid FW_BACKPRESSURE: ${msg}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    const action = parts[1] as FwBackpressureAction;
+    if (!FW_BACKPRESSURE_ACTIONS.has(action)) {
+      logger.error(`FW_BACKPRESSURE has unknown action: ${parts[1]}`);
+      response.type = SerialWorkerResponseType.UNKNOWN;
+      return response;
+    }
+
+    response.payload = { transferId: parts[0], action, reason: parts[2] };
     return response;
   }
 

--- a/astros_api/src/serial/message_handler.ts
+++ b/astros_api/src/serial/message_handler.ts
@@ -11,7 +11,7 @@ import type {
   FwProgressResponse,
   FwTransferBeginAckResponse,
   FwTransferEndAckResponse,
-  PollRepsonse,
+  PollResponse,
   RegistrationResponse,
   ScriptDeployResponse,
   ScriptRunResponse,
@@ -84,8 +84,8 @@ export class MessageHandler {
     return result;
   }
 
-  public handlePollAck(msg: string): PollRepsonse {
-    const response = { type: SerialWorkerResponseType.POLL } as PollRepsonse;
+  public handlePollAck(msg: string): PollResponse {
+    const response = { type: SerialWorkerResponseType.POLL } as PollResponse;
 
     const parts = msg.split(MessageHelper.US);
 

--- a/astros_api/src/serial/message_helper.ts
+++ b/astros_api/src/serial/message_helper.ts
@@ -78,4 +78,14 @@ export class MessageHelper {
     const n = Number(raw);
     return Number.isSafeInteger(n) ? n : null;
   }
+
+  // Strict SHA-256 hex parser: exactly 64 lowercase hex chars (per the wire
+  // contract in .docs/protocol.md "Shared values"). Lowercase-only matters
+  // because the server's reference digest from crypto.createHash('sha256')
+  // is always lowercase; a permissive parser that allowed uppercase would
+  // produce false-positive HASH_MISMATCH reports later in the flow. Returns
+  // the validated hash unchanged on success, null otherwise.
+  static parseSha256Hex(raw: string): string | null {
+    return /^[0-9a-f]{64}$/.test(raw) ? raw : null;
+  }
 }

--- a/astros_api/src/serial/message_helper.ts
+++ b/astros_api/src/serial/message_helper.ts
@@ -29,6 +29,19 @@ export class MessageHelper {
     [SerialMessageType.FORMAT_SD_ACK, SerialMsgConst.FORMAT_SD_ACK],
     [SerialMessageType.FORMAT_SD_NAK, SerialMsgConst.FORMAT_SD_NAK],
     [SerialMessageType.SERVO_TEST, SerialMsgConst.SERVO_TEST],
+
+    // Firmware OTA wire protocol — see .docs/protocol.md § A.
+    [SerialMessageType.FW_TRANSFER_BEGIN, SerialMsgConst.FW_TRANSFER_BEGIN],
+    [SerialMessageType.FW_TRANSFER_BEGIN_ACK, SerialMsgConst.FW_TRANSFER_BEGIN_ACK],
+    [SerialMessageType.FW_CHUNK, SerialMsgConst.FW_CHUNK],
+    [SerialMessageType.FW_CHUNK_ACK, SerialMsgConst.FW_CHUNK_ACK],
+    [SerialMessageType.FW_CHUNK_NAK, SerialMsgConst.FW_CHUNK_NAK],
+    [SerialMessageType.FW_TRANSFER_END, SerialMsgConst.FW_TRANSFER_END],
+    [SerialMessageType.FW_TRANSFER_END_ACK, SerialMsgConst.FW_TRANSFER_END_ACK],
+    [SerialMessageType.FW_DEPLOY_BEGIN, SerialMsgConst.FW_DEPLOY_BEGIN],
+    [SerialMessageType.FW_PROGRESS, SerialMsgConst.FW_PROGRESS],
+    [SerialMessageType.FW_DEPLOY_DONE, SerialMsgConst.FW_DEPLOY_DONE],
+    [SerialMessageType.FW_BACKPRESSURE, SerialMsgConst.FW_BACKPRESSURE],
   ]);
 
   public static readonly MessageTimeouts: Map<SerialMessageType, number> = new Map([
@@ -37,6 +50,13 @@ export class MessageHelper {
     [SerialMessageType.DEPLOY_SCRIPT, 5000],
     [SerialMessageType.RUN_SCRIPT, 5000],
     [SerialMessageType.RUN_COMMAND, 5000],
+
+    // Firmware OTA outgoing types. FW_CHUNK uses the protocol's per-frame
+    // ACK timeout (1500 ms); the others are job-level handshakes.
+    [SerialMessageType.FW_TRANSFER_BEGIN, 5000],
+    [SerialMessageType.FW_CHUNK, 1500],
+    [SerialMessageType.FW_TRANSFER_END, 5000],
+    [SerialMessageType.FW_DEPLOY_BEGIN, 5000],
   ]);
 
   static uint8ArrayToNum(arr: Uint8Array): number {

--- a/astros_api/src/serial/message_helper.ts
+++ b/astros_api/src/serial/message_helper.ts
@@ -68,4 +68,14 @@ export class MessageHelper {
 
     return num;
   }
+
+  // Strict unsigned-integer parser for wire-protocol fields. Rejects anything
+  // parseInt would silently accept (e.g. '42junk', '1.5', '-3', leading
+  // whitespace) and guards against precision loss past Number.MAX_SAFE_INTEGER.
+  // Returns null on any rejection so the caller can route the frame to UNKNOWN.
+  static parseUint(raw: string): number | null {
+    if (!/^\d+$/.test(raw)) return null;
+    const n = Number(raw);
+    return Number.isSafeInteger(n) ? n : null;
+  }
 }

--- a/astros_api/src/serial/serial_message.ts
+++ b/astros_api/src/serial/serial_message.ts
@@ -26,6 +26,22 @@ export enum SerialMessageType {
   FORMAT_SD_NAK,
   SERVO_TEST, // from web server
   SERVO_TEST_ACK,
+
+  // Firmware OTA wire protocol; see .docs/protocol.md § A. Reserved range
+  // 30-40. Numeric values are explicit so a future insertion above this
+  // block does not silently shift them. AstrOs.ESP must hold the same
+  // numbers — both copies of .docs/protocol.md are the source of truth.
+  FW_TRANSFER_BEGIN = 30, // from web server
+  FW_TRANSFER_BEGIN_ACK = 31,
+  FW_CHUNK = 32, // from web server
+  FW_CHUNK_ACK = 33,
+  FW_CHUNK_NAK = 34,
+  FW_TRANSFER_END = 35, // from web server
+  FW_TRANSFER_END_ACK = 36,
+  FW_DEPLOY_BEGIN = 37, // from web server
+  FW_PROGRESS = 38,
+  FW_DEPLOY_DONE = 39,
+  FW_BACKPRESSURE = 40,
 }
 
 export class SerialMsgConst {
@@ -51,6 +67,18 @@ export class SerialMsgConst {
   static readonly FORMAT_SD_NAK = 'FORMAT_SD_NAK';
   static readonly SERVO_TEST = 'SERVO_TEST';
   static readonly SERVO_TEST_ACK = 'SERVO_TEST_ACK';
+
+  static readonly FW_TRANSFER_BEGIN = 'FW_TRANSFER_BEGIN';
+  static readonly FW_TRANSFER_BEGIN_ACK = 'FW_TRANSFER_BEGIN_ACK';
+  static readonly FW_CHUNK = 'FW_CHUNK';
+  static readonly FW_CHUNK_ACK = 'FW_CHUNK_ACK';
+  static readonly FW_CHUNK_NAK = 'FW_CHUNK_NAK';
+  static readonly FW_TRANSFER_END = 'FW_TRANSFER_END';
+  static readonly FW_TRANSFER_END_ACK = 'FW_TRANSFER_END_ACK';
+  static readonly FW_DEPLOY_BEGIN = 'FW_DEPLOY_BEGIN';
+  static readonly FW_PROGRESS = 'FW_PROGRESS';
+  static readonly FW_DEPLOY_DONE = 'FW_DEPLOY_DONE';
+  static readonly FW_BACKPRESSURE = 'FW_BACKPRESSURE';
 }
 
 export interface SerialMsgValidationResult {

--- a/astros_api/src/serial/serial_worker_response.ts
+++ b/astros_api/src/serial/serial_worker_response.ts
@@ -68,39 +68,57 @@ export interface ScriptRunResponse extends ISerialWorkerResponse {
 // ---------------------------------------------------------------------------
 // Firmware OTA inbound responses. Each wraps the parsed typed payload from
 // .docs/protocol.md § A so the dispatcher (c.6) can route by type.
+//
+// These interfaces deliberately do NOT extend ISerialWorkerResponse: that
+// base carries `Record<string, any>` as an escape hatch for legacy `as`
+// casts elsewhere in this file, and inheriting it would let `.payload`
+// slip through as `any` even on the UnknownSerialResponse branch — defeating
+// the whole point of the discriminated union. Each Fw*Response narrows
+// `type` to a single literal so handlers can return `Fw*Response |
+// UnknownSerialResponse` and force callers to discriminate before reading
+// `payload`. They remain structurally compatible with ISerialWorkerResponse
+// (a `type: SerialWorkerResponseType` field), so the eventual dispatcher in
+// c.6 can accept either family.
 // ---------------------------------------------------------------------------
 
-export interface FwTransferBeginAckResponse extends ISerialWorkerResponse {
-  type: SerialWorkerResponseType;
+// Marker response returned by every FW_* handler when the wire payload fails
+// validation. No `payload` field — callers MUST discriminate against this
+// case before reading payload from the success-shape sibling.
+export interface UnknownSerialResponse {
+  type: SerialWorkerResponseType.UNKNOWN;
+}
+
+export interface FwTransferBeginAckResponse {
+  type: SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK;
   payload: FwTransferBeginAck;
 }
 
-export interface FwChunkAckResponse extends ISerialWorkerResponse {
-  type: SerialWorkerResponseType;
+export interface FwChunkAckResponse {
+  type: SerialWorkerResponseType.FW_CHUNK_ACK;
   payload: FwChunkAck;
 }
 
-export interface FwChunkNakResponse extends ISerialWorkerResponse {
-  type: SerialWorkerResponseType;
+export interface FwChunkNakResponse {
+  type: SerialWorkerResponseType.FW_CHUNK_NAK;
   payload: FwChunkNak;
 }
 
-export interface FwTransferEndAckResponse extends ISerialWorkerResponse {
-  type: SerialWorkerResponseType;
+export interface FwTransferEndAckResponse {
+  type: SerialWorkerResponseType.FW_TRANSFER_END_ACK;
   payload: FwTransferEndAck;
 }
 
-export interface FwProgressResponse extends ISerialWorkerResponse {
-  type: SerialWorkerResponseType;
+export interface FwProgressResponse {
+  type: SerialWorkerResponseType.FW_PROGRESS;
   payload: FwProgress;
 }
 
-export interface FwDeployDoneResponse extends ISerialWorkerResponse {
-  type: SerialWorkerResponseType;
+export interface FwDeployDoneResponse {
+  type: SerialWorkerResponseType.FW_DEPLOY_DONE;
   payload: FwDeployDone;
 }
 
-export interface FwBackpressureResponse extends ISerialWorkerResponse {
-  type: SerialWorkerResponseType;
+export interface FwBackpressureResponse {
+  type: SerialWorkerResponseType.FW_BACKPRESSURE;
   payload: FwBackpressure;
 }

--- a/astros_api/src/serial/serial_worker_response.ts
+++ b/astros_api/src/serial/serial_worker_response.ts
@@ -1,4 +1,13 @@
 import { ControlModule } from 'src/models/index.js';
+import type {
+  FwTransferBeginAck,
+  FwChunkAck,
+  FwChunkNak,
+  FwTransferEndAck,
+  FwProgress,
+  FwDeployDone,
+  FwBackpressure,
+} from 'src/models/firmware/firmware_messages.js';
 
 export enum SerialWorkerResponseType {
   UNKNOWN,
@@ -10,6 +19,15 @@ export enum SerialWorkerResponseType {
   SCRIPT_RUN,
   SEND_SERIAL_MESSAGE,
   UPDATE_CLIENTS,
+
+  // Firmware OTA inbound messages — see .docs/protocol.md § A.
+  FW_TRANSFER_BEGIN_ACK,
+  FW_CHUNK_ACK,
+  FW_CHUNK_NAK,
+  FW_TRANSFER_END_ACK,
+  FW_PROGRESS,
+  FW_DEPLOY_DONE,
+  FW_BACKPRESSURE,
 }
 
 export interface ISerialWorkerResponse extends Record<string, any> {
@@ -45,4 +63,44 @@ export interface ScriptRunResponse extends ISerialWorkerResponse {
   success: boolean;
   scriptId: string;
   controller: ControlModule;
+}
+
+// ---------------------------------------------------------------------------
+// Firmware OTA inbound responses. Each wraps the parsed typed payload from
+// .docs/protocol.md § A so the dispatcher (c.6) can route by type.
+// ---------------------------------------------------------------------------
+
+export interface FwTransferBeginAckResponse extends ISerialWorkerResponse {
+  type: SerialWorkerResponseType;
+  payload: FwTransferBeginAck;
+}
+
+export interface FwChunkAckResponse extends ISerialWorkerResponse {
+  type: SerialWorkerResponseType;
+  payload: FwChunkAck;
+}
+
+export interface FwChunkNakResponse extends ISerialWorkerResponse {
+  type: SerialWorkerResponseType;
+  payload: FwChunkNak;
+}
+
+export interface FwTransferEndAckResponse extends ISerialWorkerResponse {
+  type: SerialWorkerResponseType;
+  payload: FwTransferEndAck;
+}
+
+export interface FwProgressResponse extends ISerialWorkerResponse {
+  type: SerialWorkerResponseType;
+  payload: FwProgress;
+}
+
+export interface FwDeployDoneResponse extends ISerialWorkerResponse {
+  type: SerialWorkerResponseType;
+  payload: FwDeployDone;
+}
+
+export interface FwBackpressureResponse extends ISerialWorkerResponse {
+  type: SerialWorkerResponseType;
+  payload: FwBackpressure;
 }

--- a/astros_api/src/serial/serial_worker_response.ts
+++ b/astros_api/src/serial/serial_worker_response.ts
@@ -34,7 +34,7 @@ export interface ISerialWorkerResponse extends Record<string, any> {
   type: SerialWorkerResponseType;
 }
 
-export interface PollRepsonse extends ISerialWorkerResponse {
+export interface PollResponse extends ISerialWorkerResponse {
   type: SerialWorkerResponseType;
   controller: ControlModule;
 }


### PR DESCRIPTION
  Summary

  Implements the server-side wire layer for the cross-repo OTA protocol. Ships 11 new FW_* SerialMessageType values (30–40) with full
  serializer/handler coverage and typed payloads. Also includes a small protocol.md amendment (paired with AstrOs.ESP develop f4d84d8) closing a gap
  in the original contract.

  No flash-job orchestration or api_server.ts dispatch wiring — the handlers ship with full input validation but no caller. c.6 wires them into a
  state machine.

  Context

  - Parent plan: .docs/plans/20260427-2202-firmware-ota-decomposition.md
  - This PR's plan: .docs/plans/20260428-2043-firmware-ota-c-1-fw-message-types.md
  - Protocol contract: .docs/protocol.md § A
  - Cross-repo: AstrOs.ESP develop now contains the matching protocol.md amendment at commit f4d84d8.

  What's in this PR

  Foundation (astros_api/src/serial/):
  - serial_message.ts — 11 explicit FW_* enum values (30–40) + matching validator strings.
  - message_helper.ts — ValidationMap entries for all 11; MessageTimeouts for the 4 outgoing types (5000 ms for
  FW_TRANSFER_BEGIN/FW_TRANSFER_END/FW_DEPLOY_BEGIN, 1500 ms for FW_CHUNK per the contract's per-frame ACK spec).
  - serial_worker_response.ts — 7 new inbound enum values + 7 response interfaces extending ISerialWorkerResponse.

  Typed payloads (new astros_api/src/models/firmware/firmware_messages.ts):
  - 11 typed interfaces matching protocol.md field layouts.
  - FwStage enum (QUEUED | UPLOADING_TO_MASTER | SENDING | VERIFYING | REBOOTING | VERSION_CONFIRMED | FAILED) shared with the master role on
  AstrOs.ESP.

  Outgoing generators (message_generator.ts):
  - generateFwTransferBegin, generateFwChunk, generateFwTransferEnd, generateFwDeployBegin. Each builds the wire string from a typed payload, returns
   MessageGeneratorResponse(msg, controllers, metaData=transferId).

  Incoming handlers (message_handler.ts):
  - handleFwTransferBeginAck, handleFwChunkAck, handleFwChunkNak, handleFwTransferEndAck, handleFwProgress, handleFwDeployDone, handleFwBackpressure.
  - Full input validation: field count, numeric parsing, enum membership for stages/statuses/reasons/actions. Malformed input routes to
  SerialWorkerResponseType.UNKNOWN with a logged error.

  Tests (21 new):
  - message_generator.test.ts: 4 outgoing-format tests against expected wire strings.
  - message_handler.test.ts: 12 tests covering 7 happy paths + 5 negative-path validation cases.

  Protocol amendment (paired with AstrOs.ESP)

  FW_TRANSFER_BEGIN_ACK was listed in protocol.md § A's message-types table but missing from the payload field layouts. This PR adds the spec inline
  with the other layouts:

  FW_TRANSFER_BEGIN_ACK: transfer-id<US>status
                         status = "OK" on success; otherwise a snake_case
                         rejection code (e.g., "sd_full", "busy",
                         "unsupported_version")

  The same change landed on AstrOs.ESP develop at commit f4d84d8 before this PR was opened. After this PR merges, the two protocol.md copies will be
  byte-for-byte identical again.

  File count

  9 files — under the soft ≤10 cap. Breakdown in the c.1 plan.

  Verification

  - npm run build clean (lint + tsc) in astros_api/.
  - npm run test green: 294 / 294 across 34 test files (was 273; +21 net new).
  - npm run prettier:write and npm run lint:fix clean.

  Intentionally out of scope

  - No flash-job state machine or orchestration logic — c.6.
  - No api_server.ts dispatch wiring for the new inbound handlers — also c.6. The handlers ship unused in this PR; only the unit tests consume them.
  - No GitHub release fetch, file upload, on-disk cache — c.3 through c.5.
  - No firmware-side OTA receiver — sub-projects a and b in AstrOs.ESP.

  Honest verification gap

  This PR exercises the wire layer in isolation. There is no end-to-end serial round-trip test against a real master — that arrives with c.6 when
  there's an orchestrator to drive a flow against a PTY-stub or real hardware. Until then, the unit tests are the only consumer of the new generators
   and handlers.

  Test plan (reviewer)

  - Pull the branch, cd astros_api && npm install && npm run build && npm run test — expect 294 green.
  - Compare the new FW_* enum integer values (30–40) in serial_message.ts against .docs/protocol.md § "Reserved enum ranges" + the message-types
  table in § A. They must match exactly; both repos depend on the numbers.
  - Compare firmware_messages.ts interface fields against protocol.md § A's payload field layouts. FwTransferBegin.targets ↔ target-list, FwProgress
  field order, FwDeployDoneResult.error === '' for OK outcomes, etc.
  - Spot-check that f4d84d8 on AstrOs.ESP develop matches the protocol amendment in this PR (same line added to protocol.md payload layouts).
  - Review the negative-path handler tests ('rejects unknown reason codes' etc.) — confirm the validation set matches protocol.md for each enum-style
   field (FwChunkNakReason, FwTransferEndStatus, FwBackpressureAction, FwStage).