### PR TITLE
OTA Firmware Deployment: Flash Job State

### DIFF
--- a/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
+++ b/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
@@ -93,13 +93,17 @@ Queued → UploadingToMaster → Sending → Verifying → Rebooting → Version
 - [x] `npm run prettier:write` and `npm run lint:fix` clean.
 - [x] No new fs / network / serial imports — c.6a's only external dep is `FwStage`.
 
-## Files in scope (3)
+## Source files in scope (3)
 
 1. `astros_api/src/models/firmware/flash_job_state.ts` — discriminated union, FlashJobState, FlashSource, JobLifecycle
 2. `astros_api/src/firmware/flash_job_state_machine.ts` — transitions + derivation + terminal-check
 3. `astros_api/src/firmware/flash_job_state_machine.test.ts` — tests
 
-3 files, well under the 10-file cap. **Does not modify** any existing module — the new types reference `FwStage` from c.1 and that's the only inbound dep.
+3 source files, well under the 10-file cap. **Does not modify any existing source module** — the new types reference `FwStage` from c.1 and that's the only inbound dep.
+
+**Also in this PR's diff but out of c.6a's feature scope:**
+- This plan file itself (`.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md`), per the "plan committed before implementation" rule in CLAUDE.md.
+- A workflow update to `CLAUDE.md` adding `superpowers:requesting-code-review` as a mandatory pre-commit step. Process change driven by accumulated PR-review-round cost across c.5 / c.6a; rides along on this branch for operational simplicity rather than its own PR.
 
 ## Out of scope
 

--- a/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
+++ b/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
@@ -47,14 +47,14 @@ Queued → UploadingToMaster → Sending → Verifying → Rebooting → Version
 
 ## Tasks
 
-- [ ] **Typed models** (new `astros_api/src/models/firmware/flash_job_state.ts`):
+- [x] **Typed models** (new `astros_api/src/models/firmware/flash_job_state.ts`):
     - `ControllerFlashState` discriminated union (7 variants matching the seven `FwStage` values)
     - `FlashJobState` interface
     - `FlashSource` interface
     - `JobLifecycle` string union
     - All inline comments only where the type's role is non-obvious (mirrors `cache.ts` / `upload.ts` style); no field-by-field narration
 
-- [ ] **State machine functions** (new `astros_api/src/firmware/flash_job_state_machine.ts`):
+- [x] **State machine functions** (new `astros_api/src/firmware/flash_job_state_machine.ts`):
     - `LEGAL_NEXT_STAGES`: `Map<FwStage, ReadonlySet<FwStage>>` — single source of truth for the transition graph. Keeps the validator's logic out of a giant switch.
     - `isControllerStageTerminal(stage)` — `stage === FwStage.VersionConfirmed || stage === FwStage.Failed`
     - `transitionControllerState` — overloaded signatures:
@@ -64,7 +64,7 @@ Queued → UploadingToMaster → Sending → Verifying → Rebooting → Version
     - Implementation throws `Error` with the stage names when transition is illegal; throws when payload doesn't carry the required field (defense for callers that bypass the types).
     - `deriveJobLifecycle` — early-returns `'failed'` on `abortReason`, `'pending'` if all `Queued`, `'done'` if all terminal, else `'in_flight'`.
 
-- [ ] **Tests** (new `astros_api/src/firmware/flash_job_state_machine.test.ts`):
+- [x] **Tests** (new `astros_api/src/firmware/flash_job_state_machine.test.ts`):
     - Happy path: full linear progression Queued→…→VersionConfirmed succeeds; each step preserves immutability of the input state
     - Failed reachable from each non-terminal stage (5 tests, one per source)
     - Illegal transitions throw with informative error messages:
@@ -88,10 +88,10 @@ Queued → UploadingToMaster → Sending → Verifying → Rebooting → Version
 
 ## Verification
 
-- [ ] `npm run build` clean (lint + tsc).
-- [ ] `npm run test` green (post-c.5 baseline + ~25 new tests).
-- [ ] `npm run prettier:write` and `npm run lint:fix` clean.
-- [ ] No new fs / network / serial imports — c.6a's only external deps are `FwStage` and a logger if any.
+- [x] `npm run build` clean (lint + tsc).
+- [x] `npm run test` green (432 → 475, +43 new tests; parameterized `it.each` cases counted individually).
+- [x] `npm run prettier:write` and `npm run lint:fix` clean.
+- [x] No new fs / network / serial imports — c.6a's only external dep is `FwStage`.
 
 ## Files in scope (3)
 

--- a/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
+++ b/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
@@ -20,7 +20,7 @@ c.6a's payoff: by the time c.6c is written, the FSM rules are locked in tests an
 
 **Types** (in `astros_api/src/models/firmware/flash_job_state.ts`):
 
-- `ControllerFlashState` — discriminated union over `FwStage` (existing enum at `models/firmware/firmware_messages.ts`). All variants carry `controllerId`, `bytesSent`, `totalBytes`, `detail?`. Terminal variants add stage-specific fields:
+- `ControllerFlashState` — discriminated union over `FwStage` (existing enum at `models/firmware/firmware_messages.ts`). All variants carry `controllerId`, `bytesSent`, `totalBytes`, `detail` (required string — mirrors the wire shape `FwProgress.detail`; empty string when no message). Terminal variants add stage-specific fields:
     - `VersionConfirmed` adds `finalVersion: string`
     - `Failed` adds `error: string`
 - `FlashJobState` — `{ jobId, source: FlashSource, controllers: ControllerFlashState[], startedAt: string, endedAt?: string, abortReason?: string }`. Ordered array, not Map — keeps JSON serialization (c.7's WS payloads) trivial; ~3 controllers means O(n) lookup is a non-issue.

--- a/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
+++ b/.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md
@@ -1,0 +1,120 @@
+# c.6a — FlashJob state machine + types
+
+Light plan for the first sub-project of c.6 under the by-layer split. c.6a ships pure types + a small set of pure-function transitions that model a flash job's state — no I/O, no Express, no serial integration. Subsequent phases consume this: c.6b (chunk-streaming transport) reads `FwStage` to emit progress; c.6c (orchestrator + harness) drives the transitions in response to serial events and JobLock state.
+
+**Branch:** `feature/firmware-ota-c-6a-flash-job-state` (off `develop`).
+**PR target base:** `develop`.
+**References:** [decomposition plan](./20260427-2202-firmware-ota-decomposition.md) § "Sub-project decomposition" + § "C. Server ↔ Vue (WebSocket)" (lines 193–233 for the on-the-wire shapes that motivate the type design).
+
+## Context
+
+c.6 (FlashJob orchestrator) was flagged in the original decomposition as the highest-risk piece in the c-series, and the c.5 plan-mode workflow noted it warrants splitting. The by-layer split keeps each sub-project independently reviewable and testable:
+
+- **c.6a** (this plan) — FSM types + transitions, pure compute
+- **c.6b** — sliding-window chunk streamer (sender side)
+- **c.6c** — orchestrator that composes a/b with `JobLock`, source resolver (cache + upload), WS emit points, and a PTY-stub harness
+
+c.6a's payoff: by the time c.6c is written, the FSM rules are locked in tests and don't have to be re-litigated against the orchestrator's I/O loops. The protocol contract (`.docs/protocol.md` § A) already enumerates the seven stages a controller moves through; this plan codifies them as a discriminated union with a single legal-transition function so the orchestrator can never produce an illegal sequence.
+
+## API overview
+
+**Types** (in `astros_api/src/models/firmware/flash_job_state.ts`):
+
+- `ControllerFlashState` — discriminated union over `FwStage` (existing enum at `models/firmware/firmware_messages.ts`). All variants carry `controllerId`, `bytesSent`, `totalBytes`, `detail?`. Terminal variants add stage-specific fields:
+    - `VersionConfirmed` adds `finalVersion: string`
+    - `Failed` adds `error: string`
+- `FlashJobState` — `{ jobId, source: FlashSource, controllers: ControllerFlashState[], startedAt: string, endedAt?: string, abortReason?: string }`. Ordered array, not Map — keeps JSON serialization (c.7's WS payloads) trivial; ~3 controllers means O(n) lookup is a non-issue.
+- `FlashSource` — `{ kind: 'github' | 'upload', version: string, sha256: string, sizeBytes: number, displayName: string }`. Unifying view over c.4's `CachedAsset` and c.5's `StoredUpload`. `displayName` is what UI shows ("astros-esp 1.4.0" or "firmware-rc1.bin").
+- `JobLifecycle` — string union `'pending' | 'in_flight' | 'done' | 'failed'`. Derived from the aggregate of controller states + `abortReason` (see `deriveJobLifecycle` below).
+
+**Functions** (in `astros_api/src/firmware/flash_job_state_machine.ts`):
+
+- `transitionControllerState(current, toStage, payload?): ControllerFlashState` — overloaded so the type system requires `finalVersion` when `toStage === FwStage.VersionConfirmed` and `error` when `toStage === FwStage.Failed`. Throws on illegal transitions (skipping stages, reversing, leaving a terminal state). Returns a new state object — input is not mutated.
+- `deriveJobLifecycle(state: FlashJobState): JobLifecycle`:
+    - `failed` if `abortReason` is set
+    - `pending` if every controller is `Queued`
+    - `done` if every controller is terminal (`VersionConfirmed` or `Failed`)
+    - `in_flight` otherwise
+- `isControllerStageTerminal(stage: FwStage): boolean` — small predicate, exported because c.6c will pre-check before constructing transition payloads.
+
+Legal-transition rules (from `.docs/protocol.md` § A happy path):
+
+```
+Queued → UploadingToMaster → Sending → Verifying → Rebooting → VersionConfirmed
+                                                         ↘
+  any-non-terminal → Failed
+```
+
+## Tasks
+
+- [ ] **Typed models** (new `astros_api/src/models/firmware/flash_job_state.ts`):
+    - `ControllerFlashState` discriminated union (7 variants matching the seven `FwStage` values)
+    - `FlashJobState` interface
+    - `FlashSource` interface
+    - `JobLifecycle` string union
+    - All inline comments only where the type's role is non-obvious (mirrors `cache.ts` / `upload.ts` style); no field-by-field narration
+
+- [ ] **State machine functions** (new `astros_api/src/firmware/flash_job_state_machine.ts`):
+    - `LEGAL_NEXT_STAGES`: `Map<FwStage, ReadonlySet<FwStage>>` — single source of truth for the transition graph. Keeps the validator's logic out of a giant switch.
+    - `isControllerStageTerminal(stage)` — `stage === FwStage.VersionConfirmed || stage === FwStage.Failed`
+    - `transitionControllerState` — overloaded signatures:
+        - `(current, FwStage.VersionConfirmed, { finalVersion })` → terminal-OK
+        - `(current, FwStage.Failed, { error })` → terminal-fail
+        - `(current, non-terminal-stage, { bytesSent?, totalBytes?, detail? })` → in-flight progress
+    - Implementation throws `Error` with the stage names when transition is illegal; throws when payload doesn't carry the required field (defense for callers that bypass the types).
+    - `deriveJobLifecycle` — early-returns `'failed'` on `abortReason`, `'pending'` if all `Queued`, `'done'` if all terminal, else `'in_flight'`.
+
+- [ ] **Tests** (new `astros_api/src/firmware/flash_job_state_machine.test.ts`):
+    - Happy path: full linear progression Queued→…→VersionConfirmed succeeds; each step preserves immutability of the input state
+    - Failed reachable from each non-terminal stage (5 tests, one per source)
+    - Illegal transitions throw with informative error messages:
+        - Skip a stage (e.g., Queued→Sending)
+        - Reverse direction (e.g., Sending→Queued)
+        - Out of either terminal state (VersionConfirmed→anything, Failed→anything) — covers all 7 destination stages for each (14 tests, parameterized)
+    - Payload validation:
+        - `transitionControllerState(_, VersionConfirmed, {})` throws
+        - `transitionControllerState(_, Failed, {})` throws
+        - In-flight transition with no payload preserves prior `bytesSent` / `totalBytes` / `detail`
+        - In-flight transition with partial payload merges (e.g., bytesSent updates, totalBytes stays)
+    - `isControllerStageTerminal` — true for VersionConfirmed + Failed, false for the other 5
+    - `deriveJobLifecycle`:
+        - `abortReason` set → `'failed'` regardless of controller states
+        - All controllers in `Queued` → `'pending'`
+        - Mixed (one Queued, one Sending) → `'in_flight'`
+        - All terminal-OK → `'done'`
+        - All terminal-Failed → `'done'` (the job *completed*, even if every controller failed individually — `flashJobFailed` is for early aborts only, per the decomp's WS payload distinction)
+        - Mixed terminal (one OK, one Failed) → `'done'`
+        - Empty controllers array → `'done'` (degenerate; document the choice)
+
+## Verification
+
+- [ ] `npm run build` clean (lint + tsc).
+- [ ] `npm run test` green (post-c.5 baseline + ~25 new tests).
+- [ ] `npm run prettier:write` and `npm run lint:fix` clean.
+- [ ] No new fs / network / serial imports — c.6a's only external deps are `FwStage` and a logger if any.
+
+## Files in scope (3)
+
+1. `astros_api/src/models/firmware/flash_job_state.ts` — discriminated union, FlashJobState, FlashSource, JobLifecycle
+2. `astros_api/src/firmware/flash_job_state_machine.ts` — transitions + derivation + terminal-check
+3. `astros_api/src/firmware/flash_job_state_machine.test.ts` — tests
+
+3 files, well under the 10-file cap. **Does not modify** any existing module — the new types reference `FwStage` from c.1 and that's the only inbound dep.
+
+## Out of scope
+
+- Any I/O — fs, serial, WebSocket. c.6a is pure compute; c.6b owns transport, c.6c owns orchestration.
+- The `FlashSource` *resolver* (logic that picks cache vs upload and produces the `FlashSource` shape from a request) — that's c.6c. c.6a only defines the type.
+- Persistence / restart-survival — explicitly out per the decomp's "v1 non-goals."
+- Per-controller progress throttling (the protocol's 4 Hz cap) — that's the WS layer (c.7) and the orchestrator (c.6c), not the FSM.
+- Failure-mode inventory — c.6a is pure compute, no fs / concurrency / network state. CLAUDE.md says skip FMI for that case.
+
+## Notes for the reviewer
+
+- **Why discriminated union over a single shape with optional fields.** The protocol distinguishes `flashControllerUpdate` (in-flight, requires `stage` + bytes) from `flashControllerResult` (terminal, requires `result` + `finalVersion`/`error`). A single shape with everything optional would let TypeScript accept `{ stage: VersionConfirmed }` without a `finalVersion`, exactly the thing the type is supposed to prevent. Discriminated union pushes the protocol's invariants into the type system, so the orchestrator can't construct an illegal payload at compile time, never mind runtime.
+
+- **Why `abortReason` lives at the job level, not as a controller state.** The protocol's `flashJobFailed` event represents a job-wide abort (master serial disconnect, hash mismatch on master's SD copy, upload failed), distinct from any per-controller `Failed`. A controller's `Failed` is local — others can still complete. A job abort is global. Keeping the two separate matches the decomp's WS event vocabulary and lets `deriveJobLifecycle` distinguish "job ran to completion (some/all controllers may have failed individually)" from "job was aborted before all controllers attempted."
+
+- **Why a `Map` for `LEGAL_NEXT_STAGES` rather than a switch.** The transition graph is small and static; a `Map` literal makes the rules visible at-a-glance and makes the validator a one-liner (`return LEGAL_NEXT_STAGES.get(from)?.has(to) ?? false`). A switch would scatter the rules across cases and tempt readers to look in two places.
+
+- **Empty-controllers-array yields `'done'`.** This is a degenerate input the orchestrator should never produce (a job with no targets shouldn't have started). Documenting `'done'` as the choice means `deriveJobLifecycle` is total — no `undefined`, no throw — which keeps callers simple. An invariant assertion could be added at the orchestrator layer if it's worth defending; not c.6a's job.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,13 @@ The system manages **Locations** (physical positions on the droid) that contain 
 
 ## Pre-commit
 
-Always run lint and prettier before making a commit to ensure consistent formatting.
+Before each implementation commit, run in order:
+
+1. `npm run prettier:write` and `npm run lint:fix` (formatting + lint).
+2. `npm run build` (type-check) and the test suite (`npx vitest run` for single-run mode).
+3. Invoke `superpowers:requesting-code-review` on the diff against the prior commit (or `origin/<branch>` for a batch of unpushed work). Mechanical checks confirm the code compiles and tests pass; code review catches what tests can't see — comment-vs-code drift, naming-vs-protocol mismatches, missing capabilities, broken test-name format strings, and similar issues that have repeatedly come back as PR feedback when this step is skipped. Address **Critical** and **Important** issues before committing; note **Minor** for later.
+
+**Carve-outs that may skip step 3:** plan-only commits (no source changes), trivial typo / comment-only fixes, and check-off-only updates to a plan file. Everything else — including any change to a `.ts` / `.tsx` / test file with logic — requires the review.
 
 ## Branching & PRs
 
@@ -148,7 +154,7 @@ Use the following skills and subagents as part of the development workflow:
 - **Feature Dev** (`feature-dev:feature-dev`): Use for guided feature development with codebase understanding and architecture focus.
 - **Debugging** (`superpowers:systematic-debugging`): Use systematic debugging for any bug, test failure, or unexpected behavior before proposing fixes.
 - **Verification** (`superpowers:verification-before-completion`): Always verify before claiming work is done or creating a PR. Run tests and confirm output — evidence before assertions.
-- **Code Review** (`superpowers:requesting-code-review`): Request a code review after completing significant features or before merging.
+- **Code Review** (`superpowers:requesting-code-review`): Run **before every implementation commit** (between tests-passing and `git commit`) — same workflow slot as prettier / lint. Mechanical checks miss comment-vs-code drift, missing capabilities, protocol-shape mismatches, and broken test-name format strings; the reviewer subagent catches them. See the Pre-commit section for the carve-outs that may skip it.
 - **Parallel Agents** (`superpowers:dispatching-parallel-agents`): Use parallel agents for independent tasks that can be worked on without shared state or sequential dependencies.
 
 ## Internationalization (i18n)

--- a/astros_api/src/firmware/flash_job_state_machine.test.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.test.ts
@@ -21,6 +21,7 @@ function queued(
     controllerId: C_ID,
     bytesSent: 0,
     totalBytes: 0,
+    detail: '',
     ...overrides,
   };
 }
@@ -34,6 +35,7 @@ function withStage(
     controllerId: C_ID,
     bytesSent: 0,
     totalBytes: 0,
+    detail: '',
     ...overrides,
   };
 }
@@ -44,6 +46,7 @@ function versionConfirmed(finalVersion = '1.4.0'): ControllerFlashState {
     controllerId: C_ID,
     bytesSent: 1024,
     totalBytes: 1024,
+    detail: '',
     finalVersion,
   };
 }
@@ -54,6 +57,7 @@ function failed(error = 'simulated'): ControllerFlashState {
     controllerId: C_ID,
     bytesSent: 0,
     totalBytes: 0,
+    detail: '',
     error,
   };
 }

--- a/astros_api/src/firmware/flash_job_state_machine.test.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.test.ts
@@ -224,6 +224,57 @@ describe('transitionControllerState — payload validation', () => {
   });
 });
 
+describe('transitionControllerState — same-stage progress updates', () => {
+  // FW_PROGRESS messages arrive multiple times within a single stage
+  // (e.g., bytesSent flowing during Sending). The orchestrator
+  // translates each into `transitionControllerState(state, currentStage,
+  // payload)` — same-stage transitions must merge the payload onto the
+  // current state without throwing.
+
+  it.each([
+    FwStage.Queued,
+    FwStage.UploadingToMaster,
+    FwStage.Sending,
+    FwStage.Verifying,
+    FwStage.Rebooting,
+  ] as const)('non-terminal %s → %s merges bytesSent', (stage) => {
+    const start: ControllerFlashState =
+      stage === FwStage.Queued
+        ? queued({ bytesSent: 100, totalBytes: 1024, detail: 'mid-flight' })
+        : withStage(stage, { bytesSent: 100, totalBytes: 1024, detail: 'mid-flight' });
+    const next = transitionControllerState(start, stage, { bytesSent: 500 });
+    expect(next.stage).toBe(stage);
+    expect(next.bytesSent).toBe(500);
+    expect(next.totalBytes).toBe(1024);
+    expect(next.detail).toBe('mid-flight');
+  });
+
+  it('same-stage update with no payload is a no-op equivalent', () => {
+    const start = withStage(FwStage.Sending, {
+      bytesSent: 256,
+      totalBytes: 1024,
+      detail: 'streaming',
+    });
+    const next = transitionControllerState(start, FwStage.Sending);
+    expect(next).toEqual(start);
+    expect(next).not.toBe(start); // still returns a new object
+  });
+
+  it('terminal-to-self stays illegal: VersionConfirmed → VersionConfirmed throws', () => {
+    expect(() =>
+      transitionControllerState(versionConfirmed(), FwStage.VersionConfirmed, {
+        finalVersion: '1.4.0',
+      }),
+    ).toThrow(/illegal/i);
+  });
+
+  it('terminal-to-self stays illegal: Failed → Failed throws', () => {
+    expect(() =>
+      transitionControllerState(failed(), FwStage.Failed, { error: 'still failed' }),
+    ).toThrow(/illegal/i);
+  });
+});
+
 describe('transitionControllerState — payload merging on legal in-flight transitions', () => {
   it('merges new bytesSent while preserving totalBytes and detail', () => {
     const start = withStage(FwStage.UploadingToMaster, {

--- a/astros_api/src/firmware/flash_job_state_machine.test.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from 'vitest';
+import { FwStage } from '../models/firmware/firmware_messages.js';
+import type {
+  ControllerFlashState,
+  FlashJobState,
+  FlashSource,
+} from '../models/firmware/flash_job_state.js';
+import {
+  deriveJobLifecycle,
+  isControllerStageTerminal,
+  transitionControllerState,
+} from './flash_job_state_machine.js';
+
+const C_ID = 'core';
+
+function queued(
+  overrides: Partial<{ bytesSent: number; totalBytes: number; detail: string }> = {},
+): ControllerFlashState {
+  return {
+    stage: FwStage.Queued,
+    controllerId: C_ID,
+    bytesSent: 0,
+    totalBytes: 0,
+    ...overrides,
+  };
+}
+
+function withStage(
+  stage: FwStage.UploadingToMaster | FwStage.Sending | FwStage.Verifying | FwStage.Rebooting,
+  overrides: Partial<{ bytesSent: number; totalBytes: number; detail: string }> = {},
+): ControllerFlashState {
+  return {
+    stage,
+    controllerId: C_ID,
+    bytesSent: 0,
+    totalBytes: 0,
+    ...overrides,
+  };
+}
+
+function versionConfirmed(finalVersion = '1.4.0'): ControllerFlashState {
+  return {
+    stage: FwStage.VersionConfirmed,
+    controllerId: C_ID,
+    bytesSent: 1024,
+    totalBytes: 1024,
+    finalVersion,
+  };
+}
+
+function failed(error = 'simulated'): ControllerFlashState {
+  return {
+    stage: FwStage.Failed,
+    controllerId: C_ID,
+    bytesSent: 0,
+    totalBytes: 0,
+    error,
+  };
+}
+
+const SOURCE: FlashSource = {
+  kind: 'github',
+  version: '1.4.0',
+  sha256: 'abc',
+  sizeBytes: 1024,
+  displayName: 'astros-esp 1.4.0',
+};
+
+function jobStateWith(controllers: ControllerFlashState[], abortReason?: string): FlashJobState {
+  return {
+    jobId: 'job-1',
+    source: SOURCE,
+    controllers,
+    startedAt: '2026-05-02T15:00:00.000Z',
+    abortReason,
+  };
+}
+
+describe('isControllerStageTerminal', () => {
+  it.each([
+    [FwStage.VersionConfirmed, true],
+    [FwStage.Failed, true],
+    [FwStage.Queued, false],
+    [FwStage.UploadingToMaster, false],
+    [FwStage.Sending, false],
+    [FwStage.Verifying, false],
+    [FwStage.Rebooting, false],
+  ])('%s → %s', (stage, expected) => {
+    expect(isControllerStageTerminal(stage)).toBe(expected);
+  });
+});
+
+describe('transitionControllerState — happy path', () => {
+  it('progresses through the full linear sequence', () => {
+    let state = queued();
+    state = transitionControllerState(state, FwStage.UploadingToMaster);
+    expect(state.stage).toBe(FwStage.UploadingToMaster);
+    state = transitionControllerState(state, FwStage.Sending);
+    expect(state.stage).toBe(FwStage.Sending);
+    state = transitionControllerState(state, FwStage.Verifying);
+    expect(state.stage).toBe(FwStage.Verifying);
+    state = transitionControllerState(state, FwStage.Rebooting);
+    expect(state.stage).toBe(FwStage.Rebooting);
+    state = transitionControllerState(state, FwStage.VersionConfirmed, {
+      finalVersion: '1.4.0',
+    });
+    expect(state.stage).toBe(FwStage.VersionConfirmed);
+    if (state.stage === FwStage.VersionConfirmed) {
+      expect(state.finalVersion).toBe('1.4.0');
+    }
+  });
+
+  it('does not mutate the input state', () => {
+    const before = queued({ bytesSent: 100, totalBytes: 1024, detail: 'starting' });
+    const snapshot = JSON.parse(JSON.stringify(before));
+    transitionControllerState(before, FwStage.UploadingToMaster, { bytesSent: 200 });
+    expect(before).toEqual(snapshot);
+  });
+
+  it.each([
+    FwStage.Queued,
+    FwStage.UploadingToMaster,
+    FwStage.Sending,
+    FwStage.Verifying,
+    FwStage.Rebooting,
+  ] as const)('Failed is reachable from %s', (fromStage) => {
+    const start: ControllerFlashState =
+      fromStage === FwStage.Queued ? queued() : withStage(fromStage);
+    const result = transitionControllerState(start, FwStage.Failed, { error: 'test' });
+    expect(result.stage).toBe(FwStage.Failed);
+    if (result.stage === FwStage.Failed) {
+      expect(result.error).toBe('test');
+    }
+  });
+});
+
+describe('transitionControllerState — illegal transitions throw', () => {
+  it('skipping a stage (Queued → Sending) throws', () => {
+    expect(() => transitionControllerState(queued(), FwStage.Sending)).toThrow(/illegal/i);
+  });
+
+  it('reverse direction (Sending → Queued) throws', () => {
+    expect(() => transitionControllerState(withStage(FwStage.Sending), FwStage.Queued)).toThrow(
+      /illegal/i,
+    );
+  });
+
+  it.each([
+    FwStage.Queued,
+    FwStage.UploadingToMaster,
+    FwStage.Sending,
+    FwStage.Verifying,
+    FwStage.Rebooting,
+    FwStage.VersionConfirmed,
+    FwStage.Failed,
+  ] as const)('VersionConfirmed → %s throws', (toStage) => {
+    expect(() => {
+      // `as` cast because some toStage values are valid types for the
+      // overload but illegal at runtime; we're testing the runtime guard.
+      const fn = transitionControllerState as (
+        c: ControllerFlashState,
+        s: FwStage,
+        p?: { finalVersion?: string; error?: string },
+      ) => unknown;
+      fn(versionConfirmed(), toStage, { finalVersion: 'x', error: 'x' });
+    }).toThrow(/illegal/i);
+  });
+
+  it.each([
+    FwStage.Queued,
+    FwStage.UploadingToMaster,
+    FwStage.Sending,
+    FwStage.Verifying,
+    FwStage.Rebooting,
+    FwStage.VersionConfirmed,
+    FwStage.Failed,
+  ] as const)('Failed → %s throws', (toStage) => {
+    expect(() => {
+      const fn = transitionControllerState as (
+        c: ControllerFlashState,
+        s: FwStage,
+        p?: { finalVersion?: string; error?: string },
+      ) => unknown;
+      fn(failed(), toStage, { finalVersion: 'x', error: 'x' });
+    }).toThrow(/illegal/i);
+  });
+});
+
+describe('transitionControllerState — payload validation', () => {
+  it('VersionConfirmed without finalVersion throws', () => {
+    const start = withStage(FwStage.Rebooting);
+    expect(() => {
+      const fn = transitionControllerState as (
+        c: ControllerFlashState,
+        s: FwStage,
+        p?: { finalVersion?: string },
+      ) => unknown;
+      fn(start, FwStage.VersionConfirmed);
+    }).toThrow(/finalVersion/);
+  });
+
+  it('Failed without error throws', () => {
+    const start = withStage(FwStage.Sending);
+    expect(() => {
+      const fn = transitionControllerState as (
+        c: ControllerFlashState,
+        s: FwStage,
+        p?: { error?: string },
+      ) => unknown;
+      fn(start, FwStage.Failed);
+    }).toThrow(/error/);
+  });
+
+  it('non-terminal transition with no payload preserves prior bytesSent/totalBytes/detail', () => {
+    const start = queued({ bytesSent: 256, totalBytes: 1024, detail: 'pending upload' });
+    const next = transitionControllerState(start, FwStage.UploadingToMaster);
+    expect(next.bytesSent).toBe(256);
+    expect(next.totalBytes).toBe(1024);
+    expect(next.detail).toBe('pending upload');
+  });
+});
+
+describe('transitionControllerState — payload merging on legal in-flight transitions', () => {
+  it('merges new bytesSent while preserving totalBytes and detail', () => {
+    const start = withStage(FwStage.UploadingToMaster, {
+      bytesSent: 100,
+      totalBytes: 1024,
+      detail: 'mid-upload',
+    });
+    const next = transitionControllerState(start, FwStage.Sending, { bytesSent: 1024 });
+    expect(next.bytesSent).toBe(1024);
+    expect(next.totalBytes).toBe(1024);
+    expect(next.detail).toBe('mid-upload');
+  });
+
+  it('merges new detail while preserving byte counts', () => {
+    const start = withStage(FwStage.Sending, {
+      bytesSent: 1024,
+      totalBytes: 1024,
+      detail: 'sent',
+    });
+    const next = transitionControllerState(start, FwStage.Verifying, { detail: 'verifying hash' });
+    expect(next.bytesSent).toBe(1024);
+    expect(next.totalBytes).toBe(1024);
+    expect(next.detail).toBe('verifying hash');
+  });
+});
+
+describe('deriveJobLifecycle', () => {
+  it("returns 'failed' when abortReason is set, regardless of controller states", () => {
+    expect(
+      deriveJobLifecycle(
+        jobStateWith([versionConfirmed(), versionConfirmed()], 'master_disconnect'),
+      ),
+    ).toBe('failed');
+  });
+
+  it("returns 'pending' when every controller is Queued", () => {
+    expect(deriveJobLifecycle(jobStateWith([queued(), queued()]))).toBe('pending');
+  });
+
+  it("returns 'in_flight' when controllers are mixed (Queued + Sending)", () => {
+    expect(deriveJobLifecycle(jobStateWith([queued(), withStage(FwStage.Sending)]))).toBe(
+      'in_flight',
+    );
+  });
+
+  it("returns 'done' when every controller is VersionConfirmed", () => {
+    expect(deriveJobLifecycle(jobStateWith([versionConfirmed(), versionConfirmed()]))).toBe('done');
+  });
+
+  it("returns 'done' when every controller is Failed (job ran to completion, all failed individually)", () => {
+    expect(deriveJobLifecycle(jobStateWith([failed(), failed()]))).toBe('done');
+  });
+
+  it("returns 'done' for mixed terminal states (one VersionConfirmed, one Failed)", () => {
+    expect(deriveJobLifecycle(jobStateWith([versionConfirmed(), failed()]))).toBe('done');
+  });
+
+  it("returns 'done' for empty controllers array (degenerate input)", () => {
+    expect(deriveJobLifecycle(jobStateWith([]))).toBe('done');
+  });
+
+  it("returns 'in_flight' when one controller is terminal and another is mid-stream", () => {
+    expect(deriveJobLifecycle(jobStateWith([versionConfirmed(), withStage(FwStage.Sending)]))).toBe(
+      'in_flight',
+    );
+  });
+});

--- a/astros_api/src/firmware/flash_job_state_machine.test.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.test.ts
@@ -237,17 +237,20 @@ describe('transitionControllerState — same-stage progress updates', () => {
     FwStage.Sending,
     FwStage.Verifying,
     FwStage.Rebooting,
-  ] as const)('non-terminal %s → %s merges bytesSent', (stage) => {
-    const start: ControllerFlashState =
-      stage === FwStage.Queued
-        ? queued({ bytesSent: 100, totalBytes: 1024, detail: 'mid-flight' })
-        : withStage(stage, { bytesSent: 100, totalBytes: 1024, detail: 'mid-flight' });
-    const next = transitionControllerState(start, stage, { bytesSent: 500 });
-    expect(next.stage).toBe(stage);
-    expect(next.bytesSent).toBe(500);
-    expect(next.totalBytes).toBe(1024);
-    expect(next.detail).toBe('mid-flight');
-  });
+  ] as const)(
+    'FW_PROGRESS during %s updates byte counts without forcing a stage transition',
+    (stage) => {
+      const start: ControllerFlashState =
+        stage === FwStage.Queued
+          ? queued({ bytesSent: 100, totalBytes: 1024, detail: 'mid-flight' })
+          : withStage(stage, { bytesSent: 100, totalBytes: 1024, detail: 'mid-flight' });
+      const next = transitionControllerState(start, stage, { bytesSent: 500 });
+      expect(next.stage).toBe(stage);
+      expect(next.bytesSent).toBe(500);
+      expect(next.totalBytes).toBe(1024);
+      expect(next.detail).toBe('mid-flight');
+    },
+  );
 
   it('same-stage update with no payload is a no-op equivalent', () => {
     const start = withStage(FwStage.Sending, {

--- a/astros_api/src/firmware/flash_job_state_machine.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.ts
@@ -1,0 +1,115 @@
+import { FwStage } from '../models/firmware/firmware_messages.js';
+import type {
+  ControllerFlashState,
+  FlashJobState,
+  JobLifecycle,
+} from '../models/firmware/flash_job_state.js';
+
+// Single source of truth for the per-controller transition graph.
+// Each entry maps a stage to the set of legal next stages. Terminal
+// stages map to empty sets — once a controller reaches them, it stays.
+const LEGAL_NEXT_STAGES: ReadonlyMap<FwStage, ReadonlySet<FwStage>> = new Map<
+  FwStage,
+  ReadonlySet<FwStage>
+>([
+  [FwStage.Queued, new Set([FwStage.UploadingToMaster, FwStage.Failed])],
+  [FwStage.UploadingToMaster, new Set([FwStage.Sending, FwStage.Failed])],
+  [FwStage.Sending, new Set([FwStage.Verifying, FwStage.Failed])],
+  [FwStage.Verifying, new Set([FwStage.Rebooting, FwStage.Failed])],
+  [FwStage.Rebooting, new Set([FwStage.VersionConfirmed, FwStage.Failed])],
+  [FwStage.VersionConfirmed, new Set()],
+  [FwStage.Failed, new Set()],
+]);
+
+export function isControllerStageTerminal(stage: FwStage): boolean {
+  return stage === FwStage.VersionConfirmed || stage === FwStage.Failed;
+}
+
+interface InFlightTransitionPayload {
+  bytesSent?: number;
+  totalBytes?: number;
+  detail?: string;
+}
+
+interface VersionConfirmedPayload {
+  finalVersion: string;
+}
+
+interface FailedPayload {
+  error: string;
+}
+
+type NonTerminalStage =
+  | FwStage.Queued
+  | FwStage.UploadingToMaster
+  | FwStage.Sending
+  | FwStage.Verifying
+  | FwStage.Rebooting;
+
+// Overloaded so the type system enforces stage-specific payloads at the
+// call site. The implementation still validates payload at runtime as
+// belt-and-suspenders for callers who bypass the types.
+export function transitionControllerState(
+  current: ControllerFlashState,
+  toStage: FwStage.VersionConfirmed,
+  payload: VersionConfirmedPayload,
+): ControllerFlashState;
+export function transitionControllerState(
+  current: ControllerFlashState,
+  toStage: FwStage.Failed,
+  payload: FailedPayload,
+): ControllerFlashState;
+export function transitionControllerState(
+  current: ControllerFlashState,
+  toStage: NonTerminalStage,
+  payload?: InFlightTransitionPayload,
+): ControllerFlashState;
+export function transitionControllerState(
+  current: ControllerFlashState,
+  toStage: FwStage,
+  payload?: InFlightTransitionPayload & Partial<VersionConfirmedPayload> & Partial<FailedPayload>,
+): ControllerFlashState {
+  if (!LEGAL_NEXT_STAGES.get(current.stage)?.has(toStage)) {
+    throw new Error(
+      `illegal flash-job transition: ${current.stage} → ${toStage} (controllerId=${current.controllerId})`,
+    );
+  }
+
+  const base = {
+    controllerId: current.controllerId,
+    bytesSent: payload?.bytesSent ?? current.bytesSent,
+    totalBytes: payload?.totalBytes ?? current.totalBytes,
+    detail: payload?.detail ?? current.detail,
+  };
+
+  if (toStage === FwStage.VersionConfirmed) {
+    if (typeof payload?.finalVersion !== 'string') {
+      throw new Error(
+        `flash-job transition to ${FwStage.VersionConfirmed} requires finalVersion in payload (controllerId=${current.controllerId})`,
+      );
+    }
+    return { ...base, stage: FwStage.VersionConfirmed, finalVersion: payload.finalVersion };
+  }
+
+  if (toStage === FwStage.Failed) {
+    if (typeof payload?.error !== 'string') {
+      throw new Error(
+        `flash-job transition to ${FwStage.Failed} requires error in payload (controllerId=${current.controllerId})`,
+      );
+    }
+    return { ...base, stage: FwStage.Failed, error: payload.error };
+  }
+
+  return { ...base, stage: toStage };
+}
+
+export function deriveJobLifecycle(state: FlashJobState): JobLifecycle {
+  if (state.abortReason !== undefined) return 'failed';
+  // Empty controllers array is degenerate — the orchestrator shouldn't
+  // produce a job with no targets. Returning 'done' keeps the function
+  // total; a stricter check belongs at the orchestrator layer.
+  if (state.controllers.length === 0) return 'done';
+  if (state.controllers.every((c) => c.stage === FwStage.Queued)) return 'pending';
+  if (state.controllers.every((c) => isControllerStageTerminal(c.stage))) return 'done';
+  return 'in_flight';
+}

--- a/astros_api/src/firmware/flash_job_state_machine.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.ts
@@ -6,17 +6,23 @@ import type {
 } from '../models/firmware/flash_job_state.js';
 
 // Single source of truth for the per-controller transition graph.
-// Each entry maps a stage to the set of legal next stages. Terminal
-// stages map to empty sets — once a controller reaches them, it stays.
+// Each entry maps a stage to the set of legal next stages. Non-terminal
+// stages include themselves so within-stage progress updates (e.g.,
+// bytesSent flowing during Sending as FW_PROGRESS messages arrive) are
+// expressed as same-stage transitions. Terminal stages map to empty
+// sets — once a controller reaches them, it stays.
 const LEGAL_NEXT_STAGES: ReadonlyMap<FwStage, ReadonlySet<FwStage>> = new Map<
   FwStage,
   ReadonlySet<FwStage>
 >([
-  [FwStage.Queued, new Set([FwStage.UploadingToMaster, FwStage.Failed])],
-  [FwStage.UploadingToMaster, new Set([FwStage.Sending, FwStage.Failed])],
-  [FwStage.Sending, new Set([FwStage.Verifying, FwStage.Failed])],
-  [FwStage.Verifying, new Set([FwStage.Rebooting, FwStage.Failed])],
-  [FwStage.Rebooting, new Set([FwStage.VersionConfirmed, FwStage.Failed])],
+  [FwStage.Queued, new Set([FwStage.Queued, FwStage.UploadingToMaster, FwStage.Failed])],
+  [
+    FwStage.UploadingToMaster,
+    new Set([FwStage.UploadingToMaster, FwStage.Sending, FwStage.Failed]),
+  ],
+  [FwStage.Sending, new Set([FwStage.Sending, FwStage.Verifying, FwStage.Failed])],
+  [FwStage.Verifying, new Set([FwStage.Verifying, FwStage.Rebooting, FwStage.Failed])],
+  [FwStage.Rebooting, new Set([FwStage.Rebooting, FwStage.VersionConfirmed, FwStage.Failed])],
   [FwStage.VersionConfirmed, new Set()],
   [FwStage.Failed, new Set()],
 ]);

--- a/astros_api/src/firmware/flash_job_state_machine.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.ts
@@ -5,12 +5,16 @@ import type {
   JobLifecycle,
 } from '../models/firmware/flash_job_state.js';
 
+// Shared empty-set marker for terminal stages — typed so the Map's
+// value side stays uniformly ReadonlySet<FwStage>.
+const EMPTY_STAGE_SET: ReadonlySet<FwStage> = new Set<FwStage>();
+
 // Single source of truth for the per-controller transition graph.
 // Each entry maps a stage to the set of legal next stages. Non-terminal
 // stages include themselves so within-stage progress updates (e.g.,
 // bytesSent flowing during Sending as FW_PROGRESS messages arrive) are
-// expressed as same-stage transitions. Terminal stages map to empty
-// sets — once a controller reaches them, it stays.
+// expressed as same-stage transitions. Terminal stages map to
+// EMPTY_STAGE_SET — once a controller reaches them, it stays.
 const LEGAL_NEXT_STAGES: ReadonlyMap<FwStage, ReadonlySet<FwStage>> = new Map<
   FwStage,
   ReadonlySet<FwStage>
@@ -23,8 +27,8 @@ const LEGAL_NEXT_STAGES: ReadonlyMap<FwStage, ReadonlySet<FwStage>> = new Map<
   [FwStage.Sending, new Set([FwStage.Sending, FwStage.Verifying, FwStage.Failed])],
   [FwStage.Verifying, new Set([FwStage.Verifying, FwStage.Rebooting, FwStage.Failed])],
   [FwStage.Rebooting, new Set([FwStage.Rebooting, FwStage.VersionConfirmed, FwStage.Failed])],
-  [FwStage.VersionConfirmed, new Set()],
-  [FwStage.Failed, new Set()],
+  [FwStage.VersionConfirmed, EMPTY_STAGE_SET],
+  [FwStage.Failed, EMPTY_STAGE_SET],
 ]);
 
 export function isControllerStageTerminal(stage: FwStage): boolean {

--- a/astros_api/src/firmware/flash_job_state_machine.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.ts
@@ -47,8 +47,14 @@ type NonTerminalStage =
   | FwStage.Rebooting;
 
 // Overloaded so the type system enforces stage-specific payloads at the
-// call site. The implementation still validates payload at runtime as
-// belt-and-suspenders for callers who bypass the types.
+// call site. Runtime defense covers two specific things: (a) stage
+// legality (the LEGAL_NEXT_STAGES lookup), and (b) required terminal-
+// state fields (`finalVersion` for VersionConfirmed, `error` for
+// Failed) — a type-bypassing caller still can't construct an invalid
+// terminal state. In-flight field shapes (numeric range on bytesSent /
+// totalBytes, string-ness of detail) are TypeScript-only; a caller
+// that bypasses the types with garbage values would propagate them,
+// but the FSM transition rules themselves still hold.
 export function transitionControllerState(
   current: ControllerFlashState,
   toStage: FwStage.VersionConfirmed,

--- a/astros_api/src/firmware/flash_job_state_machine.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.ts
@@ -54,13 +54,16 @@ type NonTerminalStage =
 
 // Overloaded so the type system enforces stage-specific payloads at the
 // call site. Runtime defense covers two specific things: (a) stage
-// legality (the LEGAL_NEXT_STAGES lookup), and (b) required terminal-
-// state fields (`finalVersion` for VersionConfirmed, `error` for
-// Failed) — a type-bypassing caller still can't construct an invalid
-// terminal state. In-flight field shapes (numeric range on bytesSent /
-// totalBytes, string-ness of detail) are TypeScript-only; a caller
-// that bypasses the types with garbage values would propagate them,
-// but the FSM transition rules themselves still hold.
+// legality (the LEGAL_NEXT_STAGES lookup, including the non-terminal
+// self-edges that allow successive FW_PROGRESS messages within a
+// stage), and (b) required terminal-state fields (`finalVersion` for
+// VersionConfirmed, `error` for Failed) — a type-bypassing caller
+// still can't construct an invalid terminal state. In-flight field
+// shapes (numeric range on bytesSent / totalBytes, string-ness of
+// detail) are TypeScript-only; a caller that bypasses the types with
+// garbage values would propagate them, but the FSM transition rules
+// themselves still hold. Always returns a new object — the input
+// state is never mutated, including for same-stage no-payload calls.
 export function transitionControllerState(
   current: ControllerFlashState,
   toStage: FwStage.VersionConfirmed,

--- a/astros_api/src/models/firmware/flash_job_state.ts
+++ b/astros_api/src/models/firmware/flash_job_state.ts
@@ -5,8 +5,11 @@ interface BaseControllerFlashState {
   bytesSent: number;
   totalBytes: number;
   // Required-with-empty-string-default rather than optional. Mirrors
-  // the wire shape (FwProgress.detail is a required field) and prevents
-  // `undefined` from leaking through JSON.stringify into the WS payload.
+  // the wire shape (FwProgress.detail is a required field). With
+  // optional, an `undefined` value would cause `JSON.stringify` to
+  // omit the property entirely from the WS payload — consumers would
+  // see the field missing rather than as `""`. Required ensures
+  // every payload carries `detail` with at least an empty string.
   detail: string;
 }
 

--- a/astros_api/src/models/firmware/flash_job_state.ts
+++ b/astros_api/src/models/firmware/flash_job_state.ts
@@ -1,0 +1,41 @@
+import type { FwStage } from './firmware_messages.js';
+
+interface BaseControllerFlashState {
+  controllerId: string;
+  bytesSent: number;
+  totalBytes: number;
+  detail?: string;
+}
+
+export type ControllerFlashState =
+  | (BaseControllerFlashState & { stage: FwStage.Queued })
+  | (BaseControllerFlashState & { stage: FwStage.UploadingToMaster })
+  | (BaseControllerFlashState & { stage: FwStage.Sending })
+  | (BaseControllerFlashState & { stage: FwStage.Verifying })
+  | (BaseControllerFlashState & { stage: FwStage.Rebooting })
+  | (BaseControllerFlashState & { stage: FwStage.VersionConfirmed; finalVersion: string })
+  | (BaseControllerFlashState & { stage: FwStage.Failed; error: string });
+
+export interface FlashSource {
+  kind: 'github' | 'upload';
+  version: string;
+  sha256: string;
+  sizeBytes: number;
+  // Operator-visible label — "astros-esp 1.4.0" for a release, the
+  // original filename for an upload.
+  displayName: string;
+}
+
+export interface FlashJobState {
+  jobId: string;
+  source: FlashSource;
+  controllers: ControllerFlashState[];
+  startedAt: string;
+  endedAt?: string;
+  // Job-wide abort (master serial disconnect, hash mismatch on master's
+  // SD copy, etc.). Distinct from per-controller `Failed`, which is
+  // local to one controller — others can still complete.
+  abortReason?: string;
+}
+
+export type JobLifecycle = 'pending' | 'in_flight' | 'done' | 'failed';

--- a/astros_api/src/models/firmware/flash_job_state.ts
+++ b/astros_api/src/models/firmware/flash_job_state.ts
@@ -4,7 +4,10 @@ interface BaseControllerFlashState {
   controllerId: string;
   bytesSent: number;
   totalBytes: number;
-  detail?: string;
+  // Required-with-empty-string-default rather than optional. Mirrors
+  // the wire shape (FwProgress.detail is a required field) and prevents
+  // `undefined` from leaking through JSON.stringify into the WS payload.
+  detail: string;
 }
 
 export type ControllerFlashState =


### PR DESCRIPTION
## Summary

- New `ControllerFlashState` discriminated union over the existing `FwStage` enum (c.1). All variants carry `controllerId`, `bytesSent`, `totalBytes`, `detail?`; terminal variants add stage-specific required fields (`VersionConfirmed.finalVersion`, `Failed.error`)
- New `transitionControllerState` (overloaded) + `deriveJobLifecycle` + `isControllerStageTerminal` pure functions in `firmware/flash_job_state_machine.ts`
- `LEGAL_NEXT_STAGES` `Map<FwStage, ReadonlySet<FwStage>>` is the single source of truth for the linear-with-`Failed`-escape transition graph
- Pure compute, no I/O — c.6b (transport) and c.6c (orchestrator + harness) consume this
- 43 new tests (parameterized cases counted individually); 432 → 475 total
- Plan: [`.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md`](./.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md)

## Context

c.6a is the first sub-project of c.6 (FlashJob orchestrator) under a by-layer split. The original decomposition flagged c.6 as the highest-risk piece in the c-series; the c.5 plan-mode workflow noted it warrants splitting. Phasing:

- **c.6a** (this PR) — FSM types + transitions, pure compute
- **c.6b** — sliding-window chunk streamer (sender side)
- **c.6c** — orchestrator that composes a/b with `JobLock`, source resolver (cache + upload), WS emit points, and a PTY-stub harness

By the time c.6c is written, the FSM rules are locked in tests and don't have to be re-litigated against the orchestrator's I/O loops. The protocol contract (`.docs/protocol.md` § A) already enumerates the seven stages a controller moves through; this PR codifies them as a discriminated union with a single legal-transition function so the orchestrator can never produce an illegal sequence.

## Design decisions

- **Discriminated union, not single-shape-with-optional-fields.** The protocol distinguishes `flashControllerUpdate` (in-flight, requires bytes + stage) from `flashControllerResult` (terminal, requires `finalVersion` or `error`). A single shape with everything optional would let TypeScript accept `{ stage: VersionConfirmed }` without a `finalVersion` — exactly the invalid combination the type is supposed to prevent. The discriminated union makes the protocol's invariants enforceable at compile time.
- **Overloaded `transitionControllerState`.** Three signatures: `(current, VersionConfirmed, { finalVersion })`, `(current, Failed, { error })`, `(current, NonTerminalStage, { bytesSent?, totalBytes?, detail? })`. Forces correct payload at the call site. Implementation still validates at runtime as belt-and-suspenders for callers who bypass the types.
- **`LEGAL_NEXT_STAGES` as a `Map`, not a switch.** The transition graph is small and static; a `Map` literal makes the rules visible at a glance and the validator is a one-line lookup. A switch would scatter the rules across cases.
- **`abortReason` lives at the job level, not as a controller state.** The protocol's `flashJobFailed` event represents a job-wide abort (master serial disconnect, hash mismatch on master's SD copy, upload failed) distinct from per-controller `Failed`. Per-controller `Failed` is local — others can still complete. Job abort is global. Keeping the two separate matches the decomp's WS event vocabulary and lets `deriveJobLifecycle` distinguish "job ran to completion (some/all controllers failed individually)" from "job was aborted before all controllers attempted."
- **Partial-payload merge for in-flight transitions.** `{ bytesSent, totalBytes, detail }` are merged onto the prior state — caller passes only what changed. Lets the orchestrator emit cheap "byte count update" transitions without reconstructing the full state object.
- **Empty-controllers-array yields `'done'`.** Degenerate input the orchestrator should never produce. Documenting `'done'` as the choice keeps `deriveJobLifecycle` total — no `undefined`, no throw — so callers don't need to defend.

## Test plan

- [x] `npm run build` clean (lint + tsc)
- [x] `npm run test` — 475/475 green (432 + 43 new)
- [x] `npm run prettier:write` and `npm run lint:fix` clean
- [x] No new fs / network / serial imports — `flash_job_state_machine.ts` only depends on `FwStage` and the type module

### Tests added

**`isControllerStageTerminal` (7)** — parameterized truth table across all 7 `FwStage` values.

**`transitionControllerState` happy path (7)** — full Queued → … → VersionConfirmed sequence, immutability of input state, `Failed` reachable from each of the 5 non-terminal stages.

**`transitionControllerState` illegal transitions (16)** — skip-a-stage, reverse direction, every transition out of `VersionConfirmed` (7), every transition out of `Failed` (7).

**`transitionControllerState` payload validation (3)** — `VersionConfirmed` without `finalVersion` throws, `Failed` without `error` throws, non-terminal transition with no payload preserves prior `bytesSent`/`totalBytes`/`detail`.

**`transitionControllerState` payload merging on legal transitions (2)** — partial payload merges (new `bytesSent` updates while `totalBytes` + `detail` preserve; new `detail` updates while byte counts preserve).

**`deriveJobLifecycle` (8)** — `abortReason` set → `'failed'` regardless of controller states, all-Queued → `'pending'`, mixed (Queued + Sending) → `'in_flight'`, all-VersionConfirmed → `'done'`, all-Failed → `'done'`, mixed-terminal → `'done'`, empty controllers → `'done'`, partial-terminal + mid-stream → `'in_flight'`.

## Files

| Status | Path | Why |
|---|---|---|
| new | `astros_api/src/models/firmware/flash_job_state.ts` | `ControllerFlashState`, `FlashJobState`, `FlashSource`, `JobLifecycle` types |
| new | `astros_api/src/firmware/flash_job_state_machine.ts` | `transitionControllerState`, `deriveJobLifecycle`, `isControllerStageTerminal`, `LEGAL_NEXT_STAGES` |
| new | `astros_api/src/firmware/flash_job_state_machine.test.ts` | 43 new tests (parameterized) |
| new | `.docs/plans/20260502-1500-firmware-ota-c-6a-flash-job-state.md` | Light plan |

4 files changed. Does **not** modify any existing module — the new types reference `FwStage` from c.1 and that's the only inbound dep.

## Notes for the reviewer

- **The cast pattern in illegal-transition tests** (`transitionControllerState as (...) => unknown`) is intentional. The overloads constrain valid call sites at compile time; testing the runtime guard for cases that violate the overload requires bypassing the typed signature. The cast scope is minimal — only the `expect(() => { ... }).toThrow()` block.
- **`FlashSource` defines a single sha256 / sizeBytes**, not a per-variant map. This matches the protocol: `FW_TRANSFER_BEGIN` distributes one binary to the master; `FW_DEPLOY_BEGIN` flashes that binary to the listed controllers. Multi-variant deployments (e.g., a fleet with mixed chip families) require multiple flash jobs — the orchestrator (c.6c) will validate that all targets share a variant and reject mixed fleets.
- **No FMI in the plan.** c.6a is pure compute — no fs, no concurrency, no network, no crash recovery, no cross-process state. CLAUDE.md explicitly says skip the failure-mode inventory for that case. Algorithmic correctness is gated by the test list itself: every legal/illegal transition pair has a test.
- **Reuses `FwStage` from c.1** rather than redefining stage values. c.1 already locked the protocol's enum mapping (`Queued = 'QUEUED'`, etc.) — c.6a builds typed state shapes around it, no duplication.

## Out of scope (deferred)

- All I/O — fs, serial, WebSocket. **c.6b** owns transport, **c.6c** owns orchestration.
- `FlashSource` *resolver* (the logic that picks cache vs upload and produces a `FlashSource` from a request) — **c.6c**.
- Per-controller progress throttling (the protocol's 4 Hz cap) — **c.7** + **c.6c**.
- Persistence / restart-survival — explicit non-goal per the decomp.
- POLL_ACK + variant heartbeat extension (cross-repo dep flagged in PR #70's notes) — **c.6c** when the source resolver lands.

