### PR TITLE
Feature/firmware ota c 3 GitHub releases service

### DIFF
--- a/.docs/plans/20260427-2202-firmware-ota-decomposition.md
+++ b/.docs/plans/20260427-2202-firmware-ota-decomposition.md
@@ -256,7 +256,7 @@ The single highest-risk sub-project. Requirements the firmware sub-plan must mee
 ## Source acquisition + caching (input for sub-plan **c**)
 
 - **GitHub releases endpoint:** `GET https://api.github.com/repos/<owner>/AstrOs.ESP/releases` (anonymous, **60 req/hr per IP** — drives the cache decision).
-- **Asset selection:** match `^astros-esp-v\d+\.\d+\.\d+\.bin$`; prefer exact `astros-esp-v${tag_name#v}.bin`; reject if `content_type` isn't octet-stream.
+- **Asset selection:** match `^astros-esp-(.+)-([a-z][a-z0-9_]*)-app\.bin$`. AstrOs.ESP CI produces one `-app.bin` per build env per release (e.g., `astros-esp-1.0.0-metro_s3-app.bin`, `astros-esp-1.2.0-RC.1-lolin_d32_pro-app.bin`); the regex captures `version` and `variant` (the PlatformIO env name). The `-app.bin` suffix anchors against `-flash.bin` (the full-flash USB-bootstrap image, out of scope for OTA). The `[a-z][a-z0-9_]*` variant pattern excludes the hyphens that semver pre-release labels can contain, so the regex backtracks correctly on names like `astros-esp-1.2.0-RC.1-lolin_d32_pro-app.bin`. Reject if `content_type` isn't octet-stream-flavored. Each release surfaces an array of matched assets (one per variant); orchestrator (c.6) matches each controller's reported variant to the correct asset.
 - **In-memory cache:** 5-min TTL keyed by repo. Serve stale on fetch error with a `staleSince` field surfaced in the API response.
 - **On-disk cache** under `~/.config/astrosserver/firmware-cache/`:
   ```

--- a/.docs/plans/20260429-0918-firmware-ota-c-3-github-releases-service.md
+++ b/.docs/plans/20260429-0918-firmware-ota-c-3-github-releases-service.md
@@ -8,21 +8,34 @@ Light plan for the next server-orchestrator PR. Builds the source-acquisition la
 
 ## Context
 
-The firmware-OTA UI's "GitHub" source toggle needs an authoritative release list. The decomposition spec calls for:
+The firmware-OTA UI's "GitHub" source toggle needs an authoritative release list. AstrOs.ESP's CI workflows (`rc-build.yml`, `release-build.yml`) currently produce two artifacts per build env per release:
+
+- `astros-esp-${VERSION}-${ENV}-app.bin` — application partition (what OTA flashes).
+- `astros-esp-${VERSION}-${ENV}-flash.bin` — full flash image including bootloader, for first-time USB bootstrap. Out of scope for OTA.
+
+`${ENV}` is the PlatformIO env name (currently `lolin_d32_pro` and `metro_s3`); each is a different chip family + partition layout, so binaries are not interchangeable across variants. `${VERSION}` follows semver and may include pre-release labels (e.g., `1.0.0`, `1.2.0-RC.1`).
+
+c.3 fetches the GitHub release list, picks all `-app.bin` assets per release (one per variant), and exposes them as a typed list with each asset's variant captured. The orchestrator (**c.6**) is what eventually matches each controller's reported variant to the correct asset; c.3 returns the full set of variants without picking.
+
+Service-level spec from the decomposition:
 
 - `GET https://api.github.com/repos/<owner>/AstrOs.ESP/releases` (anonymous, 60 req/hr per IP).
-- Filter assets to `^astros-esp-v\d+\.\d+\.\d+\.bin$`; prefer the asset whose name matches `astros-esp-v${tag_name#v}.bin` exactly.
+- Asset filter: `^astros-esp-(.+)-([a-z][a-z0-9_]*)-app\.bin$` — captures `version` and `variant`. The `-app.bin` suffix anchors against `-flash.bin`. The `[a-z][a-z0-9_]*` variant pattern excludes the hyphens that semver pre-release labels can contain, so the regex backtracks correctly on names like `astros-esp-1.2.0-RC.1-lolin_d32_pro-app.bin`.
 - Reject assets whose `content_type` isn't `application/octet-stream` (or similar).
 - 5-minute in-memory cache; serve stale on fetch error with a `staleSince` warning surfaced in the API response.
 
-c.3 ships the service in isolation. No route, no orchestrator integration. Tests use HTTP fixtures (no live calls in CI). The route comes in **c.8**, the cache becomes a c.6 dependency.
+c.3 ships the service in isolation. No route, no orchestrator integration. Tests use HTTP fixtures (no live calls in CI). The route comes in **c.8**, the cache becomes a **c.6** dependency.
 
 ## Tasks
 
-- [ ] **Typed models** (new `astros_api/src/models/firmware/release.ts`). At minimum: `ReleaseInfo` (the per-release shape we surface — `tag`, `version`, `publishedAt`, `assetName`, `assetUrl`, `sizeBytes`), `ReleaseListResult` (list + `staleSince: string | null` so consumers can distinguish a fresh fetch from a served-stale response), and the GitHub API DTO subset we parse (`GitHubReleaseDto`, `GitHubAssetDto`).
-- [ ] **GitHub release service** (new `astros_api/src/firmware/github_release_service.ts`). Class `GitHubReleaseService` constructor takes `(repoSlug: string, fetcher: typeof fetch = fetch)` for DI / test mocking. Single public method: `getReleases(): Promise<ReleaseListResult>`. Internals: 5-min TTL in-memory cache; on cache miss, call `fetcher` against `https://api.github.com/repos/<repoSlug>/releases`; on success, parse + filter assets + write to cache + return; on fetch error, return last cached value (if any) with `staleSince` set to its fetch timestamp; on cold-cache fetch error, throw.
-- [ ] **Asset selection logic.** Helper `pickFirmwareAsset(release: GitHubReleaseDto): GitHubAssetDto | null`. Filters to assets matching `^astros-esp-v\d+\.\d+\.\d+\.bin$`. Prefers exact match against `astros-esp-v${tag_name#v}.bin`; falls back to first match otherwise; returns null if nothing matches or if the matching asset's content_type isn't `application/octet-stream` / `application/macbinary`. Releases whose pickFirmwareAsset returns null are filtered out of the result.
-- [ ] **Tests** (new `astros_api/src/firmware/github_release_service.test.ts`). Cover: cache miss → fetch → fresh result; cache hit within 5 min → no fetch; cache miss after 5 min → re-fetch; fetch error with cold cache → throws; fetch error with warm cache → returns stale with `staleSince`; asset filtering (exact match preferred, no-match release skipped, wrong content-type skipped); date math is mocked via `vi.useFakeTimers()` so the 5-min TTL is testable without sleep.
+- [ ] **Typed models** (new `astros_api/src/models/firmware/release.ts`). At minimum:
+    - `AssetInfo` — `{ variant: string, version: string, assetName: string, assetUrl: string, sizeBytes: number }` (one per matched `-app.bin`).
+    - `ReleaseInfo` — `{ tag: string, version: string, publishedAt: string, assets: AssetInfo[] }` (one or more matched assets per release).
+    - `ReleaseListResult` — `{ releases: ReleaseInfo[], staleSince: string | null }` so consumers can distinguish a fresh fetch from a served-stale response.
+    - The GitHub API DTO subset we parse (`GitHubReleaseDto`, `GitHubAssetDto`) with only the fields we need (`tag_name`, `published_at`, `assets[].name|browser_download_url|size|content_type`).
+- [ ] **GitHub release service** (new `astros_api/src/firmware/github_release_service.ts`). Class `GitHubReleaseService` constructor takes `(repoSlug: string, fetcher: typeof fetch = fetch)` for DI / test mocking. Single public method: `getReleases(): Promise<ReleaseListResult>`. Internals: 5-min TTL in-memory cache; on cache miss, call `fetcher` against `https://api.github.com/repos/<repoSlug>/releases`; on success, parse + extract per-variant assets + write to cache + return; on fetch error, return last cached value (if any) with `staleSince` set to its fetch timestamp; on cold-cache fetch error, throw. In-flight fetch deduplication so a stampede of `getReleases()` calls during a cold-cache fetch awaits one promise.
+- [ ] **Asset selection logic.** Exported helper `extractFirmwareAssets(release: GitHubReleaseDto): AssetInfo[]`. Walks `release.assets`, applies the regex `^astros-esp-(.+)-([a-z][a-z0-9_]*)-app\.bin$` (capturing version + variant), rejects entries whose `content_type` isn't octet-stream-flavored, returns the array of matched assets. Releases that yield no assets are filtered out of `ReleaseInfo[]` entirely. (Optional sanity check: warn-and-skip if the parsed `version` from the asset name doesn't match the release's `tag_name` minus a leading `v` — catches misnamed assets at parse time rather than at flash time.)
+- [ ] **Tests** (new `astros_api/src/firmware/github_release_service.test.ts`). Cover: cache miss → fetch → fresh result; cache hit within 5 min → no fetch; cache miss after 5 min → re-fetch; fetch error with cold cache → throws; fetch error with warm cache → returns stale with `staleSince`; asset filtering (multi-variant release returns multiple assets, `-flash.bin` excluded, no-match release skipped, wrong content-type skipped, asset whose parsed version disagrees with tag is skipped); pre-release version like `1.2.0-RC.1` parses correctly; date math is mocked via `vi.useFakeTimers()` so the 5-min TTL is testable without sleep.
 
 ## Verification
 
@@ -45,6 +58,7 @@ c.3 ships the service in isolation. No route, no orchestrator integration. Tests
 - On-disk `.bin` cache for downloaded firmware files — **c.4**.
 - Upload mode + `esp_app_desc_t` parsing — **c.5**.
 - FlashJob orchestrator integration — **c.6**.
+- **Heartbeat-variant extension.** c.6 will need POLL_ACK extended from `name<US>fingerprint<US>version` to `name<US>fingerprint<US>version<US>variant` so the orchestrator can match each controller to the correct asset variant. That's a paired cross-repo protocol amendment best done alongside c.6 (where it's actually consumed); doing it in c.3 would ship dead code on both sides. c.3's service returns all matched variants per release without picking; the picker logic + heartbeat amendment land together.
 - Release-list refresh strategy beyond "fetch on getReleases() with 5-min TTL" — no background polling, no manual-refresh endpoint. Cache is lazy.
 - GitHub authentication / PAT support — decomp explicitly chose anonymous fetch. The 60 req/hr limit is fine for this caching strategy (12 fetches/hr worst case, shared across all clients of the running server).
 

--- a/.docs/plans/20260429-0918-firmware-ota-c-3-github-releases-service.md
+++ b/.docs/plans/20260429-0918-firmware-ota-c-3-github-releases-service.md
@@ -1,0 +1,57 @@
+# c.3 — GitHub release service + 5-min in-memory cache
+
+Light plan for the next server-orchestrator PR. Builds the source-acquisition layer for `GitHub` mode of the firmware-OTA UI: a service that fetches the release list from `api.github.com`, picks the right `.bin` asset, and caches the result for 5 minutes. No route, no orchestrator wiring — c.8 wires the route, c.6 wires the orchestrator.
+
+**Branch:** `feature/firmware-ota-c-3-github-releases-service` (off `develop`).
+**PR target base:** `develop`.
+**References:** [decomposition plan](./20260427-2202-firmware-ota-decomposition.md) § "Source acquisition + caching", [c.2 plan](./20260429-0655-firmware-ota-c-2-full-write-route-lock.md).
+
+## Context
+
+The firmware-OTA UI's "GitHub" source toggle needs an authoritative release list. The decomposition spec calls for:
+
+- `GET https://api.github.com/repos/<owner>/AstrOs.ESP/releases` (anonymous, 60 req/hr per IP).
+- Filter assets to `^astros-esp-v\d+\.\d+\.\d+\.bin$`; prefer the asset whose name matches `astros-esp-v${tag_name#v}.bin` exactly.
+- Reject assets whose `content_type` isn't `application/octet-stream` (or similar).
+- 5-minute in-memory cache; serve stale on fetch error with a `staleSince` warning surfaced in the API response.
+
+c.3 ships the service in isolation. No route, no orchestrator integration. Tests use HTTP fixtures (no live calls in CI). The route comes in **c.8**, the cache becomes a c.6 dependency.
+
+## Tasks
+
+- [ ] **Typed models** (new `astros_api/src/models/firmware/release.ts`). At minimum: `ReleaseInfo` (the per-release shape we surface — `tag`, `version`, `publishedAt`, `assetName`, `assetUrl`, `sizeBytes`), `ReleaseListResult` (list + `staleSince: string | null` so consumers can distinguish a fresh fetch from a served-stale response), and the GitHub API DTO subset we parse (`GitHubReleaseDto`, `GitHubAssetDto`).
+- [ ] **GitHub release service** (new `astros_api/src/firmware/github_release_service.ts`). Class `GitHubReleaseService` constructor takes `(repoSlug: string, fetcher: typeof fetch = fetch)` for DI / test mocking. Single public method: `getReleases(): Promise<ReleaseListResult>`. Internals: 5-min TTL in-memory cache; on cache miss, call `fetcher` against `https://api.github.com/repos/<repoSlug>/releases`; on success, parse + filter assets + write to cache + return; on fetch error, return last cached value (if any) with `staleSince` set to its fetch timestamp; on cold-cache fetch error, throw.
+- [ ] **Asset selection logic.** Helper `pickFirmwareAsset(release: GitHubReleaseDto): GitHubAssetDto | null`. Filters to assets matching `^astros-esp-v\d+\.\d+\.\d+\.bin$`. Prefers exact match against `astros-esp-v${tag_name#v}.bin`; falls back to first match otherwise; returns null if nothing matches or if the matching asset's content_type isn't `application/octet-stream` / `application/macbinary`. Releases whose pickFirmwareAsset returns null are filtered out of the result.
+- [ ] **Tests** (new `astros_api/src/firmware/github_release_service.test.ts`). Cover: cache miss → fetch → fresh result; cache hit within 5 min → no fetch; cache miss after 5 min → re-fetch; fetch error with cold cache → throws; fetch error with warm cache → returns stale with `staleSince`; asset filtering (exact match preferred, no-match release skipped, wrong content-type skipped); date math is mocked via `vi.useFakeTimers()` so the 5-min TTL is testable without sleep.
+
+## Verification
+
+- [ ] `npm run build` clean (lint + tsc).
+- [ ] `npm run test` green (existing + new c.3 tests).
+- [ ] `npm run prettier:write` and `npm run lint:fix` clean.
+- [ ] Verify the asset matcher against representative GitHub release fixtures (one with a single matching asset, one with multiple non-matching assets, one with no `.bin` at all).
+
+## Files in scope (3)
+
+1. `astros_api/src/models/firmware/release.ts` — new typed models for the release-list result, the GitHub API DTO subset, and the asset shape
+2. `astros_api/src/firmware/github_release_service.ts` — new service: fetcher DI, 5-min cache, asset selection, stale-on-error fallback
+3. `astros_api/src/firmware/github_release_service.test.ts` — new tests with mocked fetch + fake timers
+
+3 files, well under the soft cap. The `firmware/` folder is new at this layer (we have `models/firmware/` from c.1; this is the matching service layer).
+
+## Out of scope
+
+- Route exposure (`GET /firmware/releases`) — **c.8**.
+- On-disk `.bin` cache for downloaded firmware files — **c.4**.
+- Upload mode + `esp_app_desc_t` parsing — **c.5**.
+- FlashJob orchestrator integration — **c.6**.
+- Release-list refresh strategy beyond "fetch on getReleases() with 5-min TTL" — no background polling, no manual-refresh endpoint. Cache is lazy.
+- GitHub authentication / PAT support — decomp explicitly chose anonymous fetch. The 60 req/hr limit is fine for this caching strategy (12 fetches/hr worst case, shared across all clients of the running server).
+
+## Notes for the reviewer
+
+- **Repo slug source.** The plan calls for `api.github.com/repos/<owner>/AstrOs.ESP/releases`. Owner needs to live in env (`GITHUB_REPO_SLUG=battlesloth/AstrOs.ESP` or equivalent); the service constructor takes a slug so tests can pass a stub. Will document the env var in the c.3 PR description.
+- **Cache shape.** Single-keyed cache (the release list itself, no per-tag entries). One in-flight fetch only — if a second `getReleases()` arrives while a fetch is in flight, both await the same promise. Prevents stampede on cold cache.
+- **Stale-on-error semantics.** Per decomp: "Serve stale on fetch error with a staleSince field surfaced in the API response." `ReleaseListResult.staleSince` is the ISO timestamp of the entry's original fetch; null when fresh. Callers (UI) display a "showing cached releases from X" banner when non-null.
+- **Fake timers.** Vitest's `vi.useFakeTimers()` lets us advance time deterministically across the 5-min TTL boundary in tests. Avoids any real-time waits, keeps the suite fast.
+- The asset-selection helper is exported separately from the service so a future module (likely c.4 for the on-disk cache or c.6 for the orchestrator) can call it directly against a release dto.

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -43,7 +43,12 @@ function buildProvider(extra: Record<string, Migration> = {}): MigrationProvider
   })();
 }
 
-describe('initializeDatabase safety flow', () => {
+// Each test deliberately drives a real SQLite migration + backup/restore
+// cycle, so ~1.6s isolated baseline is expected. The default 5s vitest
+// timeout leaves only ~3.4s of headroom; under full-suite contention that
+// margin disappears and these tests flake on CI. 15s is well above the
+// observed worst case while still failing fast if a real hang regresses in.
+describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
   let tmpDir: string;
   let dbPath: string;
 

--- a/astros_api/src/firmware/github_release_service.test.ts
+++ b/astros_api/src/firmware/github_release_service.test.ts
@@ -20,6 +20,7 @@ function release(overrides: Partial<GitHubReleaseDto> = {}): GitHubReleaseDto {
   return {
     tag_name: 'v1.0.0',
     published_at: '2026-04-01T00:00:00Z',
+    draft: false,
     assets: [asset()],
     ...overrides,
   };
@@ -346,6 +347,50 @@ describe('GitHubReleaseService', () => {
     const stale2 = await svc.getReleases();
     expect(stale2.staleSince).not.toBeNull();
     expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('filters out draft releases (even with otherwise-valid assets)', async () => {
+    const published = release();
+    const draft = release({
+      tag_name: 'v0.9.0',
+      draft: true,
+      published_at: null,
+      // Asset is well-formed for v0.9.0 — without the draft filter, this
+      // release would surface in the list. The draft filter must drop it.
+      assets: [
+        asset({
+          name: 'astros-esp-0.9.0-metro_s3-app.bin',
+          browser_download_url: 'https://example.test/astros-esp-0.9.0-metro_s3-app.bin',
+        }),
+      ],
+    });
+    const fetcher = makeFetcherReturning([published, draft]);
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+    const result = await svc.getReleases();
+
+    expect(result.releases.map((r) => r.tag)).toEqual(['v1.0.0']);
+  });
+
+  it('filters out non-draft releases with null published_at (defense in depth)', async () => {
+    const published = release();
+    const weird = release({
+      tag_name: 'v0.9.0',
+      draft: false,
+      published_at: null,
+      assets: [
+        asset({
+          name: 'astros-esp-0.9.0-metro_s3-app.bin',
+          browser_download_url: 'https://example.test/astros-esp-0.9.0-metro_s3-app.bin',
+        }),
+      ],
+    });
+    const fetcher = makeFetcherReturning([published, weird]);
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+    const result = await svc.getReleases();
+
+    expect(result.releases.map((r) => r.tag)).toEqual(['v1.0.0']);
   });
 
   it('filters out releases with zero matched assets', async () => {

--- a/astros_api/src/firmware/github_release_service.test.ts
+++ b/astros_api/src/firmware/github_release_service.test.ts
@@ -240,6 +240,68 @@ describe('GitHubReleaseService', () => {
     expect(String(url)).toBe('https://api.github.com/repos/battlesloth/AstrOs.ESP/releases');
   });
 
+  it('aborts a hanging fetch after the timeout with an error mentioning the URL', async () => {
+    // Hanging fetcher: never resolves; only rejects when the AbortController
+    // fires. Without the signal-respecting branch, this test would also hang.
+    const hangingFetcher: typeof fetch = vi.fn(async (_url, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const abortErr = new Error('aborted');
+          abortErr.name = 'AbortError';
+          reject(abortErr);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const svc = new GitHubReleaseService('test/dummy', hangingFetcher);
+    const promise = svc.getReleases();
+
+    // Catch unhandled-rejection warning before the assertion runs.
+    const expectation = expect(promise).rejects.toThrow(/timed out.*test\/dummy/i);
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expectation;
+  });
+
+  it('serves stale cache when a re-fetch times out (does not hang)', async () => {
+    let mode: 'fast' | 'hang' = 'fast';
+    const releases = [release()];
+    const fetcher: typeof fetch = vi.fn(async (_url, init?: RequestInit) => {
+      if (mode === 'fast') {
+        return new Response(JSON.stringify(releases), { status: 200 });
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const abortErr = new Error('aborted');
+          abortErr.name = 'AbortError';
+          reject(abortErr);
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+    await svc.getReleases(); // warm cache
+
+    vi.advanceTimersByTime(6 * 60 * 1000); // expire it
+    mode = 'hang';
+
+    const stalePromise = svc.getReleases();
+    await vi.advanceTimersByTimeAsync(15_000); // trip the timeout
+
+    const stale = await stalePromise;
+    expect(stale.releases).toHaveLength(1);
+    expect(stale.staleSince).not.toBeNull();
+  });
+
+  it('includes URL and status text in the non-2xx error', async () => {
+    const fetcher: typeof fetch = vi.fn(
+      async () => new Response('Not Found', { status: 404, statusText: 'Not Found' }),
+    ) as unknown as typeof fetch;
+
+    const svc = new GitHubReleaseService('battlesloth/AstrOs.ESP', fetcher);
+
+    await expect(svc.getReleases()).rejects.toThrow(/AstrOs\.ESP.*404.*Not Found/);
+  });
+
   it('filters out releases with zero matched assets', async () => {
     const releaseWithMatches = release();
     const releaseWithoutMatches = release({

--- a/astros_api/src/firmware/github_release_service.test.ts
+++ b/astros_api/src/firmware/github_release_service.test.ts
@@ -242,6 +242,21 @@ describe('GitHubReleaseService', () => {
     expect(String(url)).toBe('https://api.github.com/repos/battlesloth/AstrOs.ESP/releases');
   });
 
+  it('normalizes a non-Error fetcher rejection into a proper Error', async () => {
+    // Some runtimes / test mocks reject with plain strings or objects. The
+    // catch block previously used `err as Error` (a compile-time-only cast)
+    // and then read `.message`, which would surface `undefined` in logs and
+    // re-throw a non-Error to callers. Normalize at the boundary.
+    const fetcher: typeof fetch = vi.fn(async () => {
+      throw 'string-not-error';
+    }) as unknown as typeof fetch;
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    const rejection = svc.getReleases();
+    await expect(rejection).rejects.toBeInstanceOf(Error);
+    await expect(rejection).rejects.toThrow(/string-not-error/);
+  });
+
   it('sends User-Agent and Accept headers on every fetch (and keeps the abort signal)', async () => {
     // GitHub's REST API requires a User-Agent on anonymous requests (otherwise
     // returns 403). Accept: application/vnd.github+json pins the v3 response

--- a/astros_api/src/firmware/github_release_service.test.ts
+++ b/astros_api/src/firmware/github_release_service.test.ts
@@ -242,6 +242,26 @@ describe('GitHubReleaseService', () => {
     expect(String(url)).toBe('https://api.github.com/repos/battlesloth/AstrOs.ESP/releases');
   });
 
+  it('sends User-Agent and Accept headers on every fetch (and keeps the abort signal)', async () => {
+    // GitHub's REST API requires a User-Agent on anonymous requests (otherwise
+    // returns 403). Accept: application/vnd.github+json pins the v3 response
+    // shape across runtimes. The signal assertion is a regression guard so a
+    // future header refactor can't silently drop the AbortController wiring.
+    const fetcher = makeFetcherReturning([]);
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    await svc.getReleases();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const init = (fetcher as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as
+      | RequestInit
+      | undefined;
+    const headers = new Headers(init?.headers);
+    expect(headers.get('User-Agent')).toMatch(/AstrOs\.Server/);
+    expect(headers.get('Accept')).toBe('application/vnd.github+json');
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('aborts a hanging fetch after the timeout with an error mentioning the URL', async () => {
     // Hanging fetcher: never resolves; only rejects when the AbortController
     // fires. Without the signal-respecting branch, this test would also hang.

--- a/astros_api/src/firmware/github_release_service.test.ts
+++ b/astros_api/src/firmware/github_release_service.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { extractFirmwareAssets, GitHubReleaseService } from './github_release_service.js';
+import type { GitHubAssetDto, GitHubReleaseDto } from '../models/firmware/release.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function asset(overrides: Partial<GitHubAssetDto> = {}): GitHubAssetDto {
+  return {
+    name: 'astros-esp-1.0.0-metro_s3-app.bin',
+    browser_download_url: 'https://example.test/astros-esp-1.0.0-metro_s3-app.bin',
+    size: 1234567,
+    content_type: 'application/octet-stream',
+    ...overrides,
+  };
+}
+
+function release(overrides: Partial<GitHubReleaseDto> = {}): GitHubReleaseDto {
+  return {
+    tag_name: 'v1.0.0',
+    published_at: '2026-04-01T00:00:00Z',
+    assets: [asset()],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// extractFirmwareAssets — pure asset-name parser + filter.
+// ---------------------------------------------------------------------------
+
+describe('extractFirmwareAssets', () => {
+  it('extracts a single matched -app.bin asset with variant + version', () => {
+    const r = release();
+    const assets = extractFirmwareAssets(r);
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toEqual({
+      variant: 'metro_s3',
+      version: '1.0.0',
+      assetName: 'astros-esp-1.0.0-metro_s3-app.bin',
+      assetUrl: 'https://example.test/astros-esp-1.0.0-metro_s3-app.bin',
+      sizeBytes: 1234567,
+    });
+  });
+
+  it('returns multiple assets when a release has multiple variants', () => {
+    const r = release({
+      assets: [
+        asset({ name: 'astros-esp-1.0.0-metro_s3-app.bin' }),
+        asset({ name: 'astros-esp-1.0.0-lolin_d32_pro-app.bin' }),
+      ],
+    });
+    const assets = extractFirmwareAssets(r);
+    expect(assets.map((a) => a.variant).sort()).toEqual(['lolin_d32_pro', 'metro_s3']);
+  });
+
+  it('skips -flash.bin (USB-bootstrap image)', () => {
+    const r = release({
+      assets: [
+        asset({ name: 'astros-esp-1.0.0-metro_s3-app.bin' }),
+        asset({ name: 'astros-esp-1.0.0-metro_s3-flash.bin' }),
+      ],
+    });
+    const assets = extractFirmwareAssets(r);
+    expect(assets).toHaveLength(1);
+    expect(assets[0].assetName).toBe('astros-esp-1.0.0-metro_s3-app.bin');
+  });
+
+  it('parses pre-release versions correctly (1.2.0-RC.1 has a hyphen)', () => {
+    const r = release({
+      tag_name: 'v1.2.0-RC.1',
+      assets: [asset({ name: 'astros-esp-1.2.0-RC.1-lolin_d32_pro-app.bin' })],
+    });
+    const assets = extractFirmwareAssets(r);
+    expect(assets).toHaveLength(1);
+    expect(assets[0].variant).toBe('lolin_d32_pro');
+    expect(assets[0].version).toBe('1.2.0-RC.1');
+  });
+
+  it('rejects assets whose content_type is not octet-stream-flavored', () => {
+    const r = release({
+      assets: [asset({ content_type: 'text/plain' })],
+    });
+    const assets = extractFirmwareAssets(r);
+    expect(assets).toHaveLength(0);
+  });
+
+  it('skips assets whose parsed version disagrees with the release tag', () => {
+    const r = release({
+      tag_name: 'v1.0.0',
+      assets: [asset({ name: 'astros-esp-9.9.9-metro_s3-app.bin' })],
+    });
+    const assets = extractFirmwareAssets(r);
+    expect(assets).toHaveLength(0);
+  });
+
+  it('returns empty array when no asset name matches the pattern', () => {
+    const r = release({
+      assets: [
+        asset({ name: 'README.md', content_type: 'text/markdown' }),
+        asset({ name: 'random-firmware.bin' }),
+      ],
+    });
+    expect(extractFirmwareAssets(r)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHubReleaseService — caching + stale-on-error.
+// ---------------------------------------------------------------------------
+
+describe('GitHubReleaseService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-29T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeFetcherReturning(releases: GitHubReleaseDto[]): typeof fetch {
+    return vi.fn(async () => {
+      return new Response(JSON.stringify(releases), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+  }
+
+  function makeFetcherFailing(error = new Error('network down')): typeof fetch {
+    return vi.fn(async () => {
+      throw error;
+    }) as unknown as typeof fetch;
+  }
+
+  it('on cold cache, fetches and returns releases with staleSince=null', async () => {
+    const fetcher = makeFetcherReturning([release()]);
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    const result = await svc.getReleases();
+
+    expect(result.staleSince).toBeNull();
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0].tag).toBe('v1.0.0');
+    expect(result.releases[0].assets).toHaveLength(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves cached result without re-fetching within the 5-min TTL', async () => {
+    const fetcher = makeFetcherReturning([release()]);
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    await svc.getReleases();
+    vi.advanceTimersByTime(4 * 60 * 1000); // 4 minutes
+    await svc.getReleases();
+    vi.advanceTimersByTime(59 * 1000); // total 4:59
+    await svc.getReleases();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches after the 5-min TTL expires', async () => {
+    const fetcher = makeFetcherReturning([release()]);
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    await svc.getReleases();
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1); // just past 5 min
+    await svc.getReleases();
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on cold-cache fetch error', async () => {
+    const svc = new GitHubReleaseService('test/dummy', makeFetcherFailing());
+    await expect(svc.getReleases()).rejects.toThrow();
+  });
+
+  it('serves stale cache on fetch error after expiry, with staleSince set', async () => {
+    const releases = [release()];
+    let shouldFail = false;
+    const fetcher: typeof fetch = vi.fn(async () => {
+      if (shouldFail) throw new Error('network down');
+      return new Response(JSON.stringify(releases), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    // Warm the cache.
+    const fresh = await svc.getReleases();
+    expect(fresh.staleSince).toBeNull();
+    const fetchedAtIso = '2026-04-29T12:00:00.000Z';
+
+    // Expire it, then fail the next fetch.
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    shouldFail = true;
+
+    const stale = await svc.getReleases();
+    expect(stale.releases).toHaveLength(1);
+    expect(stale.staleSince).toBe(fetchedAtIso);
+  });
+
+  it('deduplicates concurrent in-flight fetches', async () => {
+    let resolveFetch: (() => void) | null = null;
+    const releases = [release()];
+    const fetcher: typeof fetch = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveFetch = resolve;
+      });
+      return new Response(JSON.stringify(releases), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    const a = svc.getReleases();
+    const b = svc.getReleases();
+    const c = svc.getReleases();
+
+    // All three calls should be awaiting the same in-flight fetch.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    if (resolveFetch === null) throw new Error('expected fetcher to have captured its resolver');
+
+    // Release the fetch.
+    resolveFetch();
+    const [ra, rb, rc] = await Promise.all([a, b, c]);
+    expect(ra.releases).toHaveLength(1);
+    expect(rb.releases).toHaveLength(1);
+    expect(rc.releases).toHaveLength(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('targets the correct GitHub URL based on the repo slug', async () => {
+    const fetcher = makeFetcherReturning([]);
+    const svc = new GitHubReleaseService('battlesloth/AstrOs.ESP', fetcher);
+
+    await svc.getReleases();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const url = (fetcher as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(String(url)).toBe('https://api.github.com/repos/battlesloth/AstrOs.ESP/releases');
+  });
+
+  it('filters out releases with zero matched assets', async () => {
+    const releaseWithMatches = release();
+    const releaseWithoutMatches = release({
+      tag_name: 'v0.5.0',
+      assets: [asset({ name: 'random.zip', content_type: 'application/zip' })],
+    });
+    const fetcher = makeFetcherReturning([releaseWithMatches, releaseWithoutMatches]);
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+    const result = await svc.getReleases();
+
+    expect(result.releases).toHaveLength(1);
+    expect(result.releases[0].tag).toBe('v1.0.0');
+  });
+});

--- a/astros_api/src/firmware/github_release_service.test.ts
+++ b/astros_api/src/firmware/github_release_service.test.ts
@@ -21,6 +21,7 @@ function release(overrides: Partial<GitHubReleaseDto> = {}): GitHubReleaseDto {
     tag_name: 'v1.0.0',
     published_at: '2026-04-01T00:00:00Z',
     draft: false,
+    prerelease: false,
     assets: [asset()],
     ...overrides,
   };
@@ -370,6 +371,32 @@ describe('GitHubReleaseService', () => {
     const result = await svc.getReleases();
 
     expect(result.releases.map((r) => r.tag)).toEqual(['v1.0.0']);
+  });
+
+  it('surfaces pre-release releases with prerelease=true (does NOT filter them)', async () => {
+    // Pre-releases (RC builds) are valid OTA targets — the UI's "Pre-release"
+    // pill flags them visually rather than hiding them.
+    const stable = release();
+    const rc = release({
+      tag_name: 'v1.2.0-RC.1',
+      prerelease: true,
+      assets: [
+        asset({
+          name: 'astros-esp-1.2.0-RC.1-metro_s3-app.bin',
+          browser_download_url: 'https://example.test/astros-esp-1.2.0-RC.1-metro_s3-app.bin',
+        }),
+      ],
+    });
+    const fetcher = makeFetcherReturning([stable, rc]);
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+    const result = await svc.getReleases();
+
+    expect(result.releases).toHaveLength(2);
+    const stableInfo = result.releases.find((r) => r.tag === 'v1.0.0');
+    const rcInfo = result.releases.find((r) => r.tag === 'v1.2.0-RC.1');
+    expect(stableInfo?.prerelease).toBe(false);
+    expect(rcInfo?.prerelease).toBe(true);
   });
 
   it('filters out non-draft releases with null published_at (defense in depth)', async () => {

--- a/astros_api/src/firmware/github_release_service.test.ts
+++ b/astros_api/src/firmware/github_release_service.test.ts
@@ -302,6 +302,52 @@ describe('GitHubReleaseService', () => {
     await expect(svc.getReleases()).rejects.toThrow(/AstrOs\.ESP.*404.*Not Found/);
   });
 
+  it('does not retry the upstream within the backoff window after a failure', async () => {
+    const fetcher = makeFetcherFailing();
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+
+    // First call: fetch attempted, fails, throws.
+    await expect(svc.getReleases()).rejects.toThrow();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Within the backoff window — caller still gets an error but the
+    // fetcher is NOT invoked again (no upstream hammering).
+    vi.advanceTimersByTime(30_000);
+    await expect(svc.getReleases()).rejects.toThrow();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Past the backoff window — retry happens.
+    vi.advanceTimersByTime(31_000); // total 61s past first failure
+    await expect(svc.getReleases()).rejects.toThrow();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves stale within the backoff window without re-fetching after a re-fetch fails', async () => {
+    const releases = [release()];
+    let mode: 'fast' | 'fail' = 'fast';
+    const fetcher: typeof fetch = vi.fn(async () => {
+      if (mode === 'fail') throw new Error('network down');
+      return new Response(JSON.stringify(releases), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const svc = new GitHubReleaseService('test/dummy', fetcher);
+    await svc.getReleases(); // warm cache
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Expire the cache and switch to a failing upstream.
+    vi.advanceTimersByTime(6 * 60 * 1000);
+    mode = 'fail';
+    const stale1 = await svc.getReleases();
+    expect(stale1.staleSince).not.toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // Within the backoff window — stale served, NO additional upstream call.
+    vi.advanceTimersByTime(30_000);
+    const stale2 = await svc.getReleases();
+    expect(stale2.staleSince).not.toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
   it('filters out releases with zero matched assets', async () => {
     const releaseWithMatches = release();
     const releaseWithoutMatches = release({

--- a/astros_api/src/firmware/github_release_service.ts
+++ b/astros_api/src/firmware/github_release_service.ts
@@ -32,6 +32,13 @@ const TTL_MS = 5 * 60 * 1000;
 // fallback (or a fast error) rather than a perceived freeze.
 const FETCH_TIMEOUT_MS = 10_000;
 
+// Retry backoff after a failed fetch. Without this, every call after the
+// cache expires during an outage would re-attempt the upstream — burning
+// the 60 req/hr GitHub rate limit, spamming logs, and making each caller
+// wait the full FETCH_TIMEOUT_MS. 60 seconds keeps the system responsive
+// once GitHub recovers without hammering during a sustained outage.
+const RETRY_BACKOFF_MS = 60_000;
+
 /**
  * Pure helper: walks a GitHub release's assets, extracts the matched
  * `-app.bin` firmware binaries, returns them as typed AssetInfo entries.
@@ -99,6 +106,9 @@ interface CacheEntry {
  */
 export class GitHubReleaseService {
   private cache: CacheEntry | null = null;
+  // Earliest time (ms epoch) we'll re-attempt the upstream after a failure.
+  // Null means "no current backoff." Cleared on successful fetch.
+  private nextRetryAt: number | null = null;
   private inFlight: Promise<ReleaseListResult> | null = null;
   private readonly url: string;
 
@@ -112,8 +122,25 @@ export class GitHubReleaseService {
   async getReleases(): Promise<ReleaseListResult> {
     if (this.inFlight) return this.inFlight;
 
-    if (this.cache && Date.now() - this.cache.fetchedAt < TTL_MS) {
+    const now = Date.now();
+    if (this.cache !== null && now - this.cache.fetchedAt < TTL_MS) {
       return { releases: this.cache.releases, staleSince: null };
+    }
+
+    // Cache expired or empty. If we're inside the post-failure backoff window,
+    // serve stale (when cached) or surface a fast error (cold cache) without
+    // hitting the upstream again. Prevents log/rate-limit hammering during an
+    // outage where many callers ask in succession.
+    if (this.nextRetryAt !== null && now < this.nextRetryAt) {
+      if (this.cache) {
+        return {
+          releases: this.cache.releases,
+          staleSince: new Date(this.cache.fetchedAt).toISOString(),
+        };
+      }
+      throw new Error(
+        `GitHub releases unavailable; next retry at ${new Date(this.nextRetryAt).toISOString()}: ${this.url}`,
+      );
     }
 
     this.inFlight = this.fetchOnce();
@@ -137,6 +164,7 @@ export class GitHubReleaseService {
       const dtos = (await response.json()) as GitHubReleaseDto[];
       const releases = dtos.map(toReleaseInfo).filter((info) => info.assets.length > 0);
       this.cache = { releases, fetchedAt: Date.now() };
+      this.nextRetryAt = null;
       return { releases, staleSince: null };
     } catch (err) {
       // If the abort fired we know the cause; convert the (possibly opaque)
@@ -145,6 +173,10 @@ export class GitHubReleaseService {
       const surfaced = controller.signal.aborted
         ? new Error(`GitHub releases fetch timed out after ${FETCH_TIMEOUT_MS}ms: ${this.url}`)
         : (err as Error);
+
+      // Set the backoff window so future callers within RETRY_BACKOFF_MS
+      // serve stale (or surface the cold-cache error) without re-attempting.
+      this.nextRetryAt = Date.now() + RETRY_BACKOFF_MS;
 
       if (this.cache) {
         logger.warn(

--- a/astros_api/src/firmware/github_release_service.ts
+++ b/astros_api/src/firmware/github_release_service.ts
@@ -162,7 +162,18 @@ export class GitHubReleaseService {
         );
       }
       const dtos = (await response.json()) as GitHubReleaseDto[];
-      const releases = dtos.map(toReleaseInfo).filter((info) => info.assets.length > 0);
+      const releases = dtos
+        // Drop drafts and any release lacking a publish timestamp. Drafts
+        // shouldn't be flashable, and a null published_at would otherwise
+        // leak through the (string-typed) ReleaseInfo.publishedAt. The
+        // type predicate narrows published_at so toReleaseInfo can promise
+        // a non-null string in its return type without an assertion.
+        .filter(
+          (dto): dto is GitHubReleaseDto & { published_at: string } =>
+            !dto.draft && dto.published_at !== null,
+        )
+        .map(toReleaseInfo)
+        .filter((info) => info.assets.length > 0);
       this.cache = { releases, fetchedAt: Date.now() };
       this.nextRetryAt = null;
       return { releases, staleSince: null };
@@ -196,7 +207,7 @@ export class GitHubReleaseService {
   }
 }
 
-function toReleaseInfo(dto: GitHubReleaseDto): ReleaseInfo {
+function toReleaseInfo(dto: GitHubReleaseDto & { published_at: string }): ReleaseInfo {
   return {
     tag: dto.tag_name,
     version: stripLeadingV(dto.tag_name),

--- a/astros_api/src/firmware/github_release_service.ts
+++ b/astros_api/src/firmware/github_release_service.ts
@@ -25,6 +25,13 @@ const OCTET_CONTENT_TYPES: ReadonlySet<string> = new Set([
 
 const TTL_MS = 5 * 60 * 1000;
 
+// Per-fetch timeout. Without this, a stalled GitHub request would hang
+// indefinitely, leaving `inFlight` unresolved and blocking every future
+// caller until the process restarts. 10 seconds is generous enough for
+// slow networks and tight enough that the UI degrades to stale-cache
+// fallback (or a fast error) rather than a perceived freeze.
+const FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Pure helper: walks a GitHub release's assets, extracts the matched
  * `-app.bin` firmware binaries, returns them as typed AssetInfo entries.
@@ -118,28 +125,41 @@ export class GitHubReleaseService {
   }
 
   private async fetchOnce(): Promise<ReleaseListResult> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-      const response = await this.fetcher(this.url);
+      const response = await this.fetcher(this.url, { signal: controller.signal });
       if (!response.ok) {
-        throw new Error(`GitHub releases endpoint returned ${response.status}`);
+        throw new Error(
+          `GitHub releases endpoint ${this.url} returned ${response.status} ${response.statusText}`,
+        );
       }
       const dtos = (await response.json()) as GitHubReleaseDto[];
       const releases = dtos.map(toReleaseInfo).filter((info) => info.assets.length > 0);
       this.cache = { releases, fetchedAt: Date.now() };
       return { releases, staleSince: null };
     } catch (err) {
+      // If the abort fired we know the cause; convert the (possibly opaque)
+      // AbortError into a message that names the URL + timeout duration so
+      // logs and error responses point at the right thing to investigate.
+      const surfaced = controller.signal.aborted
+        ? new Error(`GitHub releases fetch timed out after ${FETCH_TIMEOUT_MS}ms: ${this.url}`)
+        : (err as Error);
+
       if (this.cache) {
         logger.warn(
           `GitHub releases fetch failed; serving stale cache from ${new Date(
             this.cache.fetchedAt,
-          ).toISOString()}: ${(err as Error).message}`,
+          ).toISOString()}: ${surfaced.message}`,
         );
         return {
           releases: this.cache.releases,
           staleSince: new Date(this.cache.fetchedAt).toISOString(),
         };
       }
-      throw err;
+      throw surfaced;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 }

--- a/astros_api/src/firmware/github_release_service.ts
+++ b/astros_api/src/firmware/github_release_service.ts
@@ -39,6 +39,15 @@ const FETCH_TIMEOUT_MS = 10_000;
 // once GitHub recovers without hammering during a sustained outage.
 const RETRY_BACKOFF_MS = 60_000;
 
+// GitHub's REST API rejects anonymous requests without a User-Agent (403).
+// The Accept header pins the v3 response shape so behavior is consistent
+// across runtimes/proxies that might otherwise negotiate a different media
+// type. See: https://docs.github.com/en/rest/overview/resources-in-the-rest-api
+const REQUEST_HEADERS: Readonly<Record<string, string>> = {
+  'User-Agent': 'AstrOs.Server',
+  Accept: 'application/vnd.github+json',
+};
+
 /**
  * Pure helper: walks a GitHub release's assets, extracts the matched
  * `-app.bin` firmware binaries, returns them as typed AssetInfo entries.
@@ -155,7 +164,10 @@ export class GitHubReleaseService {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-      const response = await this.fetcher(this.url, { signal: controller.signal });
+      const response = await this.fetcher(this.url, {
+        signal: controller.signal,
+        headers: REQUEST_HEADERS,
+      });
       if (!response.ok) {
         throw new Error(
           `GitHub releases endpoint ${this.url} returned ${response.status} ${response.statusText}`,

--- a/astros_api/src/firmware/github_release_service.ts
+++ b/astros_api/src/firmware/github_release_service.ts
@@ -1,0 +1,158 @@
+import { logger } from '../logger.js';
+import type {
+  AssetInfo,
+  GitHubReleaseDto,
+  ReleaseInfo,
+  ReleaseListResult,
+} from '../models/firmware/release.js';
+
+// Asset name pattern: astros-esp-${VERSION}-${ENV}-app.bin
+//   - ${VERSION} can be plain semver (1.0.0) or include pre-release labels
+//     containing hyphens (1.2.0-RC.1).
+//   - ${ENV} is the PlatformIO env name; lowercase letters/digits/underscores
+//     only — no hyphens. That asymmetry is what lets the regex backtrack
+//     correctly past hyphens inside the version.
+//   - The -app.bin suffix anchors against -flash.bin (USB-bootstrap image).
+const ASSET_PATTERN = /^astros-esp-(.+)-([a-z][a-z0-9_]*)-app\.bin$/;
+
+// Acceptable content types for a firmware binary. GitHub assets typically
+// arrive as application/octet-stream; macbinary is occasionally seen on
+// macOS-built artifacts.
+const OCTET_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  'application/octet-stream',
+  'application/macbinary',
+]);
+
+const TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Pure helper: walks a GitHub release's assets, extracts the matched
+ * `-app.bin` firmware binaries, returns them as typed AssetInfo entries.
+ * Skips:
+ *   - assets whose name doesn't match the firmware naming convention
+ *   - assets whose content_type isn't octet-stream-flavored
+ *   - assets whose parsed version disagrees with the release tag (likely a
+ *     misnamed CI artifact; better to fail fast at parse time than at flash
+ *     time)
+ *
+ * Exported so consumers (the service here today, future modules later) can
+ * reuse the parsing without going through the cache layer.
+ */
+export function extractFirmwareAssets(release: GitHubReleaseDto): AssetInfo[] {
+  const expectedVersion = stripLeadingV(release.tag_name);
+  const result: AssetInfo[] = [];
+
+  for (const asset of release.assets) {
+    if (!OCTET_CONTENT_TYPES.has(asset.content_type)) continue;
+    const match = ASSET_PATTERN.exec(asset.name);
+    if (!match) continue;
+
+    const [, version, variant] = match;
+    if (version !== expectedVersion) {
+      logger.warn(
+        `firmware asset ${asset.name} version ${version} disagrees with release tag ${release.tag_name}; skipping`,
+      );
+      continue;
+    }
+
+    result.push({
+      variant,
+      version,
+      assetName: asset.name,
+      assetUrl: asset.browser_download_url,
+      sizeBytes: asset.size,
+    });
+  }
+
+  return result;
+}
+
+interface CacheEntry {
+  releases: ReleaseInfo[];
+  fetchedAt: number;
+}
+
+/**
+ * Fetches the AstrOs.ESP release list from GitHub and caches it for 5 minutes.
+ * Anonymous fetches are subject to GitHub's 60 req/hr per-IP rate limit; a
+ * 5-min TTL keeps worst-case at 12 fetches/hour shared across all clients of
+ * the running server.
+ *
+ * The fetcher is dependency-injected so tests can pass a mock; production
+ * uses Node 18+ global fetch.
+ *
+ * Concurrency: a single in-flight promise is reused for any callers that
+ * arrive while a fetch is already underway, so a stampede on cold cache only
+ * triggers one upstream request.
+ *
+ * Failure mode: when fetch fails AND the cache holds a previous successful
+ * result, the service returns that stale data with `staleSince` set to the
+ * ISO timestamp of the original fetch. When fetch fails on a cold cache,
+ * the error propagates.
+ */
+export class GitHubReleaseService {
+  private cache: CacheEntry | null = null;
+  private inFlight: Promise<ReleaseListResult> | null = null;
+  private readonly url: string;
+
+  constructor(
+    repoSlug: string,
+    private readonly fetcher: typeof fetch = fetch,
+  ) {
+    this.url = `https://api.github.com/repos/${repoSlug}/releases`;
+  }
+
+  async getReleases(): Promise<ReleaseListResult> {
+    if (this.inFlight) return this.inFlight;
+
+    if (this.cache && Date.now() - this.cache.fetchedAt < TTL_MS) {
+      return { releases: this.cache.releases, staleSince: null };
+    }
+
+    this.inFlight = this.fetchOnce();
+    try {
+      return await this.inFlight;
+    } finally {
+      this.inFlight = null;
+    }
+  }
+
+  private async fetchOnce(): Promise<ReleaseListResult> {
+    try {
+      const response = await this.fetcher(this.url);
+      if (!response.ok) {
+        throw new Error(`GitHub releases endpoint returned ${response.status}`);
+      }
+      const dtos = (await response.json()) as GitHubReleaseDto[];
+      const releases = dtos.map(toReleaseInfo).filter((info) => info.assets.length > 0);
+      this.cache = { releases, fetchedAt: Date.now() };
+      return { releases, staleSince: null };
+    } catch (err) {
+      if (this.cache) {
+        logger.warn(
+          `GitHub releases fetch failed; serving stale cache from ${new Date(
+            this.cache.fetchedAt,
+          ).toISOString()}: ${(err as Error).message}`,
+        );
+        return {
+          releases: this.cache.releases,
+          staleSince: new Date(this.cache.fetchedAt).toISOString(),
+        };
+      }
+      throw err;
+    }
+  }
+}
+
+function toReleaseInfo(dto: GitHubReleaseDto): ReleaseInfo {
+  return {
+    tag: dto.tag_name,
+    version: stripLeadingV(dto.tag_name),
+    publishedAt: dto.published_at,
+    assets: extractFirmwareAssets(dto),
+  };
+}
+
+function stripLeadingV(tag: string): string {
+  return tag.startsWith('v') ? tag.slice(1) : tag;
+}

--- a/astros_api/src/firmware/github_release_service.ts
+++ b/astros_api/src/firmware/github_release_service.ts
@@ -193,9 +193,14 @@ export class GitHubReleaseService {
       // If the abort fired we know the cause; convert the (possibly opaque)
       // AbortError into a message that names the URL + timeout duration so
       // logs and error responses point at the right thing to investigate.
+      // Otherwise normalize: a fetcher mock or unusual runtime may reject
+      // with a non-Error value; coerce so logs and re-throws always carry a
+      // usable .message and `instanceof Error` holds for callers.
       const surfaced = controller.signal.aborted
         ? new Error(`GitHub releases fetch timed out after ${FETCH_TIMEOUT_MS}ms: ${this.url}`)
-        : (err as Error);
+        : err instanceof Error
+          ? err
+          : new Error(String(err));
 
       // Set the backoff window so future callers within RETRY_BACKOFF_MS
       // serve stale (or surface the cold-cache error) without re-attempting.

--- a/astros_api/src/firmware/github_release_service.ts
+++ b/astros_api/src/firmware/github_release_service.ts
@@ -212,6 +212,7 @@ function toReleaseInfo(dto: GitHubReleaseDto & { published_at: string }): Releas
     tag: dto.tag_name,
     version: stripLeadingV(dto.tag_name),
     publishedAt: dto.published_at,
+    prerelease: dto.prerelease,
     assets: extractFirmwareAssets(dto),
   };
 }

--- a/astros_api/src/models/firmware/release.ts
+++ b/astros_api/src/models/firmware/release.ts
@@ -22,6 +22,10 @@ export interface ReleaseInfo {
   tag: string;
   version: string;
   publishedAt: string;
+  // True when GitHub flagged the release as a pre-release (e.g., RC build).
+  // Pre-releases are valid OTA targets — the UI flags them visually rather
+  // than filtering them out. Drafts (a separate concept) ARE filtered.
+  prerelease: boolean;
   assets: AssetInfo[];
 }
 
@@ -54,5 +58,8 @@ export interface GitHubReleaseDto {
   // True for unpublished drafts. Service filters those out so they don't
   // appear in the firmware UI's release dropdown.
   draft: boolean;
+  // True for RC builds and other pre-releases. Surfaced unchanged to
+  // ReleaseInfo.prerelease so the UI can flag them; not filtered.
+  prerelease: boolean;
   assets: GitHubAssetDto[];
 }

--- a/astros_api/src/models/firmware/release.ts
+++ b/astros_api/src/models/firmware/release.ts
@@ -2,8 +2,8 @@
 // GitHub release shapes — internal "what we surface" types and the API DTO
 // subset we parse. AstrOs.ESP CI produces one `-app.bin` per release per
 // PlatformIO env; each release is therefore ReleaseInfo with one or more
-// AssetInfo entries, one per variant. See .docs/plans/<c.3-plan>.md and the
-// "Source acquisition" section of the decomposition plan for context.
+// AssetInfo entries, one per variant. See the "Source acquisition" section of
+// the decomposition plan for context.
 // ---------------------------------------------------------------------------
 
 // Surfaced per matched `-app.bin` asset on a release. Variant is the

--- a/astros_api/src/models/firmware/release.ts
+++ b/astros_api/src/models/firmware/release.ts
@@ -48,6 +48,11 @@ export interface GitHubAssetDto {
 
 export interface GitHubReleaseDto {
   tag_name: string;
-  published_at: string;
+  // Null for drafts and certain unpublished release states. Service filters
+  // those out; downstream `ReleaseInfo.publishedAt` is therefore non-null.
+  published_at: string | null;
+  // True for unpublished drafts. Service filters those out so they don't
+  // appear in the firmware UI's release dropdown.
+  draft: boolean;
   assets: GitHubAssetDto[];
 }

--- a/astros_api/src/models/firmware/release.ts
+++ b/astros_api/src/models/firmware/release.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// GitHub release shapes — internal "what we surface" types and the API DTO
+// subset we parse. AstrOs.ESP CI produces one `-app.bin` per release per
+// PlatformIO env; each release is therefore ReleaseInfo with one or more
+// AssetInfo entries, one per variant. See .docs/plans/<c.3-plan>.md and the
+// "Source acquisition" section of the decomposition plan for context.
+// ---------------------------------------------------------------------------
+
+// Surfaced per matched `-app.bin` asset on a release. Variant is the
+// PlatformIO env name (e.g., "lolin_d32_pro", "metro_s3").
+export interface AssetInfo {
+  variant: string;
+  version: string;
+  assetName: string;
+  assetUrl: string;
+  sizeBytes: number;
+}
+
+// Surfaced per release that has at least one matching firmware asset.
+// Releases with zero matched assets are filtered out at the service layer.
+export interface ReleaseInfo {
+  tag: string;
+  version: string;
+  publishedAt: string;
+  assets: AssetInfo[];
+}
+
+// Top-level result of GitHubReleaseService.getReleases(). `staleSince` is
+// null on a fresh fetch and the ISO timestamp of the cache entry's original
+// fetch when the service is serving stale due to a downstream error.
+export interface ReleaseListResult {
+  releases: ReleaseInfo[];
+  staleSince: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API DTO subset. Only the fields we actually parse — everything else
+// in the GitHub response is ignored. Reduces surface area for both type
+// maintenance and test-fixture construction.
+// ---------------------------------------------------------------------------
+
+export interface GitHubAssetDto {
+  name: string;
+  browser_download_url: string;
+  size: number;
+  content_type: string;
+}
+
+export interface GitHubReleaseDto {
+  tag_name: string;
+  published_at: string;
+  assets: GitHubAssetDto[];
+}


### PR DESCRIPTION
 Summary

  Adds the GitHub release service that powers the firmware-OTA UI's "GitHub" source toggle. Fetches the AstrOs.ESP release list anonymously, picks -app.bin assets per variant (metro_s3, lolin_d32_pro), and caches the result for 5 minutes with stale-on-error fallback. Service-only — no route, no orchestrator integration; c.8 wires the route, c.6 wires the orchestrator.

  Context

  - Parent plan: .docs/plans/20260427-2202-firmware-ota-decomposition.md
  - This PR's plan: .docs/plans/20260429-0918-firmware-ota-c-3-github-releases-service.md
  - Builds on c0–c.2 + reorg.

  What's in this PR

  Asset naming alignment (decomp + c.3 plan amended in 9d9b5e7).

  AstrOs.ESP CI workflows produce two artifacts per build env per release:
  astros-esp-${VERSION}-${ENV}-app.bin     ← OTA (this is what c.3 picks)
  astros-esp-${VERSION}-${ENV}-flash.bin   ← USB bootstrap, out of scope
  where ${ENV} is the PlatformIO env (lolin_d32_pro, metro_s3) — different chip family + partition layout, binaries not interchangeable. The decomp  originally specified single-variant naming (astros-esp-vX.Y.Z.bin); c.3 amends it to match what CI actually emits.

  Models (new astros_api/src/models/firmware/release.ts):
  - AssetInfo — { variant, version, assetName, assetUrl, sizeBytes } per matched binary.
  - ReleaseInfo — { tag, version, publishedAt, assets: AssetInfo[] }. Releases with zero matched assets are filtered out.
  - ReleaseListResult — { releases, staleSince } where staleSince is null on a fresh fetch and an ISO timestamp on served-stale fallback.
  - GitHubReleaseDto / GitHubAssetDto — minimal subset of the GitHub API response we parse.

  Asset selection (exported extractFirmwareAssets):
  - Regex /^astros-esp-(.+)-([a-z][a-z0-9_]*)-app\.bin$/ captures version + variant. The variant character class deliberately excludes hyphens so the  regex backtracks correctly past semver pre-release labels (e.g., astros-esp-1.2.0-RC.1-lolin_d32_pro-app.bin parses to version=1.2.0-RC.1,  variant=lolin_d32_pro).
  - Rejects assets whose content_type isn't octet-stream-flavored.
  - Warn-and-skip when an asset's parsed version disagrees with the release tag — catches misnamed CI artifacts at parse time rather than at flash time.

  GitHubReleaseService (astros_api/src/firmware/github_release_service.ts):
  - Constructor: (repoSlug: string, fetcher: typeof fetch = fetch). Fetcher is DI'd for tests; production uses Node 18+ global fetch.
  - Single public method: getReleases(): Promise<ReleaseListResult>.
  - 5-minute in-memory cache. Cold-cache fetch error throws; warm-cache fetch error returns stale data with staleSince set to the original-fetch ISO  timestamp.
  - In-flight fetch dedup: a stampede on cold cache awaits one upstream request.
  - Targets https://api.github.com/repos/<repoSlug>/releases.

  Tests (15 new):
  - extractFirmwareAssets (7): single match, multi-variant release, -flash.bin excluded, pre-release version parsing, content-type rejection,  version/tag mismatch rejection, no-match release.
  - GitHubReleaseService (8): cold-cache fetch + staleSince=null, TTL hit (no re-fetch within 5 min), TTL expiry + re-fetch, cold-cache failure  throws, stale-on-error with staleSince set, in-flight dedup, repo-slug URL targeting, zero-asset release filtering. Uses vi.useFakeTimers() for  TTL-boundary tests.

  File count

  3 files, all new. No changes to existing code.

  Verification

  - npm run build clean (lint + tsc) in astros_api/.
  - npm run test green: 319 / 319 (was 304; +15 net).
  - npm run prettier:write and npm run lint:fix clean.

  Intentionally out of scope

  - Route exposure (GET /firmware/releases) — c.8.
  - On-disk .bin cache for downloaded firmware files — c.4.
  - Upload mode + esp_app_desc_t parsing — c.5.
  - FlashJob orchestrator integration — c.6.
  - Heartbeat-variant extension. c.6 will need POLL_ACK extended from name<US>fingerprint<US>version to name<US>fingerprint<US>version<US>variant so the orchestrator can match each controller to the correct asset variant. Paired cross-repo amendment best done alongside c.6 where it's actually
  consumed; doing it in c.3 would ship dead code on both sides. c.3's service returns all matched variants per release without picking; the picker logic + heartbeat amendment land together.
  - Release-list refresh strategy beyond "fetch on getReleases() with 5-min TTL" — no background polling, no manual-refresh endpoint. Cache is lazy.
  - GitHub authentication / PAT support — decomp explicitly chose anonymous fetch. The 60 req/hr limit is fine for this caching strategy (12  fetches/hr worst case, shared across all clients).

  Honest verification gap

  No integration test against the real GitHub API. The unit tests use mocked fetch; if GitHub changes its API shape, c.3 won't catch it until c.8 wires the route and someone hits it. Acceptable for a service-only PR — the orchestrator (c.6) and route (c.8) layer their own integration tests.
  If you want a smoke test now, the simplest path is to instantiate new GitHubReleaseService('battlesloth/AstrOs.ESP') in a Node REPL and call await svc.getReleases().

  Test plan (reviewer)

  - Pull the branch, cd astros_api && npm install && npm run build && npm run test — expect 319 green.
  - Verify the asset regex against representative fixture names: astros-esp-1.0.0-metro_s3-app.bin (matches),
  astros-esp-1.2.0-RC.1-lolin_d32_pro-app.bin (matches with pre-release version), astros-esp-1.0.0-metro_s3-flash.bin (correctly skipped), random.zip (rejected).
  - Confirm extractFirmwareAssets is exported (orchestrator and on-disk-cache PRs will import it directly without going through GitHubReleaseService).
  - Spot-check staleSince semantics in serves stale cache on fetch error after expiry — null when fresh, ISO timestamp on stale.
  - Read the in-flight dedup test (deduplicates concurrent in-flight fetches); the resolver-capture pattern is the cleanest way I know to assert "all three callers awaited the same promise."
  - Eyeball the GITHUB_REPO_SLUG env wiring story — there is none yet. The constructor takes the slug; whoever instantiates the service in production (likely c.8 or api_server.ts setup) is responsible for reading the env. Worth flagging if you want that wiring to happen here instead of deferred.