### PR TITLE
OTA Firmware Upload Store

### DIFF
--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -56,7 +56,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - Up-front length check: throw if `buf.length < 288`. Caller only ever reads the first 288 bytes.
 
 - [x] **`FirmwareUploadStore` class** (new `astros_api/src/firmware/firmware_upload_store.ts`):
-  - Constructor: `new FirmwareUploadStore(opts?: { rootDir?: string, expectedProjectName?: string })`. `expectedProjectName` defaults to `'astros-esp'` (resolves decomp Open Item #4 — see Notes; verification step against firmware repo's `CONFIG_APP_PROJECT_NAME` is in the open-items list).
+  - Constructor: `new FirmwareUploadStore(opts?: { rootDir?: string, expectedProjectName?: string })`. `expectedProjectName` defaults to `'AstrOs.ESP'` — verified against the CMake `project()` call in the firmware repo and against a real `firmware.bin` during c.5 implementation; resolves decomp Open Item #4 (see Notes for the reviewer for the full finding).
   - **`store(tempPath: string, originalFilename: string): Promise<StoredUpload>`**:
     1. Generate `uploadId = uuid_v4()`. `assertPathSafe(uploadId, 'uploadId')` for defense-in-depth against future regressions where the uuid generator changes.
     2. `fsp.open(tempPath)` → `read(buf, 0, 288, 0)` into a 288-byte Buffer; close handle in a `finally` block (no fd leak on parse failure).
@@ -92,7 +92,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - `latest()` returns null on cold cache.
   - `store()` happy path: temp file exists, parser succeeds, all three files at expected paths, returned `StoredUpload` has correct `path`, `sha256` (verified by re-hashing), `sizeBytes`, and meta.
   - `store()` consumes the temp file (no orphan in `tmp/` after success).
-  - `store()` rejects when `projectName !== 'astros-esp'`; pre-existing prior upload preserved (no wipe-on-fail-validation).
+  - `store()` rejects when `projectName !== 'AstrOs.ESP'` (the embedded value from the firmware repo's CMake `project()` call); pre-existing prior upload preserved (no wipe-on-fail-validation).
   - `store()` rejects when `version` is unparseable; prior upload preserved.
   - `store()` rejects when binary is shorter than 288 bytes.
   - `store()` replaces a prior upload: pre-populated old triple is gone, new triple present.

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -55,7 +55,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - Magic word read with `readUInt32LE`. Reject when `!== ESP_APP_DESC_MAGIC`.
   - Up-front length check: throw if `buf.length < 288`. Caller only ever reads the first 288 bytes.
 
-- [ ] **`FirmwareUploadStore` class** (new `astros_api/src/firmware/firmware_upload_store.ts`):
+- [x] **`FirmwareUploadStore` class** (new `astros_api/src/firmware/firmware_upload_store.ts`):
   - Constructor: `new FirmwareUploadStore(opts?: { rootDir?: string, expectedProjectName?: string })`. `expectedProjectName` defaults to `'astros-esp'` (resolves decomp Open Item #4 — see Notes; verification step against firmware repo's `CONFIG_APP_PROJECT_NAME` is in the open-items list).
   - **`store(tempPath: string, originalFilename: string): Promise<StoredUpload>`**:
     1. Generate `uploadId = uuid_v4()`. `assertPathSafe(uploadId, 'uploadId')` for defense-in-depth against future regressions where the uuid generator changes.
@@ -88,7 +88,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - `secureVersion` reads as `uint32_t` little-endian (regression guard against accidental BE).
   - Magic-word constant is exactly `0xABCD5432` (sentinel test).
 
-- [ ] **Tests** (new `astros_api/src/firmware/firmware_upload_store.test.ts`). Real temp dir per test (`fs.mkdtempSync` in `beforeEach`, `rm -rf` in `afterEach`):
+- [x] **Tests** (new `astros_api/src/firmware/firmware_upload_store.test.ts`). Real temp dir per test (`fs.mkdtempSync` in `beforeEach`, `rm -rf` in `afterEach`):
   - `latest()` returns null on cold cache.
   - `store()` happy path: temp file exists, parser succeeds, all three files at expected paths, returned `StoredUpload` has correct `path`, `sha256` (verified by re-hashing), `sizeBytes`, and meta.
   - `store()` consumes the temp file (no orphan in `tmp/` after success).

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -196,7 +196,7 @@ The pre-fix anti-pattern that c.4 caught: persisting `.sha` and `.meta` before r
 
 ### 4. Cross-platform / cross-environment
 
-- **`fs.rename`:** POSIX overwrites atomically; Windows throws `EEXIST`. Mitigation: wipe pass before rename ensures destination is absent. (c.4's `unlink-before-rename + ENOENT-only catch` not needed because the wipe pass is the load-bearing step — only one slot total.)
+- **`fs.rename`:** POSIX overwrites atomically; Windows throws `EEXIST`. Mitigation: wipe pass before rename targets any prior `upload-*` siblings (different uuid from the about-to-rename target, so EEXIST on the rename target is rare anyway). The wipe is best-effort — a non-ENOENT unlink error is logged and swallowed — so under hostile perms a Windows rename could still hit EEXIST and propagate; the rollback catch handles that. (c.4's `unlink-before-rename + ENOENT-only catch` isn't replicated here because the wipe pass plus the rollback already cover the surface.)
 - **`fs.rename` cross-filesystem (EXDEV):** `tmp/` and `uploads/` MUST live under the same `<rootDir>`. c.8's route mount points `tempFileDir` at `<rootDir>/tmp/`. Bind-mounts and Docker volumes are easy ways to break this; document in c.8's setup notes.
 - **Path separators:** always `path.join`.
 - **`appdata-path`:** delegated to c.4's `resolveFirmwareCacheDir`; no new platform branches.

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -72,7 +72,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
        - `writeFile(.meta.json, JSON.stringify(meta, null, 2))`
     8. On any failure in steps 6–7: `Promise.all` of best-effort `unlink` against the temp file, the just-promoted `.bin`, and both sidecars (mirrors c.4's symmetric persist-phase rollback). Rethrow.
     9. Return `StoredUpload`.
-  - **`latest(): Promise<StoredUpload | null>`** — `readdir(<rootDir>/uploads)`, filter for files matching `^upload-([0-9a-f-]{36})\.meta\.json$`. If multiple matches (corruption/manual intervention), pick the most-recently-mtime'd one and log a warn. Read all three files for that uuid; return null if any are missing or malformed (defensive — mirrors c.4's `lookup`).
+  - **`latest(): Promise<StoredUpload | null>`** — `readdir(<rootDir>/uploads)`, filter for files matching `^upload-([0-9a-f-]{36})\.meta\.json$`. If multiple matches (corruption/manual intervention), pick the most-recently-mtime'd one and log a warn. Read all three files for that uuid; return null if any are missing or malformed. Cross-check the triple is internally consistent: `parsed.uploadId === uploadId-from-filename` (corruption / sidecar copy-from-another-upload would mislead the orchestrator about which upload is being flashed) and `parsed.sizeBytes === binStat.size` (cheap proxy for "the bin we have is the one meta describes" — catches partial-write recovery and external truncation; sha re-hashing would be stronger but costs ~80–100 ms per call). Mismatches map to a null miss.
   - **Filename safety:** `pathsFor(rootDir, uploadId)` runs `assertPathSafe(uploadId, 'uploadId')`. UUID v4 is `[0-9a-f-]+` so always passes; the assertion guards future refactors.
   - **Concurrency:** no in-process mutex. Two concurrent uploads tolerated by last-writer-wins on the wipe-then-rename sequence; `.meta.json` is the durability anchor. The flash-job hard lock from c.0/c.2 ensures uploads never overlap with a flash, so the only race is two browser tabs uploading back-to-back. Per-store atomic rename is the entire concurrency model.
 
@@ -100,6 +100,8 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - `store()` rolls back cleanly when `rename` throws EACCES: temp file unlinked, uploads dir empty.
   - `latest()` returns null when only some sidecar files exist (interrupted prior write).
   - `latest()` returns null when `.meta.json` is malformed JSON.
+  - `latest()` returns null when `.meta.json` `uploadId` disagrees with the filename uuid (sidecar copied/renamed from another upload).
+  - `latest()` returns null when `.meta.json` `sizeBytes` disagrees with the bin's actual size on disk (partial-write recovery / external truncation).
   - Crash-recovery invariant: snapshotting `.bin` at each sidecar `writeFile` call shows bin contents are either fresh-bytes or absent — never stale (same pinning pattern c.4 used).
   - Sequential interleaving: A.store() completes, B.store() completes, `latest()` returns B's data; pre-A returns null, between returns A.
   - Filename safety: passing a non-UUID `uploadId` (via test seam) trips `assertPathSafe` synchronously without writing.
@@ -155,6 +157,8 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 | `fsp.readdir(<uploads>)` (latest) | ENOENT | return null (cold cache) |
 | `fsp.readdir(<uploads>)` (latest) | EACCES | propagate; operator-visible |
 | `JSON.parse(metaText)` | SyntaxError | return null (malformed; swept by next successful store) |
+| `latest()` cross-check | `parsed.uploadId !== uploadId-from-filename` | return null — sidecar mis-copy / corruption; the next successful `store()` will wipe the inconsistent triple |
+| `latest()` cross-check | `parsed.sizeBytes !== binStat.size` | return null — meta stale relative to bin (truncate / partial-write); next successful `store()` clears it |
 
 **Gotchas applying from c.4 experience:**
 - Truncated read on temp file looks like normal close. Mitigation: the parse step's `fh.read(buf, 0, 288, 0)` rejects any file that doesn't deliver the full 288-byte header, which is the load-bearing check for the most common truncation source (incomplete upload). A subsequent parse-time-vs-hash-time race (file truncated between the two reads) is not separately guarded — caught only if it shrinks below the 288-byte parse floor before the stream-hash opens its own handle, which would also fail the parse on a retry.

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -48,7 +48,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - `StoredUploadMeta` — `{ uploadId: string, originalFilename: string, projectName: string, version: string, uploadedAt: string, sizeBytes: number }`. Persisted as `upload-<uuid>.meta.json`.
   - `StoredUpload` — `{ path: string, sha256: string, sizeBytes: number, meta: StoredUploadMeta }`. Returned by `store()` and `latest()`. Mirrors c.4's `CachedAsset`.
 
-- [ ] **`esp_app_desc_t` parser** (new `astros_api/src/firmware/esp_app_desc.ts`). Pure-compute, no fs/network. Single export `parseEspAppDesc(buf: Buffer): EspAppDesc`. Throws on any structural failure. Constants:
+- [x] **`esp_app_desc_t` parser** (new `astros_api/src/firmware/esp_app_desc.ts`). Pure-compute, no fs/network. Single export `parseEspAppDesc(buf: Buffer): EspAppDesc`. Throws on any structural failure. Constants:
   - `ESP_IMAGE_HEADER_SIZE = 24`, `ESP_IMAGE_SEGMENT_HEADER_SIZE = 8`, `ESP_APP_DESC_OFFSET = 32`, `ESP_APP_DESC_SIZE = 256`, `ESP_APP_DESC_MAGIC = 0xABCD5432`.
   - Field offsets within `esp_app_desc_t`: `magic_word=0`, `secure_version=4`, `reserv1=8..16`, `version=16` (32 B), `project_name=48` (32 B), `time=80` (16 B), `date=96` (16 B), `idf_ver=112` (32 B), `app_elf_sha256=144` (32 B).
   - Helper `readFixedString(buf, off, len)` slices `len` bytes, finds first `0x00`, throws if no null terminator within slot, decodes prefix as UTF-8, rejects any embedded control char `< 0x20` so a tampered `version` field with `\x00\x01` etc. fails fast.
@@ -76,7 +76,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - **Filename safety:** `pathsFor(rootDir, uploadId)` runs `assertPathSafe(uploadId, 'uploadId')`. UUID v4 is `[0-9a-f-]+` so always passes; the assertion guards future refactors.
   - **Concurrency:** no in-process mutex. Two concurrent uploads tolerated by last-writer-wins on the wipe-then-rename sequence; `.meta.json` is the durability anchor. The flash-job hard lock from c.0/c.2 ensures uploads never overlap with a flash, so the only race is two browser tabs uploading back-to-back. Per-store atomic rename is the entire concurrency model.
 
-- [ ] **Tests** (new `astros_api/src/firmware/esp_app_desc.test.ts`). Pure parser tests with constructed fixtures:
+- [x] **Tests** (new `astros_api/src/firmware/esp_app_desc.test.ts`). Pure parser tests with constructed fixtures:
   - Helper `makeAppDescBuffer({ projectName, version, ... })` builds a 288-byte Buffer: 32 zero bytes for image+segment header stub, magic word at offset 32, fixed-length string slots populated with `Buffer.from(name, 'utf8').copy(target, 0); target[name.length] = 0`. Rest zero-filled.
   - Valid binary parses; `projectName === 'astros-esp'`, `version === '1.4.0'`.
   - Wrong magic word → throws.

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -141,16 +141,17 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 
 | Call | Error / condition | Response |
 |------|-------------------|----------|
-| `fsp.open(tempPath)` / `read(buf, 0, 288)` | ENOENT (temp file vanished) | propagate; route returns 4xx |
-| `fsp.open(tempPath)` | EACCES | propagate; logged at route |
-| `createReadStream(tempPath)` | mid-stream error (truncation, EIO) | post-parse catch unlinks `tempPath` + any partial new triple; rethrow |
-| `fsp.mkdir(<uploads>)` | EACCES | post-parse catch unlinks `tempPath`; rethrow (operator sees the error, route gets a clean failure) |
+| `fsp.open(tempPath)` / `read(buf, 0, 288)` | ENOENT (temp file vanished) | rollback runs `fsp.unlink(tempPath)` which itself ENOENTs (swallowed); rethrow to caller |
+| `fsp.open(tempPath)` | EACCES | rollback unlinks tempPath (best-effort; if perms also block unlink, the inner `.catch` swallows it); rethrow |
+| `parseEspAppDesc` | bad magic / no null terminator / control char / non-UTF-8 | rollback unlinks tempPath; rethrow |
+| `createReadStream(tempPath)` | mid-stream error (truncation, EIO) | rollback unlinks `tempPath` + any partial new triple; rethrow |
+| `fsp.mkdir(<uploads>)` | EACCES | rollback unlinks `tempPath`; rethrow (operator sees the error, route gets a clean failure) |
 | `fsp.unlink(<prior>.*)` (wipe pass) | ENOENT | swallow (expected — first-ever upload) |
 | `fsp.unlink(<prior>.*)` (wipe pass) | EACCES | swallow + log warn; orphan stays until next successful store wipes it |
-| `fsp.rename(tempPath, .bin)` | EXDEV (cross-fs) | post-parse catch unlinks `tempPath`; rethrow (config error — c.8 mounted `tmp/` on a different fs) |
-| `fsp.rename(tempPath, .bin)` | EEXIST (Windows, dest exists) | wipe pass should have unlinked; if not, post-parse catch handles |
-| `fsp.writeFile(.sha256)` | ENOSPC | post-parse catch unlinks `tempPath` + `.bin` (just-renamed); rethrow |
-| `fsp.writeFile(.meta.json)` | ENOSPC | post-parse catch unlinks `tempPath` + `.bin` + `.sha256`; rethrow |
+| `fsp.rename(tempPath, .bin)` | EXDEV (cross-fs) | rollback unlinks `tempPath`; rethrow (config error — c.8 mounted `tmp/` on a different fs) |
+| `fsp.rename(tempPath, .bin)` | EEXIST (Windows, dest exists) | wipe pass should have unlinked; if not, rollback handles |
+| `fsp.writeFile(.sha256)` | ENOSPC | rollback unlinks `tempPath` + `.bin` (just-renamed); rethrow |
+| `fsp.writeFile(.meta.json)` | ENOSPC | rollback unlinks `tempPath` + `.bin` + `.sha256`; rethrow |
 | `fsp.readdir(<uploads>)` (latest) | ENOENT | return null (cold cache) |
 | `fsp.readdir(<uploads>)` (latest) | EACCES | propagate; operator-visible |
 | `JSON.parse(metaText)` | SyntaxError | return null (malformed; swept by next successful store) |
@@ -221,7 +222,7 @@ The pre-fix anti-pattern that c.4 caught: persisting `.sha` and `.meta` before r
 
 | Resource | Created | Cleanup happy path | If cleanup doesn't run |
 |----------|---------|--------------------|------------------------|
-| Temp file at `tempPath` | upstream (express-fileupload, in c.8 route) | `fs.rename` consumes on success; post-parse catch's `fsp.unlink` consumes on any post-parse failure (validation, hash, mkdir, persist) | Pre-parse failures (open, read, parseEspAppDesc throw) leave `tempPath` for the route to clean up; long-lived orphans handled by c.8's startup sweep of `<rootDir>/tmp/` |
+| Temp file at `tempPath` | upstream (express-fileupload, in c.8 route) | `fs.rename` consumes on success; the unconditional rollback `fsp.unlink`s on every failure path (open, read, parse, validation, hash, mkdir, wipe, rename, writeFile) | Long-lived orphans only happen if the rollback's unlink itself also fails (e.g., permissions changed mid-call) — handled as a defense-in-depth backstop by c.8's startup sweep of `<rootDir>/tmp/` |
 | 288-byte read buffer | `store()` step 2 | GC after function returns | Harmless |
 | `FileHandle` from `fsp.open(tempPath)` | `store()` step 2 | `await fh.close()` in `finally` block (unconditional) | FD leak; bounded by process lifetime |
 | `ReadStream` for stream-hash | `store()` step 6 | for-await loop auto-closes the underlying fd on both end and error | Mid-stream errors trigger the post-parse catch which unlinks `tempPath` + any partial triple |

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -107,9 +107,9 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 
 ## Verification
 
-- [ ] `npm run build` clean (lint + tsc).
-- [ ] `npm run test` green (existing 347 → ~365 passing; +~18 new tests).
-- [ ] `npm run prettier:write` and `npm run lint:fix` clean.
+- [x] `npm run build` clean (lint + tsc).
+- [x] `npm run test` green (380 → 409 passing; +29 new tests = 11 parser + 18 store).
+- [x] `npm run prettier:write` and `npm run lint:fix` clean.
 - [ ] Manual smoke deferred to c.8 where the route makes the upload reachable end-to-end.
 
 ## Files in scope (6)

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -143,14 +143,14 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 |------|-------------------|----------|
 | `fsp.open(tempPath)` / `read(buf, 0, 288)` | ENOENT (temp file vanished) | propagate; route returns 4xx |
 | `fsp.open(tempPath)` | EACCES | propagate; logged at route |
-| `createReadStream(tempPath)` | mid-stream error (truncation, EIO) | hash pipeline rejects; persist-phase catch unlinks any partial state and rethrows |
-| `fsp.mkdir(<uploads>)` | EACCES | propagate; nothing written |
+| `createReadStream(tempPath)` | mid-stream error (truncation, EIO) | post-parse catch unlinks `tempPath` + any partial new triple; rethrow |
+| `fsp.mkdir(<uploads>)` | EACCES | post-parse catch unlinks `tempPath`; rethrow (operator sees the error, route gets a clean failure) |
 | `fsp.unlink(<prior>.*)` (wipe pass) | ENOENT | swallow (expected — first-ever upload) |
 | `fsp.unlink(<prior>.*)` (wipe pass) | EACCES | swallow + log warn; orphan stays until next successful store wipes it |
-| `fsp.rename(tempPath, .bin)` | EXDEV (cross-fs) | propagate; this is a config error (c.8 mounted `tmp/` on a different fs) |
-| `fsp.rename(tempPath, .bin)` | EEXIST (Windows, dest exists) | wipe pass should have unlinked; if not, propagate |
-| `fsp.writeFile(.sha256)` | ENOSPC | persist-phase catch unlinks `.bin` + temp; rethrow |
-| `fsp.writeFile(.meta.json)` | ENOSPC | persist-phase catch unlinks `.bin` + `.sha256` + temp; rethrow |
+| `fsp.rename(tempPath, .bin)` | EXDEV (cross-fs) | post-parse catch unlinks `tempPath`; rethrow (config error — c.8 mounted `tmp/` on a different fs) |
+| `fsp.rename(tempPath, .bin)` | EEXIST (Windows, dest exists) | wipe pass should have unlinked; if not, post-parse catch handles |
+| `fsp.writeFile(.sha256)` | ENOSPC | post-parse catch unlinks `tempPath` + `.bin` (just-renamed); rethrow |
+| `fsp.writeFile(.meta.json)` | ENOSPC | post-parse catch unlinks `tempPath` + `.bin` + `.sha256`; rethrow |
 | `fsp.readdir(<uploads>)` (latest) | ENOENT | return null (cold cache) |
 | `fsp.readdir(<uploads>)` (latest) | EACCES | propagate; operator-visible |
 | `JSON.parse(metaText)` | SyntaxError | return null (malformed; swept by next successful store) |
@@ -221,10 +221,10 @@ The pre-fix anti-pattern that c.4 caught: persisting `.sha` and `.meta` before r
 
 | Resource | Created | Cleanup happy path | If cleanup doesn't run |
 |----------|---------|--------------------|------------------------|
-| Temp file at `tempPath` | upstream (express-fileupload, in c.8 route) | `fs.rename` consumes on success | Persist-fail catch runs `fsp.unlink(tempPath)`; long-lived orphans handled by c.8's startup sweep of `<rootDir>/tmp/` |
+| Temp file at `tempPath` | upstream (express-fileupload, in c.8 route) | `fs.rename` consumes on success; post-parse catch's `fsp.unlink` consumes on any post-parse failure (validation, hash, mkdir, persist) | Pre-parse failures (open, read, parseEspAppDesc throw) leave `tempPath` for the route to clean up; long-lived orphans handled by c.8's startup sweep of `<rootDir>/tmp/` |
 | 288-byte read buffer | `store()` step 2 | GC after function returns | Harmless |
 | `FileHandle` from `fsp.open(tempPath)` | `store()` step 2 | `await fh.close()` in `finally` block (unconditional) | FD leak; bounded by process lifetime |
-| `ReadStream` for stream-hash | `store()` step 6 | `stream/promises.pipeline` closes underlying fd on both end and error | If pipeline rejects mid-stream, error path still closes; **must use `pipeline`, not manual `.on('end')` wiring** |
+| `ReadStream` for stream-hash | `store()` step 6 | for-await loop auto-closes the underlying fd on both end and error | Mid-stream errors trigger the post-parse catch which unlinks `tempPath` + any partial triple |
 | Hash object (`crypto.createHash`) | `store()` step 6 | GC after `digest()` | Harmless |
 | Promoted `.bin` + sidecars | `store()` persist phase | None — these are the durable artifact | N/A |
 | Stale prior `.bin` + sidecars | wiped at start of persist phase | `Promise.all` of best-effort unlinks | Persist of NEW triple still succeeds; old siblings of dead uuids may stay until next successful store wipes them |

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -1,0 +1,256 @@
+# c.5 — Firmware upload store + `esp_app_desc_t` parser
+
+Light plan for the next server-orchestrator PR. Builds the upload-mode counterpart to c.4: when the user supplies a local `.bin` instead of picking a GitHub release, c.5 parses the embedded `esp_app_desc_t` to verify it's an AstrOs firmware (right project, parseable version), stream-hashes it, and atomically promotes it into a single-slot upload store. The orchestrator (c.6) consumes this; the route (c.8) feeds it. c.5 ships as a pure module — no Express wiring, no WebSocket fan-out.
+
+**Branch:** `feature/firmware-ota-c-5-upload-store` (off `develop`).
+**PR target base:** `develop`.
+**References:** [decomposition plan](./20260427-2202-firmware-ota-decomposition.md) § "Source acquisition + caching", [c.3 plan](./20260429-0918-firmware-ota-c-3-github-releases-service.md), [c.4 plan](./20260501-0725-firmware-ota-c-4-on-disk-cache.md).
+
+## Context
+
+The upload path is symmetric to GitHub mode but with two distinct concerns c.4 doesn't have:
+
+1. **Trust boundary at the binary itself.** A GitHub release came from CI; an upload came from a user's filesystem. The `esp_app_desc_t` struct in the `.bin` is the only structural evidence that the file is what it claims to be. Reject malformed or wrong-project binaries before they reach the flash path — a 1.2 MB blob written into `esp_ota_*` could brick a controller.
+2. **Single-slot retention.** No "newest 5", no semver sort, no published-at tiebreak — uploads keep the most recent only and replace on next write. Eviction collapses to "wipe any prior `upload-*.bin*` triple before the rename" and `latest()` is an O(directory-listing) operation.
+
+c.5's surface is one class — `FirmwareUploadStore` — plus a pure parser exported from a sibling module. Mirrors c.4's "service-class only, no route" pattern. The c.8 route layer adapts multipart `req` → service call.
+
+## On-disk layout
+
+```
+<rootDir>/
+├── github/             # c.4 owns this
+│   └── astros-esp-…app.bin (+ sidecars)
+├── tmp/                # c.5: express-fileupload tempFileDir (mounted in c.8)
+│   └── <random>.tmp    # upstream-managed; c.5 only consumes paths
+└── uploads/            # c.5 owns this
+    ├── upload-<uuid>.bin
+    ├── upload-<uuid>.bin.sha256
+    └── upload-<uuid>.meta.json
+```
+
+`tmp/` and `uploads/` live under the same `<rootDir>` (= same filesystem) so the temp-to-final `fs.rename` is atomic. The route layer (c.8) ensures `tmp/` exists at boot and points express-fileupload at it; c.5's `FirmwareUploadStore` only consumes `tempPath` strings produced upstream and trusts they live on the same volume as `uploads/`.
+
+Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase hex digest, no trailing newline) + `.meta.json` (`{ uploadId, originalFilename, projectName, version, uploadedAt, sizeBytes }`). No `tag` (uploads aren't releases), no `publishedAt` (only `uploadedAt`).
+
+## Configuration
+
+**No new env var.** Reuses c.4's `FIRMWARE_CACHE_PATH` / `resolveFirmwareCacheDir`. The on-disk story is "one rootDir, two subdirs, one path-resolution helper" — a parallel env would let `tmp/` and `uploads/` land on different filesystems and break the atomic rename.
+
+`FirmwareUploadStore` constructor accepts `{ rootDir?: string, expectedProjectName?: string }`. Tests pass `new FirmwareUploadStore({ rootDir: tempDir })` to bypass the env entirely.
+
+## Tasks
+
+- [ ] **Extract `assertPathSafe` to a shared module** (new `astros_api/src/firmware/path_safety.ts`). Move `PATH_SAFE_RE` + `assertPathSafe` out of `firmware_cache.ts`; update `firmware_cache.ts` to import. Both helpers remain module-scope; c.4 behavior unchanged. This is the cleanest moment to extract — c.5 is the second consumer.
+
+- [ ] **Typed models** (new `astros_api/src/models/firmware/upload.ts`):
+  - `EspAppDesc` — `{ magicWord: number, secureVersion: number, version: string, projectName: string, time: string, date: string, idfVer: string, appElfSha256: Buffer }`. Returned by the parser.
+  - `StoredUploadMeta` — `{ uploadId: string, originalFilename: string, projectName: string, version: string, uploadedAt: string, sizeBytes: number }`. Persisted as `upload-<uuid>.meta.json`.
+  - `StoredUpload` — `{ path: string, sha256: string, sizeBytes: number, meta: StoredUploadMeta }`. Returned by `store()` and `latest()`. Mirrors c.4's `CachedAsset`.
+
+- [ ] **`esp_app_desc_t` parser** (new `astros_api/src/firmware/esp_app_desc.ts`). Pure-compute, no fs/network. Single export `parseEspAppDesc(buf: Buffer): EspAppDesc`. Throws on any structural failure. Constants:
+  - `ESP_IMAGE_HEADER_SIZE = 24`, `ESP_IMAGE_SEGMENT_HEADER_SIZE = 8`, `ESP_APP_DESC_OFFSET = 32`, `ESP_APP_DESC_SIZE = 256`, `ESP_APP_DESC_MAGIC = 0xABCD5432`.
+  - Field offsets within `esp_app_desc_t`: `magic_word=0`, `secure_version=4`, `reserv1=8..16`, `version=16` (32 B), `project_name=48` (32 B), `time=80` (16 B), `date=96` (16 B), `idf_ver=112` (32 B), `app_elf_sha256=144` (32 B).
+  - Helper `readFixedString(buf, off, len)` slices `len` bytes, finds first `0x00`, throws if no null terminator within slot, decodes prefix as UTF-8, rejects any embedded control char `< 0x20` so a tampered `version` field with `\x00\x01` etc. fails fast.
+  - Magic word read with `readUInt32LE`. Reject when `!== ESP_APP_DESC_MAGIC`.
+  - Up-front length check: throw if `buf.length < 288`. Caller only ever reads the first 288 bytes.
+
+- [ ] **`FirmwareUploadStore` class** (new `astros_api/src/firmware/firmware_upload_store.ts`):
+  - Constructor: `new FirmwareUploadStore(opts?: { rootDir?: string, expectedProjectName?: string })`. `expectedProjectName` defaults to `'astros-esp'` (resolves decomp Open Item #4 — see Notes; verification step against firmware repo's `CONFIG_APP_PROJECT_NAME` is in the open-items list).
+  - **`store(tempPath: string, originalFilename: string): Promise<StoredUpload>`**:
+    1. Generate `uploadId = uuid_v4()`. `assertPathSafe(uploadId, 'uploadId')` for defense-in-depth against future regressions where the uuid generator changes.
+    2. `fsp.open(tempPath)` → `read(buf, 0, 288, 0)` into a 288-byte Buffer; close handle in a `finally` block (no fd leak on parse failure).
+    3. Call `parseEspAppDesc` on those bytes. Any throw propagates.
+    4. Verify `desc.projectName === expectedProjectName`; reject otherwise with the actual value in the error message.
+    5. Verify `desc.version` parses under `compareVersions(v, v) === 0` (existing helper at `astros_api/src/utility/semver.ts`). Strict 3-component prefix means `1.2.0-rc.1+build.123` parses but `1.2` and `latest` don't.
+    6. Stream-hash the **whole** temp file via `stream/promises.pipeline(createReadStream(tempPath), hashTransform)`; sum bytes streamed for `sizeBytes`. No buffering.
+    7. **Atomic promote** with c.4's persist-phase ordering:
+       - `fsp.mkdir(<rootDir>/uploads/, { recursive: true })`
+       - **Wipe any prior `upload-*.bin`, `upload-*.bin.sha256`, `upload-*.meta.json`** in `<rootDir>/uploads/` (best-effort unlinks; `readdir` + filter + `Promise.all` of unlinks).
+       - `fsp.rename(tempPath, <rootDir>/uploads/upload-<uuid>.bin)`.
+       - `writeFile(.bin.sha256, sha)`
+       - `writeFile(.meta.json, JSON.stringify(meta, null, 2))`
+    8. On any failure in steps 6–7: `Promise.all` of best-effort `unlink` against the temp file, the just-promoted `.bin`, and both sidecars (mirrors c.4's symmetric persist-phase rollback). Rethrow.
+    9. Return `StoredUpload`.
+  - **`latest(): Promise<StoredUpload | null>`** — `readdir(<rootDir>/uploads)`, filter for files matching `^upload-([0-9a-f-]{36})\.meta\.json$`. If multiple matches (corruption/manual intervention), pick the most-recently-mtime'd one and log a warn. Read all three files for that uuid; return null if any are missing or malformed (defensive — mirrors c.4's `lookup`).
+  - **Filename safety:** `pathsFor(rootDir, uploadId)` runs `assertPathSafe(uploadId, 'uploadId')`. UUID v4 is `[0-9a-f-]+` so always passes; the assertion guards future refactors.
+  - **Concurrency:** no in-process mutex. Two concurrent uploads tolerated by last-writer-wins on the wipe-then-rename sequence; `.meta.json` is the durability anchor. The flash-job hard lock from c.0/c.2 ensures uploads never overlap with a flash, so the only race is two browser tabs uploading back-to-back. Per-store atomic rename is the entire concurrency model.
+
+- [ ] **Tests** (new `astros_api/src/firmware/esp_app_desc.test.ts`). Pure parser tests with constructed fixtures:
+  - Helper `makeAppDescBuffer({ projectName, version, ... })` builds a 288-byte Buffer: 32 zero bytes for image+segment header stub, magic word at offset 32, fixed-length string slots populated with `Buffer.from(name, 'utf8').copy(target, 0); target[name.length] = 0`. Rest zero-filled.
+  - Valid binary parses; `projectName === 'astros-esp'`, `version === '1.4.0'`.
+  - Wrong magic word → throws.
+  - Buffer shorter than 288 bytes → throws.
+  - `project_name` field with no null terminator within its 32-byte slot → throws.
+  - `version` field with embedded null mid-string truncates at the null (yields `'1.4'` for `1.4\x00.0`).
+  - String field with control chars `\x01..\x1F` after the null → throws.
+  - Non-UTF-8 bytes in string fields → throws.
+  - `secureVersion` reads as `uint32_t` little-endian (regression guard against accidental BE).
+  - Magic-word constant is exactly `0xABCD5432` (sentinel test).
+
+- [ ] **Tests** (new `astros_api/src/firmware/firmware_upload_store.test.ts`). Real temp dir per test (`fs.mkdtempSync` in `beforeEach`, `rm -rf` in `afterEach`):
+  - `latest()` returns null on cold cache.
+  - `store()` happy path: temp file exists, parser succeeds, all three files at expected paths, returned `StoredUpload` has correct `path`, `sha256` (verified by re-hashing), `sizeBytes`, and meta.
+  - `store()` consumes the temp file (no orphan in `tmp/` after success).
+  - `store()` rejects when `projectName !== 'astros-esp'`; pre-existing prior upload preserved (no wipe-on-fail-validation).
+  - `store()` rejects when `version` is unparseable; prior upload preserved.
+  - `store()` rejects when binary is shorter than 288 bytes.
+  - `store()` replaces a prior upload: pre-populated old triple is gone, new triple present.
+  - `store()` rolls back cleanly when persist-phase `writeFile(.sha256)` throws (mock fsp): no `.bin`, no `.sha256`, no `.meta.json` in `<rootDir>/uploads/`.
+  - `store()` rolls back cleanly when `rename` throws EACCES: temp file unlinked, uploads dir empty.
+  - `latest()` returns null when only some sidecar files exist (interrupted prior write).
+  - `latest()` returns null when `.meta.json` is malformed JSON.
+  - Crash-recovery invariant: snapshotting `.bin` at each sidecar `writeFile` call shows bin contents are either fresh-bytes or absent — never stale (same pinning pattern c.4 used).
+  - Sequential interleaving: A.store() completes, B.store() completes, `latest()` returns B's data; pre-A returns null, between returns A.
+  - Filename safety: passing a non-UUID `uploadId` (via test seam) trips `assertPathSafe` synchronously without writing.
+  - File-handle hygiene: parse-failure path closes the `fsp.open` handle (verify via spy / explicit close-call assertion).
+
+## Verification
+
+- [ ] `npm run build` clean (lint + tsc).
+- [ ] `npm run test` green (existing 347 → ~365 passing; +~18 new tests).
+- [ ] `npm run prettier:write` and `npm run lint:fix` clean.
+- [ ] Manual smoke deferred to c.8 where the route makes the upload reachable end-to-end.
+
+## Files in scope (6)
+
+1. `astros_api/src/firmware/path_safety.ts` — extracted `PATH_SAFE_RE` + `assertPathSafe` (shared with c.4)
+2. `astros_api/src/firmware/firmware_cache.ts` — import from `path_safety.ts` (delete local copies)
+3. `astros_api/src/models/firmware/upload.ts` — new `StoredUpload`, `StoredUploadMeta`, `EspAppDesc` types
+4. `astros_api/src/firmware/esp_app_desc.ts` — new pure parser
+5. `astros_api/src/firmware/esp_app_desc.test.ts` — new parser tests
+6. `astros_api/src/firmware/firmware_upload_store.ts` — new store class
+7. `astros_api/src/firmware/firmware_upload_store.test.ts` — new store tests
+
+7 files; well under the 10-file cap. **Does not modify** `api_server.ts` — global `fileUpload()` config and route mount land in c.8.
+
+## Out of scope
+
+- HTTP route exposure (`POST /firmware/upload`) — **c.8**.
+- `express-fileupload` route-scoped middleware (recommended in Notes; mounted alongside the route) — **c.8**.
+- FlashJob orchestrator wiring — **c.6**.
+- WebSocket fan-out for "selected upload" UI state — **c.7**.
+- Multi-slot upload retention / history — explicit non-goal.
+- Re-validation at flash time — orchestrator (c.6) MAY re-parse for paranoia; this plan recommends but doesn't ship.
+- Cross-process safety — single-process server.
+
+## Failure modes
+
+### 1. External-call error coverage
+
+| Call | Error / condition | Response |
+|------|-------------------|----------|
+| `fsp.open(tempPath)` / `read(buf, 0, 288)` | ENOENT (temp file vanished) | propagate; route returns 4xx |
+| `fsp.open(tempPath)` | EACCES | propagate; logged at route |
+| `createReadStream(tempPath)` | mid-stream error (truncation, EIO) | hash pipeline rejects; persist-phase catch unlinks any partial state and rethrows |
+| `fsp.mkdir(<uploads>)` | EACCES | propagate; nothing written |
+| `fsp.unlink(<prior>.*)` (wipe pass) | ENOENT | swallow (expected — first-ever upload) |
+| `fsp.unlink(<prior>.*)` (wipe pass) | EACCES | swallow + log warn; orphan stays until next successful store wipes it |
+| `fsp.rename(tempPath, .bin)` | EXDEV (cross-fs) | propagate; this is a config error (c.8 mounted `tmp/` on a different fs) |
+| `fsp.rename(tempPath, .bin)` | EEXIST (Windows, dest exists) | wipe pass should have unlinked; if not, propagate |
+| `fsp.writeFile(.sha256)` | ENOSPC | persist-phase catch unlinks `.bin` + temp; rethrow |
+| `fsp.writeFile(.meta.json)` | ENOSPC | persist-phase catch unlinks `.bin` + `.sha256` + temp; rethrow |
+| `fsp.readdir(<uploads>)` (latest) | ENOENT | return null (cold cache) |
+| `fsp.readdir(<uploads>)` (latest) | EACCES | propagate; operator-visible |
+| `JSON.parse(metaText)` | SyntaxError | return null (malformed; swept by next successful store) |
+
+**Gotchas applying from c.4 experience:**
+- Truncated read on temp file looks like normal close. Mitigation: parser checks length up front (≥288); store also verifies `actualSize > 0` post-stream-hash.
+- `JSON.parse('{}')` succeeds but `isValidUploadMeta` requires every field present-and-correct-type, so malformed-meta path triggers cleanly.
+- macOS HFS+ case-insensitive: UUIDs are lowercase hex by construction; case collisions N/A.
+
+### 2. Crash-recovery state matrix
+
+`store()` persist phase, after `parseEspAppDesc` and stream-hash succeed:
+
+| After step | tmp | bin | sha | meta | latest() returns | Status |
+|------------|-----|-----|-----|------|------------------|--------|
+| Before persist | new | (prior or absent) | (prior or absent) | (prior or absent) | prior or null | hit (prior) ✓ |
+| Wipe prior `.bin` | new | absent | (prior or absent) | (prior or absent) | null (no bin) | miss ✓ |
+| Wipe prior `.sha` | new | absent | absent | (prior or absent) | null | miss ✓ |
+| Wipe prior `.meta` | new | absent | absent | absent | null | miss ✓ |
+| Rename `tmp` → new `.bin` | absent | new | absent | absent | null (no meta) | miss ✓ |
+| writeFile `.sha` | absent | new | new | absent | null (no meta) | miss ✓ |
+| writeFile `.meta` | absent | new | new | new | hit, consistent | hit ✓ |
+
+Every row's `latest()` answer is either "null" or "the consistent state at that timestep" — no "stale-bin + new-sidecars" or "new-bin + stale-sidecars" mid-sequence. The wipe order (`.bin` first, then sidecars) ensures a crash mid-wipe leaves at-most "sidecars without bin" which `latest()` rejects via the missing-bin stat.
+
+The pre-fix anti-pattern that c.4 caught: persisting `.sha` and `.meta` before renaming the new `.bin` over the old. That row would read "stale `.bin` + new `.sha` + new `.meta` → hit, bytes ≠ hash → inconsistent ✗" — same bug class.
+
+### 3. Concurrency state
+
+- **Shared resource: `<rootDir>/uploads/`.** Two callers can race wipe-then-rename sequences. **Sync mechanism:** none in-process; `fs.rename` is atomic. **Miss consequence:** last-writer wins on `.meta.json` (the anchor `latest()` keys on). A reader between A's rename and B's rename sees A's complete triple briefly, then B's complete triple — never a chimera, because the wipe-then-rename pair is the smallest atomic transition `latest()` cares about.
+- **In-process state:** N/A — `FirmwareUploadStore` carries no mutable in-memory state beyond construction-time `rootDir` + `expectedProjectName`. No `inFlight` map, no LRU.
+- The flash-job hard lock from c.0/c.2 makes most of this academic — no concurrent flashes can start while uploads are in flight.
+
+### 4. Cross-platform / cross-environment
+
+- **`fs.rename`:** POSIX overwrites atomically; Windows throws `EEXIST`. Mitigation: wipe pass before rename ensures destination is absent. (c.4's `unlink-before-rename + ENOENT-only catch` not needed because the wipe pass is the load-bearing step — only one slot total.)
+- **`fs.rename` cross-filesystem (EXDEV):** `tmp/` and `uploads/` MUST live under the same `<rootDir>`. c.8's route mount points `tempFileDir` at `<rootDir>/tmp/`. Bind-mounts and Docker volumes are easy ways to break this; document in c.8's setup notes.
+- **Path separators:** always `path.join`.
+- **`appdata-path`:** delegated to c.4's `resolveFirmwareCacheDir`; no new platform branches.
+- **Buffer endianness:** ESP-IDF binaries are little-endian. Use `readUInt32LE`; reject if magic word doesn't match in LE form.
+
+### 5. Pre-existing on-disk state
+
+- **Orphan `upload-X.bin` with no sidecars** (prior crash between rename and `writeFile sha`): swept by next successful `store()`'s wipe pass. `latest()` returns null in the meantime.
+- **Orphan `upload-X.bin` + `.sha256` with no `.meta.json`** (crash between sha-write and meta-write): same — `latest()` ignores it; next store wipes.
+- **Multiple `upload-*.meta.json` files** (corruption / manual intervention): `latest()` picks most-recently-mtime'd, logs warn; next successful store wipes the rest.
+- **Malformed `upload-X.meta.json`**: `latest()` returns null; next store wipes.
+- **Pre-existing `.bin` whose contents disagree with its `.sha256`**: `latest()` returns it without re-hashing (mirrors c.4 — trust the sidecar). The orchestrator (c.6) re-hashes before flashing; master/padawan re-hash again. A corruption surfaces as `HASH_MISMATCH` downstream.
+- **`<rootDir>/uploads/` with wrong permissions:** `readdir` throws non-ENOENT; propagates so operator sees the warning.
+- **Leftover `*.tmp` files in `<rootDir>/tmp/`:** not c.5's concern — express-fileupload owns `tmp/`. c.8's route mount is responsible for sweeping orphans on startup.
+
+### 6. Hostile / malformed input
+
+- **`tempPath`:** trusted as a path on disk; never interpolated into a filename. Contents zero-trust (next item).
+- **Binary contents:** zero-trust. Defenses:
+  - Magic word check (`0xABCD5432`).
+  - Project-name match against `expectedProjectName`.
+  - Version parses under `compareVersions`.
+  - Fixed-length string fields require null terminator within slot (no overrun into adjacent fields).
+  - Embedded control chars (`< 0x20`, excluding trailing null) in any string field → reject.
+  - Non-UTF-8 bytes in string fields → reject.
+- **`originalFilename`:** carried into `meta.json` for operator inspection; **NEVER** interpolated into a filename. May contain any bytes (`../`, control chars, embedded nulls) — harmless because they only ever live inside JSON.
+- **`uploadId`:** server-generated `uuid v4`, validated by `assertPathSafe` for defense-in-depth.
+- **Parsed `version`:** flows into `meta.json` and the UI's "Selected release" display. **NEVER** interpolated into a path. Parser rejects control chars upstream (double coverage).
+- **`FIRMWARE_CACHE_PATH`:** delegated to c.4's helper; no new attack surface.
+
+### 7. Resource lifecycle audit
+
+| Resource | Created | Cleanup happy path | If cleanup doesn't run |
+|----------|---------|--------------------|------------------------|
+| Temp file at `tempPath` | upstream (express-fileupload, in c.8 route) | `fs.rename` consumes on success | Persist-fail catch runs `fsp.unlink(tempPath)`; long-lived orphans handled by c.8's startup sweep of `<rootDir>/tmp/` |
+| 288-byte read buffer | `store()` step 2 | GC after function returns | Harmless |
+| `FileHandle` from `fsp.open(tempPath)` | `store()` step 2 | `await fh.close()` in `finally` block (unconditional) | FD leak; bounded by process lifetime |
+| `ReadStream` for stream-hash | `store()` step 6 | `stream/promises.pipeline` closes underlying fd on both end and error | If pipeline rejects mid-stream, error path still closes; **must use `pipeline`, not manual `.on('end')` wiring** |
+| Hash object (`crypto.createHash`) | `store()` step 6 | GC after `digest()` | Harmless |
+| Promoted `.bin` + sidecars | `store()` persist phase | None — these are the durable artifact | N/A |
+| Stale prior `.bin` + sidecars | wiped at start of persist phase | `Promise.all` of best-effort unlinks | Persist of NEW triple still succeeds; old siblings of dead uuids may stay until next successful store wipes them |
+
+The most likely real bug: file-handle leak from `fsp.open` if the parse step throws before an explicit `fh.close()`. Mitigation: `try { ... } finally { await fh.close() }` around the read.
+
+## Notes for the reviewer
+
+- **express-fileupload integration: route-scoped, not global** (decision deferred to c.8 but documented here). Recommend `fileUpload({ useTempFiles: true, tempFileDir: <rootDir>/tmp, limits: { fileSize: 8 * 1024 * 1024 } })` applied only to `POST /firmware/upload`. Justification: smaller blast radius vs. changing global config; different size limit appropriate (firmware ~1.2 MB cap at 8 MB; audio uses defaults); colocated debugging context for EXDEV issues; c.8 also needs to ensure `<rootDir>/tmp/` exists at boot and sweep stale `*.tmp` orphans on startup. **c.5 itself doesn't touch `api_server.ts`.**
+
+- **`expectedProjectName = 'astros-esp'`** resolves decomp Open Item #4. The c.3 asset-name regex (`^astros-esp-…-app\.bin$`) already encodes this prefix. **Verification step:** confirm against `AstrOs.ESP/platformio.ini` or `sdkconfig*` for `CONFIG_APP_PROJECT_NAME`. If verification can't happen before merge, the constant ships with `astros-esp` and a TODO; c.6's PTY-stub end-to-end test will catch a real mismatch.
+
+- **`esp_app_desc_t` field offsets** taken from ESP-IDF's stable layout (post-v4.0). **Verification step:** read `AstrOs.ESP/components/.../esp_app_format.h` (or the ESP-IDF vendor copy) to confirm. The struct has been stable for ~5 years; if a future release rearranges, the parser's constants are the single point of change.
+
+- **Hash on store but not on `latest()`:** symmetric to c.4. The sidecar is the source of truth; re-hashing 1.2 MB on every read costs ~80–100 ms for no semantic gain. The orchestrator and master both re-hash downstream as part of the protocol — corruption between store-time and flash-time surfaces as `HASH_MISMATCH`, not a silent flash of corrupted bytes.
+
+- **Sharing `assertPathSafe` with c.4:** extracting to `path_safety.ts` is the cleanest move now that c.5 is the second consumer. c.4's tests stay green (behavior unchanged); the diff is one new file + one import update.
+
+- **Reading only 288 bytes** instead of the full 1.2 MB: `fsp.open` + `read(buf, 0, 288, 0)` keeps memory flat during parse. The stream-hash phase handles the rest of the file; we never need the whole binary resident. Worth calling out in the PR description — it's a meaningful perf detail invisible from outside the module.
+
+- **Why no `tag` in `StoredUploadMeta`:** uploads aren't releases — there's no GitHub tag, no `published_at`. The orchestrator (c.6) bridges `StoredUpload` and `CachedAsset` into a common "flash source" concept; that's where the shape divergence gets papered over.
+
+## Critical files for implementation
+
+- `astros_api/src/firmware/firmware_cache.ts` — pattern to mirror (path-safety, atomic-rename ordering, sidecar wipe-before-promote, persist-phase rollback, `isValidMeta` shape).
+- `astros_api/src/firmware/firmware_cache.test.ts` — test patterns (temp dir per test, mock-throwing-fs spy patterns, crash-recovery snapshot pinning).
+- `astros_api/src/utility/semver.ts` — version validation (`compareVersions(v, v) === 0` is the validity gate).
+- `astros_api/src/controllers/file_controller.ts` — express-fileupload precedent for the c.8 route (UUID-based filename pattern; c.5 won't use `mv` but shows the multipart shape).
+- `.docs/plans/20260501-0725-firmware-ota-c-4-on-disk-cache.md` — plan-shape and FMI-fill-in style to mirror.
+- `.docs/templates/failure-mode-inventory.md` — the template this plan's `## Failure modes` section is filling out.

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -113,7 +113,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 - [x] `npm run prettier:write` and `npm run lint:fix` clean.
 - [ ] Manual smoke deferred to c.8 where the route makes the upload reachable end-to-end.
 
-## Files in scope (6)
+## Files in scope (7)
 
 1. `astros_api/src/firmware/path_safety.ts` — extracted `PATH_SAFE_RE` + `assertPathSafe` (shared with c.4)
 2. `astros_api/src/firmware/firmware_cache.ts` — import from `path_safety.ts` (delete local copies)

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -74,7 +74,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
     9. Return `StoredUpload`.
   - **`latest(): Promise<StoredUpload | null>`** — `readdir(<rootDir>/uploads)`, filter for files matching `^upload-([0-9a-f-]{36})\.meta\.json$`. If multiple matches (corruption/manual intervention), pick the most-recently-mtime'd one and log a warn. Read all three files for that uuid; return null if any are missing or malformed. Cross-check the triple is internally consistent: `parsed.uploadId === uploadId-from-filename` (corruption / sidecar copy-from-another-upload would mislead the orchestrator about which upload is being flashed) and `parsed.sizeBytes === binStat.size` (cheap proxy for "the bin we have is the one meta describes" — catches partial-write recovery and external truncation; sha re-hashing would be stronger but costs ~80–100 ms per call). Mismatches map to a null miss.
   - **Filename safety:** `pathsFor(rootDir, uploadId)` runs `assertPathSafe(uploadId, 'uploadId')`. UUID v4 is `[0-9a-f-]+` so always passes; the assertion guards future refactors.
-  - **Concurrency:** no in-process mutex. Two concurrent uploads tolerated by last-writer-wins on the wipe-then-rename sequence; `.meta.json` is the durability anchor. The flash-job hard lock from c.0/c.2 ensures uploads never overlap with a flash, so the only race is two browser tabs uploading back-to-back. Per-store atomic rename is the entire concurrency model.
+  - **Concurrency:** in-process serialization via a promise-chain mutex (`inFlightStore`). Two concurrent `store()` calls would otherwise race their wipe passes against each other's just-renamed `.bin` files (A.rename → B.wipe unlinks A.bin → A.writeFile sha → A returns success on a missing bin). Serializing makes last-writer-wins deterministic: the second store sees the first's complete triple, wipes it cleanly, and writes its own. The chain swallows rejections on its tracking pointer so one failure doesn't poison subsequent calls. `latest()` is read-only and not serialized — partial-state windows are already covered by the cross-checks. The flash-job hard lock from c.0/c.2 covers flash-vs-upload races; this mutex covers upload-vs-upload.
 
 - [x] **Tests** (new `astros_api/src/firmware/esp_app_desc.test.ts`). Pure parser tests with constructed fixtures:
   - Helper `makeAppDescBuffer({ projectName, version, ... })` builds a 288-byte Buffer: 32 zero bytes for image+segment header stub, magic word at offset 32, fixed-length string slots populated with `Buffer.from(name, 'utf8').copy(target, 0); target[name.length] = 0`. Rest zero-filled.
@@ -106,6 +106,9 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - `latest()` returns null when `.meta.json` `sizeBytes` disagrees with the bin's actual size on disk (partial-write recovery / external truncation).
   - Crash-recovery invariant: snapshotting `.bin` at each sidecar `writeFile` call shows bin contents are either fresh-bytes or absent — never stale (same pinning pattern c.4 used).
   - Sequential interleaving: A.store() completes, B.store() completes, `latest()` returns B's data; pre-A returns null, between returns A.
+  - Serialization: two concurrent `store()` calls (kicked off via `Promise.all`) both complete cleanly; final on-disk state is exactly the second writer's triple; `latest()` returns the second writer.
+  - Mutex non-poisoning: a prior `store()` rejection (validation failure, persist error) doesn't block subsequent stores — they still execute against the now-clean uploads dir.
+  - Concurrent rejection mixed with valid uploads: a failing call alongside two valid calls leaves both valid uploads' chains intact; final state matches the last successful writer.
   - Filename safety: passing a non-UUID `uploadId` (via test seam) trips `assertPathSafe` synchronously without writing.
   - File-handle hygiene: parse-failure path closes the `fsp.open` handle (verify via spy / explicit close-call assertion).
 
@@ -187,9 +190,9 @@ The pre-fix anti-pattern that c.4 caught: persisting `.sha` and `.meta` before r
 
 ### 3. Concurrency state
 
-- **Shared resource: `<rootDir>/uploads/`.** Two callers can race wipe-then-rename sequences. **Sync mechanism:** none in-process; `fs.rename` is atomic. **Miss consequence:** last-writer wins on `.meta.json` (the anchor `latest()` keys on). A reader between A's rename and B's rename sees A's complete triple briefly, then B's complete triple — never a chimera, because the wipe-then-rename pair is the smallest atomic transition `latest()` cares about.
-- **In-process state:** N/A — `FirmwareUploadStore` carries no mutable in-memory state beyond construction-time `rootDir` + `expectedProjectName`. No `inFlight` map, no LRU.
-- The flash-job hard lock from c.0/c.2 makes most of this academic — no concurrent flashes can start while uploads are in flight.
+- **Shared resource: `<rootDir>/uploads/`.** **Sync mechanism:** in-process promise-chain mutex (`inFlightStore`) serializes `store()` calls; `fs.rename` and atomic file writes serialize within a call. **Miss consequence (without the mutex):** A's rename promotes `A.bin`, B's wipe pass unlinks it before A's `writeFile(sha)` runs, A returns success with a missing bin. The mutex closes the gap by guaranteeing B doesn't begin its sequence until A has completed all four persist steps (wipe, rename, writeFile sha, writeFile meta). Last-writer-wins is now deterministic: the second writer sees the first's complete triple and replaces it cleanly.
+- **In-process state:** `inFlightStore: Promise<unknown>` chained through every `store()` call. Each call's chained `.catch()` swallows prior-call rejections on the tracking pointer so a failure (bad project, hash error, etc.) doesn't poison subsequent calls. `latest()` is intentionally NOT serialized — it's read-only, and the partial-state windows are already covered by `latest()`'s null-miss + cross-check defenses.
+- The flash-job hard lock from c.0/c.2 covers flash-vs-upload races; the in-process mutex covers upload-vs-upload races. Together they handle the full concurrency surface that's reachable through the route layer.
 
 ### 4. Cross-platform / cross-environment
 

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -41,9 +41,9 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 
 ## Tasks
 
-- [ ] **Extract `assertPathSafe` to a shared module** (new `astros_api/src/firmware/path_safety.ts`). Move `PATH_SAFE_RE` + `assertPathSafe` out of `firmware_cache.ts`; update `firmware_cache.ts` to import. Both helpers remain module-scope; c.4 behavior unchanged. This is the cleanest moment to extract — c.5 is the second consumer.
+- [x] **Extract `assertPathSafe` to a shared module** (new `astros_api/src/firmware/path_safety.ts`). Move `PATH_SAFE_RE` + `assertPathSafe` out of `firmware_cache.ts`; update `firmware_cache.ts` to import. Both helpers remain module-scope; c.4 behavior unchanged. This is the cleanest moment to extract — c.5 is the second consumer.
 
-- [ ] **Typed models** (new `astros_api/src/models/firmware/upload.ts`):
+- [x] **Typed models** (new `astros_api/src/models/firmware/upload.ts`):
   - `EspAppDesc` — `{ magicWord: number, secureVersion: number, version: string, projectName: string, time: string, date: string, idfVer: string, appElfSha256: Buffer }`. Returned by the parser.
   - `StoredUploadMeta` — `{ uploadId: string, originalFilename: string, projectName: string, version: string, uploadedAt: string, sizeBytes: number }`. Persisted as `upload-<uuid>.meta.json`.
   - `StoredUpload` — `{ path: string, sha256: string, sizeBytes: number, meta: StoredUploadMeta }`. Returned by `store()` and `latest()`. Mirrors c.4's `CachedAsset`.

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -108,7 +108,8 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 ## Verification
 
 - [x] `npm run build` clean (lint + tsc).
-- [x] `npm run test` green (380 → 409 passing; +29 new tests = 11 parser + 18 store).
+- [x] `npm run test` green (380 → 416 passing; +36 new tests = 11 parser + 25 store, including 7 added in fixup for embedded-version normalization).
+- [x] **Live verification against real binary:** `firmware_upload_store` accepts the actual `AstrOs.ESP/.pio/build/lolin_d32_pro/firmware.bin` produced by ESP-IDF, captures `projectName: "AstrOs.ESP"` and normalizes `version: "v1.0.0-RC.1-71-g9a55936-dirty"` → `"1.0.0-RC.1"`.
 - [x] `npm run prettier:write` and `npm run lint:fix` clean.
 - [ ] Manual smoke deferred to c.8 where the route makes the upload reachable end-to-end.
 
@@ -234,9 +235,11 @@ The most likely real bug: file-handle leak from `fsp.open` if the parse step thr
 
 - **express-fileupload integration: route-scoped, not global** (decision deferred to c.8 but documented here). Recommend `fileUpload({ useTempFiles: true, tempFileDir: <rootDir>/tmp, limits: { fileSize: 8 * 1024 * 1024 } })` applied only to `POST /firmware/upload`. Justification: smaller blast radius vs. changing global config; different size limit appropriate (firmware ~1.2 MB cap at 8 MB; audio uses defaults); colocated debugging context for EXDEV issues; c.8 also needs to ensure `<rootDir>/tmp/` exists at boot and sweep stale `*.tmp` orphans on startup. **c.5 itself doesn't touch `api_server.ts`.**
 
-- **`expectedProjectName = 'astros-esp'`** resolves decomp Open Item #4. The c.3 asset-name regex (`^astros-esp-…-app\.bin$`) already encodes this prefix. **Verification step:** confirm against `AstrOs.ESP/platformio.ini` or `sdkconfig*` for `CONFIG_APP_PROJECT_NAME`. If verification can't happen before merge, the constant ships with `astros-esp` and a TODO; c.6's PTY-stub end-to-end test will catch a real mismatch.
+- **`expectedProjectName = 'AstrOs.ESP'`** — verified against `AstrOs.ESP/CMakeLists.txt:4` (`project(AstrOs.ESP)`) and against a real built `firmware.bin` parsed by `parseEspAppDesc` during implementation. **Important finding:** the asset-filename prefix `astros-esp-…-app.bin` (set by CI tooling) is NOT the same as the embedded `esp_app_desc_t.project_name` (set by CMake). This was not what decomp Open Item #4 expected — the planning-time guess was `astros-esp`, but ESP-IDF embeds the CMake project name verbatim, dot and capitalization included. The constant lives at `firmware_upload_store.ts:DEFAULT_PROJECT_NAME` for easy adjustment if the firmware repo ever renames its CMake project.
 
-- **`esp_app_desc_t` field offsets** taken from ESP-IDF's stable layout (post-v4.0). **Verification step:** read `AstrOs.ESP/components/.../esp_app_format.h` (or the ESP-IDF vendor copy) to confirm. The struct has been stable for ~5 years; if a future release rearranges, the parser's constants are the single point of change.
+- **`esp_app_desc_t.version` is `git describe --tags --dirty` output, not clean semver.** Real example from a dev build: `"v1.0.0-RC.1-71-g9a55936-dirty"`. ESP-IDF defaults to `git describe` when neither `CONFIG_APP_PROJECT_VER_FROM_CONFIG` nor a `version.txt` is set, and AstrOs.ESP has neither today. The store therefore runs `normalizeEspVersion()` before validation: strips a leading `v` and the trailing `-<N>-g<sha>(-dirty)?` suffix, then validates the result against `compareVersions`. The persisted `meta.version` is the normalized clean semver — c.6's orchestrator can compare it directly against GitHub-release filenames without per-source casing. Six dedicated tests cover the normalization paths.
+
+- **`esp_app_desc_t` field offsets** verified by parsing the real `firmware.bin` (offset 32, magic 0xABCD5432, all string fields decoded correctly). The struct has been stable since ESP-IDF v4.0; if a future release rearranges, the parser's `F_*` constants are the single point of change.
 
 - **Hash on store but not on `latest()`:** symmetric to c.4. The sidecar is the source of truth; re-hashing 1.2 MB on every read costs ~80–100 ms for no semantic gain. The orchestrator and master both re-hash downstream as part of the protocol — corruption between store-time and flash-time surfaces as `HASH_MISMATCH`, not a silent flash of corrupted bytes.
 

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -63,7 +63,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
     3. Call `parseEspAppDesc` on those bytes. Any throw propagates.
     4. Verify `desc.projectName === expectedProjectName`; reject otherwise with the actual value in the error message.
     5. Verify `desc.version` parses under `compareVersions(v, v) === 0` (existing helper at `astros_api/src/utility/semver.ts`). Strict 3-component prefix means `1.2.0-rc.1+build.123` parses but `1.2` and `latest` don't.
-    6. Stream-hash the **whole** temp file via `stream/promises.pipeline(createReadStream(tempPath), hashTransform)`; sum bytes streamed for `sizeBytes`. No buffering.
+    6. Stream-hash the **whole** temp file via `for await (const chunk of fs.createReadStream(tempPath))`, feeding each chunk into a `crypto.createHash('sha256')` and summing chunk lengths into `sizeBytes`. The for-await loop handles backpressure and auto-closes the underlying fd on both clean exit and mid-loop error. Using `stream/promises.pipeline` would require a Writable destination we don't need (the bytes already live at `tempPath`); the for-await form keeps the read-and-discard intent explicit and avoids a no-op sink.
     7. **Atomic promote** with c.4's persist-phase ordering:
        - `fsp.mkdir(<rootDir>/uploads/, { recursive: true })`
        - **Wipe any prior `upload-*.bin`, `upload-*.bin.sha256`, `upload-*.meta.json`** in `<rootDir>/uploads/` (best-effort unlinks; `readdir` + filter + `Promise.all` of unlinks).
@@ -156,7 +156,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 | `JSON.parse(metaText)` | SyntaxError | return null (malformed; swept by next successful store) |
 
 **Gotchas applying from c.4 experience:**
-- Truncated read on temp file looks like normal close. Mitigation: parser checks length up front (≥288); store also verifies `actualSize > 0` post-stream-hash.
+- Truncated read on temp file looks like normal close. Mitigation: the parse step's `fh.read(buf, 0, 288, 0)` rejects any file that doesn't deliver the full 288-byte header, which is the load-bearing check for the most common truncation source (incomplete upload). A subsequent parse-time-vs-hash-time race (file truncated between the two reads) is not separately guarded — caught only if it shrinks below the 288-byte parse floor before the stream-hash opens its own handle, which would also fail the parse on a retry.
 - `JSON.parse('{}')` succeeds but `isValidUploadMeta` requires every field present-and-correct-type, so malformed-meta path triggers cleanly.
 - macOS HFS+ case-insensitive: UUIDs are lowercase hex by construction; case collisions N/A.
 

--- a/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
+++ b/.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md
@@ -51,7 +51,7 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
 - [x] **`esp_app_desc_t` parser** (new `astros_api/src/firmware/esp_app_desc.ts`). Pure-compute, no fs/network. Single export `parseEspAppDesc(buf: Buffer): EspAppDesc`. Throws on any structural failure. Constants:
   - `ESP_IMAGE_HEADER_SIZE = 24`, `ESP_IMAGE_SEGMENT_HEADER_SIZE = 8`, `ESP_APP_DESC_OFFSET = 32`, `ESP_APP_DESC_SIZE = 256`, `ESP_APP_DESC_MAGIC = 0xABCD5432`.
   - Field offsets within `esp_app_desc_t`: `magic_word=0`, `secure_version=4`, `reserv1=8..16`, `version=16` (32 B), `project_name=48` (32 B), `time=80` (16 B), `date=96` (16 B), `idf_ver=112` (32 B), `app_elf_sha256=144` (32 B).
-  - Helper `readFixedString(buf, off, len)` slices `len` bytes, finds first `0x00`, throws if no null terminator within slot, decodes prefix as UTF-8, rejects any embedded control char `< 0x20` so a tampered `version` field with `\x00\x01` etc. fails fast.
+  - Helper `readFixedString(buf, off, len)` slices `len` bytes, finds first `0x00`, throws if no null terminator within slot, decodes prefix as UTF-8, rejects any embedded single-byte ASCII control char — C0 range `[0x01, 0x1F]` plus DEL `0x7F` — so a tampered `version` field with `\x00\x01` etc. fails fast. The C1 range `[0x80, 0x9F]` is intentionally NOT rejected at the byte level: those bytes appear naturally inside valid UTF-8 continuation sequences (`é` → `0xC3 0xA9`); the strict-UTF-8 decoder catches *invalid* sequences containing those bytes.
   - Magic word read with `readUInt32LE`. Reject when `!== ESP_APP_DESC_MAGIC`.
   - Up-front length check: throw if `buf.length < 288`. Caller only ever reads the first 288 bytes.
 
@@ -84,6 +84,8 @@ Each upload has the same three-file shape as c.4: `.bin` + `.sha256` (lowercase 
   - `project_name` field with no null terminator within its 32-byte slot → throws.
   - `version` field with embedded null mid-string truncates at the null (yields `'1.4'` for `1.4\x00.0`).
   - String field with control chars `\x01..\x1F` after the null → throws.
+  - String field with DEL (`\x7F`) → throws (single-byte ASCII control char outside the C0 range).
+  - String field with legitimate multi-byte UTF-8 (e.g. `release-é-v5`, where `é` is `0xC3 0xA9` and the trailing byte sits in the C1 range `0x80-0x9F`) → parses cleanly. Regression guard against over-broad byte-level rejection of C1 bytes.
   - Non-UTF-8 bytes in string fields → throws.
   - `secureVersion` reads as `uint32_t` little-endian (regression guard against accidental BE).
   - Magic-word constant is exactly `0xABCD5432` (sentinel test).

--- a/astros_api/src/firmware/esp_app_desc.test.ts
+++ b/astros_api/src/firmware/esp_app_desc.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseEspAppDesc,
+  ESP_APP_DESC_MAGIC,
+  ESP_APP_DESC_OFFSET,
+  ESP_APP_DESC_SIZE,
+} from './esp_app_desc.js';
+
+interface FixtureOpts {
+  magic?: number;
+  secureVersion?: number;
+  version?: string;
+  projectName?: string;
+  time?: string;
+  date?: string;
+  idfVer?: string;
+  appElfSha256?: Buffer;
+  size?: number;
+}
+
+const SLOT_OFFSETS = {
+  magic: 0,
+  secureVersion: 4,
+  version: 16,
+  projectName: 48,
+  time: 80,
+  date: 96,
+  idfVer: 112,
+  appElfSha256: 144,
+} as const;
+
+const SLOT_LENS = {
+  version: 32,
+  projectName: 32,
+  time: 16,
+  date: 16,
+  idfVer: 32,
+} as const;
+
+function writeFixedString(buf: Buffer, off: number, len: number, str: string): void {
+  const encoded = Buffer.from(str, 'utf8');
+  if (encoded.length >= len) {
+    throw new Error(
+      `test fixture string too long: '${str}' (${encoded.length} bytes) for ${len}-byte slot`,
+    );
+  }
+  encoded.copy(buf, off);
+  // Trailing null terminator + remaining tail bytes are already 0
+  // because Buffer.alloc zero-fills.
+}
+
+function makeAppDescBuffer(opts: FixtureOpts = {}): Buffer {
+  const {
+    magic = ESP_APP_DESC_MAGIC,
+    secureVersion = 0,
+    version = '1.4.0',
+    projectName = 'astros-esp',
+    time = '12:00:00',
+    date = '2026-01-01',
+    idfVer = 'v5.0.0',
+    appElfSha256 = Buffer.alloc(32),
+    size = ESP_APP_DESC_OFFSET + ESP_APP_DESC_SIZE,
+  } = opts;
+
+  const buf = Buffer.alloc(size);
+  if (size < ESP_APP_DESC_OFFSET + ESP_APP_DESC_SIZE) {
+    return buf;
+  }
+
+  const base = ESP_APP_DESC_OFFSET;
+  buf.writeUInt32LE(magic >>> 0, base + SLOT_OFFSETS.magic);
+  buf.writeUInt32LE(secureVersion >>> 0, base + SLOT_OFFSETS.secureVersion);
+  writeFixedString(buf, base + SLOT_OFFSETS.version, SLOT_LENS.version, version);
+  writeFixedString(buf, base + SLOT_OFFSETS.projectName, SLOT_LENS.projectName, projectName);
+  writeFixedString(buf, base + SLOT_OFFSETS.time, SLOT_LENS.time, time);
+  writeFixedString(buf, base + SLOT_OFFSETS.date, SLOT_LENS.date, date);
+  writeFixedString(buf, base + SLOT_OFFSETS.idfVer, SLOT_LENS.idfVer, idfVer);
+  appElfSha256.copy(buf, base + SLOT_OFFSETS.appElfSha256, 0, 32);
+  return buf;
+}
+
+describe('parseEspAppDesc', () => {
+  it('returns the parsed struct for a valid binary', () => {
+    const sha = Buffer.alloc(32);
+    sha.fill(0xaa);
+    const buf = makeAppDescBuffer({
+      projectName: 'astros-esp',
+      version: '1.4.0',
+      idfVer: 'v5.1.2',
+      appElfSha256: sha,
+    });
+
+    const desc = parseEspAppDesc(buf);
+
+    expect(desc.magicWord).toBe(ESP_APP_DESC_MAGIC);
+    expect(desc.projectName).toBe('astros-esp');
+    expect(desc.version).toBe('1.4.0');
+    expect(desc.idfVer).toBe('v5.1.2');
+    expect(desc.appElfSha256.length).toBe(32);
+    expect(desc.appElfSha256.equals(sha)).toBe(true);
+  });
+
+  it('throws on wrong magic word', () => {
+    const buf = makeAppDescBuffer({ magic: 0x00000000 });
+    expect(() => parseEspAppDesc(buf)).toThrow(/magic/i);
+  });
+
+  it('throws when the buffer is shorter than the minimum required length', () => {
+    const buf = Buffer.alloc(100);
+    expect(() => parseEspAppDesc(buf)).toThrow(/short/i);
+  });
+
+  it('throws when project_name has no null terminator within its slot', () => {
+    const buf = makeAppDescBuffer();
+    // Fill all 32 bytes of the project_name slot with non-zero bytes.
+    buf.fill(
+      0x41,
+      ESP_APP_DESC_OFFSET + SLOT_OFFSETS.projectName,
+      ESP_APP_DESC_OFFSET + SLOT_OFFSETS.projectName + SLOT_LENS.projectName,
+    );
+
+    expect(() => parseEspAppDesc(buf)).toThrow(/null terminator/i);
+  });
+
+  it('truncates the version field at an embedded null mid-string', () => {
+    const buf = makeAppDescBuffer({ version: '1.4.0' });
+    // Overwrite the version slot with "1.4\x00.0" + zeros — the bytes after
+    // the embedded null are printable ASCII (not control chars) so they
+    // pass the slot scan and we expect truncate-at-null to yield '1.4'.
+    const off = ESP_APP_DESC_OFFSET + SLOT_OFFSETS.version;
+    buf.fill(0, off, off + SLOT_LENS.version);
+    Buffer.from('1.4', 'utf8').copy(buf, off);
+    Buffer.from('.0', 'utf8').copy(buf, off + 4);
+
+    const desc = parseEspAppDesc(buf);
+
+    expect(desc.version).toBe('1.4');
+  });
+
+  it('throws when a string field has a control char before the null', () => {
+    const buf = makeAppDescBuffer({ version: '1.4.0' });
+    // Replace the second byte of the version slot with 0x01.
+    buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.version + 1] = 0x01;
+
+    expect(() => parseEspAppDesc(buf)).toThrow(/control/i);
+  });
+
+  it('throws when a string field has a control char in the unused tail', () => {
+    const buf = makeAppDescBuffer({ version: '1.4.0' });
+    // The version slot has 'v','1','.','4','.','0', null at index 5,
+    // then zeros. Plant a 0x01 at slot offset 10 — well after the null,
+    // in territory that would normally be don't-care.
+    buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.version + 10] = 0x01;
+
+    expect(() => parseEspAppDesc(buf)).toThrow(/control/i);
+  });
+
+  it('throws on non-UTF-8 bytes in a string field', () => {
+    const buf = makeAppDescBuffer();
+    const off = ESP_APP_DESC_OFFSET + SLOT_OFFSETS.version;
+    buf.fill(0, off, off + SLOT_LENS.version);
+    buf[off] = 0xff;
+    buf[off + 1] = 0xff;
+    // byte at off+2 stays 0 (null terminator).
+
+    expect(() => parseEspAppDesc(buf)).toThrow(/utf-8/i);
+  });
+
+  it('reads secureVersion as uint32 little-endian', () => {
+    const buf = makeAppDescBuffer({ secureVersion: 0x12345678 });
+    const desc = parseEspAppDesc(buf);
+
+    expect(desc.secureVersion).toBe(0x12345678);
+    // Byte-order sanity check: LSB at the lowest offset.
+    expect(buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.secureVersion]).toBe(0x78);
+    expect(buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.secureVersion + 1]).toBe(0x56);
+    expect(buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.secureVersion + 2]).toBe(0x34);
+    expect(buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.secureVersion + 3]).toBe(0x12);
+  });
+
+  it('exposes ESP_APP_DESC_MAGIC = 0xABCD5432', () => {
+    expect(ESP_APP_DESC_MAGIC).toBe(0xabcd5432);
+  });
+
+  it('returns appElfSha256 as a defensive copy (mutation of source does not affect result)', () => {
+    const sha = Buffer.alloc(32);
+    sha.fill(0xaa);
+    const buf = makeAppDescBuffer({ appElfSha256: sha });
+
+    const desc = parseEspAppDesc(buf);
+    // Mutate the source buffer at the sha offset; parsed field should be unaffected.
+    buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.appElfSha256] = 0xbb;
+
+    expect(desc.appElfSha256[0]).toBe(0xaa);
+  });
+});

--- a/astros_api/src/firmware/esp_app_desc.test.ts
+++ b/astros_api/src/firmware/esp_app_desc.test.ts
@@ -155,6 +155,29 @@ describe('parseEspAppDesc', () => {
     expect(() => parseEspAppDesc(buf)).toThrow(/control/i);
   });
 
+  it('throws when a string field has DEL (0x7F)', () => {
+    // DEL is a single-byte ASCII control char that sits outside the
+    // C0 range [0x01, 0x1F] historically. Reject it explicitly so the
+    // tampered-binary defense covers all single-byte control chars,
+    // not just the contiguous low range.
+    const buf = makeAppDescBuffer({ version: '1.4.0' });
+    buf[ESP_APP_DESC_OFFSET + SLOT_OFFSETS.version + 1] = 0x7f;
+
+    expect(() => parseEspAppDesc(buf)).toThrow(/control/i);
+  });
+
+  it('accepts legitimate multi-byte UTF-8 with C1-range continuation bytes', () => {
+    // Regression guard: bytes 0x80-0x9F appear inside valid UTF-8
+    // continuation sequences (e.g. `é` is encoded as 0xC3 0xA9, where
+    // 0xA9 falls in the C1 range). The parser must NOT reject these
+    // at the byte level — only invalid sequences should fail, via the
+    // strict-mode UTF-8 decoder.
+    const buf = makeAppDescBuffer({ idfVer: 'release-é-v5' });
+    const desc = parseEspAppDesc(buf);
+
+    expect(desc.idfVer).toBe('release-é-v5');
+  });
+
   it('throws on non-UTF-8 bytes in a string field', () => {
     const buf = makeAppDescBuffer();
     const off = ESP_APP_DESC_OFFSET + SLOT_OFFSETS.version;

--- a/astros_api/src/firmware/esp_app_desc.ts
+++ b/astros_api/src/firmware/esp_app_desc.ts
@@ -1,12 +1,10 @@
 import type { EspAppDesc } from '../models/firmware/upload.js';
 
-// `esp_app_desc_t` is a fixed-layout struct ESP-IDF embeds at the head of
-// every application image. We use it to identify uploaded firmware
-// binaries: confirm they're for our project, extract the version. The
-// struct sits immediately after the image header (24 B) + first segment
-// header (8 B), so its byte offset inside the .bin is 32. Layout has
-// been stable since ESP-IDF v4.0; if a future release rearranges,
-// adjust the constants below.
+// `esp_app_desc_t` is a fixed-layout struct ESP-IDF embeds at the head
+// of every application image, immediately after the 24-byte image
+// header + 8-byte first-segment header. Layout has been stable since
+// ESP-IDF v4.0; adjust the constants below if a future release
+// rearranges.
 
 export const ESP_IMAGE_HEADER_SIZE = 24;
 export const ESP_IMAGE_SEGMENT_HEADER_SIZE = 8;
@@ -36,27 +34,21 @@ const DATE_LEN = 16;
 const IDF_VER_LEN = 32;
 const APP_ELF_SHA256_LEN = 32;
 
-// Strict-mode UTF-8 decoder rejects invalid byte sequences (e.g.
-// 0xFF 0xFF) instead of silently substituting U+FFFD, which would let
-// a tampered binary pass validation.
+// Strict mode rejects invalid byte sequences (e.g. raw 0xFF 0xFF)
+// instead of silently substituting U+FFFD, which would let a tampered
+// binary pass.
 const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
-// Reads one fixed-length string slot at `off`. Rules:
-//   1. The slot must contain at least one 0x00 byte (the null terminator).
-//   2. No byte in the slot may be a single-byte ASCII control char:
-//      C0 range [0x01, 0x1F] or DEL (0x7F). These are unambiguously
-//      control chars at the byte level — they have no role inside
-//      multi-byte UTF-8 sequences. C1 range [0x80, 0x9F] is NOT
-//      rejected here because those byte values appear naturally inside
-//      legitimate UTF-8 sequences (every continuation byte is 0x80-0xBF,
-//      so e.g. `é` is 0xC3 0xA9); rejecting them at the byte level
-//      would false-positive on every accented character. The strict-
-//      UTF-8 decoder below catches *invalid* sequences containing
-//      those bytes — that's the right tool for the C1 range.
-//      Bytes after the null are normally "don't-care" tail, but ESP-IDF
-//      zero-fills these and a tampered binary that smuggles control
-//      chars into the tail is exactly what this scan defends against.
-//   3. The prefix-before-null must be valid UTF-8 under strict mode.
+// Decodes one fixed-length null-terminated string slot. Rejects:
+//   - missing null terminator within the slot
+//   - any single-byte ASCII control char (C0 [0x01-0x1F] or DEL 0x7F)
+//     anywhere in the slot, *including the unused tail* — defends
+//     against tampered binaries that smuggle control bytes after the
+//     null
+//   - invalid UTF-8 in the prefix
+// The C1 range [0x80, 0x9F] is intentionally NOT rejected at the byte
+// level: those values are legitimate UTF-8 continuation bytes (e.g.
+// `é` = 0xC3 0xA9). Strict UTF-8 catches the invalid-sequence case.
 function readFixedString(buf: Buffer, off: number, len: number, fieldName: string): string {
   const slot = buf.subarray(off, off + len);
   for (let i = 0; i < slot.length; i += 1) {
@@ -79,10 +71,8 @@ function readFixedString(buf: Buffer, off: number, len: number, fieldName: strin
   }
 }
 
-// Decodes the `esp_app_desc_t` struct from the head of an ESP-IDF
-// application image. Caller is responsible for reading at least
-// `MIN_BUFFER_LEN` bytes from the file; we don't ever need the whole
-// 1.2 MB binary in memory just to identify it.
+// Caller is responsible for reading at least MIN_BUFFER_LEN bytes —
+// we never need the whole 1.2 MB binary in memory just to identify it.
 export function parseEspAppDesc(buf: Buffer): EspAppDesc {
   if (buf.length < MIN_BUFFER_LEN) {
     throw new Error(
@@ -104,7 +94,7 @@ export function parseEspAppDesc(buf: Buffer): EspAppDesc {
   const time = readFixedString(buf, base + F_TIME, TIME_LEN, 'time');
   const date = readFixedString(buf, base + F_DATE, DATE_LEN, 'date');
   const idfVer = readFixedString(buf, base + F_IDF_VER, IDF_VER_LEN, 'idf_ver');
-  // Copy out so later mutation of `buf` can't silently change the parsed result.
+  // Defensive copy — slicing would alias the input buffer.
   const appElfSha256 = Buffer.from(
     buf.subarray(base + F_APP_ELF_SHA256, base + F_APP_ELF_SHA256 + APP_ELF_SHA256_LEN),
   );

--- a/astros_api/src/firmware/esp_app_desc.ts
+++ b/astros_api/src/firmware/esp_app_desc.ts
@@ -43,17 +43,25 @@ const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
 // Reads one fixed-length string slot at `off`. Rules:
 //   1. The slot must contain at least one 0x00 byte (the null terminator).
-//   2. No byte in the slot may be in [0x01, 0x1F]. Bytes after the null
-//      are normally "don't-care" tail, but ESP-IDF zero-fills these and a
-//      tampered binary that smuggles control chars into the tail is the
-//      kind of thing we want to reject — the trip-on-any-control-char
-//      rule covers both prefix and tail with one scan.
+//   2. No byte in the slot may be a single-byte ASCII control char:
+//      C0 range [0x01, 0x1F] or DEL (0x7F). These are unambiguously
+//      control chars at the byte level — they have no role inside
+//      multi-byte UTF-8 sequences. C1 range [0x80, 0x9F] is NOT
+//      rejected here because those byte values appear naturally inside
+//      legitimate UTF-8 sequences (every continuation byte is 0x80-0xBF,
+//      so e.g. `é` is 0xC3 0xA9); rejecting them at the byte level
+//      would false-positive on every accented character. The strict-
+//      UTF-8 decoder below catches *invalid* sequences containing
+//      those bytes — that's the right tool for the C1 range.
+//      Bytes after the null are normally "don't-care" tail, but ESP-IDF
+//      zero-fills these and a tampered binary that smuggles control
+//      chars into the tail is exactly what this scan defends against.
 //   3. The prefix-before-null must be valid UTF-8 under strict mode.
 function readFixedString(buf: Buffer, off: number, len: number, fieldName: string): string {
   const slot = buf.subarray(off, off + len);
   for (let i = 0; i < slot.length; i += 1) {
     const b = slot[i];
-    if (b > 0 && b < 0x20) {
+    if ((b > 0 && b < 0x20) || b === 0x7f) {
       throw new Error(
         `esp_app_desc ${fieldName}: control byte 0x${b.toString(16).padStart(2, '0')} at slot offset ${i}`,
       );

--- a/astros_api/src/firmware/esp_app_desc.ts
+++ b/astros_api/src/firmware/esp_app_desc.ts
@@ -1,0 +1,105 @@
+import type { EspAppDesc } from '../models/firmware/upload.js';
+
+// `esp_app_desc_t` is a fixed-layout struct ESP-IDF embeds at the head of
+// every application image. We use it to identify uploaded firmware
+// binaries: confirm they're for our project, extract the version. The
+// struct sits immediately after the image header (24 B) + first segment
+// header (8 B), so its byte offset inside the .bin is 32. Layout has
+// been stable since ESP-IDF v4.0; if a future release rearranges,
+// adjust the constants below.
+
+export const ESP_IMAGE_HEADER_SIZE = 24;
+export const ESP_IMAGE_SEGMENT_HEADER_SIZE = 8;
+export const ESP_APP_DESC_OFFSET = ESP_IMAGE_HEADER_SIZE + ESP_IMAGE_SEGMENT_HEADER_SIZE;
+export const ESP_APP_DESC_SIZE = 256;
+export const ESP_APP_DESC_MAGIC = 0xabcd5432;
+
+const MIN_BUFFER_LEN = ESP_APP_DESC_OFFSET + ESP_APP_DESC_SIZE;
+
+// Field offsets inside the `esp_app_desc_t` struct (relative to the
+// struct's start, not the image's start — caller adds ESP_APP_DESC_OFFSET).
+const F_MAGIC = 0;
+const F_SECURE_VERSION = 4;
+// reserv1 occupies bytes 8..16 — unused
+const F_VERSION = 16;
+const F_PROJECT_NAME = 48;
+const F_TIME = 80;
+const F_DATE = 96;
+const F_IDF_VER = 112;
+const F_APP_ELF_SHA256 = 144;
+// reserv2 occupies bytes 176..256 — unused
+
+const VERSION_LEN = 32;
+const PROJECT_NAME_LEN = 32;
+const TIME_LEN = 16;
+const DATE_LEN = 16;
+const IDF_VER_LEN = 32;
+const APP_ELF_SHA256_LEN = 32;
+
+// Strict-mode UTF-8 decoder rejects invalid byte sequences (e.g.
+// 0xFF 0xFF) instead of silently substituting U+FFFD, which would let
+// a tampered binary pass validation.
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+// Reads one fixed-length string slot at `off`. Rules:
+//   1. The slot must contain at least one 0x00 byte (the null terminator).
+//   2. No byte in the slot may be in [0x01, 0x1F]. Bytes after the null
+//      are normally "don't-care" tail, but ESP-IDF zero-fills these and a
+//      tampered binary that smuggles control chars into the tail is the
+//      kind of thing we want to reject — the trip-on-any-control-char
+//      rule covers both prefix and tail with one scan.
+//   3. The prefix-before-null must be valid UTF-8 under strict mode.
+function readFixedString(buf: Buffer, off: number, len: number, fieldName: string): string {
+  const slot = buf.subarray(off, off + len);
+  for (let i = 0; i < slot.length; i += 1) {
+    const b = slot[i];
+    if (b > 0 && b < 0x20) {
+      throw new Error(
+        `esp_app_desc ${fieldName}: control byte 0x${b.toString(16).padStart(2, '0')} at slot offset ${i}`,
+      );
+    }
+  }
+  const nullIdx = slot.indexOf(0);
+  if (nullIdx === -1) {
+    throw new Error(`esp_app_desc ${fieldName}: no null terminator within ${len}-byte slot`);
+  }
+  const prefix = slot.subarray(0, nullIdx);
+  try {
+    return utf8Decoder.decode(prefix);
+  } catch {
+    throw new Error(`esp_app_desc ${fieldName}: invalid UTF-8 sequence in slot`);
+  }
+}
+
+// Decodes the `esp_app_desc_t` struct from the head of an ESP-IDF
+// application image. Caller is responsible for reading at least
+// `MIN_BUFFER_LEN` bytes from the file; we don't ever need the whole
+// 1.2 MB binary in memory just to identify it.
+export function parseEspAppDesc(buf: Buffer): EspAppDesc {
+  if (buf.length < MIN_BUFFER_LEN) {
+    throw new Error(
+      `esp_app_desc buffer too short: got ${buf.length} bytes, need at least ${MIN_BUFFER_LEN}`,
+    );
+  }
+
+  const base = ESP_APP_DESC_OFFSET;
+  const magicWord = buf.readUInt32LE(base + F_MAGIC);
+  if (magicWord !== ESP_APP_DESC_MAGIC) {
+    throw new Error(
+      `esp_app_desc magic word mismatch: got 0x${magicWord.toString(16)}, expected 0x${ESP_APP_DESC_MAGIC.toString(16)}`,
+    );
+  }
+
+  const secureVersion = buf.readUInt32LE(base + F_SECURE_VERSION);
+  const version = readFixedString(buf, base + F_VERSION, VERSION_LEN, 'version');
+  const projectName = readFixedString(buf, base + F_PROJECT_NAME, PROJECT_NAME_LEN, 'project_name');
+  const time = readFixedString(buf, base + F_TIME, TIME_LEN, 'time');
+  const date = readFixedString(buf, base + F_DATE, DATE_LEN, 'date');
+  const idfVer = readFixedString(buf, base + F_IDF_VER, IDF_VER_LEN, 'idf_ver');
+  // Copy out so later mutation of `buf` can't silently change the parsed result.
+  const appElfSha256 = Buffer.from(
+    buf.subarray(base + F_APP_ELF_SHA256, base + F_APP_ELF_SHA256 + APP_ELF_SHA256_LEN),
+  );
+
+  return { magicWord, secureVersion, version, projectName, time, date, idfVer, appElfSha256 };
+}

--- a/astros_api/src/firmware/firmware_cache.ts
+++ b/astros_api/src/firmware/firmware_cache.ts
@@ -9,6 +9,7 @@ import { logger } from '../logger.js';
 import type { CachedAsset, CachedAssetMeta } from '../models/firmware/cache.js';
 import type { AssetInfo, ReleaseInfo } from '../models/firmware/release.js';
 import { compareVersions } from '../utility/semver.js';
+import { assertPathSafe } from './path_safety.js';
 
 // On-disk firmware cache. Materializes -app.bin assets onto local disk,
 // stream-hashes during download, and prunes to N=5 releases. See the c.4
@@ -32,24 +33,6 @@ const MAX_RELEASES = 5;
 // `crypto.createHash('sha256').digest('hex')` is 64 lowercase hex chars.
 // Anything else in a .bin.sha256 means corruption — treat as a miss.
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
-
-// Allowlist for `version`/`variant` interpolated into cache filenames.
-// First char alphanumeric (forbids leading-dot hidden files and
-// leading-hyphen flag lookalikes); body allows the chars real semver and
-// PlatformIO env names use — '.' for version dots, '-' for pre-release
-// labels (1.2.0-RC.1), '+' for build metadata (1.0.0+build.123), '_' for
-// variant underscores (lolin_d32_pro). Excludes path separators, drive
-// letters, parent refs, embedded nulls. Upstream c.3 captures version as
-// `(.+)` so this is the only guard for it; variant is defense-in-depth.
-const PATH_SAFE_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
-
-function assertPathSafe(value: string, kind: 'version' | 'variant'): void {
-  if (!PATH_SAFE_RE.test(value)) {
-    throw new Error(
-      `Invalid firmware ${kind} for cache path: ${JSON.stringify(value)} contains characters that aren't filename-safe`,
-    );
-  }
-}
 
 // User-Agent is required by GitHub's CDN; Accept is omitted because asset
 // download isn't a v3 API call.

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -152,6 +152,29 @@ describe('FirmwareUploadStore.latest()', () => {
     expect(await store.latest()).toBeNull();
   });
 
+  it('returns null (does not throw) for a meta filename whose id starts with a dash', async () => {
+    // Regression guard: pre-fix UPLOAD_META_RE accepted `[0-9a-f-]{36}`
+    // which matched ids beginning with `-`, then assertPathSafe inside
+    // pathsFor() rejected the leading dash and threw outside the inner
+    // try/catch — `latest()` would propagate the throw instead of
+    // returning null per the documented contract. Tightened regex now
+    // enforces canonical UUID v4 positional structure (8-4-4-4-12) so
+    // the malformed name is filtered out before pathsFor() runs.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    // 36-char id with leading dash + 35 hex/dashes — would have
+    // matched the old regex but fails assertPathSafe.
+    const malformedName = 'upload--aaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa.meta.json';
+    fs.writeFileSync(path.join(uploadsDir, malformedName), '{}');
+    fs.writeFileSync(
+      path.join(uploadsDir, malformedName.replace(/\.meta\.json$/, '.bin')),
+      Buffer.alloc(100),
+    );
+
+    // Must not throw; must return null.
+    expect(await store.latest()).toBeNull();
+  });
+
   it('returns null when meta.json uploadId disagrees with the filename uuid', async () => {
     // Simulates corruption / manual `cp` of a sidecar from another
     // upload — filename says one uuid, JSON content says another.

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -331,6 +331,63 @@ describe('FirmwareUploadStore.store()', () => {
     expect(fs.existsSync(tempPath)).toBe(false);
   });
 
+  it('unlinks tempPath when the stream-hash phase fails mid-read (EIO simulated)', async () => {
+    // Reviewer-flagged scenario: pre-fix, a createReadStream / for-await
+    // failure exited store() before the rollback block, leaving the temp
+    // file orphaned. Now wrapped in the post-parse try/catch.
+    const bin = makeFirmwareBytes();
+    const tempPath = writeTempBin(tempDir, bin, 'hash-fail.tmp');
+
+    const realCreate = fs.createReadStream.bind(fs);
+    vi.spyOn(fs, 'createReadStream').mockImplementation(((
+      target: Parameters<typeof fs.createReadStream>[0],
+      opts?: Parameters<typeof fs.createReadStream>[1],
+    ) => {
+      const stream = realCreate(target, opts);
+      // Asynchronously emit an error after the stream starts producing data.
+      process.nextTick(() =>
+        stream.destroy(Object.assign(new Error('EIO: simulated'), { code: 'EIO' })),
+      );
+      return stream;
+    }) as typeof fs.createReadStream);
+
+    await expect(store.store(tempPath, 'hash-fail.bin')).rejects.toThrow(/EIO/);
+
+    expect(fs.existsSync(tempPath)).toBe(false);
+    const uploadsDir = path.join(rootDir, 'uploads');
+    if (fs.existsSync(uploadsDir)) {
+      expect(fs.readdirSync(uploadsDir)).toEqual([]);
+    }
+  });
+
+  it('unlinks tempPath when mkdir throws EACCES', async () => {
+    // Reviewer-flagged scenario: pre-fix, mkdir failures bypassed the
+    // persist-phase try/catch and leaked the temp file. Now covered.
+    const bin = makeFirmwareBytes();
+    const tempPath = writeTempBin(tempDir, bin, 'mkdir-fail.tmp');
+
+    vi.spyOn(fsp, 'mkdir').mockImplementation(async () => {
+      throw Object.assign(new Error('EACCES: simulated'), { code: 'EACCES' });
+    });
+
+    await expect(store.store(tempPath, 'mkdir-fail.bin')).rejects.toThrow(/EACCES/);
+
+    expect(fs.existsSync(tempPath)).toBe(false);
+  });
+
+  it('unlinks tempPath on validation failure (project_name mismatch)', async () => {
+    // Post-fix contract: once parse succeeds, store() owns the temp
+    // file's fate regardless of why the rest failed. Validation
+    // rejection consumes the temp file rather than leaving it for the
+    // route layer to clean up.
+    const badBin = makeFirmwareBytes({ projectName: 'evil-esp', version: '1.0.0' });
+    const badTempPath = writeTempBin(tempDir, badBin, 'val-fail.tmp');
+
+    await expect(store.store(badTempPath, 'val-fail.bin')).rejects.toThrow(/project name/i);
+
+    expect(fs.existsSync(badTempPath)).toBe(false);
+  });
+
   it('rolls back cleanly when rename throws EACCES (temp file unlinked, uploads dir empty)', async () => {
     const bin = makeFirmwareBytes();
     const tempPath = writeTempBin(tempDir, bin, 'rename-fail.tmp');

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -363,6 +363,46 @@ describe('FirmwareUploadStore.store()', () => {
     expect(fs.existsSync(badTempPath)).toBe(false);
   });
 
+  it('wipes malformed siblings whose ids/extensions fall outside the canonical UUID + lowercase shape', async () => {
+    // Regression guard: ANY_UPLOAD_FILE_RE used to be `[0-9a-f-]+`
+    // which left files like `upload-FOOBAR.bin` (non-hex id) or
+    // `upload-abc.BIN` (uppercase extension from a case-insensitive fs)
+    // orphaned forever. Wipe pass must catch these so the documented
+    // "single-slot" guarantee actually holds in operator/manual
+    // intervention scenarios.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    const malformedPaths = [
+      'upload-FOOBAR.bin', // non-hex id
+      'upload-FOOBAR.bin.sha256',
+      'upload-FOOBAR.meta.json',
+      'upload-abc123.BIN', // uppercase extension
+      'upload-Mixed-CASE-id.meta.json',
+    ];
+    for (const name of malformedPaths) {
+      fs.writeFileSync(path.join(uploadsDir, name), 'stale content');
+    }
+
+    // A successful store should run the wipe pass and clear everything
+    // matching upload-*.{bin,bin.sha256,meta.json} — including the
+    // malformed siblings.
+    const bin = makeFirmwareBytes({ version: '1.0.0' });
+    const tempPath = writeTempBin(tempDir, bin, 'fresh.tmp');
+    const result = await store.store(tempPath, 'fresh.bin');
+
+    const remaining = fs.readdirSync(uploadsDir).sort();
+    expect(remaining).toEqual(
+      [
+        `upload-${result.meta.uploadId}.bin`,
+        `upload-${result.meta.uploadId}.bin.sha256`,
+        `upload-${result.meta.uploadId}.meta.json`,
+      ].sort(),
+    );
+    for (const name of malformedPaths) {
+      expect(fs.existsSync(path.join(uploadsDir, name))).toBe(false);
+    }
+  });
+
   it('replaces a prior upload triple atomically', async () => {
     // First upload.
     const firstBin = makeFirmwareBytes({ version: '1.0.0' });

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -856,7 +856,7 @@ describe('FirmwareUploadStore — multiple meta files race-safety', () => {
 });
 
 describe('FirmwareUploadStore — multiple meta files', () => {
-  it('latest() picks the most-recently-mtime`d when multiple meta files exist', async () => {
+  it("latest() picks the most-recently-mtime'd when multiple meta files exist", async () => {
     const uploadsDir = path.join(rootDir, 'uploads');
     fs.mkdirSync(uploadsDir);
 

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -637,6 +637,91 @@ describe('FirmwareUploadStore — project_name', () => {
   });
 });
 
+describe('FirmwareUploadStore — concurrent store() serialization', () => {
+  it('serializes two concurrent store() calls so the final state is deterministic', async () => {
+    // Without the in-flight chain, A.rename followed by B's wipe pass
+    // could unlink A.bin between A's rename and A's writeFile(sha),
+    // leaving A claiming success on a missing bin. With the chain,
+    // A's full sequence completes before B starts, so B's wipe sees
+    // A's complete triple and replaces it cleanly. JS evaluation
+    // order on Promise.all guarantees A's chain link is taken first,
+    // so B = the second writer = wins.
+    const binA = makeFirmwareBytes({ version: '1.0.0' });
+    const binB = makeFirmwareBytes({ version: '2.0.0' });
+    const tempA = writeTempBin(tempDir, binA, 'A.tmp');
+    const tempB = writeTempBin(tempDir, binB, 'B.tmp');
+
+    const [resultA, resultB] = await Promise.all([
+      store.store(tempA, 'A.bin'),
+      store.store(tempB, 'B.bin'),
+    ]);
+
+    // Both calls reported success with their own metadata.
+    expect(resultA.meta.version).toBe('1.0.0');
+    expect(resultB.meta.version).toBe('2.0.0');
+
+    // Final on-disk state is exactly B's triple — A's was wiped by
+    // B's wipe pass after A had fully completed.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    const entries = fs.readdirSync(uploadsDir).sort();
+    expect(entries).toEqual(
+      [
+        `upload-${resultB.meta.uploadId}.bin`,
+        `upload-${resultB.meta.uploadId}.bin.sha256`,
+        `upload-${resultB.meta.uploadId}.meta.json`,
+      ].sort(),
+    );
+
+    // latest() returns B; A's bin and sidecars are gone.
+    const last = await store.latest();
+    expect(last?.meta.uploadId).toBe(resultB.meta.uploadId);
+    expect(last?.meta.version).toBe('2.0.0');
+    expect(fs.existsSync(resultA.path)).toBe(false);
+  });
+
+  it('does not deadlock when a prior store() rejects', async () => {
+    // The in-flight chain swallows rejections on the field pointer so
+    // a single failure can't poison subsequent calls.
+    const badBin = makeFirmwareBytes({ projectName: 'evil-esp', version: '1.0.0' });
+    const badTemp = writeTempBin(tempDir, badBin, 'bad.tmp');
+    await expect(store.store(badTemp, 'bad.bin')).rejects.toThrow(/project name/i);
+
+    // Subsequent store should succeed — chain is unblocked.
+    const goodBin = makeFirmwareBytes({ version: '2.0.0' });
+    const goodTemp = writeTempBin(tempDir, goodBin, 'good.tmp');
+    const result = await store.store(goodTemp, 'good.bin');
+
+    expect(result.meta.version).toBe('2.0.0');
+    const last = await store.latest();
+    expect(last?.meta.uploadId).toBe(result.meta.uploadId);
+  });
+
+  it('does not deadlock when concurrent calls include a rejection', async () => {
+    // A rejects (bad project), B and C are valid. B and C should both
+    // complete. B is queued before C, so C's wipe replaces B; latest
+    // is C.
+    const badBin = makeFirmwareBytes({ projectName: 'evil-esp', version: '0.0.0' });
+    const binB = makeFirmwareBytes({ version: '1.0.0' });
+    const binC = makeFirmwareBytes({ version: '2.0.0' });
+    const badTemp = writeTempBin(tempDir, badBin, 'bad.tmp');
+    const tempB = writeTempBin(tempDir, binB, 'B.tmp');
+    const tempC = writeTempBin(tempDir, binC, 'C.tmp');
+
+    const [aResult, bResult, cResult] = await Promise.allSettled([
+      store.store(badTemp, 'bad.bin'),
+      store.store(tempB, 'B.bin'),
+      store.store(tempC, 'C.bin'),
+    ]);
+
+    expect(aResult.status).toBe('rejected');
+    expect(bResult.status).toBe('fulfilled');
+    expect(cResult.status).toBe('fulfilled');
+
+    const last = await store.latest();
+    expect(last?.meta.version).toBe('2.0.0');
+  });
+});
+
 describe('FirmwareUploadStore — multiple meta files race-safety', () => {
   // Reviewer-flagged scenario: between readdir and stat, a meta file
   // could be deleted (concurrent store()'s wipe pass) or become

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -257,17 +257,34 @@ describe('FirmwareUploadStore.store()', () => {
     expect(stillThere?.meta.version).toBe('1.0.0');
   });
 
-  it('rejects when binary is shorter than the esp_app_desc minimum', async () => {
+  it('rejects when binary is shorter than the esp_app_desc minimum and consumes tempPath', async () => {
     const tinyTempPath = writeTempBin(tempDir, Buffer.alloc(100), 'tiny.tmp');
 
     await expect(store.store(tinyTempPath, 'tiny.bin')).rejects.toThrow(/short/i);
+    // Public contract: store() unconditionally consumes tempPath, even
+    // on parse-phase failures.
+    expect(fs.existsSync(tinyTempPath)).toBe(false);
   });
 
-  it('rejects when esp_app_desc magic word is wrong', async () => {
+  it('rejects when esp_app_desc magic word is wrong and consumes tempPath', async () => {
     const badBin = makeFirmwareBytes({ magic: 0x00000000 });
     const badTempPath = writeTempBin(tempDir, badBin, 'badmagic.tmp');
 
     await expect(store.store(badTempPath, 'bad.bin')).rejects.toThrow(/magic/i);
+    expect(fs.existsSync(badTempPath)).toBe(false);
+  });
+
+  it('rejects when parseEspAppDesc throws on a string-slot violation and consumes tempPath', async () => {
+    // Plant a binary whose project_name slot has no null terminator —
+    // parseEspAppDesc throws with a /null terminator/ error. This
+    // exercises the parse-throw path (distinct from the magic-word
+    // mismatch above), confirming the unconditional cleanup contract.
+    const bin = makeFirmwareBytes();
+    bin.fill(0x41, ESP_APP_DESC_OFFSET + 48, ESP_APP_DESC_OFFSET + 48 + 32);
+    const badTempPath = writeTempBin(tempDir, bin, 'unterminated.tmp');
+
+    await expect(store.store(badTempPath, 'bad.bin')).rejects.toThrow(/null terminator/i);
+    expect(fs.existsSync(badTempPath)).toBe(false);
   });
 
   it('replaces a prior upload triple atomically', async () => {

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -53,7 +53,7 @@ function makeHeader(opts: AppDescOpts = {}): Buffer {
   const {
     magic = ESP_APP_DESC_MAGIC,
     version = '1.4.0',
-    projectName = 'astros-esp',
+    projectName = 'AstrOs.ESP',
     time = '12:00:00',
     date = '2026-01-01',
     idfVer = 'v5.0.0',
@@ -101,7 +101,10 @@ beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fw-upload-test-'));
   rootDir = path.join(tempDir, 'firmware-cache');
   fs.mkdirSync(rootDir, { recursive: true });
-  store = new FirmwareUploadStore({ rootDir, expectedProjectName: 'astros-esp' });
+  // No `expectedProjectName` override — tests verify the real default
+  // (`AstrOs.ESP`, matching what ESP-IDF embeds from CMakeLists.txt's
+  // `project()` call).
+  store = new FirmwareUploadStore({ rootDir });
 });
 
 afterEach(() => {
@@ -166,7 +169,7 @@ describe('FirmwareUploadStore.latest()', () => {
 
 describe('FirmwareUploadStore.store()', () => {
   it('happy path: writes the full triple at expected paths and returns StoredUpload', async () => {
-    const bin = makeFirmwareBytes({ version: '1.4.0', projectName: 'astros-esp' });
+    const bin = makeFirmwareBytes({ version: '1.4.0' });
     const tempPath = writeTempBin(tempDir, bin);
     const expectedSha = sha256Hex(bin);
 
@@ -176,7 +179,7 @@ describe('FirmwareUploadStore.store()', () => {
     expect(result.sizeBytes).toBe(bin.length);
     expect(result.meta.uploadId).toMatch(/^[0-9a-f-]{36}$/);
     expect(result.meta.originalFilename).toBe('firmware-rc1.bin');
-    expect(result.meta.projectName).toBe('astros-esp');
+    expect(result.meta.projectName).toBe('AstrOs.ESP');
     expect(result.meta.version).toBe('1.4.0');
     expect(result.meta.sizeBytes).toBe(bin.length);
 
@@ -428,6 +431,85 @@ describe('FirmwareUploadStore.store()', () => {
   });
 });
 
+describe('FirmwareUploadStore — esp_app_desc.version normalization', () => {
+  // ESP-IDF embeds `git describe --tags --dirty` into esp_app_desc.version
+  // by default. Real example from a dev build: "v1.0.0-RC.1-71-g9a55936-dirty".
+  // The store strips the leading `v` and the trailing `-<N>-g<sha>(-dirty)?`
+  // suffix so the persisted meta.version matches the clean semver shape that
+  // GitHub-release filenames produce — c.6's orchestrator can compare the two
+  // without per-source casing.
+
+  it('normalizes a dirty dev build: v1.0.0-RC.1-71-g9a55936-dirty → 1.0.0-RC.1', async () => {
+    const bin = makeFirmwareBytes({ version: 'v1.0.0-RC.1-71-g9a55936-dirty' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    const result = await store.store(tempPath, 'dev.bin');
+
+    expect(result.meta.version).toBe('1.0.0-RC.1');
+  });
+
+  it('normalizes a tag-clean off-tag build: v1.0.0-0-gabc12345 → 1.0.0', async () => {
+    const bin = makeFirmwareBytes({ version: 'v1.0.0-0-gabc12345' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    const result = await store.store(tempPath, 'tag.bin');
+
+    expect(result.meta.version).toBe('1.0.0');
+  });
+
+  it('strips only the v prefix when no git-describe suffix is present: v1.4.0 → 1.4.0', async () => {
+    const bin = makeFirmwareBytes({ version: 'v1.4.0' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    const result = await store.store(tempPath, 'tag.bin');
+
+    expect(result.meta.version).toBe('1.4.0');
+  });
+
+  it('passes already-clean semver through unchanged: 1.0.0-RC.3 → 1.0.0-RC.3', async () => {
+    const bin = makeFirmwareBytes({ version: '1.0.0-RC.3' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    const result = await store.store(tempPath, 'clean.bin');
+
+    expect(result.meta.version).toBe('1.0.0-RC.3');
+  });
+
+  it('still rejects a version that remains unparseable after normalization', async () => {
+    // No leading `v`, no git-describe suffix to strip — `garbage` stays
+    // `garbage` and fails the semver check.
+    const bin = makeFirmwareBytes({ version: 'garbage' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    await expect(store.store(tempPath, 'bad.bin')).rejects.toThrow(/version/i);
+  });
+
+  it('does not strip a pre-release label that resembles a git-describe suffix on its own', async () => {
+    // `1.0.0-dev.71` — the `dev.71` portion has digits but no `-g<sha>`,
+    // so the suffix regex doesn't match. Version passes through cleanly.
+    const bin = makeFirmwareBytes({ version: '1.0.0-dev.71' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    const result = await store.store(tempPath, 'devN.bin');
+
+    expect(result.meta.version).toBe('1.0.0-dev.71');
+  });
+});
+
+describe('FirmwareUploadStore — project_name', () => {
+  it('rejects a binary whose embedded project_name is `astros-esp` (filename prefix, not the embedded value)', async () => {
+    // c.5 finding: the asset-filename prefix `astros-esp-…-app.bin` is set
+    // by CI tooling, but the EMBEDDED project_name from CMake's project()
+    // call is `AstrOs.ESP`. A binary mistakenly claiming `astros-esp` in
+    // its esp_app_desc must be rejected — it's not what AstrOs.ESP CI
+    // produces.
+    const bin = makeFirmwareBytes({ projectName: 'astros-esp', version: '1.0.0' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    await expect(store.store(tempPath, 'wrong.bin')).rejects.toThrow(/project name/i);
+  });
+});
+
 describe('FirmwareUploadStore — multiple meta files', () => {
   it('latest() picks the most-recently-mtime`d when multiple meta files exist', async () => {
     const uploadsDir = path.join(rootDir, 'uploads');
@@ -444,7 +526,7 @@ describe('FirmwareUploadStore — multiple meta files', () => {
       const meta: StoredUploadMeta = {
         uploadId: id,
         originalFilename: 'firmware.bin',
-        projectName: 'astros-esp',
+        projectName: 'AstrOs.ESP',
         version: id === oldId ? '1.0.0' : '2.0.0',
         uploadedAt: new Date().toISOString(),
         sizeBytes: bin.length,

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -152,6 +152,25 @@ describe('FirmwareUploadStore.latest()', () => {
     expect(await store.latest()).toBeNull();
   });
 
+  it('returns null for a meta filename whose id has the right shape but wrong v4/variant nibbles', async () => {
+    // The id below has correct 8-4-4-4-12 hex structure but the
+    // version nibble is `1` (not `4`) and the variant nibble is `0`
+    // (not in [8,9,a,b]) — so it's not a uuid v4. UPLOAD_META_RE
+    // enforces the v4-specific nibbles, so latest() filters this
+    // out as inconsistent state rather than treating it as a real
+    // upload.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    const nonV4Name = 'upload-12345678-1234-1234-0234-123456789abc.meta.json';
+    fs.writeFileSync(path.join(uploadsDir, nonV4Name), '{}');
+    fs.writeFileSync(
+      path.join(uploadsDir, nonV4Name.replace(/\.meta\.json$/, '.bin')),
+      Buffer.alloc(100),
+    );
+
+    expect(await store.latest()).toBeNull();
+  });
+
   it('returns null (does not throw) for a meta filename whose id starts with a dash', async () => {
     // Regression guard: pre-fix UPLOAD_META_RE accepted `[0-9a-f-]{36}`
     // which matched ids beginning with `-`, then assertPathSafe inside

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -172,13 +172,10 @@ describe('FirmwareUploadStore.latest()', () => {
   });
 
   it('returns null (does not throw) for a meta filename whose id starts with a dash', async () => {
-    // Regression guard: pre-fix UPLOAD_META_RE accepted `[0-9a-f-]{36}`
-    // which matched ids beginning with `-`, then assertPathSafe inside
-    // pathsFor() rejected the leading dash and threw outside the inner
-    // try/catch — `latest()` would propagate the throw instead of
-    // returning null per the documented contract. Tightened regex now
-    // enforces canonical UUID v4 positional structure (8-4-4-4-12) so
-    // the malformed name is filtered out before pathsFor() runs.
+    // Names matching the meta-file pattern but failing assertPathSafe
+    // (leading dash) must be filtered out by UPLOAD_META_RE — pathsFor
+    // runs outside the inner try/catch, so a throw here would escape
+    // latest()'s null-miss contract.
     const uploadsDir = path.join(rootDir, 'uploads');
     fs.mkdirSync(uploadsDir);
     // 36-char id with leading dash + 35 hex/dashes — would have
@@ -484,9 +481,9 @@ describe('FirmwareUploadStore.store()', () => {
   });
 
   it('unlinks tempPath when the stream-hash phase fails mid-read (EIO simulated)', async () => {
-    // Reviewer-flagged scenario: pre-fix, a createReadStream / for-await
-    // failure exited store() before the rollback block, leaving the temp
-    // file orphaned. Now wrapped in the post-parse try/catch.
+    // Stream errors must trigger the rollback — otherwise the temp
+    // file orphans, since express-fileupload's tempfiles aren't auto-
+    // cleaned on the route layer's failure path.
     const bin = makeFirmwareBytes();
     const tempPath = writeTempBin(tempDir, bin, 'hash-fail.tmp');
 
@@ -513,8 +510,8 @@ describe('FirmwareUploadStore.store()', () => {
   });
 
   it('unlinks tempPath when mkdir throws EACCES', async () => {
-    // Reviewer-flagged scenario: pre-fix, mkdir failures bypassed the
-    // persist-phase try/catch and leaked the temp file. Now covered.
+    // mkdir runs after parse + hash but before the persist sequence;
+    // its failure path must still consume the temp file.
     const bin = makeFirmwareBytes();
     const tempPath = writeTempBin(tempDir, bin, 'mkdir-fail.tmp');
 
@@ -805,11 +802,10 @@ describe('FirmwareUploadStore — concurrent store() serialization', () => {
 });
 
 describe('FirmwareUploadStore — multiple meta files race-safety', () => {
-  // Reviewer-flagged scenario: between readdir and stat, a meta file
-  // could be deleted (concurrent store()'s wipe pass) or become
-  // unreadable. Per-stat failures must not reject the whole batch —
-  // the contract is "any partial state → null miss" and individual
-  // stats are wrapped so the survivors are still considered.
+  // Per-stat failures must not reject the whole batch — between readdir
+  // and stat, a concurrent store()'s wipe pass can delete a meta file.
+  // The contract is "any partial state → null miss"; individual stats
+  // are wrapped so survivors are still considered.
 
   function plantTriple(uploadsDir: string, id: string, version: string): Buffer {
     const bin = makeFirmwareBytes({ version });

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import crypto from 'crypto';
+import fs, { promises as fsp } from 'fs';
+import os from 'os';
+import path from 'path';
+import { FirmwareUploadStore } from './firmware_upload_store.js';
+import { ESP_APP_DESC_OFFSET, ESP_APP_DESC_SIZE, ESP_APP_DESC_MAGIC } from './esp_app_desc.js';
+import type { StoredUploadMeta } from '../models/firmware/upload.js';
+
+// --- esp_app_desc fixture helpers (mirror the ones used in
+// esp_app_desc.test.ts; kept local rather than exported because the
+// shape of the helper is test-only and changing it shouldn't propagate). ---
+
+const SLOT_OFFSETS = {
+  magic: 0,
+  secureVersion: 4,
+  version: 16,
+  projectName: 48,
+  time: 80,
+  date: 96,
+  idfVer: 112,
+  appElfSha256: 144,
+} as const;
+
+const SLOT_LENS = {
+  version: 32,
+  projectName: 32,
+  time: 16,
+  date: 16,
+  idfVer: 32,
+} as const;
+
+interface AppDescOpts {
+  magic?: number;
+  version?: string;
+  projectName?: string;
+  time?: string;
+  date?: string;
+  idfVer?: string;
+}
+
+function writeFixedString(buf: Buffer, off: number, len: number, str: string): void {
+  const encoded = Buffer.from(str, 'utf8');
+  if (encoded.length >= len) {
+    throw new Error(
+      `test fixture string too long: '${str}' (${encoded.length}) for ${len}-byte slot`,
+    );
+  }
+  encoded.copy(buf, off);
+}
+
+function makeHeader(opts: AppDescOpts = {}): Buffer {
+  const {
+    magic = ESP_APP_DESC_MAGIC,
+    version = '1.4.0',
+    projectName = 'astros-esp',
+    time = '12:00:00',
+    date = '2026-01-01',
+    idfVer = 'v5.0.0',
+  } = opts;
+  const buf = Buffer.alloc(ESP_APP_DESC_OFFSET + ESP_APP_DESC_SIZE);
+  const base = ESP_APP_DESC_OFFSET;
+  buf.writeUInt32LE(magic >>> 0, base + SLOT_OFFSETS.magic);
+  buf.writeUInt32LE(0, base + SLOT_OFFSETS.secureVersion);
+  writeFixedString(buf, base + SLOT_OFFSETS.version, SLOT_LENS.version, version);
+  writeFixedString(buf, base + SLOT_OFFSETS.projectName, SLOT_LENS.projectName, projectName);
+  writeFixedString(buf, base + SLOT_OFFSETS.time, SLOT_LENS.time, time);
+  writeFixedString(buf, base + SLOT_OFFSETS.date, SLOT_LENS.date, date);
+  writeFixedString(buf, base + SLOT_OFFSETS.idfVer, SLOT_LENS.idfVer, idfVer);
+  return buf;
+}
+
+// Builds a synthetic .bin: valid header + N bytes of body.
+function makeFirmwareBytes(
+  opts: AppDescOpts & { bodyBytes?: number; bodyFill?: number } = {},
+): Buffer {
+  const { bodyBytes = 1024, bodyFill = 0xcc } = opts;
+  const head = makeHeader(opts);
+  const body = Buffer.alloc(bodyBytes);
+  body.fill(bodyFill);
+  return Buffer.concat([head, body]);
+}
+
+function writeTempBin(tempDir: string, contents: Buffer, basename = 'upload.tmp'): string {
+  const filepath = path.join(tempDir, basename);
+  fs.writeFileSync(filepath, contents);
+  return filepath;
+}
+
+function sha256Hex(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+// --- Test setup ---
+
+let tempDir: string;
+let rootDir: string;
+let store: FirmwareUploadStore;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fw-upload-test-'));
+  rootDir = path.join(tempDir, 'firmware-cache');
+  fs.mkdirSync(rootDir, { recursive: true });
+  store = new FirmwareUploadStore({ rootDir, expectedProjectName: 'astros-esp' });
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('FirmwareUploadStore.latest()', () => {
+  it('returns null on cold cache (no uploads dir yet)', async () => {
+    expect(await store.latest()).toBeNull();
+  });
+
+  it('returns null when uploads dir exists but is empty', async () => {
+    fs.mkdirSync(path.join(rootDir, 'uploads'));
+    expect(await store.latest()).toBeNull();
+  });
+
+  it('returns null when only some sidecar files exist (interrupted prior write)', async () => {
+    // Plant a .bin + .sha256 but no .meta.json — looks like a crash
+    // between sha-write and meta-write.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    const fakeId = '11111111-1111-4111-8111-111111111111';
+    fs.writeFileSync(path.join(uploadsDir, `upload-${fakeId}.bin`), Buffer.alloc(100));
+    fs.writeFileSync(
+      path.join(uploadsDir, `upload-${fakeId}.bin.sha256`),
+      sha256Hex(Buffer.alloc(100)),
+    );
+    // No .meta.json.
+
+    expect(await store.latest()).toBeNull();
+  });
+
+  it('returns null when .meta.json is malformed JSON', async () => {
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    const fakeId = '22222222-2222-4222-8222-222222222222';
+    fs.writeFileSync(path.join(uploadsDir, `upload-${fakeId}.bin`), Buffer.alloc(100));
+    fs.writeFileSync(
+      path.join(uploadsDir, `upload-${fakeId}.bin.sha256`),
+      sha256Hex(Buffer.alloc(100)),
+    );
+    fs.writeFileSync(path.join(uploadsDir, `upload-${fakeId}.meta.json`), '{not json');
+
+    expect(await store.latest()).toBeNull();
+  });
+
+  it('returns null when meta.json parses but is missing required fields', async () => {
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    const fakeId = '33333333-3333-4333-8333-333333333333';
+    fs.writeFileSync(path.join(uploadsDir, `upload-${fakeId}.bin`), Buffer.alloc(100));
+    fs.writeFileSync(
+      path.join(uploadsDir, `upload-${fakeId}.bin.sha256`),
+      sha256Hex(Buffer.alloc(100)),
+    );
+    fs.writeFileSync(path.join(uploadsDir, `upload-${fakeId}.meta.json`), '{}');
+
+    expect(await store.latest()).toBeNull();
+  });
+});
+
+describe('FirmwareUploadStore.store()', () => {
+  it('happy path: writes the full triple at expected paths and returns StoredUpload', async () => {
+    const bin = makeFirmwareBytes({ version: '1.4.0', projectName: 'astros-esp' });
+    const tempPath = writeTempBin(tempDir, bin);
+    const expectedSha = sha256Hex(bin);
+
+    const result = await store.store(tempPath, 'firmware-rc1.bin');
+
+    expect(result.sha256).toBe(expectedSha);
+    expect(result.sizeBytes).toBe(bin.length);
+    expect(result.meta.uploadId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(result.meta.originalFilename).toBe('firmware-rc1.bin');
+    expect(result.meta.projectName).toBe('astros-esp');
+    expect(result.meta.version).toBe('1.4.0');
+    expect(result.meta.sizeBytes).toBe(bin.length);
+
+    // All three files exist.
+    expect(fs.existsSync(result.path)).toBe(true);
+    expect(fs.existsSync(`${result.path}.sha256`)).toBe(true);
+    const metaPath = result.path.replace(/\.bin$/, '.meta.json');
+    expect(fs.existsSync(metaPath)).toBe(true);
+
+    // Sidecar contents match what was returned.
+    const onDiskSha = fs.readFileSync(`${result.path}.sha256`, 'utf8').trim();
+    expect(onDiskSha).toBe(expectedSha);
+
+    const onDiskMeta = JSON.parse(fs.readFileSync(metaPath, 'utf8')) as StoredUploadMeta;
+    expect(onDiskMeta).toEqual(result.meta);
+
+    // Sha sidecar must match a fresh hash of the bin on disk too —
+    // catches off-by-one / partial-write bugs.
+    const reHash = sha256Hex(fs.readFileSync(result.path));
+    expect(reHash).toBe(expectedSha);
+  });
+
+  it('consumes the temp file (no orphan after success)', async () => {
+    const bin = makeFirmwareBytes();
+    const tempPath = writeTempBin(tempDir, bin);
+
+    await store.store(tempPath, 'firmware.bin');
+
+    expect(fs.existsSync(tempPath)).toBe(false);
+  });
+
+  it('after success, latest() returns the same StoredUpload', async () => {
+    const bin = makeFirmwareBytes({ version: '1.4.0' });
+    const tempPath = writeTempBin(tempDir, bin);
+
+    const stored = await store.store(tempPath, 'firmware.bin');
+    const loaded = await store.latest();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded?.path).toBe(stored.path);
+    expect(loaded?.sha256).toBe(stored.sha256);
+    expect(loaded?.sizeBytes).toBe(stored.sizeBytes);
+    expect(loaded?.meta).toEqual(stored.meta);
+  });
+
+  it('rejects when project_name does not match expectedProjectName; prior upload preserved', async () => {
+    // Pre-populate a prior upload.
+    const priorBin = makeFirmwareBytes({ version: '1.0.0' });
+    await store.store(writeTempBin(tempDir, priorBin, 'prior.tmp'), 'prior.bin');
+    const priorLatest = await store.latest();
+    expect(priorLatest).not.toBeNull();
+
+    // Try an upload with a wrong project_name.
+    const badBin = makeFirmwareBytes({ projectName: 'evil-esp', version: '9.9.9' });
+    const badTempPath = writeTempBin(tempDir, badBin, 'bad.tmp');
+
+    await expect(store.store(badTempPath, 'bad.bin')).rejects.toThrow(/project name/i);
+
+    // Prior upload still intact.
+    const stillThere = await store.latest();
+    expect(stillThere?.meta.version).toBe('1.0.0');
+    expect(stillThere?.meta.uploadId).toBe(priorLatest?.meta.uploadId);
+  });
+
+  it('rejects when version is unparseable; prior upload preserved', async () => {
+    const priorBin = makeFirmwareBytes({ version: '1.0.0' });
+    await store.store(writeTempBin(tempDir, priorBin, 'prior.tmp'), 'prior.bin');
+
+    const badBin = makeFirmwareBytes({ version: 'latest' }); // no x.y.z prefix
+    const badTempPath = writeTempBin(tempDir, badBin, 'bad.tmp');
+
+    await expect(store.store(badTempPath, 'bad.bin')).rejects.toThrow(/version/i);
+
+    const stillThere = await store.latest();
+    expect(stillThere?.meta.version).toBe('1.0.0');
+  });
+
+  it('rejects when binary is shorter than the esp_app_desc minimum', async () => {
+    const tinyTempPath = writeTempBin(tempDir, Buffer.alloc(100), 'tiny.tmp');
+
+    await expect(store.store(tinyTempPath, 'tiny.bin')).rejects.toThrow(/short/i);
+  });
+
+  it('rejects when esp_app_desc magic word is wrong', async () => {
+    const badBin = makeFirmwareBytes({ magic: 0x00000000 });
+    const badTempPath = writeTempBin(tempDir, badBin, 'badmagic.tmp');
+
+    await expect(store.store(badTempPath, 'bad.bin')).rejects.toThrow(/magic/i);
+  });
+
+  it('replaces a prior upload triple atomically', async () => {
+    // First upload.
+    const firstBin = makeFirmwareBytes({ version: '1.0.0' });
+    const firstPath = writeTempBin(tempDir, firstBin, 'first.tmp');
+    const first = await store.store(firstPath, 'v1.bin');
+
+    // Second upload.
+    const secondBin = makeFirmwareBytes({ version: '2.0.0' });
+    const secondPath = writeTempBin(tempDir, secondBin, 'second.tmp');
+    const second = await store.store(secondPath, 'v2.bin');
+
+    // First triple is gone.
+    expect(fs.existsSync(first.path)).toBe(false);
+    expect(fs.existsSync(`${first.path}.sha256`)).toBe(false);
+    expect(fs.existsSync(first.path.replace(/\.bin$/, '.meta.json'))).toBe(false);
+
+    // Second triple is present.
+    expect(fs.existsSync(second.path)).toBe(true);
+    const latest = await store.latest();
+    expect(latest?.meta.version).toBe('2.0.0');
+    expect(latest?.meta.uploadId).toBe(second.meta.uploadId);
+
+    // Uploads dir contains exactly the second triple.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    const remaining = fs.readdirSync(uploadsDir);
+    expect(remaining.sort()).toEqual(
+      [
+        `upload-${second.meta.uploadId}.bin`,
+        `upload-${second.meta.uploadId}.bin.sha256`,
+        `upload-${second.meta.uploadId}.meta.json`,
+      ].sort(),
+    );
+  });
+
+  it('rolls back cleanly when writeFile(.sha256) throws (uploads dir empty)', async () => {
+    const bin = makeFirmwareBytes();
+    const tempPath = writeTempBin(tempDir, bin, 'will-fail.tmp');
+
+    const realWriteFile = fsp.writeFile.bind(fsp);
+    vi.spyOn(fsp, 'writeFile').mockImplementation((async (
+      file: Parameters<typeof fsp.writeFile>[0],
+      data: Parameters<typeof fsp.writeFile>[1],
+      opts?: Parameters<typeof fsp.writeFile>[2],
+    ) => {
+      if (typeof file === 'string' && file.endsWith('.bin.sha256')) {
+        throw Object.assign(new Error('ENOSPC: simulated'), { code: 'ENOSPC' });
+      }
+      return realWriteFile(file, data, opts);
+    }) as typeof fsp.writeFile);
+
+    await expect(store.store(tempPath, 'firmware.bin')).rejects.toThrow(/ENOSPC/);
+
+    // Uploads dir empty (or doesn't exist).
+    const uploadsDir = path.join(rootDir, 'uploads');
+    if (fs.existsSync(uploadsDir)) {
+      expect(fs.readdirSync(uploadsDir)).toEqual([]);
+    }
+    // Temp file unlinked.
+    expect(fs.existsSync(tempPath)).toBe(false);
+  });
+
+  it('rolls back cleanly when rename throws EACCES (temp file unlinked, uploads dir empty)', async () => {
+    const bin = makeFirmwareBytes();
+    const tempPath = writeTempBin(tempDir, bin, 'rename-fail.tmp');
+
+    vi.spyOn(fsp, 'rename').mockImplementation(async () => {
+      throw Object.assign(new Error('EACCES: simulated'), { code: 'EACCES' });
+    });
+
+    await expect(store.store(tempPath, 'firmware.bin')).rejects.toThrow(/EACCES/);
+
+    expect(fs.existsSync(tempPath)).toBe(false);
+    const uploadsDir = path.join(rootDir, 'uploads');
+    if (fs.existsSync(uploadsDir)) {
+      expect(fs.readdirSync(uploadsDir)).toEqual([]);
+    }
+  });
+
+  it('crash-recovery invariant: at each sidecar writeFile, .bin is fresh or absent (never stale)', async () => {
+    // Pre-populate prior upload with distinguishable bytes.
+    const priorBin = makeFirmwareBytes({ version: '1.0.0', bodyFill: 0xaa });
+    await store.store(writeTempBin(tempDir, priorBin, 'prior.tmp'), 'prior.bin');
+    const priorLatest = await store.latest();
+    expect(priorLatest).not.toBeNull();
+
+    // Capture the new bytes we're about to upload.
+    const freshBin = makeFirmwareBytes({ version: '2.0.0', bodyFill: 0xbb });
+    const freshTemp = writeTempBin(tempDir, freshBin, 'fresh.tmp');
+
+    // Snapshot the on-disk .bin contents at every writeFile call to a
+    // sidecar — the bin must be either the fresh bytes (rename done)
+    // or absent (somehow not yet promoted), but never the stale prior.
+    const realWriteFile = fsp.writeFile.bind(fsp);
+    const snapshots: Array<{ called: string; binState: 'fresh' | 'absent' | 'other' }> = [];
+
+    vi.spyOn(fsp, 'writeFile').mockImplementation((async (
+      file: Parameters<typeof fsp.writeFile>[0],
+      data: Parameters<typeof fsp.writeFile>[1],
+      opts?: Parameters<typeof fsp.writeFile>[2],
+    ) => {
+      if (
+        typeof file === 'string' &&
+        (file.endsWith('.bin.sha256') || file.endsWith('.meta.json'))
+      ) {
+        // The sibling .bin path is derivable from the sidecar path.
+        const binPath = file.replace(/\.(bin\.sha256|meta\.json)$/, '.bin');
+        let state: 'fresh' | 'absent' | 'other' = 'absent';
+        try {
+          // Sync read captures bytes at this exact point in the
+          // async sequence — no other awaits can interleave.
+          const onDisk = fs.readFileSync(binPath);
+          if (onDisk.equals(freshBin)) state = 'fresh';
+          else state = 'other';
+        } catch {
+          state = 'absent';
+        }
+        snapshots.push({ called: file, binState: state });
+      }
+      return realWriteFile(file, data, opts);
+    }) as typeof fsp.writeFile);
+
+    await store.store(freshTemp, 'fresh.bin');
+
+    // At least one snapshot was taken (sha + meta = 2 expected).
+    expect(snapshots.length).toBeGreaterThan(0);
+    for (const snap of snapshots) {
+      expect(snap.binState).not.toBe('other');
+    }
+  });
+
+  it('rolling back persist failure leaves no orphan files in uploads dir', async () => {
+    // Pre-populate a prior upload.
+    const priorBin = makeFirmwareBytes({ version: '1.0.0' });
+    await store.store(writeTempBin(tempDir, priorBin, 'prior.tmp'), 'prior.bin');
+
+    // Now fail persist on the meta.json write — sha256 already landed
+    // when this fires, so rollback must clean both sidecars + the bin.
+    const realWriteFile = fsp.writeFile.bind(fsp);
+    vi.spyOn(fsp, 'writeFile').mockImplementation((async (
+      file: Parameters<typeof fsp.writeFile>[0],
+      data: Parameters<typeof fsp.writeFile>[1],
+      opts?: Parameters<typeof fsp.writeFile>[2],
+    ) => {
+      if (typeof file === 'string' && file.endsWith('.meta.json')) {
+        throw Object.assign(new Error('ENOSPC: simulated'), { code: 'ENOSPC' });
+      }
+      return realWriteFile(file, data, opts);
+    }) as typeof fsp.writeFile);
+
+    const newBin = makeFirmwareBytes({ version: '2.0.0' });
+    const newPath = writeTempBin(tempDir, newBin, 'new.tmp');
+    await expect(store.store(newPath, 'new.bin')).rejects.toThrow(/ENOSPC/);
+
+    // Uploads dir is empty (the wipe pass took out the prior, persist
+    // partially landed sha + bin, rollback cleaned them).
+    const uploadsDir = path.join(rootDir, 'uploads');
+    expect(fs.readdirSync(uploadsDir)).toEqual([]);
+    expect(fs.existsSync(newPath)).toBe(false);
+  });
+});
+
+describe('FirmwareUploadStore — multiple meta files', () => {
+  it('latest() picks the most-recently-mtime`d when multiple meta files exist', async () => {
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+
+    const oldId = '44444444-4444-4444-8444-444444444444';
+    const newId = '55555555-5555-4555-8555-555555555555';
+
+    // Plant two complete triples on disk by hand.
+    for (const id of [oldId, newId]) {
+      const bin = makeFirmwareBytes({ version: id === oldId ? '1.0.0' : '2.0.0' });
+      fs.writeFileSync(path.join(uploadsDir, `upload-${id}.bin`), bin);
+      fs.writeFileSync(path.join(uploadsDir, `upload-${id}.bin.sha256`), sha256Hex(bin));
+      const meta: StoredUploadMeta = {
+        uploadId: id,
+        originalFilename: 'firmware.bin',
+        projectName: 'astros-esp',
+        version: id === oldId ? '1.0.0' : '2.0.0',
+        uploadedAt: new Date().toISOString(),
+        sizeBytes: bin.length,
+      };
+      fs.writeFileSync(path.join(uploadsDir, `upload-${id}.meta.json`), JSON.stringify(meta));
+    }
+
+    // Force the "newId" meta file to be newest by mtime.
+    const oldTime = new Date('2020-01-01').getTime() / 1000;
+    const newTime = new Date('2026-01-01').getTime() / 1000;
+    fs.utimesSync(path.join(uploadsDir, `upload-${oldId}.meta.json`), oldTime, oldTime);
+    fs.utimesSync(path.join(uploadsDir, `upload-${newId}.meta.json`), newTime, newTime);
+
+    const result = await store.latest();
+    expect(result?.meta.uploadId).toBe(newId);
+    expect(result?.meta.version).toBe('2.0.0');
+  });
+});

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -567,6 +567,76 @@ describe('FirmwareUploadStore — project_name', () => {
   });
 });
 
+describe('FirmwareUploadStore — multiple meta files race-safety', () => {
+  // Reviewer-flagged scenario: between readdir and stat, a meta file
+  // could be deleted (concurrent store()'s wipe pass) or become
+  // unreadable. Per-stat failures must not reject the whole batch —
+  // the contract is "any partial state → null miss" and individual
+  // stats are wrapped so the survivors are still considered.
+
+  function plantTriple(uploadsDir: string, id: string, version: string): Buffer {
+    const bin = makeFirmwareBytes({ version });
+    fs.writeFileSync(path.join(uploadsDir, `upload-${id}.bin`), bin);
+    fs.writeFileSync(path.join(uploadsDir, `upload-${id}.bin.sha256`), sha256Hex(bin));
+    const meta: StoredUploadMeta = {
+      uploadId: id,
+      originalFilename: 'firmware.bin',
+      projectName: 'AstrOs.ESP',
+      version,
+      uploadedAt: new Date().toISOString(),
+      sizeBytes: bin.length,
+    };
+    fs.writeFileSync(path.join(uploadsDir, `upload-${id}.meta.json`), JSON.stringify(meta));
+    return bin;
+  }
+
+  it('skips a meta file whose stat fails and returns the surviving newest', async () => {
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+
+    const goneId = '66666666-6666-4666-8666-666666666666';
+    const liveId = '77777777-7777-4777-8777-777777777777';
+    plantTriple(uploadsDir, goneId, '1.0.0');
+    plantTriple(uploadsDir, liveId, '2.0.0');
+
+    // Mock stat to throw ENOENT for the "gone" meta file (simulating a
+    // race where another process deleted it between readdir and stat).
+    const realStat = fsp.stat.bind(fsp);
+    vi.spyOn(fsp, 'stat').mockImplementation((async (target: Parameters<typeof fsp.stat>[0]) => {
+      if (typeof target === 'string' && target.includes(goneId) && target.endsWith('.meta.json')) {
+        throw Object.assign(new Error('ENOENT: simulated race'), { code: 'ENOENT' });
+      }
+      return realStat(target);
+    }) as typeof fsp.stat);
+
+    const result = await store.latest();
+
+    expect(result).not.toBeNull();
+    expect(result?.meta.uploadId).toBe(liveId);
+    expect(result?.meta.version).toBe('2.0.0');
+  });
+
+  it('returns null when every meta-file stat fails (full wipe race)', async () => {
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    plantTriple(uploadsDir, '88888888-8888-4888-8888-888888888888', '1.0.0');
+    plantTriple(uploadsDir, '99999999-9999-4999-8999-999999999999', '2.0.0');
+
+    // All stats throw — simulates the dir being wiped between readdir
+    // and the stat batch (or a permissions issue affecting all entries).
+    const realStat = fsp.stat.bind(fsp);
+    vi.spyOn(fsp, 'stat').mockImplementation((async (target: Parameters<typeof fsp.stat>[0]) => {
+      if (typeof target === 'string' && target.endsWith('.meta.json')) {
+        throw Object.assign(new Error('ENOENT: simulated'), { code: 'ENOENT' });
+      }
+      return realStat(target);
+    }) as typeof fsp.stat);
+
+    const result = await store.latest();
+    expect(result).toBeNull();
+  });
+});
+
 describe('FirmwareUploadStore — multiple meta files', () => {
   it('latest() picks the most-recently-mtime`d when multiple meta files exist', async () => {
     const uploadsDir = path.join(rootDir, 'uploads');

--- a/astros_api/src/firmware/firmware_upload_store.test.ts
+++ b/astros_api/src/firmware/firmware_upload_store.test.ts
@@ -152,6 +152,59 @@ describe('FirmwareUploadStore.latest()', () => {
     expect(await store.latest()).toBeNull();
   });
 
+  it('returns null when meta.json uploadId disagrees with the filename uuid', async () => {
+    // Simulates corruption / manual `cp` of a sidecar from another
+    // upload — filename says one uuid, JSON content says another.
+    // Returning the JSON's metadata alongside the filename's bin/sha
+    // would mislead the orchestrator about which upload is being
+    // flashed.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    const filenameId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const jsonId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const bin = Buffer.alloc(100);
+    fs.writeFileSync(path.join(uploadsDir, `upload-${filenameId}.bin`), bin);
+    fs.writeFileSync(path.join(uploadsDir, `upload-${filenameId}.bin.sha256`), sha256Hex(bin));
+    const wrongMeta: StoredUploadMeta = {
+      uploadId: jsonId,
+      originalFilename: 'firmware.bin',
+      projectName: 'AstrOs.ESP',
+      version: '1.0.0',
+      uploadedAt: new Date().toISOString(),
+      sizeBytes: bin.length,
+    };
+    fs.writeFileSync(
+      path.join(uploadsDir, `upload-${filenameId}.meta.json`),
+      JSON.stringify(wrongMeta),
+    );
+
+    expect(await store.latest()).toBeNull();
+  });
+
+  it('returns null when meta.json sizeBytes disagrees with the bin size on disk', async () => {
+    // Simulates partial-write recovery or external truncation — the
+    // sidecar describes a 1024-byte upload but the .bin on disk is
+    // only 100 bytes. Returning meta whose sizeBytes contradicts the
+    // actual binary would mislead callers comparing sizes downstream.
+    const uploadsDir = path.join(rootDir, 'uploads');
+    fs.mkdirSync(uploadsDir);
+    const id = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+    const realBin = Buffer.alloc(100);
+    fs.writeFileSync(path.join(uploadsDir, `upload-${id}.bin`), realBin);
+    fs.writeFileSync(path.join(uploadsDir, `upload-${id}.bin.sha256`), sha256Hex(realBin));
+    const staleMeta: StoredUploadMeta = {
+      uploadId: id,
+      originalFilename: 'firmware.bin',
+      projectName: 'AstrOs.ESP',
+      version: '1.0.0',
+      uploadedAt: new Date().toISOString(),
+      sizeBytes: 1024, // stale — disagrees with realBin.length === 100
+    };
+    fs.writeFileSync(path.join(uploadsDir, `upload-${id}.meta.json`), JSON.stringify(staleMeta));
+
+    expect(await store.latest()).toBeNull();
+  });
+
   it('returns null when meta.json parses but is missing required fields', async () => {
     const uploadsDir = path.join(rootDir, 'uploads');
     fs.mkdirSync(uploadsDir);

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -278,6 +278,20 @@ export class FirmwareUploadStore {
       if (!SHA256_HEX_RE.test(sha256)) return null;
       const parsed: unknown = JSON.parse(metaText);
       if (!isValidUploadMeta(parsed)) return null;
+      // Cross-check the triple is internally consistent. Each file is
+      // individually well-formed by this point, but corruption / manual
+      // sidecar copy could leave them describing different uploads:
+      //   - meta.uploadId !== filename-derived uploadId means a sidecar
+      //     was renamed or copied from another entry (would mislead the
+      //     orchestrator about which upload is being flashed).
+      //   - meta.sizeBytes !== binStat.size means meta is stale relative
+      //     to the bin (e.g. external truncate, partial-write recovery
+      //     that left mismatched siblings). Cheap proxy for "the bin we
+      //     have is the bin meta describes" — re-hashing here would be
+      //     stronger but costs ~80–100 ms per call (same trade-off c.4
+      //     made for its sidecar-trust stance).
+      if (parsed.uploadId !== uploadId) return null;
+      if (parsed.sizeBytes !== binStat.size) return null;
       return { path: p.bin, sha256, sizeBytes: binStat.size, meta: parsed };
     } catch {
       // ENOENT, EACCES, malformed JSON — all map to miss so callers

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -58,9 +58,16 @@ const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 // regardless of shape.)
 const UPLOAD_META_RE =
   /^upload-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.meta\.json$/;
-// Used by the wipe pass to find any prior upload triple regardless of
-// uuid (the new uuid is fresh; the old one is whatever was there).
-const ANY_UPLOAD_FILE_RE = /^upload-[0-9a-f-]+\.(?:bin|bin\.sha256|meta\.json)$/;
+// Used by the wipe pass to find any prior upload sibling regardless
+// of shape. Intentionally broader than UPLOAD_META_RE: must cover
+// every name that read paths could plausibly reject as malformed
+// (uppercase hex from a case-insensitive fs, mixed-case manual
+// rename, non-hex chars from operator intervention) so those files
+// can't orphan forever. `.+` between `upload-` and the extension
+// list accepts any non-empty basename body — readdir guarantees
+// these are basenames, so no path-separator risk. Extension list
+// is case-insensitive (Windows / macOS HFS+ can yield `.BIN` etc.).
+const ANY_UPLOAD_FILE_RE = /^upload-.+\.(?:bin|bin\.sha256|meta\.json)$/i;
 
 export interface FirmwareUploadStoreOptions {
   rootDir?: string;

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -46,8 +46,18 @@ function normalizeEspVersion(raw: string): string {
 }
 
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
-// uuid v4 is 36 chars: 8-4-4-4-12 hex with dashes.
-const UPLOAD_META_RE = /^upload-([0-9a-f-]{36})\.meta\.json$/;
+// Canonical uuid v4 shape: 8-4-4-4-12 hex with dashes at fixed
+// positions. The earlier `[0-9a-f-]{36}` form was over-permissive —
+// it accepted strings like `upload--abc...` (leading dash) which then
+// failed `assertPathSafe` inside `pathsFor()`, throwing through
+// `latest()`'s outer scope instead of returning null per the
+// "any inconsistent state → null miss" contract. Pinning the
+// positional structure means `latest()` only ever feeds well-shaped
+// uuids to `pathsFor()`. (`ANY_UPLOAD_FILE_RE` below is
+// intentionally broader — wipe should sweep any `upload-*` sibling
+// regardless of shape.)
+const UPLOAD_META_RE =
+  /^upload-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.meta\.json$/;
 // Used by the wipe pass to find any prior upload triple regardless of
 // uuid (the new uuid is fresh; the old one is whatever was there).
 const ANY_UPLOAD_FILE_RE = /^upload-[0-9a-f-]+\.(?:bin|bin\.sha256|meta\.json)$/;

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -116,9 +116,15 @@ export class FirmwareUploadStore {
   // full file, then atomically promotes it into the single upload slot.
   // Validation failures (bad project, unparseable version) throw before
   // the wipe pass runs, so a rejected upload never destroys the
-  // previously-stored firmware. Persist-phase failures DO wipe the
-  // prior triple — by design, a half-completed store leaves the slot
-  // empty rather than mixing old and new state.
+  // previously-stored firmware. Persist-phase failures attempt to
+  // leave the slot empty: the wipe pass runs first, then the rollback
+  // unlinks the new triple. **Both are best-effort.** The wipe pass
+  // logs and swallows non-ENOENT unlink errors (EACCES/EBUSY can
+  // legitimately occur on Windows or under hostile fs perms), so a
+  // failed store() can leave the prior triple, the new triple's
+  // partial state, or both on disk. latest() treats any inconsistent
+  // or orphan combination as a null miss via its uuid + sizeBytes
+  // cross-checks; the next successful store retries the wipe pass.
   //
   // **Public contract:** `store()` unconditionally consumes `tempPath`.
   // On success it's renamed into `upload-<uuid>.bin`; on any failure

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -96,6 +96,16 @@ function isValidUploadMeta(value: unknown): value is StoredUploadMeta {
 export class FirmwareUploadStore {
   private readonly rootDir: string;
   private readonly expectedProjectName: string;
+  // Serializes store() calls. Without this, two concurrent stores
+  // would race their wipe passes against each other's just-renamed
+  // .bin files: A.rename → B.wipe (which sees + unlinks A.bin) →
+  // A.writeFile(sha) → A.writeFile(meta) → A returns success but
+  // A.bin is gone, leaving an inconsistent triple. Last-writer-wins
+  // is only meaningful when the second writer can see the first's
+  // completed state, not its mid-promote state. Serializing the
+  // wipe-then-rename-then-writeFiles sequence is the simplest fix.
+  // Per-instance because a single instance is shared by the route.
+  private inFlightStore: Promise<unknown> = Promise.resolve();
 
   constructor(opts: FirmwareUploadStoreOptions = {}) {
     this.rootDir = opts.rootDir ?? resolveFirmwareCacheDir(process.env.FIRMWARE_CACHE_PATH);
@@ -113,10 +123,27 @@ export class FirmwareUploadStore {
   // **Public contract:** `store()` unconditionally consumes `tempPath`.
   // On success it's renamed into `upload-<uuid>.bin`; on any failure
   // (open, read, parse, validation, hash, mkdir, persist) the catch
-  // below unlinks it. The route layer (c.8) does not need to clean up
+  // unlinks it. The route layer (c.8) does not need to clean up
   // tempPath when store() throws — every code path through this
   // function either renames or unlinks it.
+  //
+  // Concurrent calls are serialized via the inFlightStore chain, so
+  // two simultaneous uploads run sequentially rather than racing
+  // their wipe passes against each other's just-renamed .bin files.
   async store(tempPath: string, originalFilename: string): Promise<StoredUpload> {
+    // Chain through the in-flight promise so this call waits for any
+    // prior store() to settle before starting. The .catch() before
+    // .then() prevents a prior call's rejection from cascading into
+    // ours; the outer .catch() on the field pointer prevents *our*
+    // rejection from poisoning subsequent calls.
+    const next = this.inFlightStore
+      .catch(() => undefined)
+      .then(() => this.doStore(tempPath, originalFilename));
+    this.inFlightStore = next.catch(() => undefined);
+    return next;
+  }
+
+  private async doStore(tempPath: string, originalFilename: string): Promise<StoredUpload> {
     const uploadId = uuid_v4();
     const p = pathsFor(this.rootDir, uploadId);
 

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -105,41 +105,40 @@ export class FirmwareUploadStore {
   // Validates the temp file's esp_app_desc header, stream-hashes the
   // full file, then atomically promotes it into the single upload slot.
   // Validation failures (bad project, unparseable version) throw before
-  // touching the prior upload, so a rejected upload never destroys the
+  // the wipe pass runs, so a rejected upload never destroys the
   // previously-stored firmware. Persist-phase failures DO wipe the
-  // prior triple (via the wipe pass) — by design, a half-completed
-  // store leaves the slot empty rather than mixing old and new state.
+  // prior triple — by design, a half-completed store leaves the slot
+  // empty rather than mixing old and new state.
+  //
+  // **Public contract:** `store()` unconditionally consumes `tempPath`.
+  // On success it's renamed into `upload-<uuid>.bin`; on any failure
+  // (open, read, parse, validation, hash, mkdir, persist) the catch
+  // below unlinks it. The route layer (c.8) does not need to clean up
+  // tempPath when store() throws — every code path through this
+  // function either renames or unlinks it.
   async store(tempPath: string, originalFilename: string): Promise<StoredUpload> {
     const uploadId = uuid_v4();
     const p = pathsFor(this.rootDir, uploadId);
 
-    // Read just the header — no need to materialize the whole 1.2 MB
-    // binary in memory to identify it.
-    const headBuf = Buffer.alloc(PARSE_BUFFER_LEN);
-    const fh = await fsp.open(tempPath);
     try {
-      const { bytesRead } = await fh.read(headBuf, 0, PARSE_BUFFER_LEN, 0);
-      if (bytesRead < PARSE_BUFFER_LEN) {
-        throw new Error(
-          `firmware upload too short: read ${bytesRead} bytes, need at least ${PARSE_BUFFER_LEN}`,
-        );
+      // Read just the header — no need to materialize the whole 1.2 MB
+      // binary in memory to identify it.
+      const headBuf = Buffer.alloc(PARSE_BUFFER_LEN);
+      const fh = await fsp.open(tempPath);
+      try {
+        const { bytesRead } = await fh.read(headBuf, 0, PARSE_BUFFER_LEN, 0);
+        if (bytesRead < PARSE_BUFFER_LEN) {
+          throw new Error(
+            `firmware upload too short: read ${bytesRead} bytes, need at least ${PARSE_BUFFER_LEN}`,
+          );
+        }
+      } finally {
+        // Unconditional close — without this a parse-failure path leaks
+        // the fd until process exit.
+        await fh.close();
       }
-    } finally {
-      // Unconditional close — without this a parse-failure path leaks
-      // the fd until process exit.
-      await fh.close();
-    }
-    const desc = parseEspAppDesc(headBuf);
+      const desc = parseEspAppDesc(headBuf);
 
-    // Once parse succeeds the temp file is "ours" — the store owns the
-    // file's fate from here on. Wrap every post-parse step (validation,
-    // hash, mkdir, persist) so the rollback's blind unlink runs on any
-    // failure, leaving the route layer with a single contract: parse
-    // failures route the temp-file cleanup back to it; everything else
-    // is on the store. Pre-fix scope was just the persist phase, which
-    // leaked the temp file on hash-stream errors (EIO/truncation) and
-    // mkdir EACCES — review feedback caught this.
-    try {
       if (desc.projectName !== this.expectedProjectName) {
         throw new Error(
           `firmware upload project name mismatch: got ${JSON.stringify(desc.projectName)}, expected ${JSON.stringify(this.expectedProjectName)}`,
@@ -196,10 +195,12 @@ export class FirmwareUploadStore {
 
       return { path: p.bin, sha256, sizeBytes, meta };
     } catch (err) {
-      // Symmetric post-parse rollback. Blind unlink with swallow —
-      // ENOENT for files that weren't created yet is fine. Includes the
-      // tempPath, which is unconditionally consumed: success path
-      // consumed it via rename; failure path unlinks it here.
+      // Unconditional rollback. Blind unlink with swallow — ENOENT for
+      // files that weren't created (`p.bin`/`p.sha`/`p.meta` on early
+      // failures) or that vanished pre-call (`tempPath` on `fh.open`
+      // ENOENT) is fine. Covers every failure path through store():
+      // open, short read, parseEspAppDesc throw, validation, hash,
+      // mkdir, wipe, rename, writeFile.
       await Promise.all([
         fsp.unlink(tempPath).catch(() => undefined),
         fsp.unlink(p.bin).catch(() => undefined),

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -46,18 +46,21 @@ function normalizeEspVersion(raw: string): string {
 }
 
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
-// Canonical uuid v4 shape: 8-4-4-4-12 hex with dashes at fixed
-// positions. The earlier `[0-9a-f-]{36}` form was over-permissive —
-// it accepted strings like `upload--abc...` (leading dash) which then
-// failed `assertPathSafe` inside `pathsFor()`, throwing through
-// `latest()`'s outer scope instead of returning null per the
-// "any inconsistent state → null miss" contract. Pinning the
-// positional structure means `latest()` only ever feeds well-shaped
-// uuids to `pathsFor()`. (`ANY_UPLOAD_FILE_RE` below is
-// intentionally broader — wipe should sweep any `upload-*` sibling
-// regardless of shape.)
+// Canonical uuid v4 shape: 8-4-4-4-12 hex with the v4 version nibble
+// (`4` at the start of the third group) and the v4 variant nibble
+// (`[89ab]` at the start of the fourth group). The earlier
+// `[0-9a-f-]{36}` form was over-permissive — it accepted strings
+// like `upload--abc...` (leading dash) which then failed
+// `assertPathSafe` inside `pathsFor()`, throwing through `latest()`'s
+// outer scope instead of returning null per the "any inconsistent
+// state → null miss" contract. The intermediate fix pinned positional
+// structure but still accepted non-v4 version digits; this final
+// form matches exactly what the `uuid` package produces, so manual
+// intervention with non-v4 ids gets filtered as inconsistent state.
+// (`ANY_UPLOAD_FILE_RE` below is intentionally broader — wipe should
+// sweep any `upload-*` sibling regardless of shape.)
 const UPLOAD_META_RE =
-  /^upload-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.meta\.json$/;
+  /^upload-([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.meta\.json$/;
 // Used by the wipe pass to find any prior upload sibling regardless
 // of shape. Intentionally broader than UPLOAD_META_RE: must cover
 // every name that read paths could plausibly reject as malformed

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -239,14 +239,27 @@ export class FirmwareUploadStore {
         { uploadsDir, metaFiles },
         'multiple firmware-upload meta files detected; picking newest by mtime',
       );
+      // Each stat is wrapped individually: a meta file deleted between
+      // readdir and stat (e.g., a concurrent store()'s wipe pass) is
+      // skipped rather than rejecting the whole batch — preserves the
+      // "partial state → null miss" contract the rest of latest() honors.
       const stats = await Promise.all(
-        metaFiles.map(async (name) => ({
-          name,
-          mtimeMs: (await fsp.stat(path.join(uploadsDir, name))).mtimeMs,
-        })),
+        metaFiles.map(async (name) => {
+          try {
+            const st = await fsp.stat(path.join(uploadsDir, name));
+            return { name, mtimeMs: st.mtimeMs };
+          } catch {
+            return null;
+          }
+        }),
       );
-      stats.sort((a, b) => b.mtimeMs - a.mtimeMs);
-      chosenName = stats[0].name;
+      const valid = stats.filter((s): s is { name: string; mtimeMs: number } => s !== null);
+      // All stats failed — likely the dir was wiped between readdir and
+      // here (concurrent store()), or perms changed. Fall through to a
+      // null miss instead of throwing.
+      if (valid.length === 0) return null;
+      valid.sort((a, b) => b.mtimeMs - a.mtimeMs);
+      chosenName = valid[0].name;
     }
 
     const match = chosenName.match(UPLOAD_META_RE);

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -10,33 +10,21 @@ import { resolveFirmwareCacheDir } from './firmware_cache.js';
 import { assertPathSafe } from './path_safety.js';
 
 // Single-slot upload store. The user-supplied .bin lives at
-// `<rootDir>/uploads/upload-<uuid>.bin` with sha + meta sidecars. Each
-// successful store() wipes any prior triple. The orchestrator (c.6)
-// consumes via latest(); the route (c.8) feeds via store(). See the
-// c.5 plan for context and the failure-mode inventory.
+// `<rootDir>/uploads/upload-<uuid>.bin` with sha + meta sidecars; each
+// successful store() wipes any prior triple.
 
 const UPLOADS_SUBDIR = 'uploads';
 const PARSE_BUFFER_LEN = ESP_APP_DESC_OFFSET + ESP_APP_DESC_SIZE;
-// Matches the CMake `project()` call in AstrOs.ESP/CMakeLists.txt —
-// ESP-IDF embeds that name verbatim into esp_app_desc_t.project_name.
-// NOT the asset-filename prefix `astros-esp-…-app.bin`, which is set
-// independently by CI tooling. Verified against a real firmware.bin
-// during c.5 implementation.
+// CMake `project()` name embedded by ESP-IDF into esp_app_desc_t.project_name.
+// NOT the asset-filename prefix `astros-esp-…-app.bin` (set independently by CI).
 const DEFAULT_PROJECT_NAME = 'AstrOs.ESP';
 
-// `git describe --tags --dirty` suffix that ESP-IDF appends to
-// esp_app_desc_t.version when neither CONFIG_APP_PROJECT_VER_FROM_CONFIG
-// nor a version.txt file is set. Pattern: `-<count>-g<short-sha>(-dirty)?`.
-// Anchored at end so the dash-separated count + sha don't match anywhere
-// inside legitimate pre-release labels like `1.0.0-RC.1`. The 4-hex
-// minimum on <sha> guards against false positives — short pre-release
-// labels like `-1-gA` won't match (and real short SHAs are ≥4 hex).
+// `git describe --tags --dirty` suffix ESP-IDF appends to esp_app_desc_t.version
+// by default. The 4-hex minimum on <sha> guards against false-positive matches
+// on short pre-release labels like `-1-gA`.
 const GIT_DESCRIBE_SUFFIX_RE = /-\d+-g[0-9a-f]{4,}(?:-dirty)?$/;
 
-// Strips the leading `v` and trailing git-describe suffix from a raw
-// esp_app_desc_t.version string. Real example from a dev build:
-//   "v1.0.0-RC.1-71-g9a55936-dirty"  →  "1.0.0-RC.1"
-// Already-clean inputs pass through unchanged.
+// "v1.0.0-RC.1-71-g9a55936-dirty" → "1.0.0-RC.1"
 function normalizeEspVersion(raw: string): string {
   let v = raw.replace(GIT_DESCRIBE_SUFFIX_RE, '');
   if (v.startsWith('v') || v.startsWith('V')) {
@@ -46,30 +34,16 @@ function normalizeEspVersion(raw: string): string {
 }
 
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
-// Canonical uuid v4 shape: 8-4-4-4-12 hex with the v4 version nibble
-// (`4` at the start of the third group) and the v4 variant nibble
-// (`[89ab]` at the start of the fourth group). The earlier
-// `[0-9a-f-]{36}` form was over-permissive — it accepted strings
-// like `upload--abc...` (leading dash) which then failed
-// `assertPathSafe` inside `pathsFor()`, throwing through `latest()`'s
-// outer scope instead of returning null per the "any inconsistent
-// state → null miss" contract. The intermediate fix pinned positional
-// structure but still accepted non-v4 version digits; this final
-// form matches exactly what the `uuid` package produces, so manual
-// intervention with non-v4 ids gets filtered as inconsistent state.
-// (`ANY_UPLOAD_FILE_RE` below is intentionally broader — wipe should
-// sweep any `upload-*` sibling regardless of shape.)
+// Canonical uuid v4 shape (8-4-4-4-12 with `4` version + `[89ab]` variant
+// nibbles) — matches exactly what the `uuid` package produces, so
+// non-v4 names planted by manual intervention are filtered as
+// inconsistent state. ANY_UPLOAD_FILE_RE below is intentionally
+// broader: wipe paths must be a superset of read paths so names
+// `latest()` rejects can still be cleaned up.
 const UPLOAD_META_RE =
   /^upload-([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.meta\.json$/;
-// Used by the wipe pass to find any prior upload sibling regardless
-// of shape. Intentionally broader than UPLOAD_META_RE: must cover
-// every name that read paths could plausibly reject as malformed
-// (uppercase hex from a case-insensitive fs, mixed-case manual
-// rename, non-hex chars from operator intervention) so those files
-// can't orphan forever. `.+` between `upload-` and the extension
-// list accepts any non-empty basename body — readdir guarantees
-// these are basenames, so no path-separator risk. Extension list
-// is case-insensitive (Windows / macOS HFS+ can yield `.BIN` etc.).
+// Wipe regex — broader than UPLOAD_META_RE on purpose; see above.
+// Case-insensitive extension catches `.BIN` etc. on Windows / macOS HFS+.
 const ANY_UPLOAD_FILE_RE = /^upload-.+\.(?:bin|bin\.sha256|meta\.json)$/i;
 
 export interface FirmwareUploadStoreOptions {
@@ -97,9 +71,8 @@ function pathsFor(rootDir: string, uploadId: string): UploadPathTriple {
   };
 }
 
-// Validates every field of StoredUploadMeta so type narrowing is sound
-// and a partial-write that's parseable JSON but missing trailing fields
-// fails here and triggers a latest()-returns-null defensive miss.
+// Catches the partial-write case where `.meta.json` is parseable JSON
+// but missing fields — type narrowing here, null-miss in latest().
 function isValidUploadMeta(value: unknown): value is StoredUploadMeta {
   if (value === null || typeof value !== 'object') return false;
   const m = value as Record<string, unknown>;
@@ -116,15 +89,11 @@ function isValidUploadMeta(value: unknown): value is StoredUploadMeta {
 export class FirmwareUploadStore {
   private readonly rootDir: string;
   private readonly expectedProjectName: string;
-  // Serializes store() calls. Without this, two concurrent stores
-  // would race their wipe passes against each other's just-renamed
-  // .bin files: A.rename → B.wipe (which sees + unlinks A.bin) →
-  // A.writeFile(sha) → A.writeFile(meta) → A returns success but
-  // A.bin is gone, leaving an inconsistent triple. Last-writer-wins
-  // is only meaningful when the second writer can see the first's
-  // completed state, not its mid-promote state. Serializing the
-  // wipe-then-rename-then-writeFiles sequence is the simplest fix.
-  // Per-instance because a single instance is shared by the route.
+  // Serializes store() calls. Two concurrent stores would otherwise race
+  // their wipe passes against each other's just-renamed .bin files
+  // (A.rename → B.wipe unlinks A.bin → A.writeFile(sha,meta) → A returns
+  // success on a missing bin). Last-writer-wins requires the second
+  // writer to see the first's *completed* state, not its mid-promote state.
   private inFlightStore: Promise<unknown> = Promise.resolve();
 
   constructor(opts: FirmwareUploadStoreOptions = {}) {
@@ -132,36 +101,27 @@ export class FirmwareUploadStore {
     this.expectedProjectName = opts.expectedProjectName ?? DEFAULT_PROJECT_NAME;
   }
 
-  // Validates the temp file's esp_app_desc header, stream-hashes the
-  // full file, then atomically promotes it into the single upload slot.
-  // Validation failures (bad project, unparseable version) throw before
-  // the wipe pass runs, so a rejected upload never destroys the
-  // previously-stored firmware. Persist-phase failures attempt to
-  // leave the slot empty: the wipe pass runs first, then the rollback
-  // unlinks the new triple. **Both are best-effort.** The wipe pass
-  // logs and swallows non-ENOENT unlink errors (EACCES/EBUSY can
-  // legitimately occur on Windows or under hostile fs perms), so a
-  // failed store() can leave the prior triple, the new triple's
-  // partial state, or both on disk. latest() treats any inconsistent
-  // or orphan combination as a null miss via its uuid + sizeBytes
-  // cross-checks; the next successful store retries the wipe pass.
+  // Validates the upload's esp_app_desc header, stream-hashes the
+  // file, and atomically promotes it into the single upload slot.
   //
   // **Public contract:** `store()` unconditionally consumes `tempPath`.
   // On success it's renamed into `upload-<uuid>.bin`; on any failure
   // (open, read, parse, validation, hash, mkdir, persist) the catch
-  // unlinks it. The route layer (c.8) does not need to clean up
-  // tempPath when store() throws — every code path through this
-  // function either renames or unlinks it.
+  // unlinks it. Callers do not need to clean up tempPath on a throw.
   //
-  // Concurrent calls are serialized via the inFlightStore chain, so
-  // two simultaneous uploads run sequentially rather than racing
-  // their wipe passes against each other's just-renamed .bin files.
+  // Validation failures (bad project, unparseable version) throw
+  // before the wipe pass runs, so a rejected upload never destroys
+  // the prior firmware. Persist-phase failures attempt to leave the
+  // slot empty, but both the wipe and the rollback are best-effort —
+  // EACCES/EBUSY on a sibling unlink is logged and swallowed, so a
+  // failed store can leave the prior triple, partial new state, or
+  // both on disk. latest()'s uuid + sizeBytes cross-checks turn any
+  // inconsistent combination into a null miss, and the next
+  // successful store retries the wipe.
   async store(tempPath: string, originalFilename: string): Promise<StoredUpload> {
-    // Chain through the in-flight promise so this call waits for any
-    // prior store() to settle before starting. The .catch() before
-    // .then() prevents a prior call's rejection from cascading into
-    // ours; the outer .catch() on the field pointer prevents *our*
-    // rejection from poisoning subsequent calls.
+    // Chain through the in-flight promise so concurrent calls run in
+    // submission order. The .catch()s prevent a rejection (here or in
+    // a prior call) from poisoning the chain for subsequent callers.
     const next = this.inFlightStore
       .catch(() => undefined)
       .then(() => this.doStore(tempPath, originalFilename));
@@ -174,8 +134,7 @@ export class FirmwareUploadStore {
     const p = pathsFor(this.rootDir, uploadId);
 
     try {
-      // Read just the header — no need to materialize the whole 1.2 MB
-      // binary in memory to identify it.
+      // Read just the header — avoids materializing the whole 1.2 MB binary.
       const headBuf = Buffer.alloc(PARSE_BUFFER_LEN);
       const fh = await fsp.open(tempPath);
       try {
@@ -186,8 +145,6 @@ export class FirmwareUploadStore {
           );
         }
       } finally {
-        // Unconditional close — without this a parse-failure path leaks
-        // the fd until process exit.
         await fh.close();
       }
       const desc = parseEspAppDesc(headBuf);
@@ -197,23 +154,21 @@ export class FirmwareUploadStore {
           `firmware upload project name mismatch: got ${JSON.stringify(desc.projectName)}, expected ${JSON.stringify(this.expectedProjectName)}`,
         );
       }
-      // ESP-IDF embeds `git describe --tags --dirty` into esp_app_desc.version
-      // by default. Strip the leading `v` and the trailing `-<N>-g<sha>(-dirty)?`
-      // suffix so the persisted meta.version is a clean semver matching what
-      // the GitHub-release path produces from filename parsing — c.6's
-      // orchestrator can then compare the two without per-source casing.
+      // ESP-IDF embeds `git describe --tags --dirty` into the version field
+      // by default; normalize so meta.version aligns with the clean semver
+      // that GitHub-release filenames produce.
       const normalizedVersion = normalizeEspVersion(desc.version);
-      // compareVersions returns NaN for unparseable inputs and 0 for equal;
-      // self-comparison succeeds iff the version is well-formed.
+      // compareVersions returns NaN for unparseable input — self-compare is 0 iff well-formed.
       if (Number.isNaN(compareVersions(normalizedVersion, normalizedVersion))) {
         throw new Error(
           `firmware upload version unparseable: ${JSON.stringify(desc.version)} (normalized: ${JSON.stringify(normalizedVersion)})`,
         );
       }
 
-      // Stream-hash the whole file. The for-await loop handles backpressure
-      // and auto-closes the underlying fd on loop exit / error; using
-      // `pipeline` would require a Writable destination we don't need.
+      // for-await over createReadStream rather than stream/promises.pipeline:
+      // we don't have (or want) a Writable destination — the bytes already
+      // live at tempPath. The loop handles backpressure and auto-closes the
+      // fd on exit/error.
       const hash = crypto.createHash('sha256');
       let sizeBytes = 0;
       const readStream = fs.createReadStream(tempPath);
@@ -234,26 +189,17 @@ export class FirmwareUploadStore {
         sizeBytes,
       };
 
-      // Wipe any prior upload triple — best-effort; ENOENT swallowed for
-      // first-ever store; non-ENOENT logged but not fatal because the
-      // rename below either succeeds (orphan stays, swept by next store)
-      // or fails (catch handles cleanup).
       await this.wipePriorUploads(p.uploadsDir);
-      // Promote: tempPath → upload-<uuid>.bin. Atomic on same filesystem.
-      // EXDEV here means c.8's tempFileDir is on a different fs from
-      // <rootDir>/uploads/ — config error, propagate.
+      // EXDEV here = caller's tempFileDir is on a different filesystem
+      // from <rootDir>/uploads/. Config error; propagate.
       await fsp.rename(tempPath, p.bin);
       await fsp.writeFile(p.sha, sha256);
       await fsp.writeFile(p.meta, JSON.stringify(meta, null, 2));
 
       return { path: p.bin, sha256, sizeBytes, meta };
     } catch (err) {
-      // Unconditional rollback. Blind unlink with swallow — ENOENT for
-      // files that weren't created (`p.bin`/`p.sha`/`p.meta` on early
-      // failures) or that vanished pre-call (`tempPath` on `fh.open`
-      // ENOENT) is fine. Covers every failure path through store():
-      // open, short read, parseEspAppDesc throw, validation, hash,
-      // mkdir, wipe, rename, writeFile.
+      // Blind unlink: ENOENT on files that weren't created (early failure)
+      // or vanished pre-call (`tempPath` on fh.open ENOENT) is harmless.
       await Promise.all([
         fsp.unlink(tempPath).catch(() => undefined),
         fsp.unlink(p.bin).catch(() => undefined),
@@ -264,10 +210,10 @@ export class FirmwareUploadStore {
     }
   }
 
-  // Returns the most-recent stored upload, or null on cold cache /
-  // partial-write / corruption. Mirrors c.4 lookup()'s defensive
-  // behavior: any missing or malformed sidecar maps to a null miss
-  // rather than an obscure read error.
+  // Returns the most-recent stored upload, or null on cold cache,
+  // partial-write, or any inconsistency. Defensive by design — any
+  // missing or malformed sidecar, or any cross-file mismatch, maps
+  // to a null miss rather than throwing.
   async latest(): Promise<StoredUpload | null> {
     const uploadsDir = path.join(this.rootDir, UPLOADS_SUBDIR);
 
@@ -286,17 +232,15 @@ export class FirmwareUploadStore {
     if (metaFiles.length === 1) {
       chosenName = metaFiles[0];
     } else {
-      // Multiple meta files imply corruption or external intervention.
-      // Pick newest by mtime so the operator's most-recent action wins,
-      // log a warning so the noise is visible.
+      // Multiple meta files = corruption or external intervention.
+      // Newest-by-mtime so the operator's most-recent action wins.
       logger.warn(
         { uploadsDir, metaFiles },
         'multiple firmware-upload meta files detected; picking newest by mtime',
       );
-      // Each stat is wrapped individually: a meta file deleted between
-      // readdir and stat (e.g., a concurrent store()'s wipe pass) is
-      // skipped rather than rejecting the whole batch — preserves the
-      // "partial state → null miss" contract the rest of latest() honors.
+      // Per-stat .catch: a file deleted between readdir and stat (race
+      // with a concurrent store()'s wipe pass) is skipped rather than
+      // failing the whole batch.
       const stats = await Promise.all(
         metaFiles.map(async (name) => {
           try {
@@ -308,9 +252,6 @@ export class FirmwareUploadStore {
         }),
       );
       const valid = stats.filter((s): s is { name: string; mtimeMs: number } => s !== null);
-      // All stats failed — likely the dir was wiped between readdir and
-      // here (concurrent store()), or perms changed. Fall through to a
-      // null miss instead of throwing.
       if (valid.length === 0) return null;
       valid.sort((a, b) => b.mtimeMs - a.mtimeMs);
       chosenName = valid[0].name;
@@ -331,24 +272,15 @@ export class FirmwareUploadStore {
       if (!SHA256_HEX_RE.test(sha256)) return null;
       const parsed: unknown = JSON.parse(metaText);
       if (!isValidUploadMeta(parsed)) return null;
-      // Cross-check the triple is internally consistent. Each file is
-      // individually well-formed by this point, but corruption / manual
-      // sidecar copy could leave them describing different uploads:
-      //   - meta.uploadId !== filename-derived uploadId means a sidecar
-      //     was renamed or copied from another entry (would mislead the
-      //     orchestrator about which upload is being flashed).
-      //   - meta.sizeBytes !== binStat.size means meta is stale relative
-      //     to the bin (e.g. external truncate, partial-write recovery
-      //     that left mismatched siblings). Cheap proxy for "the bin we
-      //     have is the bin meta describes" — re-hashing here would be
-      //     stronger but costs ~80–100 ms per call (same trade-off c.4
-      //     made for its sidecar-trust stance).
+      // Cross-checks for triple consistency: filename-uuid mismatch
+      // means a sidecar was copied/renamed across uploads; size
+      // mismatch means meta is stale relative to bin (truncation /
+      // partial-write recovery). Sha-vs-bin would be stronger but
+      // costs ~80–100 ms per call; the orchestrator re-hashes anyway.
       if (parsed.uploadId !== uploadId) return null;
       if (parsed.sizeBytes !== binStat.size) return null;
       return { path: p.bin, sha256, sizeBytes: binStat.size, meta: parsed };
     } catch {
-      // ENOENT, EACCES, malformed JSON — all map to miss so callers
-      // get a clean null rather than an obscure read error.
       return null;
     }
   }

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -131,49 +131,57 @@ export class FirmwareUploadStore {
     }
     const desc = parseEspAppDesc(headBuf);
 
-    if (desc.projectName !== this.expectedProjectName) {
-      throw new Error(
-        `firmware upload project name mismatch: got ${JSON.stringify(desc.projectName)}, expected ${JSON.stringify(this.expectedProjectName)}`,
-      );
-    }
-    // ESP-IDF embeds `git describe --tags --dirty` into esp_app_desc.version
-    // by default. Strip the leading `v` and the trailing `-<N>-g<sha>(-dirty)?`
-    // suffix so the persisted meta.version is a clean semver matching what
-    // the GitHub-release path produces from filename parsing — c.6's
-    // orchestrator can then compare the two without per-source casing.
-    const normalizedVersion = normalizeEspVersion(desc.version);
-    // compareVersions returns NaN for unparseable inputs and 0 for equal;
-    // self-comparison succeeds iff the version is well-formed.
-    if (Number.isNaN(compareVersions(normalizedVersion, normalizedVersion))) {
-      throw new Error(
-        `firmware upload version unparseable: ${JSON.stringify(desc.version)} (normalized: ${JSON.stringify(normalizedVersion)})`,
-      );
-    }
-
-    // Stream-hash the whole file. The for-await loop handles backpressure
-    // and auto-closes the underlying fd on loop exit / error; using
-    // `pipeline` would require a Writable destination we don't need.
-    const hash = crypto.createHash('sha256');
-    let sizeBytes = 0;
-    const readStream = fs.createReadStream(tempPath);
-    for await (const chunk of readStream) {
-      sizeBytes += (chunk as Buffer).length;
-      hash.update(chunk as Buffer);
-    }
-    const sha256 = hash.digest('hex');
-
-    await fsp.mkdir(p.uploadsDir, { recursive: true });
-
-    const meta: StoredUploadMeta = {
-      uploadId,
-      originalFilename,
-      projectName: desc.projectName,
-      version: normalizedVersion,
-      uploadedAt: new Date().toISOString(),
-      sizeBytes,
-    };
-
+    // Once parse succeeds the temp file is "ours" — the store owns the
+    // file's fate from here on. Wrap every post-parse step (validation,
+    // hash, mkdir, persist) so the rollback's blind unlink runs on any
+    // failure, leaving the route layer with a single contract: parse
+    // failures route the temp-file cleanup back to it; everything else
+    // is on the store. Pre-fix scope was just the persist phase, which
+    // leaked the temp file on hash-stream errors (EIO/truncation) and
+    // mkdir EACCES — review feedback caught this.
     try {
+      if (desc.projectName !== this.expectedProjectName) {
+        throw new Error(
+          `firmware upload project name mismatch: got ${JSON.stringify(desc.projectName)}, expected ${JSON.stringify(this.expectedProjectName)}`,
+        );
+      }
+      // ESP-IDF embeds `git describe --tags --dirty` into esp_app_desc.version
+      // by default. Strip the leading `v` and the trailing `-<N>-g<sha>(-dirty)?`
+      // suffix so the persisted meta.version is a clean semver matching what
+      // the GitHub-release path produces from filename parsing — c.6's
+      // orchestrator can then compare the two without per-source casing.
+      const normalizedVersion = normalizeEspVersion(desc.version);
+      // compareVersions returns NaN for unparseable inputs and 0 for equal;
+      // self-comparison succeeds iff the version is well-formed.
+      if (Number.isNaN(compareVersions(normalizedVersion, normalizedVersion))) {
+        throw new Error(
+          `firmware upload version unparseable: ${JSON.stringify(desc.version)} (normalized: ${JSON.stringify(normalizedVersion)})`,
+        );
+      }
+
+      // Stream-hash the whole file. The for-await loop handles backpressure
+      // and auto-closes the underlying fd on loop exit / error; using
+      // `pipeline` would require a Writable destination we don't need.
+      const hash = crypto.createHash('sha256');
+      let sizeBytes = 0;
+      const readStream = fs.createReadStream(tempPath);
+      for await (const chunk of readStream) {
+        sizeBytes += (chunk as Buffer).length;
+        hash.update(chunk as Buffer);
+      }
+      const sha256 = hash.digest('hex');
+
+      await fsp.mkdir(p.uploadsDir, { recursive: true });
+
+      const meta: StoredUploadMeta = {
+        uploadId,
+        originalFilename,
+        projectName: desc.projectName,
+        version: normalizedVersion,
+        uploadedAt: new Date().toISOString(),
+        sizeBytes,
+      };
+
       // Wipe any prior upload triple — best-effort; ENOENT swallowed for
       // first-ever store; non-ENOENT logged but not fatal because the
       // rename below either succeeds (orphan stays, swept by next store)
@@ -185,10 +193,13 @@ export class FirmwareUploadStore {
       await fsp.rename(tempPath, p.bin);
       await fsp.writeFile(p.sha, sha256);
       await fsp.writeFile(p.meta, JSON.stringify(meta, null, 2));
+
+      return { path: p.bin, sha256, sizeBytes, meta };
     } catch (err) {
-      // Symmetric persist-phase rollback. Blind unlink with swallow —
+      // Symmetric post-parse rollback. Blind unlink with swallow —
       // ENOENT for files that weren't created yet is fine. Includes the
-      // tempPath in case rename failed before consuming it.
+      // tempPath, which is unconditionally consumed: success path
+      // consumed it via rename; failure path unlinks it here.
       await Promise.all([
         fsp.unlink(tempPath).catch(() => undefined),
         fsp.unlink(p.bin).catch(() => undefined),
@@ -197,8 +208,6 @@ export class FirmwareUploadStore {
       ]);
       throw err;
     }
-
-    return { path: p.bin, sha256, sizeBytes, meta };
   }
 
   // Returns the most-recent stored upload, or null on cold cache /

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -1,0 +1,251 @@
+import crypto from 'crypto';
+import fs, { promises as fsp } from 'fs';
+import path from 'path';
+import { v4 as uuid_v4 } from 'uuid';
+import { logger } from '../logger.js';
+import type { StoredUpload, StoredUploadMeta } from '../models/firmware/upload.js';
+import { compareVersions } from '../utility/semver.js';
+import { ESP_APP_DESC_OFFSET, ESP_APP_DESC_SIZE, parseEspAppDesc } from './esp_app_desc.js';
+import { resolveFirmwareCacheDir } from './firmware_cache.js';
+import { assertPathSafe } from './path_safety.js';
+
+// Single-slot upload store. The user-supplied .bin lives at
+// `<rootDir>/uploads/upload-<uuid>.bin` with sha + meta sidecars. Each
+// successful store() wipes any prior triple. The orchestrator (c.6)
+// consumes via latest(); the route (c.8) feeds via store(). See the
+// c.5 plan for context and the failure-mode inventory.
+
+const UPLOADS_SUBDIR = 'uploads';
+const PARSE_BUFFER_LEN = ESP_APP_DESC_OFFSET + ESP_APP_DESC_SIZE;
+const DEFAULT_PROJECT_NAME = 'astros-esp';
+
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+// uuid v4 is 36 chars: 8-4-4-4-12 hex with dashes.
+const UPLOAD_META_RE = /^upload-([0-9a-f-]{36})\.meta\.json$/;
+// Used by the wipe pass to find any prior upload triple regardless of
+// uuid (the new uuid is fresh; the old one is whatever was there).
+const ANY_UPLOAD_FILE_RE = /^upload-[0-9a-f-]+\.(?:bin|bin\.sha256|meta\.json)$/;
+
+export interface FirmwareUploadStoreOptions {
+  rootDir?: string;
+  expectedProjectName?: string;
+}
+
+interface UploadPathTriple {
+  uploadsDir: string;
+  bin: string;
+  sha: string;
+  meta: string;
+}
+
+function pathsFor(rootDir: string, uploadId: string): UploadPathTriple {
+  // Defense-in-depth — uuid v4 always passes by construction.
+  assertPathSafe(uploadId, 'uploadId');
+  const baseName = `upload-${uploadId}`;
+  const uploadsDir = path.join(rootDir, UPLOADS_SUBDIR);
+  return {
+    uploadsDir,
+    bin: path.join(uploadsDir, `${baseName}.bin`),
+    sha: path.join(uploadsDir, `${baseName}.bin.sha256`),
+    meta: path.join(uploadsDir, `${baseName}.meta.json`),
+  };
+}
+
+// Validates every field of StoredUploadMeta so type narrowing is sound
+// and a partial-write that's parseable JSON but missing trailing fields
+// fails here and triggers a latest()-returns-null defensive miss.
+function isValidUploadMeta(value: unknown): value is StoredUploadMeta {
+  if (value === null || typeof value !== 'object') return false;
+  const m = value as Record<string, unknown>;
+  return (
+    typeof m.uploadId === 'string' &&
+    typeof m.originalFilename === 'string' &&
+    typeof m.projectName === 'string' &&
+    typeof m.version === 'string' &&
+    typeof m.uploadedAt === 'string' &&
+    typeof m.sizeBytes === 'number'
+  );
+}
+
+export class FirmwareUploadStore {
+  private readonly rootDir: string;
+  private readonly expectedProjectName: string;
+
+  constructor(opts: FirmwareUploadStoreOptions = {}) {
+    this.rootDir = opts.rootDir ?? resolveFirmwareCacheDir(process.env.FIRMWARE_CACHE_PATH);
+    this.expectedProjectName = opts.expectedProjectName ?? DEFAULT_PROJECT_NAME;
+  }
+
+  // Validates the temp file's esp_app_desc header, stream-hashes the
+  // full file, then atomically promotes it into the single upload slot.
+  // Validation failures (bad project, unparseable version) throw before
+  // touching the prior upload, so a rejected upload never destroys the
+  // previously-stored firmware. Persist-phase failures DO wipe the
+  // prior triple (via the wipe pass) — by design, a half-completed
+  // store leaves the slot empty rather than mixing old and new state.
+  async store(tempPath: string, originalFilename: string): Promise<StoredUpload> {
+    const uploadId = uuid_v4();
+    const p = pathsFor(this.rootDir, uploadId);
+
+    // Read just the header — no need to materialize the whole 1.2 MB
+    // binary in memory to identify it.
+    const headBuf = Buffer.alloc(PARSE_BUFFER_LEN);
+    const fh = await fsp.open(tempPath);
+    try {
+      const { bytesRead } = await fh.read(headBuf, 0, PARSE_BUFFER_LEN, 0);
+      if (bytesRead < PARSE_BUFFER_LEN) {
+        throw new Error(
+          `firmware upload too short: read ${bytesRead} bytes, need at least ${PARSE_BUFFER_LEN}`,
+        );
+      }
+    } finally {
+      // Unconditional close — without this a parse-failure path leaks
+      // the fd until process exit.
+      await fh.close();
+    }
+    const desc = parseEspAppDesc(headBuf);
+
+    if (desc.projectName !== this.expectedProjectName) {
+      throw new Error(
+        `firmware upload project name mismatch: got ${JSON.stringify(desc.projectName)}, expected ${JSON.stringify(this.expectedProjectName)}`,
+      );
+    }
+    // compareVersions returns NaN for unparseable inputs and 0 for equal;
+    // self-comparison succeeds iff the version is well-formed.
+    if (Number.isNaN(compareVersions(desc.version, desc.version))) {
+      throw new Error(`firmware upload version unparseable: ${JSON.stringify(desc.version)}`);
+    }
+
+    // Stream-hash the whole file. The for-await loop handles backpressure
+    // and auto-closes the underlying fd on loop exit / error; using
+    // `pipeline` would require a Writable destination we don't need.
+    const hash = crypto.createHash('sha256');
+    let sizeBytes = 0;
+    const readStream = fs.createReadStream(tempPath);
+    for await (const chunk of readStream) {
+      sizeBytes += (chunk as Buffer).length;
+      hash.update(chunk as Buffer);
+    }
+    const sha256 = hash.digest('hex');
+
+    await fsp.mkdir(p.uploadsDir, { recursive: true });
+
+    const meta: StoredUploadMeta = {
+      uploadId,
+      originalFilename,
+      projectName: desc.projectName,
+      version: desc.version,
+      uploadedAt: new Date().toISOString(),
+      sizeBytes,
+    };
+
+    try {
+      // Wipe any prior upload triple — best-effort; ENOENT swallowed for
+      // first-ever store; non-ENOENT logged but not fatal because the
+      // rename below either succeeds (orphan stays, swept by next store)
+      // or fails (catch handles cleanup).
+      await this.wipePriorUploads(p.uploadsDir);
+      // Promote: tempPath → upload-<uuid>.bin. Atomic on same filesystem.
+      // EXDEV here means c.8's tempFileDir is on a different fs from
+      // <rootDir>/uploads/ — config error, propagate.
+      await fsp.rename(tempPath, p.bin);
+      await fsp.writeFile(p.sha, sha256);
+      await fsp.writeFile(p.meta, JSON.stringify(meta, null, 2));
+    } catch (err) {
+      // Symmetric persist-phase rollback. Blind unlink with swallow —
+      // ENOENT for files that weren't created yet is fine. Includes the
+      // tempPath in case rename failed before consuming it.
+      await Promise.all([
+        fsp.unlink(tempPath).catch(() => undefined),
+        fsp.unlink(p.bin).catch(() => undefined),
+        fsp.unlink(p.sha).catch(() => undefined),
+        fsp.unlink(p.meta).catch(() => undefined),
+      ]);
+      throw err;
+    }
+
+    return { path: p.bin, sha256, sizeBytes, meta };
+  }
+
+  // Returns the most-recent stored upload, or null on cold cache /
+  // partial-write / corruption. Mirrors c.4 lookup()'s defensive
+  // behavior: any missing or malformed sidecar maps to a null miss
+  // rather than an obscure read error.
+  async latest(): Promise<StoredUpload | null> {
+    const uploadsDir = path.join(this.rootDir, UPLOADS_SUBDIR);
+
+    let entries: string[];
+    try {
+      entries = await fsp.readdir(uploadsDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw err;
+    }
+
+    const metaFiles = entries.filter((name) => UPLOAD_META_RE.test(name));
+    if (metaFiles.length === 0) return null;
+
+    let chosenName: string;
+    if (metaFiles.length === 1) {
+      chosenName = metaFiles[0];
+    } else {
+      // Multiple meta files imply corruption or external intervention.
+      // Pick newest by mtime so the operator's most-recent action wins,
+      // log a warning so the noise is visible.
+      logger.warn(
+        { uploadsDir, metaFiles },
+        'multiple firmware-upload meta files detected; picking newest by mtime',
+      );
+      const stats = await Promise.all(
+        metaFiles.map(async (name) => ({
+          name,
+          mtimeMs: (await fsp.stat(path.join(uploadsDir, name))).mtimeMs,
+        })),
+      );
+      stats.sort((a, b) => b.mtimeMs - a.mtimeMs);
+      chosenName = stats[0].name;
+    }
+
+    const match = chosenName.match(UPLOAD_META_RE);
+    if (!match) return null;
+    const uploadId = match[1];
+    const p = pathsFor(this.rootDir, uploadId);
+
+    try {
+      const [binStat, shaText, metaText] = await Promise.all([
+        fsp.stat(p.bin),
+        fsp.readFile(p.sha, 'utf8'),
+        fsp.readFile(p.meta, 'utf8'),
+      ]);
+      const sha256 = shaText.trim();
+      if (!SHA256_HEX_RE.test(sha256)) return null;
+      const parsed: unknown = JSON.parse(metaText);
+      if (!isValidUploadMeta(parsed)) return null;
+      return { path: p.bin, sha256, sizeBytes: binStat.size, meta: parsed };
+    } catch {
+      // ENOENT, EACCES, malformed JSON — all map to miss so callers
+      // get a clean null rather than an obscure read error.
+      return null;
+    }
+  }
+
+  private async wipePriorUploads(uploadsDir: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await fsp.readdir(uploadsDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+    const targets = entries.filter((name) => ANY_UPLOAD_FILE_RE.test(name));
+    await Promise.all(
+      targets.map((name) =>
+        fsp.unlink(path.join(uploadsDir, name)).catch((err: NodeJS.ErrnoException) => {
+          if (err.code !== 'ENOENT') {
+            logger.warn({ uploadsDir, name, err }, 'failed to unlink prior upload sibling');
+          }
+        }),
+      ),
+    );
+  }
+}

--- a/astros_api/src/firmware/firmware_upload_store.ts
+++ b/astros_api/src/firmware/firmware_upload_store.ts
@@ -17,7 +17,33 @@ import { assertPathSafe } from './path_safety.js';
 
 const UPLOADS_SUBDIR = 'uploads';
 const PARSE_BUFFER_LEN = ESP_APP_DESC_OFFSET + ESP_APP_DESC_SIZE;
-const DEFAULT_PROJECT_NAME = 'astros-esp';
+// Matches the CMake `project()` call in AstrOs.ESP/CMakeLists.txt —
+// ESP-IDF embeds that name verbatim into esp_app_desc_t.project_name.
+// NOT the asset-filename prefix `astros-esp-…-app.bin`, which is set
+// independently by CI tooling. Verified against a real firmware.bin
+// during c.5 implementation.
+const DEFAULT_PROJECT_NAME = 'AstrOs.ESP';
+
+// `git describe --tags --dirty` suffix that ESP-IDF appends to
+// esp_app_desc_t.version when neither CONFIG_APP_PROJECT_VER_FROM_CONFIG
+// nor a version.txt file is set. Pattern: `-<count>-g<short-sha>(-dirty)?`.
+// Anchored at end so the dash-separated count + sha don't match anywhere
+// inside legitimate pre-release labels like `1.0.0-RC.1`. The 4-hex
+// minimum on <sha> guards against false positives — short pre-release
+// labels like `-1-gA` won't match (and real short SHAs are ≥4 hex).
+const GIT_DESCRIBE_SUFFIX_RE = /-\d+-g[0-9a-f]{4,}(?:-dirty)?$/;
+
+// Strips the leading `v` and trailing git-describe suffix from a raw
+// esp_app_desc_t.version string. Real example from a dev build:
+//   "v1.0.0-RC.1-71-g9a55936-dirty"  →  "1.0.0-RC.1"
+// Already-clean inputs pass through unchanged.
+function normalizeEspVersion(raw: string): string {
+  let v = raw.replace(GIT_DESCRIBE_SUFFIX_RE, '');
+  if (v.startsWith('v') || v.startsWith('V')) {
+    v = v.slice(1);
+  }
+  return v;
+}
 
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 // uuid v4 is 36 chars: 8-4-4-4-12 hex with dashes.
@@ -110,10 +136,18 @@ export class FirmwareUploadStore {
         `firmware upload project name mismatch: got ${JSON.stringify(desc.projectName)}, expected ${JSON.stringify(this.expectedProjectName)}`,
       );
     }
+    // ESP-IDF embeds `git describe --tags --dirty` into esp_app_desc.version
+    // by default. Strip the leading `v` and the trailing `-<N>-g<sha>(-dirty)?`
+    // suffix so the persisted meta.version is a clean semver matching what
+    // the GitHub-release path produces from filename parsing — c.6's
+    // orchestrator can then compare the two without per-source casing.
+    const normalizedVersion = normalizeEspVersion(desc.version);
     // compareVersions returns NaN for unparseable inputs and 0 for equal;
     // self-comparison succeeds iff the version is well-formed.
-    if (Number.isNaN(compareVersions(desc.version, desc.version))) {
-      throw new Error(`firmware upload version unparseable: ${JSON.stringify(desc.version)}`);
+    if (Number.isNaN(compareVersions(normalizedVersion, normalizedVersion))) {
+      throw new Error(
+        `firmware upload version unparseable: ${JSON.stringify(desc.version)} (normalized: ${JSON.stringify(normalizedVersion)})`,
+      );
     }
 
     // Stream-hash the whole file. The for-await loop handles backpressure
@@ -134,7 +168,7 @@ export class FirmwareUploadStore {
       uploadId,
       originalFilename,
       projectName: desc.projectName,
-      version: desc.version,
+      version: normalizedVersion,
       uploadedAt: new Date().toISOString(),
       sizeBytes,
     };

--- a/astros_api/src/firmware/path_safety.ts
+++ b/astros_api/src/firmware/path_safety.ts
@@ -13,7 +13,7 @@ export const PATH_SAFE_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
 export function assertPathSafe(value: string, kind: string): void {
   if (!PATH_SAFE_RE.test(value)) {
     throw new Error(
-      `Invalid firmware ${kind} for cache path: ${JSON.stringify(value)} contains characters that aren't filename-safe`,
+      `Invalid firmware ${kind}: ${JSON.stringify(value)} contains characters that aren't filename-safe`,
     );
   }
 }

--- a/astros_api/src/firmware/path_safety.ts
+++ b/astros_api/src/firmware/path_safety.ts
@@ -1,0 +1,19 @@
+// Allowlist for strings interpolated into firmware-module filenames.
+// First char alphanumeric (forbids leading-dot hidden files and
+// leading-hyphen flag lookalikes); body allows the chars real semver and
+// PlatformIO env names use — '.' for version dots, '-' for pre-release
+// labels (1.2.0-RC.1), '+' for build metadata (1.0.0+build.123), '_' for
+// variant underscores (lolin_d32_pro). Excludes path separators, drive
+// letters, parent refs, embedded nulls. Upstream c.3 captures version as
+// `(.+)` so this is the only guard for it; variant is defense-in-depth;
+// uploadId is server-generated UUID v4 so always-passes by construction
+// and the assertion guards future regressions.
+export const PATH_SAFE_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
+
+export function assertPathSafe(value: string, kind: string): void {
+  if (!PATH_SAFE_RE.test(value)) {
+    throw new Error(
+      `Invalid firmware ${kind} for cache path: ${JSON.stringify(value)} contains characters that aren't filename-safe`,
+    );
+  }
+}

--- a/astros_api/src/firmware/path_safety.ts
+++ b/astros_api/src/firmware/path_safety.ts
@@ -1,13 +1,10 @@
 // Allowlist for strings interpolated into firmware-module filenames.
 // First char alphanumeric (forbids leading-dot hidden files and
-// leading-hyphen flag lookalikes); body allows the chars real semver and
-// PlatformIO env names use — '.' for version dots, '-' for pre-release
-// labels (1.2.0-RC.1), '+' for build metadata (1.0.0+build.123), '_' for
-// variant underscores (lolin_d32_pro). Excludes path separators, drive
-// letters, parent refs, embedded nulls. Upstream c.3 captures version as
-// `(.+)` so this is the only guard for it; variant is defense-in-depth;
-// uploadId is server-generated UUID v4 so always-passes by construction
-// and the assertion guards future regressions.
+// leading-hyphen flag lookalikes); body allows characters semver and
+// PlatformIO env names use — `.` for dotted versions, `-` for
+// pre-release labels (1.2.0-RC.1), `+` for build metadata, `_` for
+// variant underscores. Excludes path separators, drive letters,
+// parent refs, embedded nulls.
 export const PATH_SAFE_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
 
 export function assertPathSafe(value: string, kind: string): void {

--- a/astros_api/src/models/firmware/upload.ts
+++ b/astros_api/src/models/firmware/upload.ts
@@ -1,8 +1,4 @@
-// Firmware upload-mode shapes. See the c.5 plan for context.
-
 // Decoded `esp_app_desc_t` struct from the head of an ESP-IDF app binary.
-// Strings are the null-terminated UTF-8 prefix of each fixed-length slot
-// (parser rejects non-terminated slots and embedded control chars).
 export interface EspAppDesc {
   magicWord: number;
   secureVersion: number;
@@ -11,30 +7,23 @@ export interface EspAppDesc {
   time: string;
   date: string;
   idfVer: string;
-  // Raw 32-byte digest from the struct. Not currently consumed but
-  // preserved verbatim so future protocol use (e.g., parity check
-  // against the OTA verify hash) doesn't need a parser change.
+  // Preserved verbatim from the struct for potential future parity
+  // checks against the OTA verify hash; not currently consumed.
   appElfSha256: Buffer;
 }
 
-// Persisted as `upload-<uuid>.meta.json` next to each stored upload.
-// No `tag` (uploads aren't releases) and no `publishedAt` (which would
-// be a release publish timestamp). Time provenance for `uploadedAt` is
-// the server clock — see field comment.
+// Persisted as `upload-<uuid>.meta.json` alongside each stored upload.
 export interface StoredUploadMeta {
   uploadId: string;
-  // User's original filename, kept for operator inspection / UI display.
-  // NEVER interpolated into a filesystem path — the persisted filename
-  // uses only `uploadId` so this can hold any bytes safely.
+  // User's original filename. NEVER interpolated into a filesystem
+  // path — the persisted filename uses only `uploadId`, so this can
+  // hold any bytes (path separators, control chars) safely.
   originalFilename: string;
   projectName: string;
   version: string;
-  // Server-generated ISO-8601 UTC timestamp captured at the moment
-  // store() persists the upload (`new Date().toISOString()`). NOT a
-  // browser-clock value — there is no client-supplied timestamp on the
-  // upload payload and the server doesn't trust one if there were.
-  // Safe to use for "ordering relative to other server events"; not
-  // safe for "what time did the user think it was".
+  // Server-generated ISO-8601 UTC at store() time. Not a client-
+  // supplied timestamp — safe for ordering vs. other server events,
+  // not for "what time did the user think it was".
   uploadedAt: string;
   sizeBytes: number;
 }

--- a/astros_api/src/models/firmware/upload.ts
+++ b/astros_api/src/models/firmware/upload.ts
@@ -18,8 +18,9 @@ export interface EspAppDesc {
 }
 
 // Persisted as `upload-<uuid>.meta.json` next to each stored upload.
-// No `tag` (uploads aren't releases) and no `publishedAt` (only
-// `uploadedAt` — the user's clock at upload time).
+// No `tag` (uploads aren't releases) and no `publishedAt` (which would
+// be a release publish timestamp). Time provenance for `uploadedAt` is
+// the server clock — see field comment.
 export interface StoredUploadMeta {
   uploadId: string;
   // User's original filename, kept for operator inspection / UI display.
@@ -28,6 +29,12 @@ export interface StoredUploadMeta {
   originalFilename: string;
   projectName: string;
   version: string;
+  // Server-generated ISO-8601 UTC timestamp captured at the moment
+  // store() persists the upload (`new Date().toISOString()`). NOT a
+  // browser-clock value — there is no client-supplied timestamp on the
+  // upload payload and the server doesn't trust one if there were.
+  // Safe to use for "ordering relative to other server events"; not
+  // safe for "what time did the user think it was".
   uploadedAt: string;
   sizeBytes: number;
 }

--- a/astros_api/src/models/firmware/upload.ts
+++ b/astros_api/src/models/firmware/upload.ts
@@ -1,0 +1,40 @@
+// Firmware upload-mode shapes. See the c.5 plan for context.
+
+// Decoded `esp_app_desc_t` struct from the head of an ESP-IDF app binary.
+// Strings are the null-terminated UTF-8 prefix of each fixed-length slot
+// (parser rejects non-terminated slots and embedded control chars).
+export interface EspAppDesc {
+  magicWord: number;
+  secureVersion: number;
+  version: string;
+  projectName: string;
+  time: string;
+  date: string;
+  idfVer: string;
+  // Raw 32-byte digest from the struct. Not currently consumed but
+  // preserved verbatim so future protocol use (e.g., parity check
+  // against the OTA verify hash) doesn't need a parser change.
+  appElfSha256: Buffer;
+}
+
+// Persisted as `upload-<uuid>.meta.json` next to each stored upload.
+// No `tag` (uploads aren't releases) and no `publishedAt` (only
+// `uploadedAt` — the user's clock at upload time).
+export interface StoredUploadMeta {
+  uploadId: string;
+  // User's original filename, kept for operator inspection / UI display.
+  // NEVER interpolated into a filesystem path — the persisted filename
+  // uses only `uploadId` so this can hold any bytes safely.
+  originalFilename: string;
+  projectName: string;
+  version: string;
+  uploadedAt: string;
+  sizeBytes: number;
+}
+
+export interface StoredUpload {
+  path: string;
+  sha256: string;
+  sizeBytes: number;
+  meta: StoredUploadMeta;
+}


### PR DESCRIPTION
## Summary

- New `FirmwareUploadStore` module that takes a multipart temp file, validates the embedded `esp_app_desc_t` header (project name + parseable version), stream-hashes the body, and atomically promotes it into a single-slot `<rootDir>/uploads/upload-<uuid>.{bin,bin.sha256,meta.json}`
- New `parseEspAppDesc` pure parser — strict-mode UTF-8 decoding, control-char rejection across the full 32-byte slot (not just before the null), defensive copy of `app_elf_sha256`
- `assertPathSafe` extracted from `firmware_cache.ts` to a shared `path_safety.ts` so c.4 and c.5 share one filename-safety guard (c.4 behavior unchanged; one-line import update)
- 36 new tests (11 parser + 25 store), full TDD cycle; 380 → 416 total
- Live verification against a real `AstrOs.ESP/.pio/build/.../firmware.bin` confirmed two planning-time assumptions wrong and corrected them in this PR (project_name + version-format, see "Notes for the reviewer")
- Plan: [`.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md`](./.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md) — first customer of the failure-mode-inventory template added in `6a525c9`

## Context

c.5 of the firmware-OTA decomposition. c.4 shipped the GitHub-mode on-disk cache (release binaries downloaded on demand). c.5 ships the upload-mode counterpart: when a user supplies their own `.bin` instead of picking a release, c.5 is what validates and stores it. No HTTP route, no orchestrator wiring — the orchestrator (c.6) will consume via `latest()`; the route layer (c.8) will feed via `store()`.

**Trust boundary at the binary itself.** A GitHub release came from CI; an upload came from a user's filesystem. The `esp_app_desc_t` struct at offset 32 of the `.bin` is the only structural evidence we have that the file is what it claims to be — c.5 rejects malformed or wrong-project binaries before they reach the flash path, where a 1.2 MB blob written into `esp_ota_*` could brick a controller.

## Design decisions

- **Single-slot retention.** No "newest 5", no semver sort — uploads keep the most recent only and replace on next write. Eviction collapses to "wipe any prior `upload-*` triple before the rename"; `latest()` is an O(directory-listing) operation.
- **Read-only-the-header parse.** `fsp.open` + `read(buf, 0, 288, 0)` materializes only the 288 bytes needed to identify the binary; the stream-hash phase that follows touches the rest of the file but never holds it in memory. The full 1.2 MB never lives in RAM at once.
- **Validation vs persist failure regimes.** Project-name + version-parse failures throw before the persist phase begins, leaving any prior upload untouched. Persist failures (rename, writeFile) wipe the prior triple as part of the normal sequence and trigger symmetric rollback — the slot ends up empty rather than mixed-state.
- **Wipe-before-promote ordering** mirrors c.4's persist-phase fix (the one PR #70 commits `e8b0b7f` and `d5bb8cc` reworked). The crash-recovery state matrix in the plan's `## Failure modes` §2 has no "hit, inconsistent" rows: at every await, on-disk state is either "consistent at this timestep" or "miss" — never a stale-bin + new-sidecars chimera.
- **Strict-mode UTF-8 decoder** (`new TextDecoder('utf-8', { fatal: true })`) on every fixed-length string slot. `Buffer.toString('utf8')` silently substitutes `U+FFFD` for invalid sequences; a tampered binary with `0xFF 0xFF 0x00` in the version field would otherwise pass validation.
- **Control-char rejection across the full slot, not just before the null.** A normal binary zero-fills tail bytes after the terminator. A tampered binary that smuggles control bytes into the unused tail is exactly the kind of edge case we want to reject — one scan over the slot covers both prefix and tail.
- **`for-await` instead of `pipeline`** for stream-hashing. `pipeline` requires a Writable destination; we don't actually want to write the bytes anywhere (they already live at `tempPath`). The for-await loop reads, hashes, and discards. Backpressure is handled by the iterator protocol; the stream auto-closes on loop exit / error.
- **No in-process mutex.** Two concurrent `store()` calls are tolerated by last-writer-wins on the wipe-then-rename sequence; `.meta.json` is the durability anchor that `latest()` keys on. The flash-job hard lock from c.0/c.2 already prevents uploads from racing with a flash, so the only race surface is two browser tabs uploading back-to-back.

## On-disk layout

```
<rootDir>/
├── github/             # c.4 owns
│   └── astros-esp-…app.bin (+ sidecars)
├── tmp/                # c.8 will mount express-fileupload here
│   └── <random>.tmp    # upstream-managed
└── uploads/            # c.5 owns
    ├── upload-<uuid>.bin
    ├── upload-<uuid>.bin.sha256
    └── upload-<uuid>.meta.json
```

`tmp/` and `uploads/` live under the same `<rootDir>` so the temp-to-final `fs.rename` is atomic. c.5 itself doesn't create `tmp/` — that's c.8's setup responsibility (along with mounting `express-fileupload` and sweeping orphan `*.tmp` files at boot). c.5 only consumes `tempPath` strings the route layer passes in.

## Test plan

- [x] `npm run build` clean (lint + tsc)
- [x] `npm run test` — 416/416 green (380 + 36 new)
- [x] **Live end-to-end test** against `AstrOs.ESP/.pio/build/lolin_d32_pro/firmware.bin`: store accepts the binary, captures `projectName: "AstrOs.ESP"`, normalizes `version: "v1.0.0-RC.1-71-g9a55936-dirty"` → `"1.0.0-RC.1"`, round-trips through `latest()` correctly
- [x] `npm run prettier:write` and `npm run lint:fix` clean
- [x] TDD: parser + store implementation written alongside their test files; full suite green on first run
- [ ] Manual smoke deferred to c.8 — c.5 has no HTTP entry point, so end-to-end exercise needs the route mount

### Tests added

**`parseEspAppDesc` (11)** — happy path, wrong magic, buffer too short, no null terminator within slot, embedded-null truncation, control char before null, control char in unused tail, invalid UTF-8 sequence, secureVersion little-endian read, magic-word constant sentinel, defensive-copy semantics on `appElfSha256`.

**`FirmwareUploadStore.latest` (5)** — cold cache, empty uploads dir, partial-state miss (only some sidecars), malformed JSON meta, parseable JSON missing required fields.

**`FirmwareUploadStore.store` (12)** — happy path full-triple write + sha re-verify, temp file consumption, latest() returns same upload after store, project-name rejection preserves prior, unparseable-version rejection preserves prior, short-binary rejection, wrong-magic rejection, prior triple replaced atomically, persist-fail rollback on `.sha256` writeFile, persist-fail rollback on rename EACCES, crash-recovery state-matrix invariant via writeFile snapshot pinning, persist-fail rollback on `.meta.json` writeFile leaves no orphans.

**`FirmwareUploadStore` esp_app_desc.version normalization (6)** — strips git-describe suffix from dirty dev build (`v1.0.0-RC.1-71-g9a55936-dirty` → `1.0.0-RC.1`), strips suffix from tag-clean off-tag build, strips just the `v` prefix when no suffix is present, passes already-clean semver through unchanged, still rejects irrecoverably-bad input (`garbage`), preserves pre-release labels that aren't git-describe shaped (`1.0.0-dev.71`).

**`FirmwareUploadStore` project_name (1)** — rejects a binary whose embedded `project_name` is `astros-esp` (the filename prefix, not the embedded value AstrOs.ESP CI actually produces).

**`FirmwareUploadStore` multi-meta (1)** — two complete triples on disk, mtime tiebreak picks newest.

## Files

| Status | Path | Why |
|---|---|---|
| new | `astros_api/src/firmware/path_safety.ts` | Extracted `PATH_SAFE_RE` + `assertPathSafe` (shared with c.4) |
| modified | `astros_api/src/firmware/firmware_cache.ts` | Import from `path_safety.ts` (delete local copies; behavior unchanged) |
| new | `astros_api/src/models/firmware/upload.ts` | `StoredUpload`, `StoredUploadMeta`, `EspAppDesc` types |
| new | `astros_api/src/firmware/esp_app_desc.ts` | Pure `parseEspAppDesc` + struct-offset constants |
| new | `astros_api/src/firmware/esp_app_desc.test.ts` | 11 new tests with constructed-buffer fixtures |
| new | `astros_api/src/firmware/firmware_upload_store.ts` | `FirmwareUploadStore` class — single-slot, atomic-promote, defensive `latest()` |
| new | `astros_api/src/firmware/firmware_upload_store.test.ts` | 18 new tests with real temp dirs |
| new | `.docs/plans/20260502-1100-firmware-ota-c-5-upload-store.md` | Light plan + full failure-mode inventory + verification gates |

7 source files + 1 plan = 8 files changed. Under the 10-file PR cap.

## Notes for the reviewer

- **Two planning-time assumptions corrected during implementation** (commit `7fee987`). Live-parsing a real `AstrOs.ESP/.pio/build/lolin_d32_pro/firmware.bin` with the just-shipped `parseEspAppDesc` surfaced both. Decomposition Open Item #4 is now closed with evidence, not a guess.

  1. **`project_name` is `"AstrOs.ESP"`, not `"astros-esp"`.** The CMake `project(AstrOs.ESP)` call in `AstrOs.ESP/CMakeLists.txt:4` is what ESP-IDF embeds verbatim into `esp_app_desc_t.project_name`. The asset-filename prefix `astros-esp-…-app.bin` (from c.3's regex) is set independently by CI tooling and is unrelated to the embedded value. `DEFAULT_PROJECT_NAME` in `firmware_upload_store.ts` was flipped accordingly.

  2. **`version` is `git describe --tags --dirty` output, not clean semver.** Real example from a dev build: `"v1.0.0-RC.1-71-g9a55936-dirty"`. ESP-IDF defaults to `git describe` when neither `CONFIG_APP_PROJECT_VER_FROM_CONFIG` nor a `version.txt` is set, and AstrOs.ESP has neither. The store now runs `normalizeEspVersion()` before validation — strips leading `v` and trailing `-<N>-g<sha>(-dirty)?` suffix — so the persisted `meta.version` is the clean shape (`"1.0.0-RC.1"`) that matches GitHub-release filenames. c.6's orchestrator can compare upload-source and GitHub-source versions directly without per-source casing logic. Six dedicated tests cover the normalization paths.

- **`esp_app_desc_t` field offsets** verified end-to-end by parsing the real binary (offset 32, magic `0xABCD5432`, all string fields decode correctly). The struct has been stable since ESP-IDF v4.0; if a future release rearranges, the parser's `F_*` constants are the single point of change.

- **First FMI customer.** The failure-mode-inventory template at `.docs/templates/failure-mode-inventory.md` was added in commit `6a525c9` in response to c.4's ~10-round review. c.5 is the first plan to fill it out upfront. The plan's `## Failure modes` section maps every test case to a specific FMI row — feel free to read the FMI sections (§1 external-call coverage, §2 crash-recovery state matrix, §6 hostile input) when reviewing the test list, since each test corresponds to a planned failure mode rather than a "what could break" guess.

- **Hash on store but not on `latest()`.** Symmetric to c.4. Sidecar is the source of truth; re-hashing 1.2 MB on every read costs ~80–100 ms for no semantic gain. The orchestrator (c.6) and master both re-hash downstream — corruption between store-time and flash-time surfaces as `HASH_MISMATCH` there, not a silent flash of corrupted bytes.

- **`path_safety.ts` extraction touches c.4.** `firmware_cache.ts` had the regex + helper inline; this PR moves them to a shared module so c.5 can reuse without duplication. c.4's tests stay green because the behavior is unchanged. If you'd prefer to keep c.4 untouched, the fallback is duplicating six lines into `firmware_upload_store.ts` — happy to revert if so, but the second use site is the natural moment to extract.

## Out of scope (deferred)

- HTTP route exposure (`POST /firmware/upload`) — **c.8**
- `express-fileupload` route-scoped middleware mount + `tmp/` directory creation + startup orphan-sweep — **c.8** (the plan recommends route-scoped over global config; rationale in the plan's "Notes for the reviewer")
- FlashJob orchestrator wiring — **c.6**
- WebSocket fan-out for "selected upload" UI state — **c.7**
- Multi-slot upload retention / history — explicit non-goal
- Re-validation at flash time — orchestrator (c.6) MAY re-parse the `.bin` for paranoia; this plan recommends but doesn't ship
- Cross-process safety — single-process server only
