### PR TITLE
Firmware OTA full write route lock

### DIFF
--- a/.docs/plans/20260427-2202-firmware-ota-decomposition.md
+++ b/.docs/plans/20260427-2202-firmware-ota-decomposition.md
@@ -12,7 +12,7 @@ The work is significant because the existing bulk-data transport in firmware is 
 
 | # | Name | Repo | Scope | Blocked by | Plan file path | Shippable alone? |
 |---|------|------|-------|------------|----------------|-------------------|
-| **c0** | Platform prerequisites | AstrOs.Server | `JobLock` singleton with subscribe/notify, `requireUnlocked` Express middleware, new `lockStateChanged` `TransmissionType`, Vue lock store + WS handler. No firmware-version DB persistence — heartbeats arrive every 2 s and the orchestrator captures starting versions in-memory; persistence would be misleading while a controller is offline. | — | `astros-server/.docs/plans/<date>-firmware-ota-c0-job-lock.md` | Yes — `JobLock` is reusable for any future write-blocking operation. |
+| **c0** | Platform prerequisites | AstrOs.Server | `JobLock` singleton with subscribe/notify, new `lockStateChanged` `TransmissionType`, Vue lock store + WS handler. No firmware-version DB persistence — heartbeats arrive every 2 s and the orchestrator captures starting versions in-memory; persistence would be misleading while a controller is offline. (c0 originally also shipped a per-route `requireUnlocked` middleware applied to `/api/panicStop` as a smoke test; that was superseded in **c.2** by extending the existing `writeGuard`.) | — | `astros-server/.docs/plans/<date>-firmware-ota-c0-job-lock.md` | Yes — `JobLock` is reusable for any future write-blocking operation. |
 | **a** | Bulk transport hardening | AstrOs.ESP | Replace `PacketTracker` with chunked, CRC-checked, ACK-driven, streaming-receive transport. Works over both serial (master side) and ESP-NOW (padawan side). New `BulkReceiver` callback API. Side-effect: fixes the half-built script-deploy bulk path. | — | `AstrOs.ESP/.docs/plans/<date>-bulk-transport-hardening.md` (create dir; mirror Server convention) | No — only meaningful when consumed by **b**. |
 | **b** | OTA receiver | AstrOs.ESP | Master serial→SD writer; master SD→ESP-NOW forwarder (sequential); padawan ESP-NOW→`esp_ota_*` streaming writer; SHA-256 verify; commit + reboot; version-after-reboot via existing 2 s heartbeat. | **a** | `AstrOs.ESP/.docs/plans/<date>-ota-receiver.md` | No — useless without **c**. |
 | **c** | Server orchestrator | AstrOs.Server | New `SerialMessageType` values; flash-job state machine; GitHub release fetch + 5-min cache + on-disk `.bin` cache (LRU N=5); upload handler with `esp_app_desc_t` validation; SHA-256 stream-hash; per-controller progress tracking; WebSocket fan-out; integrate with `JobLock`. | **c0**, **a** protocol freeze | `astros-server/.docs/plans/<date>-firmware-ota-server.md` | No — needs UI to be useful. |
@@ -278,7 +278,7 @@ The single highest-risk sub-project. Requirements the firmware sub-plan must mee
   - `POST /playlists/*`, `POST /panic`
   - `POST /firmware/jobs` (only one flash job at a time)
   - WebSocket inbound write-class messages (`script | run | directCommand | formatSD | servoTest | sync`) → reject with `lockStateChanged` echo + `flashJobActive` error frame.
-- **Server-side enforcement:** `JobLock` singleton (`src/job_lock.ts`) with `acquire(owner): boolean`, `release(owner)`, `isLocked()`, `getOwner()`, `subscribe(fn)`. Express middleware `requireUnlocked` applied to listed routes, **after** `authHandler`.
+- **Server-side enforcement:** `JobLock` singleton (`src/job_lock.ts`) with `acquire(owner): boolean`, `release(owner)`, `isLocked()`, `getOwner()`, `subscribe(fn)`. The existing `writeGuard` (already mounted on `/api`, already centralizes the "is this a write?" decision via `BLOCKED_WRITE_METHODS` + `BLOCKED_GET_PATHS`) is extended to also take a `JobLock` and return 423 when the lock is held; an `ALLOWED_DURING_FLASH` allowlist (login + reauth only — panic is intentionally NOT allowed during flash because emitting `PANIC_STOP` mid-flash would interleave with `FW_CHUNK` frames on the serial line) controls per-route exceptions. WebSocket inbound write-class messages don't pass through Express middleware, so a small `rejectIfLocked` helper in `src/job_lock_middleware.ts` rejects them per-connection with a `lockStateChanged` echo + `flashJobActive` frame.
 - **WebSocket reflection:** every `acquire`/`release` fires `lockStateChanged` to all clients. Other UI views use this to disable write controls site-wide.
 - **Auto-release conditions:**
   1. **Master's post-reboot heartbeat returns with `version === target`** — primary release condition. Lock is held from `Push firmware` confirmation through master's full self-reboot cycle.
@@ -342,7 +342,7 @@ Each PR gets its own light plan in `.docs/plans/` with a `YYYYMMDD-HHmm-firmware
 
 **c0 — Platform prerequisites (server):**
 
-- [ ] **c0** `JobLock` singleton + `requireUnlocked` middleware + `lockStateChanged` `TransmissionType` + WS broadcast + Vue lock store + handler. Apply middleware to one example route as smoke test (full route set is **c.2**). Testable: unit + integration tests covering 423 response; live UI banner on lock-state change. Note: no DB persistence of `firmware_version` — orchestrator captures starting versions in-memory from heartbeats; persisted state would be misleading while a controller is offline.
+- [ ] **c0** `JobLock` singleton + `lockStateChanged` `TransmissionType` + WS broadcast + Vue lock store + handler. (Originally also shipped a per-route `requireUnlocked` middleware applied to `/api/panicStop` as a smoke test; superseded in **c.2** by extending `writeGuard` — full route set inherits the lock automatically.) Testable: unit tests for the JobLock primitive; live UI banner on lock-state change. Note: no DB persistence of `firmware_version` — orchestrator captures starting versions in-memory from heartbeats; persisted state would be misleading while a controller is offline.
 
 **Shared protocol freeze:**
 
@@ -359,7 +359,7 @@ Each PR gets its own light plan in `.docs/plans/` with a `YYYYMMDD-HHmm-firmware
 **c — Server orchestrator (subset shippable before b lands; runs against PTY stub):**
 
 - [ ] **c.1** `SerialMessageType` `FW_*` enum extensions + `message_generator` / `message_handler` paths + tests. Testable: serializer round-trip.
-- [ ] **c.2** Apply `requireUnlocked` middleware to full write-route set + tests.
+- [ ] **c.2** Extend `writeGuard` with a `JobLock` parameter so write-class HTTP routes return 423 during a flash job (single mount on `/api` covers the full route set automatically). Add WS-side `rejectIfLocked` for inbound write-class messages. Remove c0's now-redundant `requireUnlocked`.
 - [ ] **c.3** GitHub release service + 5-min in-memory cache + tests with HTTP fixtures.
 - [ ] **c.4** On-disk `.bin` cache + LRU eviction + SHA-256 stream-hash + tests with a 1.2 MB fixture.
 - [ ] **c.5** Upload handler + `esp_app_desc_t` parser + project-name + version validation + tests.

--- a/.docs/plans/20260429-0655-firmware-ota-c-2-full-write-route-lock.md
+++ b/.docs/plans/20260429-0655-firmware-ota-c-2-full-write-route-lock.md
@@ -1,0 +1,53 @@
+# c.2 — Apply requireUnlocked to full write-route set
+
+Light plan for the next server-orchestrator PR. Builds on c0's `JobLock` + `requireUnlocked` middleware (PR #65) and finishes the lock story so a future flash job (c.6) actually goes read-only across the API while it runs.
+
+**Branch:** `feature/firmware-ota-c-2-full-write-route-lock` (off `develop`).
+**PR target base:** `develop`.
+**References:** [decomposition plan](./20260427-2202-firmware-ota-decomposition.md) § "Hard-lock spec", [c0 plan](./20260428-0725-firmware-ota-c0-job-lock.md).
+
+## Context
+
+c0 introduced `requireUnlocked` and applied it to `POST /api/panicStop` as a smoke test. c.2 applies the same middleware to the rest of the write-class routes per the decomposition's "What it guards" list, plus rejects the one currently-implemented inbound WebSocket write-class message (`SERVO_TEST`) when the lock is held.
+
+The principle: while a flash job is running, no other code path mutates the script/playlist/controller domain or fires hardware. c.2 puts the guard everywhere it's specified to live; c.3+ then naturally inherit lock-awareness for any new routes added in the same families.
+
+No flash-job state machine, no firmware code — pure infrastructure on top of c0.
+
+## Tasks
+
+- [ ] **Threading lockMiddleware into controllers.** Add `lockMiddleware: RequestHandler` parameter to `registerScriptRoutes` / `registerPlaylistRoutes` / `registerLocationRoutes`. Apply to the write-class routes inside each (`PUT`, `DELETE`, `POST copy` for scripts/playlists; `PUT` for locations). Read routes stay unchanged.
+- [ ] **Inline routes in `api_server.ts`.** Build the middleware once at route-setup time (`requireUnlocked(this.jobLock)`) and apply to: `GET /locations/syncconfig`, `GET /locations/synccontrollers`, `GET /scripts/upload`, `GET /scripts/run`, `GET /playlists/run`, `POST /settings/formatSD`, `POST /directcommand`, `POST /panicClear`. (Existing `POST /panicStop` already locked in c0; verify no double-application.)
+- [ ] **WebSocket inbound rejection.** Add `flashJobActive` to `TransmissionType` and a typed `FlashJobActiveResponse` model + `buildFlashJobActiveResponse` factory in `lock_responses.ts`. In `handleWebsocketMessage`, when an inbound write-class message (initially: `SERVO_TEST`) arrives while the lock is held, send the originating client a `lockStateChanged` echo + a `flashJobActive` error frame and skip the normal dispatch. Don't broadcast to other clients — the rejection is per-connection.
+- [ ] **Integration tests.** New `astros_api/src/job_lock_routes.integration.test.ts` covering representative routes from each category (one per controller + several inline routes from `api_server.ts` + the WS inbound case). Mounts a real Express app + WS server with the same middleware wiring and verifies the rejection behavior end-to-end.
+
+## Verification
+
+- [ ] `npm run build` clean (lint + tsc).
+- [ ] `npm run test` green (existing 302 + new c.2 tests).
+- [ ] `npm run prettier:write` and `npm run lint:fix` clean.
+- [ ] Spot-check that every route in the decomposition's "What it guards" list has the middleware applied (or is N/A like `POST /firmware/jobs` which doesn't exist yet).
+
+## Files in scope (7)
+
+1. `astros_api/src/controllers/scripts_controller.ts` — register-fn signature + middleware on PUT/DELETE/POST copy
+2. `astros_api/src/controllers/playlist_controller.ts` — same
+3. `astros_api/src/controllers/locations_controller.ts` — same, applied to PUT
+4. `astros_api/src/api_server.ts` — build middleware once, pass to register-fn calls, apply inline; add WS inbound rejection
+5. `astros_api/src/models/enums.ts` — append `flashJobActive` to `TransmissionType`
+6. `astros_api/src/models/networking/lock_responses.ts` — new `FlashJobActiveResponse` interface + `buildFlashJobActiveResponse` factory
+7. `astros_api/src/job_lock_routes.integration.test.ts` — new HTTP + WS integration tests
+
+## Out of scope
+
+- Vue handling of `flashJobActive` (UI banner / toast on rejected actions) — deferred to **d.7**.
+- Settings / remoteConfig / audio routes — not in the decomposition's hard-lock list. Pure DB writes that don't fan out to ESPs are intentionally allowed during a flash.
+- `POST /firmware/jobs` — doesn't exist yet; **c.8** will add it with `requireUnlocked` already applied.
+- Any flash-job state machine, GitHub fetching, file upload, or new serial-protocol additions.
+
+## Notes for the reviewer
+
+- The `lockMiddleware` parameter is a `RequestHandler`, not a `JobLock` instance. Keeps controllers free of `JobLock`-domain knowledge — they just receive a middleware function and apply it.
+- WS inbound write-class set is currently `['SERVO_TEST']`. Document a clear extension point (e.g. an exported `WS_WRITE_CLASS_MESSAGE_TYPES` set) so future write-class WS msgTypes inherit the rejection automatically.
+- Per the decomposition, `requireUnlocked` sits **after** `authHandler` so unauthenticated requests still get 401 (not 423).
+- `panicStop` was c0's smoke-test route; verify it still works (i.e. that we didn't accidentally apply the middleware twice).

--- a/.docs/plans/20260429-0655-firmware-ota-c-2-full-write-route-lock.md
+++ b/.docs/plans/20260429-0655-firmware-ota-c-2-full-write-route-lock.md
@@ -1,6 +1,6 @@
-# c.2 — Apply requireUnlocked to full write-route set
+# c.2 — Apply lock guard to full write-route set
 
-Light plan for the next server-orchestrator PR. Builds on c0's `JobLock` + `requireUnlocked` middleware (PR #65) and finishes the lock story so a future flash job (c.6) actually goes read-only across the API while it runs.
+Light plan for the next server-orchestrator PR. Builds on c0's `JobLock` (PR #65) and finishes the lock story so a future flash job (c.6) actually goes read-only across the API while it runs.
 
 **Branch:** `feature/firmware-ota-c-2-full-write-route-lock` (off `develop`).
 **PR target base:** `develop`.
@@ -8,46 +8,52 @@ Light plan for the next server-orchestrator PR. Builds on c0's `JobLock` + `requ
 
 ## Context
 
-c0 introduced `requireUnlocked` and applied it to `POST /api/panicStop` as a smoke test. c.2 applies the same middleware to the rest of the write-class routes per the decomposition's "What it guards" list, plus rejects the one currently-implemented inbound WebSocket write-class message (`SERVO_TEST`) when the lock is held.
+c0 introduced `JobLock` and a per-route `requireUnlocked` middleware applied to `POST /api/panicStop` as a smoke test. c.2 finishes the lock story but **extends the existing `writeGuard`** rather than threading per-route middleware through every controller — `writeGuard` already centralizes the "is this a write?" decision (the `BLOCKED_WRITE_METHODS` + `BLOCKED_GET_PATHS` lists) and is mounted globally on `/api`. Bolting a JobLock check onto the same gate is one diff that covers every existing and future write route at once, instead of nine diffs that drift if anyone forgets one.
 
-The principle: while a flash job is running, no other code path mutates the script/playlist/controller domain or fires hardware. c.2 puts the guard everywhere it's specified to live; c.3+ then naturally inherit lock-awareness for any new routes added in the same families.
+WebSocket inbound write-class messages don't pass through Express middleware, so they get a small parallel helper (`rejectIfLocked`) that reuses the same `JobLock`.
+
+The principle: while a flash job is running, no other code path mutates state or fires hardware. `writeGuard` enforces it for HTTP; `rejectIfLocked` enforces it for WS. `requireUnlocked` from c0 is removed — the unified gate supersedes it.
 
 No flash-job state machine, no firmware code — pure infrastructure on top of c0.
 
 ## Tasks
 
-- [ ] **Threading lockMiddleware into controllers.** Add `lockMiddleware: RequestHandler` parameter to `registerScriptRoutes` / `registerPlaylistRoutes` / `registerLocationRoutes`. Apply to the write-class routes inside each (`PUT`, `DELETE`, `POST copy` for scripts/playlists; `PUT` for locations). Read routes stay unchanged.
-- [ ] **Inline routes in `api_server.ts`.** Build the middleware once at route-setup time (`requireUnlocked(this.jobLock)`) and apply to: `GET /locations/syncconfig`, `GET /locations/synccontrollers`, `GET /scripts/upload`, `GET /scripts/run`, `GET /playlists/run`, `POST /settings/formatSD`, `POST /directcommand`, `POST /panicClear`. (Existing `POST /panicStop` already locked in c0; verify no double-application.)
-- [ ] **WebSocket inbound rejection.** Add `flashJobActive` to `TransmissionType` and a typed `FlashJobActiveResponse` model + `buildFlashJobActiveResponse` factory in `lock_responses.ts`. In `handleWebsocketMessage`, when an inbound write-class message (initially: `SERVO_TEST`) arrives while the lock is held, send the originating client a `lockStateChanged` echo + a `flashJobActive` error frame and skip the normal dispatch. Don't broadcast to other clients — the rejection is per-connection.
-- [ ] **Integration tests.** New `astros_api/src/job_lock_routes.integration.test.ts` covering representative routes from each category (one per controller + several inline routes from `api_server.ts` + the WS inbound case). Mounts a real Express app + WS server with the same middleware wiring and verifies the rejection behavior end-to-end.
+- [ ] **Extend `writeGuard`.** Add `JobLock` parameter alongside `SystemStatus`. Reuse the existing `BLOCKED_WRITE_METHODS` + `BLOCKED_GET_PATHS` definition. Add an `ALLOWED_DURING_FLASH` allowlist (login + reauth only — panic is NOT allowed during flash because emitting `PANIC_STOP` mid-flash would corrupt the FW chunk stream on the serial line). Read-only check fires first (503), then flash-active check (423 + `LockedErrorResponse` body). Both gates use the same `isAllowed` helper against their respective allowlists.
+- [ ] **WebSocket inbound rejection.** Add `flashJobActive` to `TransmissionType` and a typed `FlashJobActiveResponse` model + `buildFlashJobActiveResponse` factory + `WS_WRITE_CLASS_MESSAGE_TYPES` set in `lock_responses.ts`. Replace `requireUnlocked` in `job_lock_middleware.ts` with a `rejectIfLocked` helper that, when an inbound write-class message arrives while locked, sends the originating client a `lockStateChanged` echo + `flashJobActive` frame and signals the caller to skip dispatch.
+- [ ] **`api_server.ts` wire-up.** Pass `this.jobLock` to the `writeGuard` mount call. Drop the inline `requireUnlocked` from `/panicStop` (writeGuard now handles it). Drop the `requireUnlocked` import. Thread `conn` into `handleWebsocketMessage` and call `rejectIfLocked` before the dispatch switch.
+- [ ] **Test surgery.** Add a `when a flash job is active` describe block to `write_guard.test.ts` covering: 423 + body shape on POST/PUT/PATCH/DELETE, 423 on the five serial-write GETs, login/reauth allowlisted, panic blocked (stricter than read-only), reads pass through. Replace the requireUnlocked-flavored content of `job_lock_middleware.test.ts` with `rejectIfLocked` tests. Trim the (now-orphaned) requireUnlocked HTTP describe block from `job_lock.integration.test.ts`; keep the WS connect-handshake block.
 
 ## Verification
 
 - [ ] `npm run build` clean (lint + tsc).
-- [ ] `npm run test` green (existing 302 + new c.2 tests).
+- [ ] `npm run test` green (existing + new).
 - [ ] `npm run prettier:write` and `npm run lint:fix` clean.
-- [ ] Spot-check that every route in the decomposition's "What it guards" list has the middleware applied (or is N/A like `POST /firmware/jobs` which doesn't exist yet).
+- [ ] Spot-check that every route in the decomposition's "What it guards" list is covered by `writeGuard`'s `BLOCKED_WRITE_METHODS` + `BLOCKED_GET_PATHS` (the lists already exist and match the spec).
 
-## Files in scope (7)
+## Files in scope (8)
 
-1. `astros_api/src/controllers/scripts_controller.ts` — register-fn signature + middleware on PUT/DELETE/POST copy
-2. `astros_api/src/controllers/playlist_controller.ts` — same
-3. `astros_api/src/controllers/locations_controller.ts` — same, applied to PUT
-4. `astros_api/src/api_server.ts` — build middleware once, pass to register-fn calls, apply inline; add WS inbound rejection
-5. `astros_api/src/models/enums.ts` — append `flashJobActive` to `TransmissionType`
-6. `astros_api/src/models/networking/lock_responses.ts` — new `FlashJobActiveResponse` interface + `buildFlashJobActiveResponse` factory
-7. `astros_api/src/job_lock_routes.integration.test.ts` — new HTTP + WS integration tests
+1. `astros_api/src/write_guard.ts` — `JobLock` parameter; `ALLOWED_DURING_FLASH` allowlist; 423 branch
+2. `astros_api/src/write_guard.test.ts` — `when a flash job is active` describe block (6 new tests)
+3. `astros_api/src/models/enums.ts` — append `flashJobActive` to `TransmissionType`
+4. `astros_api/src/models/networking/lock_responses.ts` — `FlashJobActiveResponse` interface + `buildFlashJobActiveResponse` factory + `WS_WRITE_CLASS_MESSAGE_TYPES` set
+5. `astros_api/src/job_lock_middleware.ts` — replace `requireUnlocked` with `rejectIfLocked` (HTTP gating moved to `writeGuard`)
+6. `astros_api/src/job_lock_middleware.test.ts` — replace requireUnlocked tests with rejectIfLocked tests (3 tests)
+7. `astros_api/src/job_lock.integration.test.ts` — drop requireUnlocked HTTP describe block; keep WS connect-handshake block
+8. `astros_api/src/api_server.ts` — pass jobLock to writeGuard mount; drop inline requireUnlocked + import; thread conn into handleWebsocketMessage; call rejectIfLocked
 
 ## Out of scope
 
-- Vue handling of `flashJobActive` (UI banner / toast on rejected actions) — deferred to **d.7**.
-- Settings / remoteConfig / audio routes — not in the decomposition's hard-lock list. Pure DB writes that don't fan out to ESPs are intentionally allowed during a flash.
-- `POST /firmware/jobs` — doesn't exist yet; **c.8** will add it with `requireUnlocked` already applied.
+- Vue handling of `flashJobActive` / disabling write controls when locked — deferred to **d.7**.
+- `POST /firmware/jobs` — doesn't exist yet; **c.8** will add it (will inherit lock automatically via `writeGuard`).
 - Any flash-job state machine, GitHub fetching, file upload, or new serial-protocol additions.
 
 ## Notes for the reviewer
 
-- The `lockMiddleware` parameter is a `RequestHandler`, not a `JobLock` instance. Keeps controllers free of `JobLock`-domain knowledge — they just receive a middleware function and apply it.
-- WS inbound write-class set is currently `['SERVO_TEST']`. Document a clear extension point (e.g. an exported `WS_WRITE_CLASS_MESSAGE_TYPES` set) so future write-class WS msgTypes inherit the rejection automatically.
-- Per the decomposition, `requireUnlocked` sits **after** `authHandler` so unauthenticated requests still get 401 (not 423).
-- `panicStop` was c0's smoke-test route; verify it still works (i.e. that we didn't accidentally apply the middleware twice).
+- `writeGuard`'s broader interpretation locks every write-class HTTP route — including settings/audio/remoteConfig writes that the decomposition's enumerated list didn't explicitly mention. This is intentional: the decomposition's principle ("no other write-class operation hits during a flash") is broader than its enumerated list, and `writeGuard` was already the right home for that principle.
+- Two distinct allowlists per gate: `ALLOWED_IN_READONLY` (login, reauth, panic stop, panic clear) and `ALLOWED_DURING_FLASH` (login, reauth only). The asymmetry is documented in `write_guard.ts` — flash is stricter because PANIC_STOP would interleave with FW_CHUNK frames on the serial line.
+- `requireUnlocked` is removed entirely. The c0 PR's version was the wrong abstraction; `writeGuard` was always the right home.
+- WS inbound write-class set is currently `['SERVO_TEST']` in `WS_WRITE_CLASS_MESSAGE_TYPES`. Future write-class WS msgTypes get added to that set and inherit rejection automatically.
+
+## Why this approach (vs. per-route `requireUnlocked`)
+
+The earlier draft of c.2 threaded a `lockMiddleware: RequestHandler` parameter through `register*Routes` for scripts/playlists/locations and applied `requireUnlocked` inline at every write-class route in `api_server.ts`. That worked but duplicated `writeGuard`'s "is this a write?" definition (`BLOCKED_WRITE_METHODS` + `BLOCKED_GET_PATHS`) — two parallel lanes guarding the same concept, each with its own allowlist. PR review caught it quickly. Extending `writeGuard` is the correct architectural answer: single source of truth for write-class detection, single mount point, every existing and future write route inherits the new gate without further plumbing.

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -41,7 +41,7 @@ import { registerRemoteConfigRoutes } from './controllers/remote_config_controll
 import { registerSettingsRoutes } from './controllers/settings_controller.js';
 import { ApiKeyValidator } from './api_key_validator.js';
 import { JobLock } from './job_lock.js';
-import { requireUnlocked } from './job_lock_middleware.js';
+import { rejectIfLocked } from './job_lock_middleware.js';
 import { buildLockStateResponse } from './models/networking/lock_responses.js';
 import { SerialMessageType } from './serial/serial_message.js';
 import {
@@ -303,7 +303,7 @@ class ApiServer {
     this.app.use(cookieParser());
     this.app.use(Express.static(path.join(__dirname, 'public')));
     this.app.use(passport.initialize());
-    this.app.use('/api', writeGuard(this.systemStatus));
+    this.app.use('/api', writeGuard(this.systemStatus, this.jobLock));
     this.app.use('/api', this.router);
 
     this.app.get('/index.html', (req, res) => {
@@ -399,7 +399,6 @@ class ApiServer {
     this.router.post(
       '/panicStop',
       this.authHandler,
-      requireUnlocked(this.jobLock),
       this.withSerialGuard((req, res, next) => this.panicStop(req, res, next)),
     );
 
@@ -494,7 +493,7 @@ class ApiServer {
       }
 
       conn.on('message', (msg) => {
-        this.handleWebsocketMessage(msg.toString());
+        this.handleWebsocketMessage(msg.toString(), conn);
       });
 
       conn.on('close', () => {
@@ -511,9 +510,16 @@ class ApiServer {
     });
   }
 
-  handleWebsocketMessage(msg: string): void {
+  handleWebsocketMessage(msg: string, conn: WebSocket): void {
     try {
       const parsed = JSON.parse(msg) as IWebSocketMessage;
+
+      // Lock guard: write-class inbound messages are rejected per-connection
+      // when a flash job is in progress. The originating client receives a
+      // lockStateChanged echo + flashJobActive frame and we skip dispatch.
+      // (HTTP write-class requests are gated separately in writeGuard at the
+      // global /api mount.)
+      if (rejectIfLocked(parsed.msgType, conn, this.jobLock)) return;
 
       switch (parsed.msgType) {
         case 'SERVO_TEST':

--- a/astros_api/src/job_lock.integration.test.ts
+++ b/astros_api/src/job_lock.integration.test.ts
@@ -1,101 +1,19 @@
-// Integration test for JobLock + requireUnlocked over a real HTTP roundtrip.
-//
-// What this verifies:
-//   - The middleware fires inside an Express handler chain.
-//   - The HTTP response carries status 423 + a LockedErrorResponse body
-//     with the expected shape.
-//   - The response transitions back to the downstream handler's response
-//     after the lock is released.
-//
-// What this does NOT verify:
-//   - That api_server.ts:setRoutes actually attaches requireUnlocked to
-//     /api/panicStop. That wire is small (one line) and verified by code
-//     review. When c.2 expands the middleware to the full write-route set,
-//     that PR's integration test should boot the real ApiServer.
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import http from 'http';
-import type { AddressInfo } from 'net';
-import express from 'express';
-import { WebSocketServer, WebSocket } from 'ws';
-import { JobLock } from './job_lock.js';
-import { requireUnlocked } from './job_lock_middleware.js';
-import {
-  buildLockStateResponse,
-  type LockedErrorResponse,
-} from './models/networking/lock_responses.js';
-import { TransmissionType } from './models/enums.js';
-
-describe('JobLock + requireUnlocked HTTP integration', () => {
-  let server: http.Server;
-  let baseUrl: string;
-  let jobLock: JobLock;
-
-  beforeAll(async () => {
-    jobLock = new JobLock();
-    const app = express();
-    app.use(express.json());
-
-    // Mirrors the middleware ordering used in api_server.ts:setRoutes for
-    // /api/panicStop, minus the auth + serial-guard wrappers that aren't part
-    // of the lock concern.
-    app.post('/api/panicStop', requireUnlocked(jobLock), (_req, res) => {
-      res.status(200).json({ message: 'ok' });
-    });
-
-    server = http.createServer(app);
-    await new Promise<void>((resolve) => server.listen(0, resolve));
-    const port = (server.address() as AddressInfo).port;
-    baseUrl = `http://127.0.0.1:${port}`;
-  });
-
-  afterAll(async () => {
-    await new Promise<void>((resolve, reject) =>
-      server.close((err) => (err ? reject(err) : resolve())),
-    );
-  });
-
-  it('passes through to the handler when the lock is not held', async () => {
-    expect(jobLock.isLocked()).toBe(false);
-
-    const res = await fetch(`${baseUrl}/api/panicStop`, { method: 'POST' });
-    const body = (await res.json()) as { message: string };
-
-    expect(res.status).toBe(200);
-    expect(body.message).toBe('ok');
-  });
-
-  it('returns 423 with LockedErrorResponse body while the lock is held', async () => {
-    jobLock.acquire('flashJob:integration');
-    try {
-      const res = await fetch(`${baseUrl}/api/panicStop`, { method: 'POST' });
-      const body = (await res.json()) as LockedErrorResponse;
-
-      expect(res.status).toBe(423);
-      expect(body.error).toBe('flashJobActive');
-      expect(body.lockOwner).toBe('flashJob:integration');
-      expect(body.since).not.toBeNull();
-    } finally {
-      jobLock.release('flashJob:integration');
-    }
-  });
-
-  it('passes through again once the lock is released', async () => {
-    jobLock.acquire('flashJob:integration');
-    jobLock.release('flashJob:integration');
-    expect(jobLock.isLocked()).toBe(false);
-
-    const res = await fetch(`${baseUrl}/api/panicStop`, { method: 'POST' });
-
-    expect(res.status).toBe(200);
-  });
-});
-
-// Verifies the late-join handshake: a WS client connecting while the lock is
+// Verifies the WS late-join handshake: a client connecting while the lock is
 // already held must receive the current state immediately, not wait for the
 // next acquire/release transition. The test mounts its own WebSocketServer
 // with a connect handler that uses buildLockStateResponse — the same helper
 // api_server.ts uses on every real connection — so a payload-shape change is
 // caught here as well as a missing initial-send in production code.
+//
+// HTTP-side write-class gating is handled by writeGuard (see write_guard.test.ts);
+// no per-route middleware is exercised here.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { AddressInfo } from 'net';
+import { WebSocketServer, WebSocket } from 'ws';
+import { JobLock } from './job_lock.js';
+import { buildLockStateResponse } from './models/networking/lock_responses.js';
+import { TransmissionType } from './models/enums.js';
+
 describe('JobLock + WS connect handshake', () => {
   let wsServer: WebSocketServer;
   let wsPort: number;

--- a/astros_api/src/job_lock_middleware.test.ts
+++ b/astros_api/src/job_lock_middleware.test.ts
@@ -1,66 +1,57 @@
 import { describe, it, expect, vi } from 'vitest';
 import { JobLock } from './job_lock.js';
-import { requireUnlocked } from './job_lock_middleware.js';
+import { rejectIfLocked } from './job_lock_middleware.js';
+import { TransmissionType } from './models/enums.js';
 
-function mockRes() {
-  const res: any = {};
-  res.status = vi.fn().mockReturnValue(res);
-  res.json = vi.fn().mockReturnValue(res);
-  return res;
+function mockWs() {
+  const ws: any = {};
+  ws.send = vi.fn();
+  return ws;
 }
 
-describe('requireUnlocked', () => {
-  it('calls next() when the lock is not held', () => {
+describe('rejectIfLocked (WebSocket inbound)', () => {
+  it('returns false and sends nothing when lock is not held', () => {
     const lock = new JobLock();
-    const middleware = requireUnlocked(lock);
-    const req: any = {};
-    const res = mockRes();
-    const next = vi.fn();
+    const conn = mockWs();
 
-    middleware(req, res, next);
+    const rejected = rejectIfLocked('SERVO_TEST', conn, lock);
 
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(res.status).not.toHaveBeenCalled();
-    expect(res.json).not.toHaveBeenCalled();
+    expect(rejected).toBe(false);
+    expect(conn.send).not.toHaveBeenCalled();
   });
 
-  it('responds 423 with LockedErrorResponse body when the lock is held', () => {
+  it('returns false for non-write-class msgType even when locked', () => {
     const lock = new JobLock();
     lock.acquire('flashJob:abc');
-    const middleware = requireUnlocked(lock);
-    const req: any = {};
-    const res = mockRes();
-    const next = vi.fn();
+    const conn = mockWs();
 
-    middleware(req, res, next);
+    const rejected = rejectIfLocked('SOMETHING_READ_CLASS', conn, lock);
 
-    expect(next).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(423);
-    expect(res.json).toHaveBeenCalledTimes(1);
-    const body = res.json.mock.calls[0][0];
-    expect(body.error).toBe('flashJobActive');
-    expect(body.lockOwner).toBe('flashJob:abc');
-    expect(body.since).not.toBeNull();
+    expect(rejected).toBe(false);
+    expect(conn.send).not.toHaveBeenCalled();
   });
 
-  it('passes again after the lock is released', () => {
+  it('returns true and sends lockStateChanged + flashJobActive when locked + write-class msgType', () => {
     const lock = new JobLock();
     lock.acquire('flashJob:abc');
-    const middleware = requireUnlocked(lock);
+    const conn = mockWs();
 
-    // First request — locked.
-    const blockedRes = mockRes();
-    const blockedNext = vi.fn();
-    middleware({} as any, blockedRes, blockedNext);
-    expect(blockedNext).not.toHaveBeenCalled();
+    const rejected = rejectIfLocked('SERVO_TEST', conn, lock);
 
-    // Release and retry.
-    lock.release('flashJob:abc');
-    const passRes = mockRes();
-    const passNext = vi.fn();
-    middleware({} as any, passRes, passNext);
+    expect(rejected).toBe(true);
+    expect(conn.send).toHaveBeenCalledTimes(2);
 
-    expect(passNext).toHaveBeenCalledTimes(1);
-    expect(passRes.status).not.toHaveBeenCalled();
+    // First frame: lockStateChanged echo with current state.
+    const first = JSON.parse(conn.send.mock.calls[0][0]);
+    expect(first.type).toBe(TransmissionType.lockStateChanged);
+    expect(first.locked).toBe(true);
+    expect(first.owner).toBe('flashJob:abc');
+
+    // Second frame: flashJobActive error with rejected msgType.
+    const second = JSON.parse(conn.send.mock.calls[1][0]);
+    expect(second.type).toBe(TransmissionType.flashJobActive);
+    expect(second.error).toBe('flashJobActive');
+    expect(second.lockOwner).toBe('flashJob:abc');
+    expect(second.rejectedMsgType).toBe('SERVO_TEST');
   });
 });

--- a/astros_api/src/job_lock_middleware.ts
+++ b/astros_api/src/job_lock_middleware.ts
@@ -1,18 +1,31 @@
-import type { RequestHandler } from 'express';
+import type { WebSocket } from 'ws';
 import type { JobLock } from './job_lock.js';
-import type { LockedErrorResponse } from './models/networking/lock_responses.js';
+import { logger } from './logger.js';
+import {
+  WS_WRITE_CLASS_MESSAGE_TYPES,
+  buildFlashJobActiveResponse,
+  buildLockStateResponse,
+} from './models/networking/lock_responses.js';
 
-export function requireUnlocked(lock: JobLock): RequestHandler {
-  return (req, res, next) => {
-    if (!lock.isLocked()) {
-      next();
-      return;
-    }
-    const body: LockedErrorResponse = {
-      error: 'flashJobActive',
-      lockOwner: lock.getOwner(),
-      since: lock.getSince(),
-    };
-    res.status(423).json(body);
-  };
+/**
+ * WebSocket-side counterpart to the HTTP gate in writeGuard. When an inbound
+ * write-class message (per WS_WRITE_CLASS_MESSAGE_TYPES) arrives while the
+ * lock is held, sends the originating client a lockStateChanged echo plus a
+ * flashJobActive error frame and signals to the caller that normal dispatch
+ * should be skipped. Returns false (and sends nothing) when the lock is free
+ * or the message is not write-class.
+ *
+ * HTTP write-class requests are gated by writeGuard at the global mount;
+ * this helper exists because WebSocket inbound doesn't pass through Express
+ * middleware.
+ */
+export function rejectIfLocked(msgType: string, conn: WebSocket, lock: JobLock): boolean {
+  if (!WS_WRITE_CLASS_MESSAGE_TYPES.has(msgType) || !lock.isLocked()) {
+    return false;
+  }
+  const state = lock.getState();
+  conn.send(JSON.stringify(buildLockStateResponse(state)));
+  conn.send(JSON.stringify(buildFlashJobActiveResponse(state, msgType)));
+  logger.warn(`websocket write-class message ${msgType} rejected: lock held by ${state.owner}`);
+  return true;
 }

--- a/astros_api/src/job_lock_middleware.ts
+++ b/astros_api/src/job_lock_middleware.ts
@@ -24,8 +24,12 @@ export function rejectIfLocked(msgType: string, conn: WebSocket, lock: JobLock):
     return false;
   }
   const state = lock.getState();
-  conn.send(JSON.stringify(buildLockStateResponse(state)));
-  conn.send(JSON.stringify(buildFlashJobActiveResponse(state, msgType)));
-  logger.warn(`websocket write-class message ${msgType} rejected: lock held by ${state.owner}`);
+  try {
+    conn.send(JSON.stringify(buildLockStateResponse(state)));
+    conn.send(JSON.stringify(buildFlashJobActiveResponse(state, msgType)));
+    logger.warn(`websocket write-class message ${msgType} rejected: lock held by ${state.owner}`);
+  } catch (err) {
+    logger.error(`error sending lock state response for rejected message ${msgType}: ${err}`);
+  }
   return true;
 }

--- a/astros_api/src/models/enums.ts
+++ b/astros_api/src/models/enums.ts
@@ -91,6 +91,7 @@ export enum TransmissionType {
   servoTest,
   systemStatus,
   lockStateChanged,
+  flashJobActive,
 }
 
 export enum TransmissionStatus {

--- a/astros_api/src/models/networking/lock_responses.ts
+++ b/astros_api/src/models/networking/lock_responses.ts
@@ -12,12 +12,27 @@ export interface LockState {
 // WebSocket broadcast payload. `type` will be TransmissionType.lockStateChanged.
 export interface LockStateResponse extends BaseResponse, LockState {}
 
-// HTTP 423 body returned by the requireUnlocked middleware.
+// HTTP 423 body returned by writeGuard when a flash job is active.
 export interface LockedErrorResponse {
   error: 'flashJobActive';
   lockOwner: string | null;
   since: string | null;
 }
+
+// WebSocket frame sent to a single client when one of its inbound write-class
+// messages was rejected because the lock is held. Mirrors LockedErrorResponse
+// (so HTTP 423 and WS rejection bodies are consistent) plus a
+// `rejectedMsgType` field so the client can tell the user which action was
+// dropped.
+export interface FlashJobActiveResponse extends BaseResponse, LockedErrorResponse {
+  // type = TransmissionType.flashJobActive
+  rejectedMsgType: string;
+}
+
+// Set of inbound WebSocket msgType values that count as "write-class" for
+// the purposes of the JobLock guard. Single source of truth — extending the
+// guard to a future write-class WS msgType is a one-line addition here.
+export const WS_WRITE_CLASS_MESSAGE_TYPES: ReadonlySet<string> = new Set(['SERVO_TEST']);
 
 // Single source of truth for the lockStateChanged WS payload, used both for
 // transition broadcasts (jobLock.subscribe handler) and the on-connect snapshot
@@ -28,5 +43,23 @@ export function buildLockStateResponse(state: LockState): LockStateResponse {
     success: true,
     message: '',
     ...state,
+  };
+}
+
+// Single source of truth for the flashJobActive WS rejection frame. Sent from
+// rejectIfLocked alongside a lockStateChanged echo so the client can both
+// reconcile lock state and surface the per-action rejection.
+export function buildFlashJobActiveResponse(
+  state: LockState,
+  rejectedMsgType: string,
+): FlashJobActiveResponse {
+  return {
+    type: TransmissionType.flashJobActive,
+    success: false,
+    message: `Write rejected: flash job active (${state.owner ?? 'unknown'})`,
+    error: 'flashJobActive',
+    lockOwner: state.owner,
+    since: state.since,
+    rejectedMsgType,
   };
 }

--- a/astros_api/src/write_guard.test.ts
+++ b/astros_api/src/write_guard.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { JobLock } from './job_lock.js';
 import { SystemStatus } from './system_status.js';
 import { writeGuard } from './write_guard.js';
 
@@ -13,8 +14,9 @@ function call(
   method: string,
   path: string,
   status: SystemStatus,
+  jobLock: JobLock = new JobLock(),
 ): { res: any; next: ReturnType<typeof vi.fn> } {
-  const guard = writeGuard(status);
+  const guard = writeGuard(status, jobLock);
   const req: any = { method, path };
   const res = mockRes();
   const next = vi.fn();
@@ -108,6 +110,73 @@ describe('writeGuard', () => {
         expect(res.json).toHaveBeenCalledWith(
           expect.objectContaining({ reasonCode: 'BACKUP_FAILED' }),
         );
+      }
+    });
+  });
+
+  describe('when a flash job is active', () => {
+    function activeFlash(): { status: SystemStatus; lock: JobLock } {
+      const status = new SystemStatus();
+      const lock = new JobLock();
+      lock.acquire('flashJob:test');
+      return { status, lock };
+    }
+
+    it('blocks POST/PUT/PATCH/DELETE with 423 + LockedErrorResponse body', () => {
+      const { status, lock } = activeFlash();
+      for (const m of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+        const { res, next } = call(m, '/scripts', status, lock);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(423);
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({ error: 'flashJobActive', lockOwner: 'flashJob:test' }),
+        );
+      }
+    });
+
+    it('blocks the five serial-write GET paths with 423', () => {
+      const { status, lock } = activeFlash();
+      const blockedGets = [
+        '/locations/syncconfig',
+        '/locations/synccontrollers',
+        '/scripts/upload',
+        '/scripts/run',
+        '/playlists/run',
+      ];
+      for (const p of blockedGets) {
+        const { res, next } = call('GET', p, status, lock);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(423);
+      }
+    });
+
+    it('allows login and reauth (allowlisted during flash)', () => {
+      const { status, lock } = activeFlash();
+      for (const p of ['/login', '/reauth']) {
+        const { res, next } = call('POST', p, status, lock);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.status).not.toHaveBeenCalled();
+      }
+    });
+
+    it('blocks panicStop and panicClear with 423 (stricter than read-only mode)', () => {
+      // Read-only allows panic so the user can halt motion during a server
+      // outage; flash-active does NOT, because emitting a PANIC_STOP frame
+      // mid-flash would interleave with FW_CHUNK frames on the serial line
+      // and corrupt the in-flight transfer.
+      const { status, lock } = activeFlash();
+      for (const p of ['/panicStop', '/panicClear']) {
+        const { res, next } = call('POST', p, status, lock);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(423);
+      }
+    });
+
+    it('allows safe reads even when locked', () => {
+      const { status, lock } = activeFlash();
+      for (const p of ['/scripts', '/playlists', '/system/status']) {
+        const { next } = call('GET', p, status, lock);
+        expect(next).toHaveBeenCalledTimes(1);
       }
     });
   });

--- a/astros_api/src/write_guard.ts
+++ b/astros_api/src/write_guard.ts
@@ -1,4 +1,5 @@
 import { RequestHandler } from 'express';
+import { JobLock } from './job_lock.js';
 import { SystemStatus } from './system_status.js';
 
 const BLOCKED_WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
@@ -10,6 +11,16 @@ const ALLOWED_IN_READONLY: Array<{ method: string; path: string }> = [
   { method: 'POST', path: '/panicClear' },
 ];
 
+// Flash-active mode is stricter than read-only: panic stop / clear are
+// intentionally NOT allowed while a flash job is running because emitting a
+// PANIC_STOP frame on the serial port would interleave with FW_CHUNK frames
+// and corrupt the in-flight transfer. Login / reauth still work so a fresh
+// session can attach to the live job.
+const ALLOWED_DURING_FLASH: Array<{ method: string; path: string }> = [
+  { method: 'POST', path: '/login' },
+  { method: 'POST', path: '/reauth' },
+];
+
 const BLOCKED_GET_PATHS = new Set([
   '/locations/syncconfig',
   '/locations/synccontrollers',
@@ -18,29 +29,62 @@ const BLOCKED_GET_PATHS = new Set([
   '/playlists/run',
 ]);
 
-export function writeGuard(systemStatus: SystemStatus): RequestHandler {
+function isAllowed(
+  list: Array<{ method: string; path: string }>,
+  method: string,
+  path: string,
+): boolean {
+  return list.some((entry) => entry.method === method && entry.path === path);
+}
+
+/**
+ * Gates write-class HTTP requests. Two distinct rejection modes share one
+ * "is this a write?" definition (BLOCKED_WRITE_METHODS + BLOCKED_GET_PATHS):
+ *
+ *   - 503 when the server is in read-only mode (DB recovery, etc.).
+ *   - 423 when a flash job is active (per .docs/protocol.md hard-lock spec).
+ *
+ * Hot path (no gates active) skips the write-class detection entirely and
+ * calls next() directly. When at least one gate is active we then check
+ * whether the request is write-class and apply the relevant gate(s).
+ * Read-only is checked first; a request must clear BOTH gates to proceed.
+ */
+export function writeGuard(systemStatus: SystemStatus, jobLock: JobLock): RequestHandler {
   return (req, res, next) => {
-    if (!systemStatus.isReadOnly()) {
+    const readOnly = systemStatus.isReadOnly();
+    const locked = jobLock.isLocked();
+
+    // Hot path: neither gate is active. Skip the write-class detection and
+    // any allowlist lookups entirely — every read AND every write passes
+    // through with a single pair of property accesses.
+    if (!readOnly && !locked) {
       next();
       return;
     }
 
-    const allowlisted = ALLOWED_IN_READONLY.some(
-      (entry) => entry.method === req.method && entry.path === req.path,
-    );
-    if (allowlisted) {
-      next();
-      return;
-    }
-
+    // At least one gate is active. Now figure out whether this request even
+    // needs gating before doing more work.
     const blockedWrite = BLOCKED_WRITE_METHODS.has(req.method);
     const blockedGet = req.method === 'GET' && BLOCKED_GET_PATHS.has(req.path);
+    if (!blockedWrite && !blockedGet) {
+      next();
+      return;
+    }
 
-    if (blockedWrite || blockedGet) {
+    if (readOnly && !isAllowed(ALLOWED_IN_READONLY, req.method, req.path)) {
       const state = systemStatus.getState();
       res.status(503).json({
         message: 'Server is in read-only mode',
         reasonCode: state.reasonCode,
+      });
+      return;
+    }
+
+    if (locked && !isAllowed(ALLOWED_DURING_FLASH, req.method, req.path)) {
+      res.status(423).json({
+        error: 'flashJobActive',
+        lockOwner: jobLock.getOwner(),
+        since: jobLock.getSince(),
       });
       return;
     }


### PR DESCRIPTION
 Summary

  Extends the existing writeGuard to gate write-class HTTP requests with 423 flashJobActive while a flash job is in progress, alongside its existing 503 read-only behavior. Adds a small rejectIfLocked helper for WebSocket inbound write-class messages (HTTP middleware doesn't apply to WS). Single source of truth for "is this a write?" — every existing and future write route inherits the new gate automatically.

  No flash-job state machine, no firmware code — pure infrastructure on top of c0.

  Context

  - Parent plan: .docs/plans/20260427-2202-firmware-ota-decomposition.md
  - This PR's plan: .docs/plans/20260429-0655-firmware-ota-c-2-full-write-route-lock.md
  - Builds on c0's JobLock (PR #65) and c.1's FW_* serializers (PR #66).

  What's in this PR

  writeGuard extension (write_guard.ts):
  - New JobLock parameter alongside SystemStatus. Hot path (neither gate active) short-circuits to next() without computing write-classness or consulting any allowlist — common case stays a pair of property accesses.
  - When at least one gate is active: write-class detection runs (reusing existing BLOCKED_WRITE_METHODS + BLOCKED_GET_PATHS), then read-only check  (503), then flash-active check (423 + LockedErrorResponse body).
  - New ALLOWED_DURING_FLASH allowlist: login + reauth only. Panic is intentionally NOT in the flash allowlist — emitting PANIC_STOP mid-flash would interleave with FW_CHUNK frames on the serial line and corrupt the in-flight transfer. Read-only mode keeps its existing panic allowlist (different rationale: server can't write to DB, but motion can still be halted).

  WebSocket inbound rejection:
  - New TransmissionType.flashJobActive + FlashJobActiveResponse model + buildFlashJobActiveResponse factory, mirroring LockedErrorResponse with a  rejectedMsgType field for client diagnosis.
  - New WS_WRITE_CLASS_MESSAGE_TYPES set (currently {'SERVO_TEST'}) as single source of truth — extending the guard to a future write-class WS  msgType is a one-line addition.
  - requireUnlocked removed entirely; replaced with rejectIfLocked helper. Per-connection rejection that sends a lockStateChanged echo +  flashJobActive frame to the originating client and skips dispatch.
  - handleWebsocketMessage now takes the WebSocket connection so it can call rejectIfLocked before dispatching SERVO_TEST.

  Wire-up (api_server.ts):
  - Passes this.jobLock to the writeGuard mount.
  - Drops the inline requireUnlocked from /panicStop (writeGuard now catches POST /panicStop via BLOCKED_WRITE_METHODS).
  - Threads conn into handleWebsocketMessage; calls rejectIfLocked before the dispatch switch.

  File count

  9 files. Net diff is −191 / +272 lines — mostly the controller signature changes from the earlier draft were reverted.

  Verification

  - npm run build clean (lint + tsc) in astros_api/.
  - npm run test green: 304 / 304 (was 302; +2 net).
  - npm run prettier:write and npm run lint:fix clean.

  Test changes:
  - +6 flash-active tests in write_guard.test.ts covering: 423 + body shape on POST/PUT/PATCH/DELETE, 423 on the five serial-write GETs, login/reauth
   allowlisted, panic blocked (stricter than read-only), reads pass through.
  - +3 rejectIfLocked unit tests in job_lock_middleware.test.ts. (Replaced the 3 removed requireUnlocked tests; net 0 in that file.)
  - −3 requireUnlocked HTTP integration tests from job_lock.integration.test.ts; the WS connect-handshake describe block is unchanged.

  Intentionally out of scope

  - Vue handling of flashJobActive (UI banner / toast on rejected actions) — deferred to d.7.
  - POST /firmware/jobs — doesn't exist yet; c.8 will add it (will inherit the lock automatically via writeGuard).
  - Any flash-job state machine, GitHub fetching, file upload, or new serial-protocol additions.

  Note on broader scope

  writeGuard's interpretation locks every write-class HTTP route — including settings/audio/remoteConfig writes that the decomposition's enumerated
  list didn't explicitly mention. This is intentional: the decomposition's principle ("no other write-class operation hits during a flash") is
  broader than its enumerated list, and writeGuard was already the right home for that principle.

  Test plan (reviewer)

  - Pull the branch, cd astros_api && npm install && npm run build && npm run test — expect 304 green.
  - Confirm writeGuard's hot path: if (!readOnly && !locked) { next(); return; } is the first thing in the returned handler (every request that
  doesn't trip a gate pays just two property accesses).
  - Spot-check ALLOWED_DURING_FLASH only contains /login and /reauth. Panic is deliberately omitted.
  - Verify requireUnlocked is fully removed (grep requireUnlocked should return no hits) and that /panicStop's middleware chain in api_server.ts no
  longer includes it.
  - In handleWebsocketMessage, confirm rejectIfLocked runs before the switch on msgType.