### PR TITLE
OTA Firmware Test Harness

### DIFF
--- a/.docs/plans/20260503-2106-firmware-ota-c-6c-2-harness.md
+++ b/.docs/plans/20260503-2106-firmware-ota-c-6c-2-harness.md
@@ -1,0 +1,1091 @@
+# c.6c.2 — In-process TypeScript stub master + PTY harness for end-to-end orchestrator testing
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up an in-process TypeScript stub master attached to a PTY pair so integration tests can drive the real `ApiServer` (HTTP, WebSocket, serial worker, `WorkerSerialBus`, `FlashJobOrchestrator`) end-to-end through happy + failure flash paths without real hardware.
+
+**Architecture:** A `socat` subprocess creates a Linux PTY pair. The server side opens one path via the existing `SerialPort` code (real `DelimiterParser`, real `serial_worker.js` thread). The stub master opens the other path via `serialport` and runs in-process — it parses inbound server frames using the real `MessageGenerator` wire format, scripts outbound responses (FW_TRANSFER_BEGIN_ACK, FW_CHUNK_ACK, FW_PROGRESS, FW_DEPLOY_DONE, POLL_ACK heartbeat), and exposes a programmatic API to trigger or skip each response. Tests boot an `ApiServer` with `SERIAL_PORT` set to one PTY path and connect HTTP + WebSocket clients to the running server, exercising the orchestrator through its real surfaces.
+
+**Tech Stack:** vitest (existing), `serialport` v12 (existing), `socat` (system package — already on the dev box), supertest (existing where used in `firmware_flash_controller.test.ts`), `ws` client for WebSocket assertions.
+
+**Branch:** `feature/firmware-ota-c-6c-2-harness` (off `develop`).
+**PR target base:** `develop`.
+**References:**
+- [c.6c.1 spec](../specs/20260503-0910-firmware-ota-c-6c-1-orchestrator-design.md) §"Out of scope" — defines c.6c.2's scope (PTY harness + integration tests).
+- [c.6c.1 plan](./20260503-0933-firmware-ota-c-6c-1-orchestrator.md) — orchestrator implementation; this plan layers integration tests over what shipped there.
+- [decomposition](./20260427-2202-firmware-ota-decomposition.md) §c (server orchestrator) and §"Test plan" row **c** — "Mock master via node-pty/socat PTY pair running a stub firmware; drive full state machine through happy + each failure mode."
+
+---
+
+## Context
+
+c.6c.1 shipped the `FlashJobOrchestrator` + HTTP/WS surface, fully unit-tested with `FakeSerialBus` and a scripted `streamerFactory`. The unit tests pin orchestrator-internal correctness — JobLock lifecycle, state-machine transitions, failure routing, WS emit semantics. What they don't cover:
+
+- Real `serial_worker.js` Worker thread → `WorkerSerialBus` → orchestrator wiring (the message-passing boundary).
+- Real `MessageGenerator` / `MessageHandler` wire framing round-trip (GS / RS / US / `\n` byte handling).
+- Real `SerialPort` + `DelimiterParser` line buffering on a serial-shaped channel.
+- Real Express + WebSocket server lifecycle during a flash (HTTP triggers → WS broadcasts).
+- Real POLL_ACK heartbeat path (master sentinel MAC + version match → `notifyMasterHeartbeat`) closing the lock under the 15-second timer.
+
+The harness exercises all of those by replacing only the lowest layer — the physical serial wire — with a PTY pair. The stub master is a **scriptable test fake**, not a behavior simulator: it implements just enough wire protocol to satisfy the orchestrator's expectations, with hooks for tests to deterministically drive each scenario. Real firmware behavior simulation lives in AstrOs.ESP (per user direction; firmware sim shares parsing code with real firmware).
+
+### Why `socat` for the PTY pair (design choice, open to redirect)
+
+Three options were considered:
+
+| Option | Mechanism | Pros | Cons |
+|--------|-----------|------|------|
+| **`socat` subprocess** ✅ recommended | Spawn `socat pty,raw,echo=0 pty,raw,echo=0`; stderr emits two `/dev/pts/N` paths | OS-level PTY pair; both ends openable as `SerialPort`; `socat` already installed locally + in apt for CI | External dep (`socat`); Linux/macOS only |
+| `node-pty` openpty | npm package; primarily for child-process spawning; no public openpty API across versions | Pure-JS ish | API mismatch; would need contorted `pty.spawn('socat', ...)` plumbing anyway |
+| `@serialport/binding-mock` | In-memory virtual serial binding | Pure JS, cross-platform, no subprocess | Bypasses the real PTY layer + DelimiterParser; not what the decomp doc asked for |
+
+**Recommendation:** `socat`. Rationale:
+1. The decomp doc says "node-pty/socat PTY pair" with a slash — alternatives, not a hard requirement. `socat` is the simpler half.
+2. The existing `astros_smoke_test/` package (different harness, different purpose) already uses `serialport` against real serial paths, so the test pattern is familiar to the codebase.
+3. CI add-on cost is `apt-get install socat` (one line in the GitHub Actions workflow when the workflow lands) — already a Linux runner, so cross-platform is a non-issue.
+4. `node-pty` adds a heavy native-build npm dep for no benefit over invoking `socat` via `child_process.spawn` directly.
+
+If reviewer prefers `node-pty` or `MockBinding`, we can swap the PTY-pair primitive without touching the stub master or test files (the dependency boundary is the `pty_pair.ts` module).
+
+### CI / platform note
+
+Tests gate on `process.platform !== 'win32'` (Linux / macOS only). Windows CI runners — if any are added later — skip the integration suite. The unit-test suite (which doesn't need PTYs) still runs everywhere.
+
+## Files in scope
+
+### New source files (3 modules + 1 fixture):
+
+| Path | Responsibility |
+|------|----------------|
+| `astros_api/src/test_harness/pty_pair.ts` | Spawns `socat`, parses stderr for the two `/dev/pts/N` paths, exposes `{ serverPath, masterPath, dispose() }`. Linux/macOS only |
+| `astros_api/src/test_harness/stub_master.ts` | In-process scriptable wire-protocol responder. Opens one PTY path via `serialport`, parses inbound frames using `MessageHandler` (or a narrow inline parser), emits scripted outbound frames using `MessageGenerator` (or a narrow inline encoder). Exposes typed control API (`autoAckUpload`, `scriptDeploy`, `injectChunkNak`, `dropAck`, `emitPollAck`, `emitDeployDone`) |
+| `astros_api/src/test_harness/integration_harness.ts` | Boots a fresh `ApiServer` on random ports with `SERIAL_PORT` set to the PTY path; exposes typed HTTP client + WS client; cleanup tears down server, sockets, PTY, socat |
+| `astros_api/test_fixtures/firmware/tiny.bin` | 4-KB binary test fixture used by upload-source tests (small enough that 4096-byte chunk size yields exactly 1 chunk; ensures the streamer's transfer-end path runs in-bounds) |
+
+### New test files (1 per scenario file, kept narrow):
+
+| Path | Responsibility |
+|------|----------------|
+| `astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts` | POST /api/firmware/flash with `kind=upload` → full happy round-trip → flashJobDone → heartbeat releases lock |
+| `astros_api/src/firmware/integration/flash_happy_github.integration.test.ts` | POST with `kind=github` against an injected GitHub release fixture → cache fetch → full round-trip |
+| `astros_api/src/firmware/integration/flash_cancel.integration.test.ts` | DELETE during upload (streamer aborts); DELETE during deploy (controllers fail-cleanup) |
+| `astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts` | Stub master injects FW_CHUNK_NAK → c.6b's Go-Back-N retransmits → completes |
+| `astros_api/src/firmware/integration/flash_heartbeat_vs_timer.integration.test.ts` | Heartbeat path (POLL_ACK with version match) releases lock pre-timer; reboot timer fallback (no heartbeat → 15-sec timer fires) |
+| `astros_api/src/firmware/integration/flash_concurrent.integration.test.ts` | Second POST returns 409 with `currentJobId` |
+
+### Modified source files:
+
+None to production code. All harness pieces live under `src/test_harness/` and integration tests under `src/firmware/integration/`. The harness is test-only; production paths are unchanged.
+
+### Build / tooling files:
+
+| Path | Change |
+|------|--------|
+| `astros_api/package.json` | Add `ws` to devDependencies if not already present; add an `integration` test script (e.g., `"test:integration": "vitest run src/firmware/integration"`) so the new suite can be run separately from the existing unit suite. Existing `npm test` continues to run everything |
+| `astros_api/vitest.config.ts` (or test-specific config) | Increase `testTimeout` for integration tests (default 5s is too tight for 15-sec reboot timer test) — either via per-test `vi.setConfig` or a separate `vitest.integration.config.ts`. Pick whichever is less invasive |
+| `astros_api/.eslintrc` (or equivalent) | If lint complains about the test_harness directory's use of `child_process.spawn` / direct serialport access, add a narrow override |
+
+### Spec / plan / QA docs:
+
+- `.docs/plans/20260503-2106-firmware-ota-c-6c-2-harness.md` (this file)
+- `.docs/qa/firmware-ota-flash.md` — extend the existing QA plan with a "Run the integration suite" section (Task 13)
+
+**Total new files:** 3 source modules + 1 binary fixture + 6 test files = ~10 new files. Below c.6c.1's 12-file footprint; consistent with the harness-only scope.
+
+## Scope guard
+
+**13 tasks total.** Per CLAUDE.md's `~8 tasks / ~3 layers` threshold this warrants a phasing question:
+
+- **Single PR (one branch, one PR vs `develop`):** Default. Mirrors c.6b (~10 tasks) and c.6c.1 (~14 tasks across 2 PRs but a single branch's plan). Reviewer load is high; mitigated by making each integration test a separate small task.
+- **Two PRs (Phase A: Tasks 1-7 = harness + happy paths; Phase B: Tasks 8-13 = failure modes + QA):** Phase A ships an end-to-end happy-path integration test (proves the harness works). Phase B layers failure-mode tests on top. Each phase is independently shippable + reviewable.
+
+**Recommendation: single PR.** The harness primitives (Tasks 1-3) are useless without at least one integration test exercising them, and splitting "happy paths" from "failure modes" produces a Phase A PR that's mostly harness code with thin test coverage — exactly the "scaffolding-heavy review" pattern c.6c.1 part 1 felt awkward about. A single PR with 13 small commits keeps each one focused.
+
+User to confirm during plan review.
+
+## Failure-mode inventory
+
+This module hits CLAUDE.md FMI triggers: **concurrency** (Worker thread, async serial I/O, Express + WS lifecycle), **cross-process state** (`socat` subprocess), and **resource lifecycle** (PTYs, file descriptors, child processes, ports, server instances). FMI sections §1, §3, §4, §7 inventoried below; §2 (state matrix) is N/A (no orchestrator-internal state — this module composes existing components); §5 (on-disk state) is N/A (test fixtures only); §6 (hostile input) is N/A (test code, no untrusted boundary).
+
+### §1 External-call error coverage
+
+| Call | Error / condition | Response |
+|------|-------------------|----------|
+| `child_process.spawn('socat', ...)` | binary not found (`ENOENT`) | Throw with a descriptive error pointing to install instructions; integration tests skip via `it.skipIf(!socatAvailable)` |
+| `socat` exits before stderr emits PTY paths | parse timeout (5-sec ceiling) | Reject the harness setup promise; test fails with "socat did not emit PTY paths within 5 sec" |
+| `socat` exits during a test | child process unexpectedly dies (e.g., killed externally, OOM) | Stub master detects port-close; surfaces as a test-level failure with the exit code and stderr tail |
+| `new SerialPort({ path: ptyPath })` on the stub-master end | path not yet ready (race with socat startup) | Retry with 100 ms backoff up to 1 sec; test fails after timeout |
+| `ApiServer.bootstrap()` rejects | Port collision, DB init failure, etc. | Surface the underlying error; test fails with full stack |
+| WS client connection rejected | server not yet listening | Retry up to 3 sec; test fails with "WS never connected" |
+| `httpClient.post('/api/firmware/flash')` | 4xx / 5xx | Test asserts the expected status + payload; failures with body for diagnosis |
+| Stub master receives malformed inbound frame | unexpected wire bytes (shouldn't happen — orchestrator emits real frames) | Log + drop; test surfaces via "expected response not received" timeout |
+| WS client receives unexpected event order | e.g., `flashJobDone` before `flashControllerResult` | Test asserts the expected event sequence; mismatch fails the test |
+
+**Common gotchas:**
+- `socat`'s stderr emits `2026/05/03 21:06:00 socat[12345.140123456789120] N PTY is /dev/pts/3` — the path is at the END of the line. Parse with a regex anchored on `PTY is `, not on column position.
+- `socat` may emit stderr lines in either order (PTY 1 vs PTY 2). Match by line index, not by content.
+- `serialport` v12 default opens the port asynchronously; tests must `await port.open()` (or wait for `'open'` event) before writing.
+- `DelimiterParser({ delimiter: '\n' })` requires `\n` not `\r\n`. Stub master must terminate frames with `\n` only.
+
+### §3 Concurrency
+
+| Shared resource | Touched by | Sync mechanism | Miss-sync consequence |
+|-----------------|-----------|----------------|------------------------|
+| PTY file descriptors | server-side `SerialPort`, stub master `SerialPort`, `socat` kernel buffer | Single owner per FD | If both ends open + close in parallel during teardown: stale FD usage. Tests sequentialize teardown via the harness `dispose()` |
+| `socat` subprocess | spawned per test, killed in `afterEach` | Test-scoped process handle | If `dispose()` skipped (test crash): orphaned `socat` + dangling PTYs. Mitigated by `process.on('exit')` cleanup hook in the harness |
+| `ApiServer` instance | spawned per test on random ports | Test-scoped server handle | If `dispose()` skipped: port leak across tests. Random ports + cleanup hook mitigate |
+| WS clients | per-test instances | Test-scoped | If not closed: server keeps connection slot open until next test starts a new server. Cleanup in `dispose()` |
+| `worker_threads.Worker` (the serial worker) | spawned by `ApiServer.setupSerialPort()` | Implicit; test depends on `ApiServer` killing its worker on close | `ApiServer` doesn't currently expose a clean shutdown path — see Task 4. We add one, or use `worker.terminate()` from the harness |
+| Stub master scripted-response queue | test code (queues), serial inbound listener (consumes) | Single-threaded JS event loop | No race; queue is a plain array drained on inbound frames |
+
+**Concurrency-relevant invariants tested:**
+- Heartbeat-vs-timer first-fire-wins (Task 11): post-`flashJobDone`, the stub master has a 15-sec window to emit POLL_ACK with version match. The test in one run lets heartbeat fire before timer; in another, doesn't emit heartbeat → asserts timer fallback fires at exactly 15 sec.
+- Concurrent flash (Task 12): two HTTP POSTs back-to-back → second returns 409 with `currentJobId`. Tests synchronization of the JobLock under serial-bound async work.
+
+### §4 Cross-platform / cross-environment
+
+- **Linux / macOS only.** Windows lacks `socat` (and PTYs in the POSIX sense). Tests gate on `process.platform === 'win32' ? it.skip : it`.
+- **Linux ≥ 4.x kernel.** `pty,raw,echo=0` requires a PTY-supporting kernel; not a real concern for Ubuntu CI runners.
+- **Path separators:** N/A (PTY paths are always `/dev/pts/...`).
+- **`worker_threads`:** same on all supported platforms.
+- **Random-port allocation:** `:0` ephemeral ports; OS-portable.
+- **Node ≥ 18.** Existing project requirement; no new dependency.
+
+### §7 Resource lifecycle
+
+| Resource | Created | Cleanup happy path | If cleanup doesn't run |
+|----------|---------|--------------------|------------------------|
+| `socat` child process | `pty_pair.ts` setup | `child.kill('SIGTERM')` in `dispose()` | Orphan process, two dangling PTYs, file descriptor leak. Mitigation: `process.on('exit')` hook in the harness force-kills any remaining children |
+| Server-side `SerialPort` | `ApiServer.setupSerialPort()` (transitively via PTY env override) | `ApiServer.shutdown()` (we add this in Task 4) closes it | FD leak; next test reuses a closed port. Mitigation: harness `dispose()` always tears down the server |
+| Stub master `SerialPort` | `stub_master.ts` setup | `dispose()` closes the port | Same as above |
+| `serial_worker.js` Worker thread | `ApiServer.setupSerialPort()` spawns it | `ApiServer.shutdown()` calls `worker.terminate()` | Worker leaks across tests; vitest detects via `--reporter=verbose` and warns |
+| Express HTTP server | `ApiServer.runWebServices()` calls `app.listen()` | `ApiServer.shutdown()` calls `httpServer.close()` and waits for `'close'` event | Port stays bound; next test on the same port fails to listen. Random ports avoid the symptom but the FD still leaks |
+| WebSocket server | `ApiServer.runWebServices()` constructs `new Server({ port })` | `ApiServer.shutdown()` calls `wss.close()` | Same as HTTP server |
+| WebSocket clients | per test | per-test `client.close()` | Connection slot remains until server shuts down |
+| Test fixtures (tiny.bin, github release fixture) | `test_fixtures/` directory, committed | N/A — read-only static files | N/A |
+| Random ephemeral port reservations | OS-managed | OS releases on socket close | If close skipped: brief port reservation until kernel reclaims (~30 sec on Linux) |
+
+**Cleanup ordering rule:** in `dispose()`, tear down in the reverse order of creation: WS clients → HTTP clients → ApiServer → stub master → PTY pair (socat). The PTY pair lives longest because both serial ports must close before socat can reap.
+
+## Tasks
+
+Each task is one logical commit. Per CLAUDE.md, `superpowers:requesting-code-review` runs between tests-passing and `git commit` for every implementation task except the carve-outs (plan-only commits, trivial typos, plan check-offs). Subagent-driven dev expected; controller (parent agent) provides per-task context to fresh implementer subagents.
+
+**TDD note:** per the user's `feedback_tdd_exceptions` memory, serial-adjacent code skips strict pre-test discipline. Tasks 1-3 (harness primitives) implement-first, then sanity-check. Tasks 5-12 (integration tests) ARE the tests; each task writes a test, runs it, and adjusts the harness if needed.
+
+---
+
+### Task 1 — `pty_pair.ts`: socat-backed PTY pair helper
+
+**Files:**
+- Create: `astros_api/src/test_harness/pty_pair.ts`
+- Create: `astros_api/src/test_harness/pty_pair.test.ts`
+
+- [ ] **Step 1: Write the helper module**
+
+```ts
+// astros_api/src/test_harness/pty_pair.ts
+import { spawn, ChildProcess } from 'child_process';
+import { logger } from '../logger.js';
+
+export interface PtyPair {
+  serverPath: string;   // /dev/pts/N — server-side ApiServer opens this
+  masterPath: string;   // /dev/pts/M — stub master opens this
+  dispose(): Promise<void>;
+}
+
+const PTY_LINE_REGEX = /N PTY is (\/dev\/pts\/\d+)/;
+const SOCAT_STARTUP_TIMEOUT_MS = 5000;
+
+export async function createPtyPair(): Promise<PtyPair> {
+  if (process.platform === 'win32') {
+    throw new Error('PtyPair: socat-based PTYs are not supported on Windows');
+  }
+
+  const child = spawn('socat', [
+    '-d', '-d',
+    'pty,raw,echo=0',
+    'pty,raw,echo=0',
+  ], { stdio: ['ignore', 'ignore', 'pipe'] });
+
+  let serverPath: string | undefined;
+  let masterPath: string | undefined;
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`socat did not emit PTY paths within ${SOCAT_STARTUP_TIMEOUT_MS}ms`));
+    }, SOCAT_STARTUP_TIMEOUT_MS);
+
+    child.stderr!.on('data', (chunk: Buffer) => {
+      for (const line of chunk.toString('utf8').split('\n')) {
+        const match = line.match(PTY_LINE_REGEX);
+        if (!match) continue;
+        if (serverPath === undefined) {
+          serverPath = match[1];
+        } else if (masterPath === undefined) {
+          masterPath = match[1];
+          clearTimeout(timer);
+          resolve();
+        }
+      }
+    });
+
+    child.on('exit', (code, signal) => {
+      if (serverPath === undefined || masterPath === undefined) {
+        clearTimeout(timer);
+        reject(new Error(`socat exited before emitting both PTY paths (code=${code}, signal=${signal})`));
+      }
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(`socat spawn failed: ${err.message}. Is socat installed? Try \`apt-get install socat\` or \`brew install socat\`.`));
+    });
+  });
+
+  await ready;
+
+  const dispose = async (): Promise<void> => {
+    if (child.exitCode !== null) return;
+    child.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve();
+      }, 1000);
+      child.on('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  };
+
+  return { serverPath: serverPath!, masterPath: masterPath!, dispose };
+}
+```
+
+- [ ] **Step 2: Write a sanity-check test (no full TDD per serial-code exception)**
+
+```ts
+// astros_api/src/test_harness/pty_pair.test.ts
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'fs';
+import { createPtyPair } from './pty_pair.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+describe('createPtyPair', () => {
+  skipIfNotPosix('emits two distinct PTY paths under /dev/pts/', async () => {
+    const pty = await createPtyPair();
+    try {
+      expect(pty.serverPath).toMatch(/^\/dev\/pts\/\d+$/);
+      expect(pty.masterPath).toMatch(/^\/dev\/pts\/\d+$/);
+      expect(pty.serverPath).not.toBe(pty.masterPath);
+      expect(existsSync(pty.serverPath)).toBe(true);
+      expect(existsSync(pty.masterPath)).toBe(true);
+    } finally {
+      await pty.dispose();
+    }
+  });
+
+  skipIfNotPosix('dispose() releases the socat process and PTY paths', async () => {
+    const pty = await createPtyPair();
+    const path = pty.serverPath;
+    await pty.dispose();
+    // After dispose, the PTY device should be gone (kernel reaps when socat exits).
+    // Allow brief grace for the kernel close.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(existsSync(path)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `cd astros_api && npx vitest run src/test_harness/pty_pair.test.ts`
+Expected: PASS on Linux/macOS; SKIP on Windows.
+
+- [ ] **Step 4: Code review**
+
+Dispatch `superpowers:requesting-code-review` on the diff vs `develop` with the prompt: "Review for socat startup races, stderr parsing edge cases, and process-cleanup leaks. Flag any case where a test failure could leave an orphan socat process."
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.Server
+git add astros_api/src/test_harness/pty_pair.ts astros_api/src/test_harness/pty_pair.test.ts
+git commit -m "feat(test_harness): add socat-backed PTY pair helper (c.6c.2 Task 1)"
+```
+
+---
+
+### Task 2 — `stub_master.ts`: scriptable wire-protocol responder
+
+**Files:**
+- Create: `astros_api/src/test_harness/stub_master.ts`
+- Create: `astros_api/src/test_harness/stub_master.test.ts`
+
+The stub master is small but has several responsibilities — separation matters. Internal structure:
+
+- **Frame parser**: reads `\n`-delimited lines from the PTY, splits by `GS`, validates the `RS`-separated header, parses payload by message type. Reuses `MessageHelper` constants (`GS`, `RS`, `US`, `MessageEOL`) but does NOT reuse `MessageHandler` (which is server-direction parsing — incoming wire format is server→master, not master→server). Inline narrow parser for the four inbound types: `FW_TRANSFER_BEGIN`, `FW_CHUNK`, `FW_TRANSFER_END`, `FW_DEPLOY_BEGIN`, plus `POLL`.
+- **Frame writer**: builds `\n`-delimited lines with the proper validation token (mirrors `MessageGenerator.generateHeader`'s shape) for outbound types: `FW_TRANSFER_BEGIN_ACK`, `FW_CHUNK_ACK`, `FW_CHUNK_NAK`, `FW_TRANSFER_END_ACK`, `FW_PROGRESS`, `FW_DEPLOY_DONE`, `FW_BACKPRESSURE`, `POLL_ACK`.
+- **Scripted-response API**: methods tests call to drive behavior. See "control API" below.
+
+- [ ] **Step 1: Write the parser + writer + class skeleton**
+
+Core interface:
+
+```ts
+// astros_api/src/test_harness/stub_master.ts
+import { SerialPort } from 'serialport';
+import { DelimiterParser } from '@serialport/parser-delimiter';
+import { MessageHelper } from '../serial/message_helper.js';
+import { SerialMessageType } from '../serial/serial_message.js';
+import type { FwStage } from '../models/firmware/firmware_messages.js';
+
+export interface StubMasterOpts {
+  ptyPath: string;
+  masterMac?: string;            // default '00:00:00:00:00:00' (sentinel per project memory)
+  masterFingerprint?: string;    // default 'master-stub'
+  masterFirmwareVersion?: string; // default '1.0.0'; tests override per scenario
+  masterVariant?: string;        // default 'astros-master-test-variant'
+}
+
+export interface InboundFrame {
+  type: SerialMessageType;
+  msgId: string;
+  payload: string;
+}
+
+export class StubMaster {
+  private port!: SerialPort;
+  private parser!: DelimiterParser;
+  private inbound: InboundFrame[] = [];
+  private inboundListeners: Array<(frame: InboundFrame) => void> = [];
+  // Scripted-response state — see Task 3.
+
+  constructor(private readonly opts: StubMasterOpts) {}
+
+  async start(): Promise<void> {
+    this.port = new SerialPort({ path: this.opts.ptyPath, baudRate: 9600, autoOpen: false });
+    await new Promise<void>((resolve, reject) => {
+      this.port.open((err) => (err ? reject(err) : resolve()));
+    });
+    this.parser = this.port.pipe(new DelimiterParser({ delimiter: '\n' }));
+    this.parser.on('data', (buf: Buffer) => this.handleInbound(buf.toString('utf8')));
+  }
+
+  async dispose(): Promise<void> {
+    if (this.port?.isOpen) {
+      await new Promise<void>((resolve) => this.port.close(() => resolve()));
+    }
+  }
+
+  private handleInbound(line: string): void {
+    const frame = parseInbound(line);
+    if (frame === null) return;  // log + drop malformed
+    this.inbound.push(frame);
+    for (const l of this.inboundListeners) l(frame);
+    this.dispatchScriptedResponse(frame);  // Task 3 logic
+  }
+
+  /** Wait for an inbound frame matching the predicate. Used by tests to synchronize. */
+  async waitForFrame(
+    predicate: (frame: InboundFrame) => boolean,
+    timeoutMs = 2000,
+  ): Promise<InboundFrame> {
+    const existing = this.inbound.find(predicate);
+    if (existing) return existing;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.inboundListeners = this.inboundListeners.filter((l) => l !== handler);
+        reject(new Error(`waitForFrame: predicate did not match within ${timeoutMs}ms. Received: ${JSON.stringify(this.inbound.slice(-5))}`));
+      }, timeoutMs);
+      const handler = (frame: InboundFrame): void => {
+        if (!predicate(frame)) return;
+        clearTimeout(timer);
+        this.inboundListeners = this.inboundListeners.filter((l) => l !== handler);
+        resolve(frame);
+      };
+      this.inboundListeners.push(handler);
+    });
+  }
+
+  /** Write a pre-built outbound frame line ('\n'-terminated). Used by Task 3 helpers. */
+  writeRaw(line: string): void {
+    this.port.write(line);
+  }
+}
+
+function parseInbound(line: string): InboundFrame | null {
+  const groups = line.split(MessageHelper.GS);
+  if (groups.length !== 2) return null;
+  const headerParts = groups[0].split(MessageHelper.RS);
+  if (headerParts.length !== 3) return null;
+  const type = parseInt(headerParts[0], 10);
+  if (Number.isNaN(type)) return null;
+  return { type: type as SerialMessageType, msgId: headerParts[2], payload: groups[1] };
+}
+```
+
+- [ ] **Step 2: Add the outbound writer helpers (mirrors MessageGenerator's wire format)**
+
+Continue in `stub_master.ts`:
+
+```ts
+// Outbound wire-format writers. Each builds a header (matching server's
+// MessageGenerator.generateHeader shape: type<RS>validation<RS>msgId)
+// followed by GS, the payload, and \n. Validation strings are the
+// known constants from MessageHelper.ValidationMap.
+
+export interface FwTransferBeginAckArgs {
+  transferId: string;
+  windowSize?: number;       // default 16 (FW_SERIAL_SLIDING_WINDOW)
+  msgId?: string;
+}
+
+export interface FwChunkAckArgs {
+  transferId: string;
+  highestContiguousSeq: number;
+  bytesSent: number;
+  windowRemaining?: number;  // default windowSize - inflight
+  msgId?: string;
+}
+
+export interface FwChunkNakArgs {
+  transferId: string;
+  lastGoodSeq: number;
+  reasonCode: 'CRC' | 'OUT_OF_ORDER' | 'BUFFER_FULL' | 'INTERNAL_ERROR';
+  msgId?: string;
+}
+
+// ... and similarly for FwTransferEndAck, FwProgress, FwDeployDone, FwBackpressure, PollAck.
+
+// Each writer composes the line and calls writeRaw(). Implementations are mechanical
+// and use the wire-format documented in .docs/protocol.md and serial_message_service.ts.
+```
+
+(Full implementations of each writer go here — straightforward, ~5-10 lines each. Total ~80-100 lines for all 7 outbound writers.)
+
+- [ ] **Step 3: Sanity-check test for round-trip parsing/writing**
+
+```ts
+// astros_api/src/test_harness/stub_master.test.ts
+import { describe, it, expect, afterEach } from 'vitest';
+import { SerialPort } from 'serialport';
+import { DelimiterParser } from '@serialport/parser-delimiter';
+import { createPtyPair, type PtyPair } from './pty_pair.js';
+import { StubMaster } from './stub_master.js';
+import { SerialMessageType } from '../serial/serial_message.js';
+import { MessageHelper } from '../serial/message_helper.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+describe('StubMaster round-trip', () => {
+  let pty: PtyPair;
+  let stub: StubMaster;
+  let serverPort: SerialPort;
+
+  afterEach(async () => {
+    await stub?.dispose();
+    if (serverPort?.isOpen) await new Promise((r) => serverPort.close(() => r(undefined)));
+    await pty?.dispose();
+  });
+
+  skipIfNotPosix('parses a server-side FW_TRANSFER_BEGIN frame', async () => {
+    pty = await createPtyPair();
+    stub = new StubMaster({ ptyPath: pty.masterPath });
+    await stub.start();
+
+    serverPort = new SerialPort({ path: pty.serverPath, baudRate: 9600 });
+    await new Promise((r) => serverPort.on('open', r));
+
+    const validation = MessageHelper.ValidationMap.get(SerialMessageType.FW_TRANSFER_BEGIN)!;
+    const header = `${SerialMessageType.FW_TRANSFER_BEGIN}${MessageHelper.RS}${validation}${MessageHelper.RS}msg-1`;
+    const payload = `xfer-1${MessageHelper.US}1024${MessageHelper.US}${'a'.repeat(64)}${MessageHelper.US}256${MessageHelper.US}body${MessageHelper.RS}master`;
+    serverPort.write(`${header}${MessageHelper.GS}${payload}${MessageHelper.MessageEOL}`);
+
+    const frame = await stub.waitForFrame((f) => f.type === SerialMessageType.FW_TRANSFER_BEGIN);
+    expect(frame.msgId).toBe('msg-1');
+    expect(frame.payload).toContain('xfer-1');
+  });
+
+  // Symmetric test: stub writes an outbound FW_TRANSFER_BEGIN_ACK, server-side
+  // raw read confirms it appears with correct framing.
+  skipIfNotPosix('writes a FW_TRANSFER_BEGIN_ACK that the server-side parser can read', async () => {
+    pty = await createPtyPair();
+    stub = new StubMaster({ ptyPath: pty.masterPath });
+    await stub.start();
+
+    serverPort = new SerialPort({ path: pty.serverPath, baudRate: 9600 });
+    await new Promise((r) => serverPort.on('open', r));
+    const serverParser = serverPort.pipe(new DelimiterParser({ delimiter: '\n' }));
+
+    const linePromise = new Promise<string>((resolve) => {
+      serverParser.once('data', (b: Buffer) => resolve(b.toString('utf8')));
+    });
+
+    stub.writeFwTransferBeginAck({ transferId: 'xfer-1', windowSize: 16, msgId: 'm1' });
+
+    const line = await linePromise;
+    expect(line).toContain('xfer-1');
+    expect(line).toContain(String(SerialMessageType.FW_TRANSFER_BEGIN_ACK));
+  });
+});
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd astros_api && npx vitest run src/test_harness/stub_master.test.ts`
+Expected: PASS on Linux/macOS.
+
+- [ ] **Step 5: Code review**
+
+Dispatch `superpowers:requesting-code-review` with the prompt: "Review for wire-format mismatches between StubMaster's writers and `MessageHandler`'s parsers — drift here would silently break every integration test. Cross-check each outbound writer against the corresponding handler in `astros_api/src/serial/message_handler.ts`. Also check that `parseInbound` correctly handles the validation-token field that `generateHeader` emits."
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add astros_api/src/test_harness/stub_master.ts astros_api/src/test_harness/stub_master.test.ts
+git commit -m "feat(test_harness): add scriptable stub master with PTY-backed serial (c.6c.2 Task 2)"
+```
+
+---
+
+### Task 3 — Stub master scripted-response API
+
+**Files:**
+- Modify: `astros_api/src/test_harness/stub_master.ts`
+- Modify: `astros_api/src/test_harness/stub_master.test.ts`
+
+Layer the deterministic-script API onto the StubMaster. Tests should be able to express:
+
+- **`autoAckUpload({ chunkAckCadence: 'every' | 'window', failAtSeq?: number })`** — automatically ACK every FW_CHUNK (or per-window batch) the orchestrator sends; ACK FW_TRANSFER_BEGIN with a configurable window size; ACK FW_TRANSFER_END with status=`OK`. If `failAtSeq` provided, send a NAK at that seq and resume normal ACK after.
+- **`scriptDeploy(controllers: Array<{ id: string; outcome: 'OK' | 'FAILED'; finalVersion?: string; error?: string; stages?: FwStage[] }>)`** — when the orchestrator sends `FW_DEPLOY_BEGIN`, emit `FW_PROGRESS` events walking through each controller's stages, then `FW_DEPLOY_DONE` with the configured outcomes.
+- **`emitPollAck({ mac?: string; firmwareVersion?: string; variant?: string })`** — emit a single POLL_ACK frame on demand. Used to:
+  1. Pre-populate the `controllerVariantCache` before a flash (each controller's variant)
+  2. Trigger the master heartbeat post-flashJobDone (master sentinel MAC + matching firmwareVersion)
+- **`disable(featureName: 'autoAckUpload' | 'scriptDeploy')`** — stop auto-responses; leaves inbound frames unhandled so tests can drive timeouts.
+
+- [ ] **Step 1: Add the API**
+
+Sketch in `stub_master.ts`:
+
+```ts
+interface AutoAckUploadConfig {
+  windowSize: number;           // default 16
+  ackCadence: 'every' | 'window';  // 'every' acks every FW_CHUNK; 'window' batches
+  failAtSeq?: number;           // if set, NAK at this seq once
+  endStatus?: 'OK' | 'HASH_MISMATCH' | 'INCOMPLETE';  // FW_TRANSFER_END_ACK status; default OK
+}
+
+interface ScriptDeployConfig {
+  controllers: Array<{
+    id: string;
+    outcome: 'OK' | 'FAILED';
+    finalVersion?: string;       // required if OK
+    error?: string;              // required if FAILED
+    stages?: FwStage[];          // default [Sending, Verifying, Rebooting, VersionConfirmed/Failed]
+  }>;
+  doneTransferId?: string;       // captured from FW_DEPLOY_BEGIN if not set
+}
+
+class StubMaster {
+  // ...existing fields...
+  private autoAckUploadCfg: AutoAckUploadConfig | null = null;
+  private autoAckUploadFailedSeq = false;  // track whether failAtSeq has fired
+  private scriptDeployCfg: ScriptDeployConfig | null = null;
+
+  autoAckUpload(cfg: Partial<AutoAckUploadConfig>): void {
+    this.autoAckUploadCfg = {
+      windowSize: 16,
+      ackCadence: 'every',
+      endStatus: 'OK',
+      ...cfg,
+    };
+    this.autoAckUploadFailedSeq = false;
+  }
+
+  scriptDeploy(cfg: ScriptDeployConfig): void {
+    this.scriptDeployCfg = cfg;
+  }
+
+  emitPollAck(opts: { mac?: string; firmwareVersion?: string; variant?: string }): void {
+    const mac = opts.mac ?? this.opts.masterMac ?? '00:00:00:00:00:00';
+    const fingerprint = this.opts.masterFingerprint ?? 'master-stub';
+    const fw = opts.firmwareVersion ?? this.opts.masterFirmwareVersion ?? '1.0.0';
+    const variant = opts.variant ?? this.opts.masterVariant ?? 'astros-master-test-variant';
+    // POLL_ACK wire format (per message_handler.handlePollAck):
+    //   parts[0] mac, parts[1] name, parts[2] fingerprint, parts[3] fwVersion, parts[4] variant
+    // separated by US; framed with the standard header GS payload \n envelope.
+    const validation = MessageHelper.ValidationMap.get(SerialMessageType.POLL_ACK)!;
+    const header = `${SerialMessageType.POLL_ACK}${MessageHelper.RS}${validation}${MessageHelper.RS}${this.nextMsgId()}`;
+    const payload = [mac, mac /* name = mac for stub */, fingerprint, fw, variant].join(MessageHelper.US);
+    this.writeRaw(`${header}${MessageHelper.GS}${payload}${MessageHelper.MessageEOL}`);
+  }
+
+  // dispatchScriptedResponse: called from handleInbound. Routes by frame.type
+  // to the matching auto-responder.
+  private dispatchScriptedResponse(frame: InboundFrame): void {
+    switch (frame.type) {
+      case SerialMessageType.FW_TRANSFER_BEGIN:
+        if (this.autoAckUploadCfg) this.respondTransferBegin(frame);
+        break;
+      case SerialMessageType.FW_CHUNK:
+        if (this.autoAckUploadCfg) this.respondChunk(frame);
+        break;
+      case SerialMessageType.FW_TRANSFER_END:
+        if (this.autoAckUploadCfg) this.respondTransferEnd(frame);
+        break;
+      case SerialMessageType.FW_DEPLOY_BEGIN:
+        if (this.scriptDeployCfg) this.respondDeployBegin(frame);
+        break;
+      // POLL is server-driven; we don't auto-reply (tests call emitPollAck explicitly)
+    }
+  }
+
+  private nextMsgId(): string { /* uuid_v4 or counter */ }
+
+  // respondTransferBegin / respondChunk / respondTransferEnd / respondDeployBegin
+  // are private helpers that build the appropriate outbound frame using the
+  // writers from Task 2 + the active config.
+}
+```
+
+- [ ] **Step 2: Implement each respondX helper**
+
+Each is ~10-20 lines. `respondChunk` is the most subtle: parses `frame.payload` for the seq number, decides whether to NAK (failAtSeq match) or ACK with `highestContiguousSeq` advancing per ACK and `windowRemaining` decrementing per chunk-in-flight (then resetting on each ACK). For the first c.6c.2 cut, the simplest implementation: respond with `highestContiguousSeq = seq` and `windowRemaining = windowSize - 0` (treating the window as immediately re-available); this satisfies the c.6b streamer's sliding-window expectations.
+
+- [ ] **Step 3: Add scripted-API tests**
+
+Tests in `stub_master.test.ts`:
+- `autoAckUpload` ACKs every FW_CHUNK with `highestContiguousSeq` advancing.
+- `autoAckUpload` with `failAtSeq=5` NAKs at seq 5 once, then resumes ACKing.
+- `scriptDeploy` walks each controller through `[Sending, Verifying, Rebooting, VersionConfirmed]` stages and emits `FW_DEPLOY_DONE` with the configured outcomes.
+- `emitPollAck` writes a 5-field POLL_ACK frame parseable by `MessageHandler.handlePollAck`.
+
+- [ ] **Step 4: Run the tests**
+
+`cd astros_api && npx vitest run src/test_harness/stub_master.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Code review**
+
+Prompt: "Find any drift between the stub master's responses and what `chunk_streamer.ts` and `flash_orchestrator.ts` consume. Specifically check: window-remaining math in FW_CHUNK_ACK, validation-token strings on outbound frames, FW_DEPLOY_DONE result-list framing (US/RS separators), POLL_ACK 5-field layout."
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add astros_api/src/test_harness/stub_master.ts astros_api/src/test_harness/stub_master.test.ts
+git commit -m "feat(test_harness): add scripted response API to StubMaster (c.6c.2 Task 3)"
+```
+
+---
+
+### Task 4 — Integration harness boot helper + ApiServer shutdown path
+
+**Files:**
+- Create: `astros_api/src/test_harness/integration_harness.ts`
+- Modify: `astros_api/src/api_server.ts` (add a `shutdown()` method)
+
+The harness:
+1. Allocates a PTY pair.
+2. Allocates random ports for HTTP + WS.
+3. Sets `process.env.SERIAL_PORT = pty.serverPath`, `API_PORT`, `WEBSOCKET_PORT`, and `JWT_KEY`.
+4. Boots an `ApiServer` (real `Init()`).
+5. Constructs the `StubMaster` on the master end of the PTY.
+6. Returns `{ server, stub, http, ws, dispose }`.
+
+The `ApiServer.shutdown()` method (new in this task) closes the HTTP server, WS server, serial port, and terminates the worker. Without this, tests leak workers + ports.
+
+- [ ] **Step 1: Add `ApiServer.shutdown()`**
+
+```ts
+// In api_server.ts
+public async shutdown(): Promise<void> {
+  if (this.serialPort?.isOpen) {
+    await new Promise<void>((resolve) => this.serialPort.close(() => resolve()));
+  }
+  if (this.serialWorker !== undefined) {
+    await this.serialWorker.terminate();
+  }
+  if (this.websocket !== undefined) {
+    await new Promise<void>((resolve) => this.websocket.close(() => resolve()));
+  }
+  if (this.httpServer !== undefined) {
+    await new Promise<void>((resolve) => this.httpServer.close(() => resolve()));
+  }
+  // Close DB to release the file lock.
+  if (this.db !== undefined) {
+    await this.db.destroy();
+  }
+}
+```
+
+(Capture `this.httpServer = this.app.listen(...)` so it can be closed; the existing code likely returns the listen-result; small refactor.)
+
+- [ ] **Step 2: Write the harness module**
+
+```ts
+// astros_api/src/test_harness/integration_harness.ts
+import { createServer } from 'net';
+import { ApiServer } from '../api_server.js';
+import { createPtyPair, PtyPair } from './pty_pair.js';
+import { StubMaster } from './stub_master.js';
+import { WebSocket } from 'ws';
+// ... HTTP client (axios or node:fetch), uuid, etc.
+
+export interface IntegrationHarness {
+  server: ApiServer;
+  stub: StubMaster;
+  httpBaseUrl: string;       // 'http://127.0.0.1:<random>'
+  wsClient: WebSocket;
+  receivedWsMessages: any[]; // buffered for assertion
+  waitForWsMessage(predicate: (msg: any) => boolean, timeoutMs?: number): Promise<any>;
+  dispose(): Promise<void>;
+}
+
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, () => {
+      const port = (server.address() as any).port;
+      server.close(() => resolve(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+export async function bootIntegrationHarness(opts?: {
+  masterFirmwareVersion?: string;
+  masterVariant?: string;
+}): Promise<IntegrationHarness> {
+  const pty = await createPtyPair();
+  const apiPort = await findFreePort();
+  const wsPort = await findFreePort();
+
+  process.env.SERIAL_PORT = pty.serverPath;
+  process.env.BAUD_RATE = '9600';
+  process.env.API_PORT = String(apiPort);
+  process.env.WEBSOCKET_PORT = String(wsPort);
+  process.env.JWT_KEY = 'test-jwt-key';
+  // Use in-memory DB or a temp directory for the integration suite.
+  // (Existing test mode does in-memory; we want NODE_ENV != 'test' so setupSerialPort runs.)
+
+  const server = await ApiServer.bootstrap();
+  const stub = new StubMaster({
+    ptyPath: pty.masterPath,
+    masterFirmwareVersion: opts?.masterFirmwareVersion,
+    masterVariant: opts?.masterVariant,
+  });
+  await stub.start();
+
+  const wsClient = new WebSocket(`ws://127.0.0.1:${wsPort}`);
+  await new Promise<void>((resolve, reject) => {
+    wsClient.once('open', () => resolve());
+    wsClient.once('error', reject);
+  });
+
+  const receivedWsMessages: any[] = [];
+  const wsListeners: Array<(m: any) => void> = [];
+  wsClient.on('message', (data) => {
+    try {
+      const parsed = JSON.parse(data.toString());
+      receivedWsMessages.push(parsed);
+      for (const l of wsListeners) l(parsed);
+    } catch (err) {
+      // Non-JSON; ignore
+    }
+  });
+
+  const waitForWsMessage = (predicate: (m: any) => boolean, timeoutMs = 5000): Promise<any> => {
+    const existing = receivedWsMessages.find(predicate);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = wsListeners.indexOf(handler);
+        if (idx >= 0) wsListeners.splice(idx, 1);
+        reject(new Error(`waitForWsMessage timeout. Received: ${JSON.stringify(receivedWsMessages.map((m) => m.type).slice(-10))}`));
+      }, timeoutMs);
+      const handler = (m: any): void => {
+        if (!predicate(m)) return;
+        clearTimeout(timer);
+        const idx = wsListeners.indexOf(handler);
+        if (idx >= 0) wsListeners.splice(idx, 1);
+        resolve(m);
+      };
+      wsListeners.push(handler);
+    });
+  };
+
+  const dispose = async (): Promise<void> => {
+    wsClient.close();
+    await stub.dispose();
+    await server.shutdown();
+    await pty.dispose();
+  };
+
+  return {
+    server,
+    stub,
+    httpBaseUrl: `http://127.0.0.1:${apiPort}`,
+    wsClient,
+    receivedWsMessages,
+    waitForWsMessage,
+    dispose,
+  };
+}
+```
+
+- [ ] **Step 3: Smoke test the harness**
+
+```ts
+// astros_api/src/test_harness/integration_harness.test.ts
+import { describe, it, expect, afterEach } from 'vitest';
+import { bootIntegrationHarness, type IntegrationHarness } from './integration_harness.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+describe('integration harness', () => {
+  let harness: IntegrationHarness | undefined;
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix('boots, accepts WS connection, receives initial systemStatus, and tears down', async () => {
+    harness = await bootIntegrationHarness();
+    const status = await harness.waitForWsMessage((m) => m.type === 'systemStatus' || m.type === 0 /* TransmissionType.systemStatus value */);
+    expect(status).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 4: Run + review + commit**
+
+Standard cycle: run vitest, code review on the diff, commit.
+
+```bash
+git add astros_api/src/test_harness/integration_harness.ts astros_api/src/test_harness/integration_harness.test.ts astros_api/src/api_server.ts
+git commit -m "feat(test_harness): add integration harness + ApiServer.shutdown (c.6c.2 Task 4)"
+```
+
+**Reviewer prompt:** "Look for resource-cleanup ordering bugs in `dispose()` and any test-pollution risk from setting `process.env` globals (one test's env values shouldn't leak into another)."
+
+---
+
+### Task 5 — Integration test: happy upload-source flash + heartbeat release
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts`
+- Create: `astros_api/test_fixtures/firmware/tiny.bin` (4 KB binary, deterministic content)
+
+This is the smoke test for the entire stack. End-to-end:
+
+1. Boot harness with `masterFirmwareVersion: '1.5.0'`, `masterVariant: 'astros-controller-v1'`.
+2. Pre-populate `controllerVariantCache` by emitting POLL_ACK from the stub master with the variant.
+3. Pre-populate the upload store with `tiny.bin` (use the existing `firmware_upload_store` directly, bypassing the HTTP route).
+4. Configure stub: `autoAckUpload({ ackCadence: 'every' })` and `scriptDeploy({ controllers: [{ id: '00:00:00:00:00:00', outcome: 'OK', finalVersion: '1.5.0' }] })`.
+5. POST `/api/firmware/flash` with `{ source: { kind: 'upload' } }`.
+6. Assert WS receives, in order: `flashJobStarted`, `flashControllerUpdate` (UploadingToMaster), `flashControllerUpdate` (Sending), `flashControllerUpdate` (Verifying), `flashControllerResult` (VersionConfirmed), `flashJobDone`.
+7. Stub master emits POLL_ACK with master sentinel MAC + matching firmwareVersion.
+8. Assert WS receives `lockStateChanged { locked: false }`.
+9. Assert `GET /api/firmware/flash` returns `null` (no active job).
+
+- [ ] **Step 1: Write `tiny.bin` fixture**
+
+Use a Node script or a one-liner to generate 4096 bytes of deterministic content:
+
+```bash
+node -e "require('fs').writeFileSync('astros_api/test_fixtures/firmware/tiny.bin', Buffer.alloc(4096, 0x42))"
+```
+
+- [ ] **Step 2: Write the integration test**
+
+(Implementation per the steps above. ~80-120 lines.)
+
+- [ ] **Step 3: Run, debug, commit**
+
+The first integration test will likely surface a few harness rough edges. Fix them in `stub_master.ts` / `integration_harness.ts` as needed. Each fix gets its own commit (subagent-driven dev flow).
+
+Final commit message: `test(integration): happy upload flash + heartbeat release (c.6c.2 Task 5)`
+
+---
+
+### Task 6 — Integration test: happy github-source flash with cache fixture
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_happy_github.integration.test.ts`
+
+Same shape as Task 5 but with `kind: 'github'`. Requires:
+1. Inject a fake `releaseService` returning a synthetic `ReleaseInfo` whose asset matches the controllers' variant. Either:
+    a) Pre-populate the on-disk cache so `cache.fetch()` returns immediately without hitting GitHub.
+    b) Add a constructor injection point on `ApiServer` for tests to swap the `githubReleaseService`. (Likely option (a) is simpler — no production-code change needed.)
+
+This task surfaces whether the harness needs an injection seam for `releaseService`. If so, add it (small: an optional constructor opt that overrides the auto-built service).
+
+Commit: `test(integration): happy github flash from cache fixture (c.6c.2 Task 6)`
+
+---
+
+### Task 7 — Integration test: cancel during upload + during deploy
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_cancel.integration.test.ts`
+
+Two test cases in one file:
+1. **Cancel during upload**: stub master configured with no auto-ack; POST flash; wait for `flashJobStarted`; DELETE flash; assert streamer abort propagates → `flashJobFailed { abortReason: 'aborted' }` → controllers transition to Failed → lock released.
+2. **Cancel during deploy**: stub master `autoAckUpload` enabled but `scriptDeploy` NOT configured (so deploy stalls awaiting FW_DEPLOY_DONE); POST flash; wait for `Sending` stage transition; DELETE flash; assert `flashJobFailed { abortReason: 'http' }` (or whatever cancel reason) + controllers in Failed + lock released.
+
+Commit: `test(integration): cancel during upload + during deploy (c.6c.2 Task 7)`
+
+---
+
+### Task 8 — Integration test: chunk NAK + Go-Back-N recovery
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts`
+
+Stub master configured with `autoAckUpload({ failAtSeq: 2 })`. POST flash. Assert:
+- Server retransmits from `lastGoodSeq + 1`.
+- Stub master ACKs the retransmitted chunks normally.
+- Flash completes successfully.
+
+This validates the c.6b chunk_streamer's Go-Back-N path under a real serial wire.
+
+Commit: `test(integration): chunk NAK + Go-Back-N retransmit (c.6c.2 Task 8)`
+
+---
+
+### Task 9 — Integration test: per-controller deploy FAILED outcome
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts`
+
+Stub master: `scriptDeploy({ controllers: [{ id: 'A', outcome: 'OK', ...}, { id: 'B', outcome: 'FAILED', error: 'crc_mismatch' }] })`.
+
+Assert:
+- `flashControllerResult` for A with VersionConfirmed
+- `flashControllerResult` for B with Failed + error
+- `flashJobDone` (NOT failed — per c.6a's `deriveJobLifecycle`, all-terminal regardless of mix)
+
+Commit: `test(integration): per-controller deploy FAILED outcome (c.6c.2 Task 9)`
+
+---
+
+### Task 10 — Integration test: heartbeat releases lock pre-timer
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts`
+
+Run a happy flash through to `flashJobDone`. Within the 15-sec reboot window, stub master emits POLL_ACK with master sentinel MAC + matching firmwareVersion. Assert `lockStateChanged { locked: false }` arrives BEFORE the 15-sec timer would have fired (use a measured delta of ~1-2 sec post-POLL_ACK).
+
+Variant test: emit POLL_ACK with WRONG firmwareVersion → orchestrator ignores → 15-sec timer eventually fires → assert lock released after that delay (use vitest's `testTimeout` ≥ 20 sec for this case).
+
+Commit: `test(integration): heartbeat-vs-timer first-fire-wins (c.6c.2 Task 10)`
+
+---
+
+### Task 11 — Integration test: reboot timer fallback fires (no heartbeat)
+
+**Files:**
+- (Could fold into Task 10's file — single test file, two `it()` blocks. Decide during implementation.)
+
+Run a happy flash through to `flashJobDone`. Stub master does NOT emit POLL_ACK. Assert `lockStateChanged { locked: false }` arrives ~15 sec after `flashJobDone` (with a tolerance band, e.g., 14.5–16 sec).
+
+This test runs slow by design. Mark with `it.concurrent` if vitest supports it, OR simply accept the 15-sec wall-clock cost. Reduces test-suite parallelism — that's fine for the integration tier.
+
+If folded into Task 10, omit this task; otherwise:
+
+Commit: `test(integration): reboot timer fallback fires after 15s (c.6c.2 Task 11)`
+
+---
+
+### Task 12 — Integration test: concurrent flash returns 409
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_concurrent.integration.test.ts`
+
+POST flash. Mid-flow (e.g., after `flashJobStarted` but before `flashJobDone`), POST a second flash. Assert second response is 409 with `{ error: 'job_already_running', currentJobId: <first-job-id> }`. Let first flash complete normally.
+
+Variant: WS sends a write-class message during the flash → assert `flashJobActive` rejection frame back. (Touches the c.2 lock-guard layer; nice to cover end-to-end.)
+
+Commit: `test(integration): concurrent flash returns 409 + flashJobActive WS rejection (c.6c.2 Task 12)`
+
+---
+
+### Task 13 — QA plan extension + final verification
+
+**Files:**
+- Modify: `.docs/qa/firmware-ota-flash.md`
+
+Append a section to the existing QA plan:
+
+```markdown
+## Integration test suite (c.6c.2)
+
+The following scenarios are now covered by the automated integration suite under
+`astros_api/src/firmware/integration/`. Operators do not need to manually verify
+these unless investigating a regression in the suite itself:
+
+- Happy upload flash (Task 5)
+- Happy github flash (Task 6)
+- Cancel during upload + deploy (Task 7)
+- Chunk NAK + Go-Back-N recovery (Task 8)
+- Per-controller deploy FAILED outcome (Task 9)
+- Heartbeat releases lock pre-timer (Task 10)
+- Reboot timer fallback fires after 15-sec (Task 11)
+- Concurrent flash returns 409 (Task 12)
+
+Run via: `cd astros_api && npm run test:integration`
+
+The remaining manual scenarios in this plan (real-hardware end-to-end smoke,
+mixed-variant location, no-controllers, source-resolution failure with real
+GitHub) still require operator attention — they cover boundaries the
+integration suite intentionally doesn't (real network, real hardware
+register, real master firmware behavior).
+```
+
+- [ ] **Verification (run before opening PR):**
+    - `cd astros_api && npm run prettier:write` clean
+    - `cd astros_api && npm run lint:fix` clean
+    - `cd astros_api && npm run build` clean
+    - `cd astros_api && npx vitest run` — full suite green (existing + new integration)
+    - `cd astros_api && npm run test:integration` — integration suite green in isolation
+    - `cd astros_vue && npm run build && npm run test:unit` clean (no Vue changes, but verify no regressions)
+    - `superpowers:requesting-code-review` on the full diff vs `develop` with the prompt: "Review for: (a) wire-format drift between StubMaster's writers and `MessageHandler`'s parsers; (b) resource leaks in the integration harness across PTY pair, socat subprocess, ApiServer, WS clients, and serial worker; (c) test flakiness — any timing-dependent assertion that could be brittle on a slower CI runner; (d) doc-vs-code drift between this plan's task descriptions and what shipped."
+
+Commit: `docs(qa): extend firmware OTA flash QA plan with integration suite + run final verification (c.6c.2 Task 13)`
+
+---
+
+## Verification
+
+- [ ] `cd astros_api && npm run build` clean (lint + tsc).
+- [ ] `cd astros_api && npx vitest run` — full suite green (existing ~630 + ~10 integration tests = ~640).
+- [ ] `cd astros_api && npm run test:integration` green in isolation; passes on a fresh check-out (no test-order dependencies).
+- [ ] `cd astros_api && npm run prettier:write` and `npm run lint:fix` clean.
+- [ ] FMI §1, §3, §4, §7 items have corresponding tests OR are explicitly marked N/A.
+- [ ] No production-code paths changed except `ApiServer.shutdown()` (Task 4) — verify with `git diff develop -- src | grep -v test_harness | grep -v integration | grep -v firmware/integration`.
+- [ ] Integration suite skips on Windows; passes on Linux. macOS not gated in CI but should pass locally if `socat` is installed (`brew install socat`).
+
+## Out of scope (deferred)
+
+Per the user redirect ("server repo only — firmware sim deferred to AstrOs.ESP") and the c.6c.1 spec §"Out of scope":
+
+- **C++ firmware simulator (full master behavior simulation)** — lives in AstrOs.ESP, where it can share parsing code with the real firmware. The stub master in this plan is a wire-protocol responder, not a behavior simulator.
+- **Padawan-side OTA simulation** — c.6c.2's stub master models a single virtual master only; per-padawan FW_DEPLOY_DONE entries are scripted, not simulated. Real per-padawan behavior covered by AstrOs.ESP's `b` series + bench testing.
+- **Full GitHub release-service network test** — deferred. We test the `kind: 'github'` path against a pre-populated cache. A real GitHub network round-trip belongs in a fixture-based test of the release service itself (already covered by `github_release_service.test.ts` with HTTP fixtures).
+- **`writeGuard` / WS lock-guard scenarios beyond `flashJobActive`** — c.2's lock-guard layer is unit-tested in its own file; we hit only the one path (concurrent-write-during-flash) in Task 12.
+- **`esp_app_desc_t` validation against real binary headers** — covered by `esp_app_desc.test.ts` with binary fixtures.
+- **Performance / throughput testing** — not a goal. The harness is for correctness.
+- **CI workflow changes** — adding `socat` to the GitHub Actions runner image is out of scope for this branch unless the CI workflow YAML is committed alongside (which is plausible — call out during plan review).
+
+## Notes for the reviewer
+
+- **Why `socat` over `node-pty`.** `node-pty` is primarily a child-process spawn lib and lacks a clean `openpty` API across versions. Using it for raw PTY pairs requires spawning `socat` as the child anyway, plus a heavy native-build npm dep. Direct `child_process.spawn('socat', ...)` is simpler and the dep is system-level (already on the dev box; one-line apt install on CI). The decomp doc's "node-pty/socat" wording uses a slash to mean "alternatives", not a hard mandate. If reviewer prefers `node-pty`, swap the `pty_pair.ts` impl — the rest of the harness doesn't care.
+- **Why integration tests live under `src/firmware/integration/` not `tests/`.** The existing project convention puts tests next to source (`*.test.ts`). Integration tests are slower and qualitatively different — they get their own subdirectory + filename suffix (`*.integration.test.ts`) so vitest can target them via `npm run test:integration` independently.
+- **Why `ApiServer.shutdown()` is added in Task 4 rather than as separate prep work.** It's a pure refactor — a single new method that captures references already held as instance fields and closes them. Tucking it into the harness-setup task keeps the refactor co-located with its first consumer; carving it into its own task would be busywork.
+- **Why the stub master's wire-format parser is inline rather than reusing `MessageHandler`.** `MessageHandler` parses messages flowing FROM master TO server (e.g., POLL_ACK, FW_*_ACK, FW_PROGRESS). The stub master needs to parse the OTHER direction (FW_TRANSFER_BEGIN, FW_CHUNK, FW_DEPLOY_BEGIN). Reusing `MessageHandler` would drag in dependencies + parse logic for the wrong direction. A narrow inline parser (~30 lines) is cheaper and clearer.
+- **Test-time vs production-time `serial_worker.js` behavior.** The worker is unchanged. Tests merely point its serial port at a PTY rather than a real device. The Worker thread, msgService, MessageHandler, MessageGenerator — all real and exercised end-to-end.
+- **Slowest test is Task 11 (reboot timer fallback) at ~15-16 sec wall-clock.** If suite runtime becomes a problem, that test could be moved to a separate `vitest --testTimeout=20000` config. For now, the integration suite is opt-in via `npm run test:integration`, so it doesn't slow the default `npm test` cycle.

--- a/.docs/qa/firmware-ota-flash.md
+++ b/.docs/qa/firmware-ota-flash.md
@@ -472,10 +472,14 @@ cd astros_api && npm run test:integration
 The integration suite is also covered by the default `npm test` / `npx vitest run`
 sweep — `test:integration` exists for fast targeted re-runs during development.
 
-The suite is **Linux/macOS only** (depends on `socat` for PTY pair allocation).
-First run takes ~5-15 sec extra for a `dist/` build (Worker threads can't load
-TS source under vitest+tsx, so the harness runs the production worker from
-compiled JS); subsequent runs skip the build.
+The suite is **Linux only** — non-Linux runners skip the integration tests
+via `skipIfNotLinux`, and `globalSetup` short-circuits there too so unit
+tests still run normally on Windows. (macOS's `socat` emits a different PTY
+path format than the helper's regex matches; rather than maintain a
+per-platform matrix without hardware to test on, the suite is gated to
+Linux.) First run on Linux takes ~5-15 sec extra for a `dist/` build
+(Worker threads can't load TS source under vitest+tsx, so the harness runs
+the production worker from compiled JS); subsequent runs skip the build.
 
 The remaining manual scenarios in this plan still require operator attention —
 they cover boundaries the integration suite intentionally doesn't:

--- a/.docs/qa/firmware-ota-flash.md
+++ b/.docs/qa/firmware-ota-flash.md
@@ -440,6 +440,51 @@ POLL_ACK forces the orchestrator onto the timer fallback.
   with `lockStateChanged` + a `flashJobActive` frame (existing c.2 behavior;
   unchanged by c.6c.1).
 
+## Integration test suite (c.6c.2)
+
+The following scenarios are covered end-to-end by the automated integration
+suite under `astros_api/src/firmware/integration/`. Each test boots a real
+`ApiServer` against a `socat`-backed PTY pair driven by an in-process
+`StubMaster` (a scriptable wire-protocol responder, NOT a firmware
+simulator — real firmware behavior simulation lives in AstrOs.ESP). Operators
+do NOT need to manually verify these scenarios unless investigating a regression
+in the suite itself.
+
+| Scenario | File | What it pins |
+|---|---|---|
+| Happy upload flash + heartbeat | `flash_happy_upload.integration.test.ts` | POST `kind=upload` → flashJobStarted → flashJobDone → master POLL_ACK heartbeat with deployed version → lock release in ~1-2s |
+| Happy github flash + heartbeat | `flash_happy_github.integration.test.ts` | POST `kind=github version=1.5.0` with injected fake fetcher returning canned release JSON; cache hit short-circuits download |
+| Cancel during upload | `flash_cancel.integration.test.ts` | DELETE while streamer awaits begin-ack → AbortController.abort → flashJobFailed{reason:'aborted'} |
+| Cancel during deploy | (same file) | DELETE after FW_DEPLOY_BEGIN → inline deploy-cancel → per-controller Failed + flashJobFailed{abortReason:'http'} |
+| Chunk NAK + Go-Back-N | `flash_chunk_nak.integration.test.ts` | autoAckUpload({failAtSeq:2}) NAKs once → streamer rewinds to lastGoodSeq+1 → seq=2 received twice → flashJobDone |
+| Mixed OK/FAILED outcomes | `flash_partial_failure.integration.test.ts` | Master OK + padawan FAILED → flashJobDone (NOT failed) per `deriveJobLifecycle`; flashControllerResult per controller with correct stage/error |
+| Heartbeat releases lock fast | `flash_heartbeat_release.integration.test.ts` | Wall-clock delta from POLL_ACK to lockStateChanged < 3000ms (heartbeat path firing, not timer) |
+| Wrong-version heartbeat ignored | (same file) | sentinel POLL_ACK with non-matching firmwareVersion → orchestrator filters → timer fallback releases lock |
+| Reboot timer fallback | `flash_reboot_timer_fallback.integration.test.ts` | No heartbeat after flashJobDone → timer fires → lock release in `rebootTimeoutMs` ± tolerance |
+| Concurrent flash returns 409 | `flash_concurrent.integration.test.ts` | Second POST during in-flight flash → 409 with currentJobId; WS SERVO_TEST → flashJobActive rejection frame |
+
+Run via:
+
+```bash
+cd astros_api && npm run test:integration
+```
+
+The integration suite is also covered by the default `npm test` / `npx vitest run`
+sweep — `test:integration` exists for fast targeted re-runs during development.
+
+The suite is **Linux/macOS only** (depends on `socat` for PTY pair allocation).
+First run takes ~5-15 sec extra for a `dist/` build (Worker threads can't load
+TS source under vitest+tsx, so the harness runs the production worker from
+compiled JS); subsequent runs skip the build.
+
+The remaining manual scenarios in this plan still require operator attention —
+they cover boundaries the integration suite intentionally doesn't:
+
+- Real-hardware end-to-end smoke against the bench rig
+- POLL_ACK protocol-level inspection with the real master firmware
+- Source-resolution against the real GitHub API (rate limits, network errors)
+- The Vue UI's rendering of progress + completion states
+
 ## Verification (run before opening the Part 2 PR)
 
 From `astros_api/`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       # The integration suite (src/firmware/integration/*) drives a real
       # ApiServer + StubMaster across a socat-backed PTY pair. Without
       # socat, createPtyPair throws and every integration test fails.
-      # Linux-only; non-POSIX runners skip via skipIfNotPosix.
+      # Linux-only; non-Linux runners skip via skipIfNotLinux.
       - name: Install socat (PTY pair for integration tests)
         run: sudo apt-get update && sudo apt-get install -y socat
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
         working-directory: astros_api
         run: npx tsc && npx tsc-alias
 
+      # The integration suite (src/firmware/integration/*) drives a real
+      # ApiServer + StubMaster across a socat-backed PTY pair. Without
+      # socat, createPtyPair throws and every integration test fails.
+      # Linux-only; non-POSIX runners skip via skipIfNotPosix.
+      - name: Install socat (PTY pair for integration tests)
+        run: sudo apt-get update && sudo apt-get install -y socat
+
       - name: Unit tests
         working-directory: astros_api
         run: npm run test -- --run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,41 @@ All implementation work goes on a feature branch that merges into `develop` via 
 
 **Exception — doc-only changes:** Edits limited to `CLAUDE.md`, `README.md`, or `.docs/` (with no code or config impact) may be committed directly to `develop`. PR overhead isn't justified for pure meta edits.
 
+## Pre-push branch review
+
+Before pushing a feature branch, run a comprehensive multi-agent review on the full diff vs `develop`:
+
+```
+/pr-review-toolkit:review-pr
+```
+
+**When required:**
+
+- Branch touches any of: `astros_api/src/test_harness/`, `astros_api/src/firmware/`, `astros_api/src/serial/`, `astros_api/src/api_server.ts`, `astros_api/src/dal/database.ts`, `astros_api/src/job_lock/` (concurrency-heavy or production-critical paths).
+- Branch has more than 5 commits (cross-commit drift accumulates beyond what per-commit review can catch).
+
+**When optional:**
+
+- 1-2 commit fixes outside the directories above — the per-commit code review is sufficient.
+
+**What it does.** Dispatches 5 specialized agents in parallel against the full branch diff vs `develop`:
+
+- `code-reviewer`: bug patterns, project-convention adherence
+- `pr-test-analyzer`: coverage gaps, vacuous assertions, mutation sensitivity
+- `silent-failure-hunter`: swallowed errors, listener leaks, partial-failure cascades
+- `type-design-analyzer`: encapsulation, invariant expression
+- `comment-analyzer`: comment-vs-code drift, stale references after refactors
+
+**Prompt the agents with hazard categories, not "review this fix."** The per-commit reviewer is framed around the change; the pre-push review must be framed around what could be wrong on the full surface. Categories that have repeatedly shown up in PR feedback on this codebase:
+
+- **Concurrency**: TOCTOU windows, stream chunk boundaries, fixed sleeps masquerading as deterministic waits, missing line buffering on stream parsers, timing-baseline bugs (client-side `Date.now()` when server-side timestamps are in the payload).
+- **Operability**: `process.exit` in library code, `close()` calls that hang on unclosed clients, `process.env` mutations across concurrent boots, listener leaks after promise resolves.
+- **Resource lifecycle**: PTY cleanup, port allocation (especially "find then bind later" schemes), worker teardown, file-descriptor leaks, env restore vs explicit-config plumbing.
+
+**Address findings.** Critical and Important items must be fixed before push. Minor items may be deferred to a follow-up commit but not silently dropped.
+
+**Why this exists.** Per-commit reviews see narrow diffs and are framed by the specific change; cross-commit drift, architectural patterns, and stale comments-after-refactor only become visible at the full-branch level. Running this skill before push catches in ~10 minutes what would otherwise come back as multiple rounds of PR feedback churn.
+
 ## Planning (MANDATORY)
 
 **NEVER write implementation code without a written, committed plan.** This is a hard rule, with the exceptions below.

--- a/astros_api/package.json
+++ b/astros_api/package.json
@@ -12,6 +12,7 @@
     "start": "node ./dist/api_server.js",
     "start:tsx": "tsx ./src/api_server.ts",
     "test": "vitest",
+    "test:integration": "vitest run src/firmware/integration",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prettier:check": "prettier --check \"src/**/*.ts\"",
     "prettier:write": "prettier --write \"src/**/*.ts\""

--- a/astros_api/src/api_server.test.ts
+++ b/astros_api/src/api_server.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiServer } from './api_server.js';
+
+describe('ApiServer.bootstrap misconfiguration', () => {
+  // ApiServer is imported as a class by the integration harness; any
+  // process.exit inside its init path would compromise graceful failure
+  // handling for callers. This suite pins the contract: missing required
+  // config rejects bootstrap() rather than calling process.exit.
+  //
+  // Note: vitest replaces process.exit with a function that throws
+  // ('process.exit unexpectedly called with ...') rather than actually
+  // exiting the worker — so we cannot distinguish "code rejected" from
+  // "code called process.exit and vitest's stub threw" by looking at
+  // the rejection alone. We must spy on process.exit and assert it was
+  // never called. Without the spy, this test would pass against the very
+  // bug it is meant to catch.
+  let prevJwt: string | undefined;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    prevJwt = process.env.JWT_KEY;
+    delete process.env.JWT_KEY;
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit(${String(code)}) called from library code`);
+    });
+  });
+
+  afterEach(() => {
+    if (prevJwt !== undefined) process.env.JWT_KEY = prevJwt;
+    exitSpy.mockRestore();
+  });
+
+  it('rejects with a JWT_KEY error rather than calling process.exit', async () => {
+    // Bypass `ApiServer.bootstrap()` and drive `Init()` directly. bootstrap
+    // wraps any Init failure as `new Error('Failed to initialize server')`
+    // with no `cause`, dropping the original message — so asserting on the
+    // generic wrapper would also match unrelated Init failures (e.g. a
+    // future regression in initializeDatabase). Calling Init() directly
+    // surfaces the JWT_KEY-specific message.
+    //
+    // skipSerialSetup is set explicitly so the test does not depend on
+    // vitest's NODE_ENV='test' routing for the serial branch. The DB
+    // branch still relies on NODE_ENV='test' to pick the in-memory
+    // adapter (no DATABASE_PATH needed); configApi runs after DB init
+    // but before the serial check, so the JWT_KEY throw fires first
+    // either way — but the explicit override removes one implicit
+    // dependency.
+    const server = new ApiServer({ configOverrides: { skipSerialSetup: true } });
+    await expect(server.Init()).rejects.toThrow(/JWT_KEY is required/);
+
+    // Load-bearing: process.exit must not have been called from library
+    // code. If it were, the spy would have recorded the call. Without
+    // this assertion, the test would pass even if Init reverted to
+    // calling process.exit — vitest's stub turns process.exit into a
+    // throw, which also satisfies the rejects.toThrow check above.
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -104,6 +104,24 @@ interface IServoTestData {
   value: number;
 }
 
+/**
+ * Optional bootstrap/constructor inputs for the ApiServer. Both fields exist
+ * to support the integration test harness:
+ *   - `workerScriptUrl`: tests point this at compiled dist/ because tsx's
+ *     loader hooks do not propagate to Worker threads, so the src/ Worker
+ *     script (with its `.js`-style imports of TS sources) cannot load under
+ *     vitest+tsx. Production leaves this undefined and gets the default
+ *     relative-to-import.meta.url URL, which lands in dist/ at runtime.
+ *   - `onWorkerError`: tests pass a callback so they can fail the test if
+ *     the Worker emits an `error` event (e.g. ERR_MODULE_NOT_FOUND on boot),
+ *     instead of relying on the existing logger.error which is silent to
+ *     the test runner.
+ */
+export interface ApiServerOptions {
+  workerScriptUrl?: URL;
+  onWorkerError?: (err: Error) => void;
+}
+
 export class ApiServer {
   private apiPort = 0;
   private websocketPort = 0;
@@ -116,6 +134,9 @@ export class ApiServer {
   private serialWorker!: Worker;
   private serialPort: any;
   private serialParser: any;
+
+  private readonly workerScriptUrl: URL;
+  private readonly onWorkerError?: (err: Error) => void;
 
   private httpServer?: import('http').Server;
 
@@ -200,7 +221,7 @@ export class ApiServer {
     };
   }
 
-  constructor() {
+  constructor(opts?: ApiServerOptions) {
     Dotenv.config({ path: __dirname + '/.env' });
 
     this.apiPort = Number.parseInt(process.env.API_PORT || '3000');
@@ -209,6 +230,16 @@ export class ApiServer {
     this.clients = new Map<string, WebSocket>();
     this.app = Express();
     this.router = Express.Router();
+
+    // Default Worker URL is the relative ./background_tasks/serial_worker.js,
+    // which resolves correctly when running compiled `node dist/api_server.js`
+    // (where dist/background_tasks/serial_worker.js exists alongside dist/logger.js).
+    // Tests override this to point at the compiled dist/ Worker because the
+    // src/ Worker file's `.js` imports cannot be resolved by Worker threads
+    // under tsx (Worker threads don't inherit the tsx loader).
+    this.workerScriptUrl =
+      opts?.workerScriptUrl ?? new URL('./background_tasks/serial_worker.js', import.meta.url);
+    this.onWorkerError = opts?.onWorkerError;
 
     // Broadcast lock state to all connected clients on every change. Subscribed
     // here (rather than in Init) so a state change emitted before Init finishes
@@ -249,8 +280,8 @@ export class ApiServer {
     this.runWebServices();
   }
 
-  public static async bootstrap(): Promise<ApiServer> {
-    const server = new ApiServer();
+  public static async bootstrap(opts?: ApiServerOptions): Promise<ApiServer> {
+    const server = new ApiServer(opts);
     try {
       await server.Init();
     } catch (error) {
@@ -462,18 +493,14 @@ export class ApiServer {
   }
 
   private setupSerialPort(): void {
-    this.serialWorker = new Worker(
-      new URL('./background_tasks/serial_worker.js', import.meta.url),
-      {
-        execArgv: process.execArgv,
-      },
-    );
+    this.serialWorker = new Worker(this.workerScriptUrl);
 
     this.serialWorker.on('exit', (exit) => {
       logger.info(exit);
     });
     this.serialWorker.on('error', (err) => {
       logger.error(err);
+      this.onWorkerError?.(err);
     });
 
     this.serialWorker.on('message', (msg) => {

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -1,3 +1,24 @@
+/**
+ * Two-mode entrypoint.
+ *
+ * - **Production / dev runs** (`node dist/api_server.js`, `tsx src/api_server.ts`):
+ *   this file is the main module. The IIFE at the bottom calls
+ *   `ApiServer.bootstrap()` automatically and installs SIGTERM/SIGINT handlers
+ *   that trigger a clean async shutdown. This is how the server runs on the
+ *   droid.
+ *
+ * - **Integration test harness** (`src/test_harness/integration_harness.ts`):
+ *   the harness imports `ApiServer` and calls `bootstrap()` itself, with
+ *   options that point the serial Worker at compiled dist/ and inject an
+ *   error callback. The `isMainModule` check at the bottom suppresses the
+ *   auto-bootstrap when this file is imported, so importing doesn't spawn
+ *   a "default" server in the test process.
+ *
+ * Production and test paths share the same class; the only differences are
+ * the constructor opts (`workerScriptUrl`, `onWorkerError`) and which side
+ * initiates `bootstrap()` / `shutdown()`.
+ */
+
 import Dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
 import path from 'path';
@@ -122,6 +143,10 @@ export interface ApiServerOptions {
   onWorkerError?: (err: Error) => void;
 }
 
+// Exported so the integration test harness can import + bootstrap an
+// instance directly. Production never imports this class — the IIFE at
+// the bottom of this file is the only production caller of `bootstrap()`.
+// See file header for the full two-mode contract.
 export class ApiServer {
   private apiPort = 0;
   private websocketPort = 0;
@@ -280,6 +305,16 @@ export class ApiServer {
     this.runWebServices();
   }
 
+  /**
+   * Construct + Init the server. Two callers:
+   *  1. Production IIFE at the bottom of this file — invoked with no args
+   *     when api_server.js is the main module.
+   *  2. Integration test harness — invoked with `opts` pointing the serial
+   *     Worker at compiled dist/ and supplying an error callback so a
+   *     Worker boot failure surfaces as a test failure.
+   *
+   * On boot failure, throws after logging the underlying cause.
+   */
   public static async bootstrap(opts?: ApiServerOptions): Promise<ApiServer> {
     const server = new ApiServer(opts);
     try {
@@ -1164,6 +1199,17 @@ export class ApiServer {
 
   //#endregion
 
+  /**
+   * Async, awaitable shutdown. Two callers:
+   *  1. Production SIGTERM/SIGINT handlers in the IIFE at the bottom of
+   *     this file — they `await shutdown()` then call `process.exit(0)`.
+   *  2. Integration test harness `dispose()` — `await`s shutdown() between
+   *     tests so each test gets a fresh ApiServer.
+   *
+   * Closes resources in dependency order: hardware (serial port + Worker),
+   * then network (WS server, HTTP server), then DB. Does NOT call
+   * `process.exit()` — the caller decides whether the process should exit.
+   */
   public async shutdown(): Promise<void> {
     logger.info('Shutting down...');
     this.animationQueue?.panicStop();
@@ -1194,9 +1240,18 @@ export class ApiServer {
   }
 }
 
-// Only auto-bootstrap when this file is run as the main module
-// (i.e., `node dist/api_server.js` or `tsx src/api_server.ts`). Tests
-// import the ApiServer class without triggering this side effect.
+// Production auto-bootstrap. Fires only when this file is the entry point
+// passed to `node` (or `tsx`) — `import.meta.url` matches the resolved
+// `argv[1]`. When the file is imported from another module — most importantly
+// the integration test harness, which does `import { ApiServer } from
+// '../api_server.js'` then calls `bootstrap()` itself — `argv[1]` is some
+// other entry (vitest's runner, etc.), the URLs don't match, and this block
+// is skipped.
+//
+// Without this guard, the harness's import would spawn a "default" ApiServer
+// the moment api_server.js loads, then collide with the harness's own
+// `bootstrap()` call on the same env-var ports. See file header for full
+// two-mode contract.
 const isMainModule = (() => {
   try {
     return import.meta.url === new URL(`file://${process.argv[1]}`).href;

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -169,24 +169,24 @@ export interface ApiServerOptions {
 }
 
 export interface ConfigOverrides {
-  serialPort?: string;
-  baudRate?: number;
-  apiPort?: number;
-  websocketPort?: number;
-  jwtKey?: string;
+  readonly serialPort?: string;
+  readonly baudRate?: number;
+  readonly apiPort?: number;
+  readonly websocketPort?: number;
+  readonly jwtKey?: string;
   /**
    * Full file path to the SQLite database (matching `initializeDatabase`'s
    * `dbPath` semantics — the file, not the directory).
    */
-  databasePath?: string;
-  firmwareCachePath?: string;
+  readonly databasePath?: string;
+  readonly firmwareCachePath?: string;
   /**
    * When true, ApiServer.Init skips serial-port setup. Mirrors the legacy
    * `NODE_ENV=test` short-circuit. The harness sets this to `false`
    * explicitly because vitest defaults NODE_ENV to 'test' (which would
    * otherwise skip serial setup, the very thing the harness is exercising).
    */
-  skipSerialSetup?: boolean;
+  readonly skipSerialSetup?: boolean;
 }
 
 // Exported so the integration test harness can import + bootstrap an

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -815,11 +815,21 @@ export class ApiServer {
       const partialWs = this.websocket;
       this.websocket = undefined;
       if (partialWs !== undefined) {
+        // ws.Server.close(cb) only fires its callback once the underlying
+        // http server has shut down — but on a WS that errored before
+        // reaching 'listening', that internal state may never resolve and
+        // close() can hang forever. Race against a short timeout so the
+        // rollback always completes; the original wsErr is the diagnostic
+        // we care about either way.
         try {
-          await new Promise<void>((resolve) => partialWs.close(() => resolve()));
-        } catch {
-          // Best-effort — the bind already failed, so the WS server may be
-          // in an undefined state. Don't mask the original wsErr.
+          await Promise.race([
+            new Promise<void>((resolve) => partialWs.close(() => resolve())),
+            new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+          ]);
+        } catch (closeErr) {
+          // Synchronous throw from partialWs.close — log but don't mask wsErr.
+          const msg = closeErr instanceof Error ? closeErr.message : String(closeErr);
+          logger.warn(`runWebServices rollback: partialWs.close threw: ${msg}`);
         }
       }
       throw wsErr;

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -2,7 +2,7 @@
  * Two-mode entrypoint.
  *
  * - **Production / dev runs** (`node dist/api_server.js`, `tsx src/api_server.ts`):
- *   this file is the main module. The IIFE at the bottom calls
+ *   this file is the main module. The auto-bootstrap block at the bottom (gated by `isMainModule`) calls
  *   `ApiServer.bootstrap()` automatically and installs SIGTERM/SIGINT handlers
  *   that trigger a clean async shutdown. This is how the server runs in the
  *   container.
@@ -190,8 +190,9 @@ export interface ConfigOverrides {
 }
 
 // Exported so the integration test harness can import + bootstrap an
-// instance directly. Production never imports this class — the IIFE at
-// the bottom of this file is the only production caller of `bootstrap()`.
+// instance directly. Production never imports this class — the auto-bootstrap
+// block at the bottom of this file is the only production caller of
+// `bootstrap()`.
 // See file header for the full two-mode contract.
 export class ApiServer {
   private apiPort = 0;
@@ -228,14 +229,17 @@ export class ApiServer {
 
   // Firmware-OTA wiring. The orchestrator + WorkerSerialBus
   // are constructed in setupSerialPort() because they depend on the serial
-  // worker; when serial setup is skipped (NODE_ENV=test, or
-  // `configOverrides.skipSerialSetup=true`) `flashOrchestrator` stays
-  // undefined — the flash routes aren't registered either, so HTTP
-  // /api/firmware/flash returns 404 in unit tests rather than tripping a
-  // null deref on the orchestrator. The firmware cache, upload store, and
-  // GitHub release service are constructed unconditionally in configApi()
-  // because they have no Worker dependency and are otherwise useful (unit
-  // tests don't reach them, but the construction is cheap).
+  // worker; when serial setup is skipped — either explicit override
+  // (`configOverrides.skipSerialSetup=true`), or no override AND
+  // NODE_ENV='test' — `flashOrchestrator` stays undefined and the flash
+  // routes aren't registered either, so HTTP /api/firmware/flash returns
+  // 404 in unit tests rather than tripping a null deref on the
+  // orchestrator. The integration harness sets skipSerialSetup=false
+  // explicitly to override vitest's NODE_ENV='test' default and exercise
+  // the serial path. The firmware cache, upload store, and GitHub release
+  // service are constructed unconditionally in configApi() because they
+  // have no Worker dependency and are otherwise useful (unit tests don't
+  // reach them, but the construction is cheap).
   private firmwareCache!: FirmwareCache;
   private firmwareUploadStore!: FirmwareUploadStore;
   private githubReleaseService!: GitHubReleaseService;
@@ -384,7 +388,7 @@ export class ApiServer {
 
   /**
    * Construct + Init the server. Two callers:
-   *  1. Production IIFE at the bottom of this file — invoked with no args
+   *  1. Production auto-bootstrap block at the bottom (gated by `isMainModule`) of this file — invoked with no args
    *     when api_server.js is the main module.
    *  2. Integration test harness — invoked with `opts` pointing the serial
    *     Worker at compiled dist/ and supplying an error callback so a
@@ -515,8 +519,8 @@ export class ApiServer {
       // Throw rather than process.exit: ApiServer is also imported as a
       // class by the integration harness, and library-style init code
       // calling process.exit makes graceful test failure (or any caller's
-      // misconfiguration handling) impossible. The auto-bootstrap IIFE at
-      // the bottom of this file owns process.exit; bootstrap()'s catch
+      // misconfiguration handling) impossible. The auto-bootstrap block
+      // at the bottom of this file owns process.exit; bootstrap()'s catch
       // logs the original error before rethrowing.
       throw new Error(
         'JWT_KEY is required (set process.env.JWT_KEY or pass configOverrides.jwtKey)',
@@ -1427,7 +1431,7 @@ export class ApiServer {
 
   /**
    * Async, awaitable shutdown. Two callers:
-   *  1. Production SIGTERM/SIGINT handlers in the IIFE at the bottom of
+   *  1. Production SIGTERM/SIGINT handlers in the auto-bootstrap block at the bottom (gated by `isMainModule`) of
    *     this file — they `await shutdown()` then call `process.exit(0)`.
    *  2. Integration test harness `dispose()` — `await`s shutdown() between
    *     tests so each test gets a fresh ApiServer.

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -169,7 +169,7 @@ export class ApiServer {
 
   private app: Application;
   private router: Router;
-  private websocket!: Server;
+  private websocket?: Server;
 
   private serialWorker!: Worker;
   private serialPort: any;
@@ -338,7 +338,7 @@ export class ApiServer {
     }
 
     logger.info('Starting web services');
-    this.runWebServices();
+    await this.runWebServices();
   }
 
   /**
@@ -635,18 +635,33 @@ export class ApiServer {
     }
   }
 
-  private runWebServices(): void {
-    this.httpServer = this.app.listen(this.apiPort, () => {
-      logger.info(`The application is listening on port ${this.apiPort}`);
+  private async runWebServices(): Promise<void> {
+    // Await both binds (HTTP listen + WS 'listening') before returning so
+    // bootstrap() rejects cleanly on EADDRINUSE in production, and so the
+    // integration harness can read the bound ports back via
+    // getBoundApiPort/getBoundWebsocketPort. Setting API_PORT/WEBSOCKET_PORT
+    // to '0' lets the kernel assign ephemeral ports — used by the harness
+    // to avoid the TOCTOU race that any "find free port, then bind it
+    // later" scheme has.
+    await new Promise<void>((resolve, reject) => {
+      const httpServer = this.app.listen(this.apiPort, () => {
+        logger.info(`The application is listening on port ${this.getBoundApiPort()}`);
+        resolve();
+      });
+      this.httpServer = httpServer;
+      httpServer.once('error', reject);
     });
 
-    this.websocket = new Server({ port: this.websocketPort });
+    const ws = (this.websocket = new Server({ port: this.websocketPort }));
 
     this.systemStatus.subscribe((state) => {
       this.updateClients({ type: TransmissionType.systemStatus, data: state });
     });
 
-    this.websocket.on('connection', (conn) => {
+    // Connection handler attached synchronously before awaiting 'listening',
+    // mirroring the prior sync setup — any client racing the bind still hits
+    // the handler.
+    ws.on('connection', (conn) => {
       const id = uuid_v4();
       this.clients.set(id, conn);
 
@@ -709,6 +724,52 @@ export class ApiServer {
 
       logger.info(`websocket connected: id=${id}`);
     });
+
+    await new Promise<void>((resolve, reject) => {
+      ws.once('listening', () => resolve());
+      ws.once('error', reject);
+    });
+    logger.info(`websocket server listening on port ${this.getBoundWebsocketPort()}`);
+  }
+
+  /**
+   * Port the HTTP server is actually bound to. Useful for callers that pass
+   * `API_PORT=0` to request an ephemeral port and need to know the kernel's
+   * assignment. Throws if called before `runWebServices` completes.
+   */
+  public getBoundApiPort(): number {
+    if (this.httpServer === undefined) {
+      throw new Error('ApiServer.getBoundApiPort: httpServer not yet running');
+    }
+    const addr = this.httpServer.address();
+    if (typeof addr !== 'object' || addr === null) {
+      throw new Error(
+        `ApiServer.getBoundApiPort: httpServer.address() returned ${typeof addr}, expected object`,
+      );
+    }
+    return addr.port;
+  }
+
+  /**
+   * Port the WebSocket server is actually bound to. See `getBoundApiPort`.
+   * Throws if called before `runWebServices` completes or if the server was
+   * configured for a unix-socket path (never the case in this codebase, but
+   * the `ws` library's address() type permits it).
+   */
+  public getBoundWebsocketPort(): number {
+    if (this.websocket === undefined) {
+      throw new Error('ApiServer.getBoundWebsocketPort: websocket not yet running');
+    }
+    const addr = this.websocket.address();
+    if (typeof addr === 'string') {
+      throw new Error(
+        'ApiServer.getBoundWebsocketPort: websocket bound to unix socket, no port available',
+      );
+    }
+    if (addr === null) {
+      throw new Error('ApiServer.getBoundWebsocketPort: websocket.address() returned null');
+    }
+    return addr.port;
   }
 
   handleWebsocketMessage(msg: string, conn: WebSocket): void {
@@ -1261,7 +1322,9 @@ export class ApiServer {
     }
 
     if (this.websocket !== undefined) {
-      await new Promise<void>((resolve) => this.websocket.close(() => resolve()));
+      const websocket = this.websocket;
+      await new Promise<void>((resolve) => websocket.close(() => resolve()));
+      this.websocket = undefined;
     }
 
     if (this.httpServer !== undefined) {

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -1368,14 +1368,31 @@ export class ApiServer {
 
     if (this.websocket !== undefined) {
       const websocket = this.websocket;
+      // ws.Server.close() only invokes its callback once every connected
+      // client has disconnected; it does NOT proactively close them. A
+      // SIGTERM with any idle client connected would otherwise hang the
+      // whole shutdown. terminate() force-destroys the underlying socket,
+      // which is appropriate on a shutdown path — no graceful handshake
+      // is required when the process is going down.
+      for (const client of websocket.clients) {
+        client.terminate();
+      }
       await new Promise<void>((resolve) => websocket.close(() => resolve()));
       this.websocket = undefined;
     }
 
     if (this.httpServer !== undefined) {
       const httpServer = this.httpServer;
+      // Same hazard as ws — http.Server.close() refuses to invoke its
+      // callback until every keep-alive connection drains naturally.
+      // closeAllConnections() (Node 18.2+) destroys those sockets so
+      // close() resolves promptly. WebSocket-upgraded sockets are
+      // unaffected by closeAllConnections, but our WS server is a
+      // separate WebSocketServer with its own internal http.Server, so
+      // there are none on this httpServer to begin with.
       await new Promise<void>((resolve, reject) => {
         httpServer.close((err) => (err ? reject(err) : resolve()));
+        httpServer.closeAllConnections();
       });
       this.httpServer = undefined;
     }

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -147,6 +147,15 @@ export interface ApiServerOptions {
    * this undefined and gets the global `fetch`.
    */
   firmwareReleaseFetcher?: typeof fetch;
+  /**
+   * Tests override the FlashJobOrchestrator's reboot-timeout (default 15s)
+   * to keep wrong-version-heartbeat / timer-fallback tests fast. Production
+   * leaves this undefined.
+   */
+  flashOrchestratorConfig?: {
+    rebootTimeoutMs?: number;
+    throttleWindowMs?: number;
+  };
 }
 
 // Exported so the integration test harness can import + bootstrap an
@@ -169,6 +178,10 @@ export class ApiServer {
   private readonly workerScriptUrl: URL;
   private readonly onWorkerError?: (err: Error) => void;
   private readonly firmwareReleaseFetcher?: typeof fetch;
+  private readonly flashOrchestratorConfig?: {
+    rebootTimeoutMs?: number;
+    throttleWindowMs?: number;
+  };
 
   private httpServer?: import('http').Server;
 
@@ -287,6 +300,7 @@ export class ApiServer {
       opts?.workerScriptUrl ?? new URL('./background_tasks/serial_worker.js', import.meta.url);
     this.onWorkerError = opts?.onWorkerError;
     this.firmwareReleaseFetcher = opts?.firmwareReleaseFetcher;
+    this.flashOrchestratorConfig = opts?.flashOrchestratorConfig;
 
     // Broadcast lock state to all connected clients on every change. Subscribed
     // here (rather than in Init) so a state change emitted before Init finishes
@@ -590,6 +604,7 @@ export class ApiServer {
           })),
       },
       emitWs: (msg) => this.updateClients(msg),
+      config: this.flashOrchestratorConfig,
     });
     registerFirmwareFlashRoutes(this.router, this.authHandler, this.flashOrchestrator);
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -1363,50 +1363,78 @@ export class ApiServer {
    */
   public async shutdown(): Promise<void> {
     logger.info('Shutting down...');
-    this.animationQueue?.panicStop();
 
-    if (this.serialPort?.isOpen) {
-      await new Promise<void>((resolve) => this.serialPort.close(() => resolve()));
-    }
-
-    if (this.serialWorker !== undefined) {
-      await this.serialWorker.terminate();
-    }
-
-    if (this.websocket !== undefined) {
-      const websocket = this.websocket;
-      // ws.Server.close() only invokes its callback once every connected
-      // client has disconnected; it does NOT proactively close them. A
-      // SIGTERM with any idle client connected would otherwise hang the
-      // whole shutdown. terminate() force-destroys the underlying socket,
-      // which is appropriate on a shutdown path — no graceful handshake
-      // is required when the process is going down.
-      for (const client of websocket.clients) {
-        client.terminate();
+    // Resilient cascade: each resource is closed in its own try/catch so a
+    // failure in one (e.g. serialPort.close errors, worker.terminate rejects
+    // on an already-exited worker) doesn't skip the rest, leaving the WS
+    // server bound, the HTTP server bound, and the DB connection open.
+    // Errors are logged with context; the SIGTERM handler / harness dispose
+    // already handle a thrown shutdown by bailing the process or test, so
+    // letting individual steps fail loudly here is strictly better than
+    // letting them cascade-suppress later steps.
+    const safeClose = async (label: string, fn: () => void | Promise<void>): Promise<void> => {
+      try {
+        await fn();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`shutdown ${label} failed: ${msg}`);
       }
-      await new Promise<void>((resolve) => websocket.close(() => resolve()));
-      this.websocket = undefined;
-    }
+    };
 
-    if (this.httpServer !== undefined) {
-      const httpServer = this.httpServer;
-      // Same hazard as ws — http.Server.close() refuses to invoke its
-      // callback until every keep-alive connection drains naturally.
-      // closeAllConnections() (Node 18.2+) destroys those sockets so
-      // close() resolves promptly. WebSocket-upgraded sockets are
-      // unaffected by closeAllConnections, but our WS server is a
-      // separate WebSocketServer with its own internal http.Server, so
-      // there are none on this httpServer to begin with.
-      await new Promise<void>((resolve, reject) => {
-        httpServer.close((err) => (err ? reject(err) : resolve()));
-        httpServer.closeAllConnections();
-      });
-      this.httpServer = undefined;
-    }
+    await safeClose('animationQueue.panicStop', () => this.animationQueue?.panicStop());
 
-    if (this.db !== undefined) {
-      await this.db.destroy();
-    }
+    await safeClose('serialPort.close', async () => {
+      if (this.serialPort?.isOpen) {
+        await new Promise<void>((resolve) => this.serialPort.close(() => resolve()));
+      }
+    });
+
+    await safeClose('serialWorker.terminate', async () => {
+      if (this.serialWorker !== undefined) {
+        await this.serialWorker.terminate();
+      }
+    });
+
+    await safeClose('websocket.close', async () => {
+      if (this.websocket !== undefined) {
+        const websocket = this.websocket;
+        // ws.Server.close() only invokes its callback once every connected
+        // client has disconnected; it does NOT proactively close them. A
+        // SIGTERM with any idle client connected would otherwise hang the
+        // whole shutdown. terminate() force-destroys the underlying socket,
+        // which is appropriate on a shutdown path — no graceful handshake
+        // is required when the process is going down.
+        for (const client of websocket.clients) {
+          client.terminate();
+        }
+        await new Promise<void>((resolve) => websocket.close(() => resolve()));
+        this.websocket = undefined;
+      }
+    });
+
+    await safeClose('httpServer.close', async () => {
+      if (this.httpServer !== undefined) {
+        const httpServer = this.httpServer;
+        // Same hazard as ws — http.Server.close() refuses to invoke its
+        // callback until every keep-alive connection drains naturally.
+        // closeAllConnections() (Node 18.2+) destroys those sockets so
+        // close() resolves promptly. WebSocket-upgraded sockets are
+        // unaffected by closeAllConnections, but our WS server is a
+        // separate WebSocketServer with its own internal http.Server, so
+        // there are none on this httpServer to begin with.
+        await new Promise<void>((resolve, reject) => {
+          httpServer.close((err) => (err ? reject(err) : resolve()));
+          httpServer.closeAllConnections();
+        });
+        this.httpServer = undefined;
+      }
+    });
+
+    await safeClose('db.destroy', async () => {
+      if (this.db !== undefined) {
+        await this.db.destroy();
+      }
+    });
   }
 }
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -398,7 +398,16 @@ export class ApiServer {
       await server.Init();
     } catch (error) {
       logger.error(error);
-      throw new Error('Failed to initialize server');
+      // Preserve the original error via `cause` so callers can inspect the
+      // underlying failure (e.g. tests asserting on JWT_KEY misconfig, or a
+      // future debug session distinguishing EADDRINUSE from a DB migration
+      // failure). Without it, the rewrap discards the only specific signal
+      // the caller has. Set as a property rather than the ES2022 `Error`
+      // constructor option because tsconfig.target is ES6 — Node 20 still
+      // exposes `cause` on the instance just fine.
+      const wrapped = new Error('Failed to initialize server');
+      (wrapped as Error & { cause?: unknown }).cause = error;
+      throw wrapped;
     }
 
     return server;

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -503,8 +503,15 @@ export class ApiServer {
 
     const jwtKey = this.configOverrides?.jwtKey ?? process.env.JWT_KEY;
     if (!jwtKey) {
-      logger.error('JWT_KEY is required (set process.env.JWT_KEY or pass configOverrides.jwtKey)');
-      process.exit(1);
+      // Throw rather than process.exit: ApiServer is also imported as a
+      // class by the integration harness, and library-style init code
+      // calling process.exit makes graceful test failure (or any caller's
+      // misconfiguration handling) impossible. The auto-bootstrap IIFE at
+      // the bottom of this file owns process.exit; bootstrap()'s catch
+      // logs the original error before rethrowing.
+      throw new Error(
+        'JWT_KEY is required (set process.env.JWT_KEY or pass configOverrides.jwtKey)',
+      );
     }
 
     this.authHandler = jwt({

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -4,8 +4,8 @@
  * - **Production / dev runs** (`node dist/api_server.js`, `tsx src/api_server.ts`):
  *   this file is the main module. The IIFE at the bottom calls
  *   `ApiServer.bootstrap()` automatically and installs SIGTERM/SIGINT handlers
- *   that trigger a clean async shutdown. This is how the server runs on the
- *   droid.
+ *   that trigger a clean async shutdown. This is how the server runs in the.
+ *   container.
  *
  * - **Integration test harness** (`src/test_harness/integration_harness.ts`):
  *   the harness imports `ApiServer` and calls `bootstrap()` itself, with

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -106,9 +106,9 @@ import { AnimationQueuePlaylist } from './serial/animation_queue/queue_item/anim
 import { PlaylistType } from './models/playlists/playlistType.js';
 import { convertPlaylistToQueueItem } from './serial/animation_queue/playlist_converter.js';
 import { PlaylistRepository } from './dal/repositories/playlist_repository.js';
-// Imported via `src/*` alias to match the converter's import path. Using a
-// relative path here would create two separate class instances under
-// esbuild-based runtimes (tsx/vitest) and break `instanceof` checks.
+// Must use `src/*` alias (not relative path) — esbuild-based runtimes
+// (tsx/vitest) treat the two import paths as separate modules and break
+// `instanceof` checks across the boundary.
 import { PlaylistCycleError } from 'src/models/playlists/playlist_cycle_error.js';
 
 interface IWebSocketMessage {
@@ -125,46 +125,19 @@ interface IServoTestData {
   value: number;
 }
 
-/**
- * Optional bootstrap/constructor inputs for the ApiServer. Both fields exist
- * to support the integration test harness:
- *   - `workerScriptUrl`: tests point this at compiled dist/ because tsx's
- *     loader hooks do not propagate to Worker threads, so the src/ Worker
- *     script (with its `.js`-style imports of TS sources) cannot load under
- *     vitest+tsx. Production leaves this undefined and gets the default
- *     relative-to-import.meta.url URL, which lands in dist/ at runtime.
- *   - `onWorkerError`: tests pass a callback so they can fail the test if
- *     the Worker emits an `error` event (e.g. ERR_MODULE_NOT_FOUND on boot),
- *     instead of relying on the existing logger.error which is silent to
- *     the test runner.
- */
+// Test-harness hooks. `workerScriptUrl` points the Worker at compiled dist/
+// because tsx loader hooks don't propagate to Worker threads. `onWorkerError`
+// surfaces Worker boot failures to the test runner (logger.error is silent
+// to vitest). `configOverrides` avoids mutating process.env so concurrent
+// harness boots don't clobber each other.
 export interface ApiServerOptions {
   workerScriptUrl?: URL;
   onWorkerError?: (err: Error) => void;
-  /**
-   * Tests inject a fake `fetch` so `GitHubReleaseService.getReleases()` returns
-   * canned release data instead of hitting GitHub's REST API. Production leaves
-   * this undefined and gets the global `fetch`.
-   */
   firmwareReleaseFetcher?: typeof fetch;
-  /**
-   * Tests override the FlashJobOrchestrator's reboot-timeout (default 15s)
-   * to keep wrong-version-heartbeat / timer-fallback tests fast. Production
-   * leaves this undefined.
-   */
   flashOrchestratorConfig?: {
     rebootTimeoutMs?: number;
     throttleWindowMs?: number;
   };
-  /**
-   * Per-instance overrides for values normally pulled from process.env.
-   * The integration harness uses this to avoid mutating the process-global
-   * environment — concurrent harness boots (in any future test pool that
-   * shares process.env across workers) would otherwise clobber each other's
-   * SERIAL_PORT / DATABASE_PATH / etc. Each field falls back to the
-   * corresponding env var when undefined, preserving production behavior
-   * for the auto-bootstrap caller.
-   */
   configOverrides?: ConfigOverrides;
 }
 
@@ -174,26 +147,16 @@ export interface ConfigOverrides {
   readonly apiPort?: number;
   readonly websocketPort?: number;
   readonly jwtKey?: string;
-  /**
-   * Full file path to the SQLite database (matching `initializeDatabase`'s
-   * `dbPath` semantics — the file, not the directory).
-   */
+  // Full path to the SQLite file (not its directory).
   readonly databasePath?: string;
   readonly firmwareCachePath?: string;
-  /**
-   * When true, ApiServer.Init skips serial-port setup. Mirrors the legacy
-   * `NODE_ENV=test` short-circuit. The harness sets this to `false`
-   * explicitly because vitest defaults NODE_ENV to 'test' (which would
-   * otherwise skip serial setup, the very thing the harness is exercising).
-   */
+  // Explicit override for the implicit `NODE_ENV=test` skip. The harness sets
+  // this `false` so vitest's default NODE_ENV doesn't suppress the serial path
+  // it's trying to exercise.
   readonly skipSerialSetup?: boolean;
 }
 
-// Exported so the integration test harness can import + bootstrap an
-// instance directly. Production never imports this class — the auto-bootstrap
-// block at the bottom of this file is the only production caller of
-// `bootstrap()`.
-// See file header for the full two-mode contract.
+// See file header for the two-mode (production / test-harness) contract.
 export class ApiServer {
   private apiPort = 0;
   private websocketPort = 0;
@@ -227,44 +190,21 @@ export class ApiServer {
   private systemStatus = new SystemStatus();
   private readonly jobLock = new JobLock();
 
-  // Firmware-OTA wiring. The orchestrator + WorkerSerialBus
-  // are constructed in setupSerialPort() because they depend on the serial
-  // worker; when serial setup is skipped — either explicit override
-  // (`configOverrides.skipSerialSetup=true`), or no override AND
-  // NODE_ENV='test' — `flashOrchestrator` stays undefined and the flash
-  // routes aren't registered either, so HTTP /api/firmware/flash returns
-  // 404 in unit tests rather than tripping a null deref on the
-  // orchestrator. The integration harness sets skipSerialSetup=false
-  // explicitly to override vitest's NODE_ENV='test' default and exercise
-  // the serial path. The firmware cache, upload store, and GitHub release
-  // service are constructed unconditionally in configApi() because they
-  // have no Worker dependency and are otherwise useful (unit tests don't
-  // reach them, but the construction is cheap).
+  // Firmware-OTA wiring. The orchestrator + WorkerSerialBus depend on the
+  // serial worker, so they're built in setupSerialPort() and stay undefined
+  // when serial setup is skipped — flash routes aren't registered then, so
+  // /api/firmware/flash 404s rather than null-derefing.
   private firmwareCache!: FirmwareCache;
   private firmwareUploadStore!: FirmwareUploadStore;
   private githubReleaseService!: GitHubReleaseService;
   private workerSerialBus?: WorkerSerialBus;
   private flashOrchestrator?: FlashJobOrchestrator;
-  // POLL_ACK-fed variant cache, keyed by controller MAC (the same id flowing
-  // through FW_PROGRESS / FW_DEPLOY_BEGIN). Populated by handlePollResponse
-  // whenever a POLL_ACK arrives with a non-empty variant; consumed by the
-  // orchestrator's controllersStore.listFlashTargets() at flash time. Entries
-  // never expire — a controller that goes offline keeps its last-known
-  // variant until the server restarts (or a fresh POLL_ACK overwrites it).
-  // Per FMI §7 row "controllers cache": stale entries are operator-recoverable
-  // (re-poll via syncControllers) and out-of-scope for c.6c.1.
+  // POLL_ACK-fed variant cache keyed by controller MAC. Entries never expire;
+  // operator recovers stale state via syncControllers (re-poll).
   private readonly controllerVariantCache = new Map<string, string>();
 
-  /**
-   * Test-only accessor for the POLL_ACK-fed variant cache. Used by the
-   * integration harness to poll-wait for a stub master's POLL_ACK to round-trip
-   * through Worker → handlePollResponse → cache.set(). Without this, tests
-   * have to sleep an arbitrary duration before flashing, which flakes under
-   * vitest's parallel-thread load.
-   *
-   * Not part of the production runtime API. Callers outside `test_harness/`
-   * should not use this.
-   */
+  // Test-only: lets the harness poll-wait for a POLL_ACK to populate the cache
+  // instead of sleeping an arbitrary duration before flashing.
   public getVariantForControllerForTest(mac: string): string | undefined {
     return this.controllerVariantCache.get(mac);
   }
@@ -292,14 +232,8 @@ export class ApiServer {
     return true;
   }
 
-  /**
-   * Wraps a serial route handler with the standard boilerplate:
-   * - short-circuits with 503 when the serial worker is unavailable
-   * - catches thrown errors and responds with 500
-   *
-   * The wrapped handler is responsible for sending its own success response,
-   * so handlers can still return 404 or other status codes when appropriate.
-   */
+  // Wraps a route: 503 when serial worker is down, 500 on thrown errors.
+  // Handler still owns its success / 404 response.
   private withSerialGuard(
     handler: (req: any, res: any, next: any) => Promise<void> | void,
   ): (req: any, res: any, next: any) => Promise<void> {
@@ -329,23 +263,14 @@ export class ApiServer {
     this.app = Express();
     this.router = Express.Router();
 
-    // Default Worker URL is the relative ./background_tasks/serial_worker.js,
-    // which resolves correctly when running compiled `node dist/api_server.js`
-    // (where dist/background_tasks/serial_worker.js exists alongside dist/logger.js).
-    // Tests override this to point at the compiled dist/ Worker because the
-    // src/ Worker file's `.js` imports cannot be resolved by Worker threads
-    // under tsx (Worker threads don't inherit the tsx loader).
+    // Worker threads don't inherit the tsx loader, so the default URL only
+    // works against compiled dist/. Tests override to point at dist/ explicitly.
     this.workerScriptUrl =
       opts?.workerScriptUrl ?? new URL('./background_tasks/serial_worker.js', import.meta.url);
     this.onWorkerError = opts?.onWorkerError;
     this.firmwareReleaseFetcher = opts?.firmwareReleaseFetcher;
     this.flashOrchestratorConfig = opts?.flashOrchestratorConfig;
 
-    // Broadcast lock state to all connected clients on every change. Subscribed
-    // here (rather than in Init) so a state change emitted before Init finishes
-    // — which won't happen today, but is a cheap guarantee — still reaches the
-    // updateClients fan-out path. The clients Map starts empty; updateClients
-    // is a no-op until WS connections land.
     this.jobLock.subscribe((state) => {
       this.updateClients(buildLockStateResponse(state));
     });
@@ -371,6 +296,9 @@ export class ApiServer {
     logger.info('Setting up routes');
     this.setRoutes();
 
+    // configOverrides.skipSerialSetup wins over NODE_ENV — vitest defaults
+    // NODE_ENV=test, which would otherwise hide the serial path from the
+    // integration harness that is specifically exercising it.
     const skipSerialSetup =
       this.configOverrides?.skipSerialSetup ?? process.env.NODE_ENV?.toLocaleLowerCase() === 'test';
     if (skipSerialSetup) {
@@ -386,29 +314,15 @@ export class ApiServer {
     await this.runWebServices();
   }
 
-  /**
-   * Construct + Init the server. Two callers:
-   *  1. Production auto-bootstrap block at the bottom (gated by `isMainModule`) of this file — invoked with no args
-   *     when api_server.js is the main module.
-   *  2. Integration test harness — invoked with `opts` pointing the serial
-   *     Worker at compiled dist/ and supplying an error callback so a
-   *     Worker boot failure surfaces as a test failure.
-   *
-   * On boot failure, throws after logging the underlying cause.
-   */
+  // Construct + Init. On boot failure, logs and rethrows wrapped with `cause`.
   public static async bootstrap(opts?: ApiServerOptions): Promise<ApiServer> {
     const server = new ApiServer(opts);
     try {
       await server.Init();
     } catch (error) {
       logger.error(error);
-      // Preserve the original error via `cause` so callers can inspect the
-      // underlying failure (e.g. tests asserting on JWT_KEY misconfig, or a
-      // future debug session distinguishing EADDRINUSE from a DB migration
-      // failure). Without it, the rewrap discards the only specific signal
-      // the caller has. Set as a property rather than the ES2022 `Error`
-      // constructor option because tsconfig.target is ES6 — Node 20 still
-      // exposes `cause` on the instance just fine.
+      // Assign `cause` as a property — the ES2022 constructor option isn't
+      // available with tsconfig.target=ES6. Node 20 still surfaces it.
       const wrapped = new Error('Failed to initialize server');
       (wrapped as Error & { cause?: unknown }).cause = error;
       throw wrapped;
@@ -428,19 +342,16 @@ export class ApiServer {
 
           const user = await repository.getByUsername(username);
 
-          // Return if user not found in database
           if (!user) {
             return done(null, false, {
               message: 'User not found',
             });
           }
-          // Return if password is wrong
           if (!user.validatePassword(password)) {
             return done(null, false, {
               message: 'Password is wrong',
             });
           }
-          // If credentials are correct, return the user object
           return done(null, user);
         },
       ),
@@ -516,12 +427,9 @@ export class ApiServer {
 
     const jwtKey = this.configOverrides?.jwtKey ?? process.env.JWT_KEY;
     if (!jwtKey) {
-      // Throw rather than process.exit: ApiServer is also imported as a
-      // class by the integration harness, and library-style init code
-      // calling process.exit makes graceful test failure (or any caller's
-      // misconfiguration handling) impossible. The auto-bootstrap block
-      // at the bottom of this file owns process.exit; bootstrap()'s catch
-      // logs the original error before rethrowing.
+      // Throw, don't process.exit — the harness imports this class and a
+      // library-level exit defeats any caller's misconfiguration handling.
+      // The auto-bootstrap block at file-bottom owns process.exit.
       throw new Error(
         'JWT_KEY is required (set process.env.JWT_KEY or pass configOverrides.jwtKey)',
       );
@@ -534,12 +442,8 @@ export class ApiServer {
 
     this.apiKeyValidator = ApiKeyValidator(this.db);
 
-    // Firmware infrastructure shared across the c.4 / c.5 / c.3 endpoints and
-    // the c.6c.1 orchestrator. Constructed unconditionally — the cache/upload
-    // store resolve their root from `configOverrides.firmwareCachePath` if
-    // supplied, otherwise FIRMWARE_CACHE_PATH (default ~/.config/astrosserver),
-    // and the release service is a thin GitHub API wrapper. None of them open
-    // the serial worker, so test mode is safe.
+    // Firmware infrastructure has no Worker dependency — safe to construct
+    // unconditionally even when serial setup is skipped.
     this.firmwareCache = new FirmwareCache({ rootDir: this.configOverrides?.firmwareCachePath });
     this.firmwareUploadStore = new FirmwareUploadStore({
       rootDir: this.configOverrides?.firmwareCachePath,
@@ -643,11 +547,9 @@ export class ApiServer {
       this.handleSerialWorkerMessage(msg);
     });
 
-    // c.6c.1 firmware-OTA orchestrator. Built here (rather than in configApi)
-    // because the WorkerSerialBus needs the serialWorker reference. Test mode
-    // skips setupSerialPort() entirely, so this branch only runs in real
-    // runtime — the flash routes are registered alongside so HTTP /api/firmware/flash
-    // 404s in tests rather than reaching an undefined orchestrator.
+    // Built here (not in configApi) because WorkerSerialBus needs the
+    // serialWorker reference. Flash routes register alongside so they 404
+    // when serial setup is skipped instead of hitting an undefined orchestrator.
     this.workerSerialBus = new WorkerSerialBus({ worker: this.serialWorker });
     this.flashOrchestrator = new FlashJobOrchestrator({
       bus: this.workerSerialBus,
@@ -656,11 +558,8 @@ export class ApiServer {
       upload: this.firmwareUploadStore,
       releaseService: this.githubReleaseService,
       controllersStore: {
-        // The variant cache is the in-memory source of truth for "which
-        // controllers have we observed alive" (POLL_ACK is the heartbeat).
-        // Returning a snapshot per call keeps the orchestrator's
-        // validateControllers free to apply trim/uniformity checks without
-        // racing a concurrent POLL_ACK update of the underlying Map.
+        // Snapshot per call so validateControllers doesn't race a concurrent
+        // POLL_ACK update of the underlying Map.
         listFlashTargets: async () =>
           Array.from(this.controllerVariantCache.entries()).map(([id, variant]) => ({
             id,
@@ -701,13 +600,10 @@ export class ApiServer {
   }
 
   private async runWebServices(): Promise<void> {
-    // Await both binds (HTTP listen + WS 'listening') before returning so
-    // bootstrap() rejects cleanly on EADDRINUSE in production, and so the
-    // integration harness can read the bound ports back via
-    // getBoundApiPort/getBoundWebsocketPort. Setting API_PORT/WEBSOCKET_PORT
-    // to '0' lets the kernel assign ephemeral ports — used by the harness
-    // to avoid the TOCTOU race that any "find free port, then bind it
-    // later" scheme has.
+    // Await both binds so bootstrap() rejects cleanly on EADDRINUSE and
+    // getBoundApiPort/getBoundWebsocketPort have something to read.
+    // API_PORT/WEBSOCKET_PORT='0' requests ephemeral ports — the harness
+    // uses this to avoid TOCTOU on "find free port, bind later".
     await new Promise<void>((resolve, reject) => {
       const httpServer = this.app.listen(this.apiPort, () => {
         logger.info(`The application is listening on port ${this.getBoundApiPort()}`);
@@ -717,17 +613,9 @@ export class ApiServer {
       httpServer.once('error', reject);
     });
 
-    // Wrap WS setup in a try/catch. If WS bind fails (e.g. websocketPort
-    // already in use), the HTTP server above is already listening — without
-    // this rollback we'd leak a live listening socket on every failed
-    // bootstrap, which manifests as cumulative EADDRINUSE flakes in tests
-    // that retry-after-failure.
-    // Capture the systemStatus unsubscribe handle so the rollback can detach
-    // the subscriber if WS bind fails. Without this, the closure would
-    // outlive the dead instance — on the next bootstrap (or a sibling
-    // instance under test), the orphaned subscriber would double-emit
-    // systemStatus frames AND keep the dead instance alive in the
-    // emitter's set.
+    // If WS bind fails the HTTP server above is already listening; the
+    // catch below rolls it back to avoid leaking a live socket and
+    // double-emitting systemStatus frames from an orphaned subscriber.
     let unsubscribeSystemStatus: (() => void) | undefined;
     try {
       const ws = (this.websocket = new Server({ port: this.websocketPort }));
@@ -736,11 +624,8 @@ export class ApiServer {
         this.updateClients({ type: TransmissionType.systemStatus, data: state });
       });
 
-      // Connection handler attached synchronously before awaiting 'listening'
-      // so any client racing the bind still hits the handler — the WS server
-      // begins accepting connections only when 'listening' fires, but
-      // attaching after the await would leave a window where the listener
-      // isn't installed yet.
+      // Attach the connection handler before awaiting 'listening' to close
+      // the window where a racing client connects without a listener.
       ws.on('connection', (conn) => {
         const id = uuid_v4();
         this.clients.set(id, conn);
@@ -756,22 +641,16 @@ export class ApiServer {
           logger.error(`websocket initial systemStatus send error: ${err}`);
         }
 
-        // Late-join snapshot: a client connecting while the lock is held would
-        // otherwise wait until the next acquire/release transition to learn the
-        // current state. Mirrors the systemStatus initial send above.
+        // Late-join lock snapshot: a client connecting while the lock is held
+        // would otherwise wait until the next acquire/release to learn state.
         try {
           conn.send(JSON.stringify(buildLockStateResponse(this.jobLock.getState())));
         } catch (err) {
           logger.error(`websocket initial lockState send error: ${err}`);
         }
 
-        // Flash-job late-join snapshot. When a client connects
-        // mid-flash, send the current FlashJobState so the operator UI can
-        // reconstruct progress without waiting for the next per-controller
-        // update. Sent only when a job is in flight; nothing is sent for the
-        // common "no active job" case (per spec §"Late-join" — no history
-        // persistence in v1, so completed jobs are not retained). Skipped in
-        // test mode where flashOrchestrator is undefined.
+        // Late-join flash-job snapshot — only emitted when a job is in flight.
+        // No history persistence in v1, so completed jobs are not retained.
         if (this.flashOrchestrator !== undefined) {
           try {
             const snapshot = decideLateJoinSnapshot(this.flashOrchestrator.getCurrentJob());
@@ -811,25 +690,18 @@ export class ApiServer {
       });
       logger.info(`websocket server listening on port ${this.getBoundWebsocketPort()}`);
     } catch (wsErr) {
-      // Roll back the HTTP bind so we don't leak a listening socket. Also
-      // close the partial WS server if it got constructed before failing
-      // (the ws library schedules its bind on next tick, so the Server
-      // instance exists even when the listen errored). And detach the
-      // systemStatus subscriber so the dead instance doesn't keep getting
-      // ticked by the emitter (and so the closure can be GC'd).
+      // Roll back: detach the systemStatus subscriber, close the HTTP
+      // server, and close any partial WS instance (ws schedules its bind
+      // on next tick, so the Server may exist even when listen errored).
       if (unsubscribeSystemStatus !== undefined) {
         unsubscribeSystemStatus();
       }
       const httpServer = this.httpServer;
       this.httpServer = undefined;
       if (httpServer !== undefined) {
-        // Surface httpServer.close errors via logger.warn rather than the
-        // prior swallow. ENOTLISTENING here means the rollback is a no-op
-        // — combined with the still-bound socket from the listen success,
-        // that's a leak the user needs to know about. We don't rethrow
-        // because the original wsErr is the failure the caller asked
-        // about; close errors during rollback are diagnostics, not the
-        // primary fault.
+        // Log close errors instead of rethrowing — wsErr is the primary
+        // fault the caller asked about; an ENOTLISTENING here would still
+        // signal a real leak the operator needs to see.
         await new Promise<void>((resolve) =>
           httpServer.close((closeErr) => {
             if (closeErr) {
@@ -842,19 +714,15 @@ export class ApiServer {
       const partialWs = this.websocket;
       this.websocket = undefined;
       if (partialWs !== undefined) {
-        // ws.Server.close(cb) only fires its callback once the underlying
-        // http server has shut down — but on a WS that errored before
-        // reaching 'listening', that internal state may never resolve and
-        // close() can hang forever. Race against a short timeout so the
-        // rollback always completes; the original wsErr is the diagnostic
-        // we care about either way.
+        // ws.Server.close() can hang forever on an instance that errored
+        // before 'listening' — race a 1s timeout so rollback always completes.
         try {
           await Promise.race([
             new Promise<void>((resolve) => partialWs.close(() => resolve())),
             new Promise<void>((resolve) => setTimeout(resolve, 1000)),
           ]);
         } catch (closeErr) {
-          // Synchronous throw from partialWs.close — log but don't mask wsErr.
+          // Don't mask wsErr.
           const msg = closeErr instanceof Error ? closeErr.message : String(closeErr);
           logger.warn(`runWebServices rollback: partialWs.close threw: ${msg}`);
         }
@@ -863,11 +731,8 @@ export class ApiServer {
     }
   }
 
-  /**
-   * Port the HTTP server is actually bound to. Useful for callers that pass
-   * `API_PORT=0` to request an ephemeral port and need to know the kernel's
-   * assignment. Throws if called before `runWebServices` completes.
-   */
+  // Resolves the kernel-assigned port when API_PORT=0. Throws if called
+  // before runWebServices completes.
   public getBoundApiPort(): number {
     if (this.httpServer === undefined) {
       throw new Error('ApiServer.getBoundApiPort: httpServer not yet running');
@@ -881,12 +746,8 @@ export class ApiServer {
     return addr.port;
   }
 
-  /**
-   * Port the WebSocket server is actually bound to. See `getBoundApiPort`.
-   * Throws if called before `runWebServices` completes or if the server was
-   * configured for a unix-socket path (never the case in this codebase, but
-   * the `ws` library's address() type permits it).
-   */
+  // See getBoundApiPort. Also throws on a unix-socket WS bind, which the
+  // ws types permit but this codebase never uses.
   public getBoundWebsocketPort(): number {
     if (this.websocket === undefined) {
       throw new Error('ApiServer.getBoundWebsocketPort: websocket not yet running');
@@ -907,11 +768,8 @@ export class ApiServer {
     try {
       const parsed = JSON.parse(msg) as IWebSocketMessage;
 
-      // Lock guard: write-class inbound messages are rejected per-connection
-      // when a flash job is in progress. The originating client receives a
-      // lockStateChanged echo + flashJobActive frame and we skip dispatch.
-      // (HTTP write-class requests are gated separately in writeGuard at the
-      // global /api mount.)
+      // Per-connection lock guard for write-class messages during a flash.
+      // HTTP requests are gated separately by writeGuard on /api.
       if (rejectIfLocked(parsed.msgType, conn, this.jobLock)) return;
 
       switch (parsed.msgType) {
@@ -994,31 +852,18 @@ export class ApiServer {
     try {
       const val = msg as PollResponse;
 
-      // Feed the variant cache + heartbeat callback BEFORE
-      // the existing DB lookups. The cache populates regardless of whether
-      // the controller is registered (DB lookup may fail for first-poll
-      // controllers before sync runs); the heartbeat callback fires only
-      // when a flash is in flight and the version matches the deployed
-      // target, so out-of-protocol heartbeats are dropped here rather than
-      // sent into the orchestrator. POLL_ACK with empty variant — older
-      // firmware that hasn't picked up the c.6c.1 protocol extension —
-      // leaves `controller.variant` undefined per handlePollAck; we skip
-      // updating the cache in that case so a regression to old firmware
-      // doesn't poison the cache with an empty string.
+      // Update the variant cache before the DB lookups below — those can
+      // fail for first-poll controllers, but the cache should still populate.
+      // Skip empty variants (pre-c.6c.1 firmware) so a regression doesn't
+      // poison the cache.
       const variant = val.controller.variant;
       if (typeof variant === 'string' && variant.length > 0) {
         this.controllerVariantCache.set(val.controller.address, variant);
       }
 
-      // Heartbeat callback: only the master's post-deploy POLL_ACK
-      // (sentinel MAC, version matches deployed target) releases the
-      // lock. Padawans poll routinely during a flash and any padawan
-      // that has already rebooted into the same target version would
-      // race the master if we didn't filter on the master sentinel.
-      // Decision logic lives in `decidePostDeployHeartbeat` — pure
-      // function, fully unit-tested. Log paths surface diagnostic
-      // gaps (empty firmwareVersion / wrong version) instead of
-      // silently relying on the 15s timer fallback.
+      // Only the master's post-deploy POLL_ACK (sentinel MAC, version
+      // matches target) releases the flash lock — padawans polling during
+      // a flash would otherwise race the master.
       const currentJob = this.flashOrchestrator?.getCurrentJob() ?? null;
       const decision = decidePostDeployHeartbeat(
         val.controller.address,
@@ -1429,28 +1274,13 @@ export class ApiServer {
 
   //#endregion
 
-  /**
-   * Async, awaitable shutdown. Two callers:
-   *  1. Production SIGTERM/SIGINT handlers in the auto-bootstrap block at the bottom (gated by `isMainModule`) of
-   *     this file — they `await shutdown()` then call `process.exit(0)`.
-   *  2. Integration test harness `dispose()` — `await`s shutdown() between
-   *     tests so each test gets a fresh ApiServer.
-   *
-   * Closes resources in dependency order: hardware (serial port + Worker),
-   * then network (WS server, HTTP server), then DB. Does NOT call
-   * `process.exit()` — the caller decides whether the process should exit.
-   */
+  // Awaitable shutdown. Closes resources in dependency order — hardware,
+  // network, DB. Caller decides whether to process.exit().
   public async shutdown(): Promise<void> {
     logger.info('Shutting down...');
 
-    // Resilient cascade: each resource is closed in its own try/catch so a
-    // failure in one (e.g. serialPort.close errors, worker.terminate rejects
-    // on an already-exited worker) doesn't skip the rest, leaving the WS
-    // server bound, the HTTP server bound, and the DB connection open.
-    // Errors are logged with context; the SIGTERM handler / harness dispose
-    // already handle a thrown shutdown by bailing the process or test, so
-    // letting individual steps fail loudly here is strictly better than
-    // letting them cascade-suppress later steps.
+    // Each step gets its own try/catch so a failure in one resource doesn't
+    // skip the rest and leave sockets / DB handles dangling.
     const safeClose = async (label: string, fn: () => void | Promise<void>): Promise<void> => {
       try {
         await fn();
@@ -1477,12 +1307,8 @@ export class ApiServer {
     await safeClose('websocket.close', async () => {
       if (this.websocket !== undefined) {
         const websocket = this.websocket;
-        // ws.Server.close() only invokes its callback once every connected
-        // client has disconnected; it does NOT proactively close them. A
-        // SIGTERM with any idle client connected would otherwise hang the
-        // whole shutdown. terminate() force-destroys the underlying socket,
-        // which is appropriate on a shutdown path — no graceful handshake
-        // is required when the process is going down.
+        // ws.Server.close() waits for clients to disconnect on their own; an
+        // idle client would hang shutdown forever. terminate() each one first.
         for (const client of websocket.clients) {
           client.terminate();
         }
@@ -1494,19 +1320,12 @@ export class ApiServer {
     await safeClose('httpServer.close', async () => {
       if (this.httpServer !== undefined) {
         const httpServer = this.httpServer;
-        // Same hazard as ws — http.Server.close() refuses to invoke its
-        // callback until every keep-alive connection drains naturally.
-        // closeAllConnections() (Node 18.2+) destroys those sockets so
-        // close() resolves promptly. WebSocket-upgraded sockets are
-        // unaffected by closeAllConnections, but our WS server is a
-        // separate WebSocketServer with its own internal http.Server, so
-        // there are none on this httpServer to begin with.
-        //
-        // Runtime guard: closeAllConnections is Node 18.2+ but the project
-        // is pinned to Node 20+ (Dockerfile, CI). The typeof check is
-        // defense in depth — if anything ever runs this on an older Node
-        // (downstream fork, an analytics container, etc.), shutdown should
-        // degrade to "wait for keep-alives to drain" rather than throw.
+        // http.Server.close() blocks on keep-alive sockets draining naturally;
+        // closeAllConnections() (Node 18.2+) destroys them so close() resolves
+        // promptly. Our WS server is a separate WebSocketServer with its own
+        // http.Server, so no upgraded sockets live on this one. The typeof
+        // guard is defense in depth — Node is pinned to 20+ in Dockerfile/CI,
+        // but a downstream fork on older Node should still gracefully degrade.
         await new Promise<void>((resolve, reject) => {
           httpServer.close((err) => (err ? reject(err) : resolve()));
           if (typeof httpServer.closeAllConnections === 'function') {
@@ -1525,23 +1344,12 @@ export class ApiServer {
   }
 }
 
-// Production auto-bootstrap. Fires only when this file is the entry point
-// passed to `node` (or `tsx`) — `import.meta.url` matches the resolved
-// `argv[1]`. When the file is imported from another module — most importantly
-// the integration test harness, which does `import { ApiServer } from
-// '../api_server.js'` then calls `bootstrap()` itself — `argv[1]` is some
-// other entry (vitest's runner, etc.), the URLs don't match, and this block
-// is skipped.
-//
-// Without this guard, the harness's import would spawn a "default" ApiServer
-// the moment api_server.js loads, then collide with the harness's own
-// `bootstrap()` call on the same env-var ports. See file header for full
-// two-mode contract.
-//
-// `pathToFileURL(path.resolve(...))` is the robust way to convert argv[1]
-// to a file URL — `argv[1]` is often a relative path (e.g. `./dist/api_server.js`
-// from `npm run start`), and `new URL('file://./dist/...')` would parse the
-// leading `.` as a host, never matching `import.meta.url`'s absolute form.
+// Auto-bootstrap only when this file is the entry point. When imported (e.g.
+// by the test harness), this block must skip so it doesn't collide with the
+// caller's own bootstrap() on the same env-var ports.
+// `pathToFileURL(path.resolve(...))` handles argv[1] being relative (e.g.
+// `./dist/api_server.js`) — `new URL('file://./...')` would parse the `.`
+// as a host and never match `import.meta.url`.
 const isMainModule = (() => {
   try {
     const argv1 = process.argv[1];

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -205,6 +205,20 @@ export class ApiServer {
   // (re-poll via syncControllers) and out-of-scope for c.6c.1.
   private readonly controllerVariantCache = new Map<string, string>();
 
+  /**
+   * Test-only accessor for the POLL_ACK-fed variant cache. Used by the
+   * integration harness to poll-wait for a stub master's POLL_ACK to round-trip
+   * through Worker → handlePollResponse → cache.set(). Without this, tests
+   * have to sleep an arbitrary duration before flashing, which flakes under
+   * vitest's parallel-thread load.
+   *
+   * Not part of the production runtime API. Callers outside `test_harness/`
+   * should not use this.
+   */
+  public getVariantForControllerForTest(mac: string): string | undefined {
+    return this.controllerVariantCache.get(mac);
+  }
+
   upload!: any;
 
   private isSerialWorkerAvailable(): boolean {

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -104,7 +104,7 @@ interface IServoTestData {
   value: number;
 }
 
-class ApiServer {
+export class ApiServer {
   private apiPort = 0;
   private websocketPort = 0;
   private clients: Map<string, WebSocket>;
@@ -116,6 +116,8 @@ class ApiServer {
   private serialWorker!: Worker;
   private serialPort: any;
   private serialParser: any;
+
+  private httpServer?: import('http').Server;
 
   private animationQueue!: AnimationQueue;
 
@@ -529,8 +531,8 @@ class ApiServer {
   }
 
   private runWebServices(): void {
-    this.app.listen(this.apiPort, () => {
-      logger.info('The application is listening on port 3000');
+    this.httpServer = this.app.listen(this.apiPort, () => {
+      logger.info(`The application is listening on port ${this.apiPort}`);
     });
 
     this.websocket = new Server({ port: this.websocketPort });
@@ -1130,22 +1132,64 @@ class ApiServer {
 
   //#endregion
 
-  shutdown(): void {
+  public async shutdown(): Promise<void> {
     logger.info('Shutting down...');
     this.animationQueue?.panicStop();
-    this.serialPort?.close();
-    this.serialWorker?.terminate();
-    this.websocket?.close();
-    process.exit(0);
+
+    if (this.serialPort?.isOpen) {
+      await new Promise<void>((resolve) => this.serialPort.close(() => resolve()));
+    }
+
+    if (this.serialWorker !== undefined) {
+      await this.serialWorker.terminate();
+    }
+
+    if (this.websocket !== undefined) {
+      await new Promise<void>((resolve) => this.websocket.close(() => resolve()));
+    }
+
+    if (this.httpServer !== undefined) {
+      const httpServer = this.httpServer;
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((err) => (err ? reject(err) : resolve()));
+      });
+      this.httpServer = undefined;
+    }
+
+    if (this.db !== undefined) {
+      await this.db.destroy();
+    }
   }
 }
 
-ApiServer.bootstrap()
-  .then((server) => {
-    process.on('SIGTERM', () => server.shutdown());
-    process.on('SIGINT', () => server.shutdown());
-  })
-  .catch((err) => {
-    console.error(err.stack);
-    process.exit(1);
-  });
+// Only auto-bootstrap when this file is run as the main module
+// (i.e., `node dist/api_server.js` or `tsx src/api_server.ts`). Tests
+// import the ApiServer class without triggering this side effect.
+const isMainModule = (() => {
+  try {
+    return import.meta.url === new URL(`file://${process.argv[1]}`).href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMainModule) {
+  ApiServer.bootstrap()
+    .then((server) => {
+      const handleSignal = async (signal: NodeJS.Signals): Promise<void> => {
+        logger.info(`Received ${signal}; shutting down...`);
+        try {
+          await server.shutdown();
+        } catch (err) {
+          logger.error(`Shutdown error: ${(err as Error).message}`);
+        }
+        process.exit(0);
+      };
+      process.on('SIGTERM', () => void handleSignal('SIGTERM'));
+      process.on('SIGINT', () => void handleSignal('SIGINT'));
+    })
+    .catch((err) => {
+      console.error(err.stack);
+      process.exit(1);
+    });
+}

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -462,7 +462,12 @@ export class ApiServer {
   }
 
   private setupSerialPort(): void {
-    this.serialWorker = new Worker(new URL('./background_tasks/serial_worker.js', import.meta.url));
+    this.serialWorker = new Worker(
+      new URL('./background_tasks/serial_worker.js', import.meta.url),
+      {
+        execArgv: process.execArgv,
+      },
+    );
 
     this.serialWorker.on('exit', (exit) => {
       logger.info(exit);

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -704,84 +704,112 @@ export class ApiServer {
       httpServer.once('error', reject);
     });
 
-    const ws = (this.websocket = new Server({ port: this.websocketPort }));
+    // Wrap WS setup in a try/catch. If WS bind fails (e.g. websocketPort
+    // already in use), the HTTP server above is already listening — without
+    // this rollback we'd leak a live listening socket on every failed
+    // bootstrap, which manifests as cumulative EADDRINUSE flakes in tests
+    // that retry-after-failure.
+    try {
+      const ws = (this.websocket = new Server({ port: this.websocketPort }));
 
-    this.systemStatus.subscribe((state) => {
-      this.updateClients({ type: TransmissionType.systemStatus, data: state });
-    });
+      this.systemStatus.subscribe((state) => {
+        this.updateClients({ type: TransmissionType.systemStatus, data: state });
+      });
 
-    // Connection handler attached synchronously before awaiting 'listening',
-    // mirroring the prior sync setup — any client racing the bind still hits
-    // the handler.
-    ws.on('connection', (conn) => {
-      const id = uuid_v4();
-      this.clients.set(id, conn);
+      // Connection handler attached synchronously before awaiting 'listening',
+      // mirroring the prior sync setup — any client racing the bind still hits
+      // the handler.
+      ws.on('connection', (conn) => {
+        const id = uuid_v4();
+        this.clients.set(id, conn);
 
-      try {
-        conn.send(
-          JSON.stringify({
-            type: TransmissionType.systemStatus,
-            data: this.systemStatus.getState(),
-          }),
-        );
-      } catch (err) {
-        logger.error(`websocket initial systemStatus send error: ${err}`);
-      }
-
-      // Late-join snapshot: a client connecting while the lock is held would
-      // otherwise wait until the next acquire/release transition to learn the
-      // current state. Mirrors the systemStatus initial send above.
-      try {
-        conn.send(JSON.stringify(buildLockStateResponse(this.jobLock.getState())));
-      } catch (err) {
-        logger.error(`websocket initial lockState send error: ${err}`);
-      }
-
-      // Flash-job late-join snapshot. When a client connects
-      // mid-flash, send the current FlashJobState so the operator UI can
-      // reconstruct progress without waiting for the next per-controller
-      // update. Sent only when a job is in flight; nothing is sent for the
-      // common "no active job" case (per spec §"Late-join" — no history
-      // persistence in v1, so completed jobs are not retained). Skipped in
-      // test mode where flashOrchestrator is undefined.
-      if (this.flashOrchestrator !== undefined) {
         try {
-          const snapshot = decideLateJoinSnapshot(this.flashOrchestrator.getCurrentJob());
-          if (snapshot.kind === 'flashJobStarted') {
-            conn.send(
-              JSON.stringify({
-                type: TransmissionType.flashJobStarted,
-                data: snapshot.data,
-              }),
-            );
-          }
+          conn.send(
+            JSON.stringify({
+              type: TransmissionType.systemStatus,
+              data: this.systemStatus.getState(),
+            }),
+          );
         } catch (err) {
-          logger.error(`websocket initial flashJobStarted send error: ${err}`);
+          logger.error(`websocket initial systemStatus send error: ${err}`);
+        }
+
+        // Late-join snapshot: a client connecting while the lock is held would
+        // otherwise wait until the next acquire/release transition to learn the
+        // current state. Mirrors the systemStatus initial send above.
+        try {
+          conn.send(JSON.stringify(buildLockStateResponse(this.jobLock.getState())));
+        } catch (err) {
+          logger.error(`websocket initial lockState send error: ${err}`);
+        }
+
+        // Flash-job late-join snapshot. When a client connects
+        // mid-flash, send the current FlashJobState so the operator UI can
+        // reconstruct progress without waiting for the next per-controller
+        // update. Sent only when a job is in flight; nothing is sent for the
+        // common "no active job" case (per spec §"Late-join" — no history
+        // persistence in v1, so completed jobs are not retained). Skipped in
+        // test mode where flashOrchestrator is undefined.
+        if (this.flashOrchestrator !== undefined) {
+          try {
+            const snapshot = decideLateJoinSnapshot(this.flashOrchestrator.getCurrentJob());
+            if (snapshot.kind === 'flashJobStarted') {
+              conn.send(
+                JSON.stringify({
+                  type: TransmissionType.flashJobStarted,
+                  data: snapshot.data,
+                }),
+              );
+            }
+          } catch (err) {
+            logger.error(`websocket initial flashJobStarted send error: ${err}`);
+          }
+        }
+
+        conn.on('message', (msg) => {
+          this.handleWebsocketMessage(msg.toString(), conn);
+        });
+
+        conn.on('close', () => {
+          this.clients.delete(id);
+          logger.info(`websocket disconnected: id=${id}`);
+        });
+
+        conn.on('error', (err) => {
+          logger.error(`websocket client error: id=${id}, ${err}`);
+          this.clients.delete(id);
+        });
+
+        logger.info(`websocket connected: id=${id}`);
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        ws.once('listening', () => resolve());
+        ws.once('error', reject);
+      });
+      logger.info(`websocket server listening on port ${this.getBoundWebsocketPort()}`);
+    } catch (wsErr) {
+      // Roll back the HTTP bind so we don't leak a listening socket. Also
+      // close the partial WS server if it got constructed before failing
+      // (the ws library schedules its bind on next tick, so the Server
+      // instance exists even when the listen errored).
+      const httpServer = this.httpServer;
+      this.httpServer = undefined;
+      if (httpServer !== undefined) {
+        await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      }
+      const partialWs = this.websocket;
+      this.websocket = undefined;
+      if (partialWs !== undefined) {
+        try {
+          await new Promise<void>((resolve) => partialWs.close(() => resolve()));
+        } catch {
+          // Best-effort — the bind already failed, so the WS server may be
+          // in an undefined state. Don't mask the original wsErr.
         }
       }
-
-      conn.on('message', (msg) => {
-        this.handleWebsocketMessage(msg.toString(), conn);
-      });
-
-      conn.on('close', () => {
-        this.clients.delete(id);
-        logger.info(`websocket disconnected: id=${id}`);
-      });
-
-      conn.on('error', (err) => {
-        logger.error(`websocket client error: id=${id}, ${err}`);
-        this.clients.delete(id);
-      });
-
-      logger.info(`websocket connected: id=${id}`);
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      ws.once('listening', () => resolve());
-      ws.once('error', reject);
-    });
-    logger.info(`websocket server listening on port ${this.getBoundWebsocketPort()}`);
+      throw wsErr;
+    }
   }
 
   /**

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -1450,9 +1450,17 @@ export class ApiServer {
         // unaffected by closeAllConnections, but our WS server is a
         // separate WebSocketServer with its own internal http.Server, so
         // there are none on this httpServer to begin with.
+        //
+        // Runtime guard: closeAllConnections is Node 18.2+ but the project
+        // is pinned to Node 20+ (Dockerfile, CI). The typeof check is
+        // defense in depth — if anything ever runs this on an older Node
+        // (downstream fork, an analytics container, etc.), shutdown should
+        // degrade to "wait for keep-alives to drain" rather than throw.
         await new Promise<void>((resolve, reject) => {
           httpServer.close((err) => (err ? reject(err) : resolve()));
-          httpServer.closeAllConnections();
+          if (typeof httpServer.closeAllConnections === 'function') {
+            httpServer.closeAllConnections();
+          }
         });
         this.httpServer = undefined;
       }

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -77,7 +77,7 @@ import { ServoTest } from './models/servo_test.js';
 import { FirmwareConfig } from './models/firmware_config.js';
 import { meetsMinimum } from './utility/semver.js';
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 import { initializeDatabase } from './dal/database.js';
 import { Kysely } from 'kysely';
@@ -1290,9 +1290,16 @@ export class ApiServer {
 // the moment api_server.js loads, then collide with the harness's own
 // `bootstrap()` call on the same env-var ports. See file header for full
 // two-mode contract.
+//
+// `pathToFileURL(path.resolve(...))` is the robust way to convert argv[1]
+// to a file URL — `argv[1]` is often a relative path (e.g. `./dist/api_server.js`
+// from `npm run start`), and `new URL('file://./dist/...')` would parse the
+// leading `.` as a host, never matching `import.meta.url`'s absolute form.
 const isMainModule = (() => {
   try {
-    return import.meta.url === new URL(`file://${process.argv[1]}`).href;
+    const argv1 = process.argv[1];
+    if (argv1 === undefined) return false;
+    return import.meta.url === pathToFileURL(path.resolve(argv1)).href;
   } catch {
     return false;
   }

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -141,6 +141,12 @@ interface IServoTestData {
 export interface ApiServerOptions {
   workerScriptUrl?: URL;
   onWorkerError?: (err: Error) => void;
+  /**
+   * Tests inject a fake `fetch` so `GitHubReleaseService.getReleases()` returns
+   * canned release data instead of hitting GitHub's REST API. Production leaves
+   * this undefined and gets the global `fetch`.
+   */
+  firmwareReleaseFetcher?: typeof fetch;
 }
 
 // Exported so the integration test harness can import + bootstrap an
@@ -162,6 +168,7 @@ export class ApiServer {
 
   private readonly workerScriptUrl: URL;
   private readonly onWorkerError?: (err: Error) => void;
+  private readonly firmwareReleaseFetcher?: typeof fetch;
 
   private httpServer?: import('http').Server;
 
@@ -265,6 +272,7 @@ export class ApiServer {
     this.workerScriptUrl =
       opts?.workerScriptUrl ?? new URL('./background_tasks/serial_worker.js', import.meta.url);
     this.onWorkerError = opts?.onWorkerError;
+    this.firmwareReleaseFetcher = opts?.firmwareReleaseFetcher;
 
     // Broadcast lock state to all connected clients on every change. Subscribed
     // here (rather than in Init) so a state change emitted before Init finishes
@@ -446,6 +454,7 @@ export class ApiServer {
     this.firmwareUploadStore = new FirmwareUploadStore();
     this.githubReleaseService = new GitHubReleaseService(
       process.env.FIRMWARE_REPO ?? 'battlesloth/AstrOs.ESP',
+      this.firmwareReleaseFetcher ?? fetch,
     );
   }
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -4,7 +4,7 @@
  * - **Production / dev runs** (`node dist/api_server.js`, `tsx src/api_server.ts`):
  *   this file is the main module. The IIFE at the bottom calls
  *   `ApiServer.bootstrap()` automatically and installs SIGTERM/SIGINT handlers
- *   that trigger a clean async shutdown. This is how the server runs in the.
+ *   that trigger a clean async shutdown. This is how the server runs in the
  *   container.
  *
  * - **Integration test harness** (`src/test_harness/integration_harness.ts`):

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -156,6 +156,37 @@ export interface ApiServerOptions {
     rebootTimeoutMs?: number;
     throttleWindowMs?: number;
   };
+  /**
+   * Per-instance overrides for values normally pulled from process.env.
+   * The integration harness uses this to avoid mutating the process-global
+   * environment — concurrent harness boots (in any future test pool that
+   * shares process.env across workers) would otherwise clobber each other's
+   * SERIAL_PORT / DATABASE_PATH / etc. Each field falls back to the
+   * corresponding env var when undefined, preserving production behavior
+   * for the auto-bootstrap caller.
+   */
+  configOverrides?: ConfigOverrides;
+}
+
+export interface ConfigOverrides {
+  serialPort?: string;
+  baudRate?: number;
+  apiPort?: number;
+  websocketPort?: number;
+  jwtKey?: string;
+  /**
+   * Full file path to the SQLite database (matching `initializeDatabase`'s
+   * `dbPath` semantics — the file, not the directory).
+   */
+  databasePath?: string;
+  firmwareCachePath?: string;
+  /**
+   * When true, ApiServer.Init skips serial-port setup. Mirrors the legacy
+   * `NODE_ENV=test` short-circuit. The harness sets this to `false`
+   * explicitly because vitest defaults NODE_ENV to 'test' (which would
+   * otherwise skip serial setup, the very thing the harness is exercising).
+   */
+  skipSerialSetup?: boolean;
 }
 
 // Exported so the integration test harness can import + bootstrap an
@@ -182,6 +213,7 @@ export class ApiServer {
     rebootTimeoutMs?: number;
     throttleWindowMs?: number;
   };
+  private readonly configOverrides?: ConfigOverrides;
 
   private httpServer?: import('http').Server;
 
@@ -196,13 +228,14 @@ export class ApiServer {
 
   // Firmware-OTA wiring. The orchestrator + WorkerSerialBus
   // are constructed in setupSerialPort() because they depend on the serial
-  // worker; in test mode (NODE_ENV=test) setupSerialPort() is skipped and
-  // `flashOrchestrator` stays undefined — the flash routes aren't registered
-  // either, so HTTP /api/firmware/flash returns 404 in tests rather than
-  // tripping a null deref on the orchestrator. The firmware cache, upload
-  // store, and GitHub release service are constructed unconditionally in
-  // configApi() because they have no Worker dependency and are otherwise
-  // useful (tests don't reach them, but the construction is cheap).
+  // worker; when serial setup is skipped (NODE_ENV=test, or
+  // `configOverrides.skipSerialSetup=true`) `flashOrchestrator` stays
+  // undefined — the flash routes aren't registered either, so HTTP
+  // /api/firmware/flash returns 404 in unit tests rather than tripping a
+  // null deref on the orchestrator. The firmware cache, upload store, and
+  // GitHub release service are constructed unconditionally in configApi()
+  // because they have no Worker dependency and are otherwise useful (unit
+  // tests don't reach them, but the construction is cheap).
   private firmwareCache!: FirmwareCache;
   private firmwareUploadStore!: FirmwareUploadStore;
   private githubReleaseService!: GitHubReleaseService;
@@ -283,8 +316,10 @@ export class ApiServer {
   constructor(opts?: ApiServerOptions) {
     Dotenv.config({ path: __dirname + '/.env' });
 
-    this.apiPort = Number.parseInt(process.env.API_PORT || '3000');
-    this.websocketPort = Number.parseInt(process.env.WEBSOCKET_PORT || '5000');
+    this.configOverrides = opts?.configOverrides;
+    this.apiPort = this.configOverrides?.apiPort ?? Number.parseInt(process.env.API_PORT || '3000');
+    this.websocketPort =
+      this.configOverrides?.websocketPort ?? Number.parseInt(process.env.WEBSOCKET_PORT || '5000');
 
     this.clients = new Map<string, WebSocket>();
     this.app = Express();
@@ -314,7 +349,9 @@ export class ApiServer {
 
   public async Init() {
     logger.info('Initializing database');
-    this.db = await initializeDatabase(this.systemStatus);
+    this.db = await initializeDatabase(this.systemStatus, {
+      dbPath: this.configOverrides?.databasePath,
+    });
 
     logger.info('Setting up authentication strategy');
     this.setAuthStrategy();
@@ -330,8 +367,12 @@ export class ApiServer {
     logger.info('Setting up routes');
     this.setRoutes();
 
-    if (process.env.NODE_ENV?.toLocaleLowerCase() === 'test') {
-      logger.warn('Running in test mode, skipping serial port setup');
+    const skipSerialSetup =
+      this.configOverrides?.skipSerialSetup ?? process.env.NODE_ENV?.toLocaleLowerCase() === 'test';
+    if (skipSerialSetup) {
+      logger.warn(
+        `Skipping serial port setup (configOverrides.skipSerialSetup=${String(this.configOverrides?.skipSerialSetup)}, NODE_ENV=${process.env.NODE_ENV ?? '<unset>'})`,
+      );
     } else {
       logger.info('Starting up serial port services');
       this.setupSerialPort();
@@ -460,9 +501,9 @@ export class ApiServer {
       });
     });
 
-    const jwtKey = process.env.JWT_KEY;
+    const jwtKey = this.configOverrides?.jwtKey ?? process.env.JWT_KEY;
     if (!jwtKey) {
-      logger.error('JWT_KEY environment variable is required');
+      logger.error('JWT_KEY is required (set process.env.JWT_KEY or pass configOverrides.jwtKey)');
       process.exit(1);
     }
 
@@ -475,11 +516,14 @@ export class ApiServer {
 
     // Firmware infrastructure shared across the c.4 / c.5 / c.3 endpoints and
     // the c.6c.1 orchestrator. Constructed unconditionally — the cache/upload
-    // store read FIRMWARE_CACHE_PATH from env (default ~/.config/astrosserver),
+    // store resolve their root from `configOverrides.firmwareCachePath` if
+    // supplied, otherwise FIRMWARE_CACHE_PATH (default ~/.config/astrosserver),
     // and the release service is a thin GitHub API wrapper. None of them open
     // the serial worker, so test mode is safe.
-    this.firmwareCache = new FirmwareCache();
-    this.firmwareUploadStore = new FirmwareUploadStore();
+    this.firmwareCache = new FirmwareCache({ rootDir: this.configOverrides?.firmwareCachePath });
+    this.firmwareUploadStore = new FirmwareUploadStore({
+      rootDir: this.configOverrides?.firmwareCachePath,
+    });
     this.githubReleaseService = new GitHubReleaseService(
       process.env.FIRMWARE_REPO ?? 'battlesloth/AstrOs.ESP',
       this.firmwareReleaseFetcher ?? fetch,
@@ -610,8 +654,9 @@ export class ApiServer {
 
     try {
       this.serialPort = new SerialPort({
-        path: process.env.SERIAL_PORT || '/dev/ttyS0',
-        baudRate: Number.parseInt(process.env.BAUD_RATE || '9600'),
+        path: this.configOverrides?.serialPort ?? process.env.SERIAL_PORT ?? '/dev/ttyS0',
+        baudRate:
+          this.configOverrides?.baudRate ?? Number.parseInt(process.env.BAUD_RATE || '9600'),
       });
 
       this.serialPort.on('error', (err: any) => {

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -709,16 +709,25 @@ export class ApiServer {
     // this rollback we'd leak a live listening socket on every failed
     // bootstrap, which manifests as cumulative EADDRINUSE flakes in tests
     // that retry-after-failure.
+    // Capture the systemStatus unsubscribe handle so the rollback can detach
+    // the subscriber if WS bind fails. Without this, the closure would
+    // outlive the dead instance — on the next bootstrap (or a sibling
+    // instance under test), the orphaned subscriber would double-emit
+    // systemStatus frames AND keep the dead instance alive in the
+    // emitter's set.
+    let unsubscribeSystemStatus: (() => void) | undefined;
     try {
       const ws = (this.websocket = new Server({ port: this.websocketPort }));
 
-      this.systemStatus.subscribe((state) => {
+      unsubscribeSystemStatus = this.systemStatus.subscribe((state) => {
         this.updateClients({ type: TransmissionType.systemStatus, data: state });
       });
 
-      // Connection handler attached synchronously before awaiting 'listening',
-      // mirroring the prior sync setup — any client racing the bind still hits
-      // the handler.
+      // Connection handler attached synchronously before awaiting 'listening'
+      // so any client racing the bind still hits the handler — the WS server
+      // begins accepting connections only when 'listening' fires, but
+      // attaching after the await would leave a window where the listener
+      // isn't installed yet.
       ws.on('connection', (conn) => {
         const id = uuid_v4();
         this.clients.set(id, conn);
@@ -792,7 +801,12 @@ export class ApiServer {
       // Roll back the HTTP bind so we don't leak a listening socket. Also
       // close the partial WS server if it got constructed before failing
       // (the ws library schedules its bind on next tick, so the Server
-      // instance exists even when the listen errored).
+      // instance exists even when the listen errored). And detach the
+      // systemStatus subscriber so the dead instance doesn't keep getting
+      // ticked by the emitter (and so the closure can be GC'd).
+      if (unsubscribeSystemStatus !== undefined) {
+        unsubscribeSystemStatus();
+      }
       const httpServer = this.httpServer;
       this.httpServer = undefined;
       if (httpServer !== undefined) {

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -810,7 +810,21 @@ export class ApiServer {
       const httpServer = this.httpServer;
       this.httpServer = undefined;
       if (httpServer !== undefined) {
-        await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+        // Surface httpServer.close errors via logger.warn rather than the
+        // prior swallow. ENOTLISTENING here means the rollback is a no-op
+        // — combined with the still-bound socket from the listen success,
+        // that's a leak the user needs to know about. We don't rethrow
+        // because the original wsErr is the failure the caller asked
+        // about; close errors during rollback are diagnostics, not the
+        // primary fault.
+        await new Promise<void>((resolve) =>
+          httpServer.close((closeErr) => {
+            if (closeErr) {
+              logger.warn(`runWebServices rollback: httpServer.close failed: ${closeErr.message}`);
+            }
+            resolve();
+          }),
+        );
       }
       const partialWs = this.websocket;
       this.websocket = undefined;

--- a/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
@@ -25,7 +25,7 @@ import { TransmissionType } from '../../models/enums.js';
 import { SerialMessageType } from '../../serial/serial_message.js';
 import { FwStage } from '../../models/firmware/firmware_messages.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
 const MASTER_VARIANT = 'astros-controller-v1';
@@ -40,7 +40,7 @@ describe('integration: cancel during upload + deploy', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'DELETE during upload phase: streamer aborts → flashJobFailed{reason:aborted} → lock release',
     async () => {
       // 1. Boot harness + pre-populate variantCache so listFlashTargets()
@@ -158,7 +158,7 @@ describe('integration: cancel during upload + deploy', () => {
     30_000,
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'DELETE during deploy phase: deploy-unsub disposed → flashJobFailed{abortReason} + per-controller Failed → lock release',
     async () => {
       // 1. Boot harness + variant cache + upload (same as upload-cancel test).

--- a/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
@@ -1,0 +1,276 @@
+// Integration tests for c.6c.2 Task 7: cancel mechanism. Two cases — cancel
+// during upload phase, cancel during deploy phase. Each verifies the
+// corresponding orchestrator branch ends in `flashJobFailed` + lock release.
+//
+// Both branches converge on the same external contract (HTTP 200 from POST +
+// DELETE, flashJobFailed on WS, lockStateChanged{locked:false}, GET → null,
+// healthy worker), but the WS event shape differs between them:
+//
+//   - Upload-cancel: AbortController.abort('http') → streamer rejects with
+//     TransferError('aborted', ...) → orchestrator's catch block routes
+//     through `failJob` which stamps BOTH `reason: 'aborted'` and
+//     `abortReason: 'aborted'` on the flashJobFailed emit.
+//   - Deploy-cancel: streamer is already settled, so abort is a no-op.
+//     Orchestrator runs the inline deploy-cancel sequence and emits
+//     flashJobFailed with ONLY `abortReason: 'http'` (no `reason` field).
+//
+// See flash_orchestrator.ts:788-826 for both cancel codepaths.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+import { SerialMessageType } from '../../serial/serial_message.js';
+import { FwStage } from '../../models/firmware/firmware_messages.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const MASTER_VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+
+describe('integration: cancel during upload + deploy', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'DELETE during upload phase: streamer aborts → flashJobFailed{reason:aborted} → lock release',
+    async () => {
+      // 1. Boot harness + pre-populate variantCache so listFlashTargets()
+      //    returns the master at flash time.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+      });
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      // 2. Seed upload so source resolution succeeds.
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+
+      // 3. Stub master is intentionally NOT configured with autoAckUpload.
+      //    The streamer will send FW_TRANSFER_BEGIN over the PTY and wait
+      //    for FW_TRANSFER_BEGIN_ACK indefinitely (well, the streamer's
+      //    1500ms begin-ack timeout — but we cancel well before that fires).
+
+      // 4. POST flash. `orchestrator.start()` awaits `streamer.run`, so the
+      //    HTTP response WILL NOT return until the streamer settles (success,
+      //    typed error, or — in this test — `AbortController.abort` →
+      //    TransferError('aborted',...) → 500). Kick the POST off without
+      //    awaiting and use the `flashJobStarted` WS event as the
+      //    "job is in flight" signal instead.
+      const flashPromise = fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+
+      // 5. Wait for flashJobStarted to confirm the job is in flight. This
+      //    fires AFTER lock acquire + source resolve but BEFORE
+      //    `await streamer.run`, so it's available even though the POST
+      //    response is still pending.
+      const startedEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobStarted, 5000);
+      const jobId = startedEvent.data.jobId;
+      expect(jobId).toBeTruthy();
+
+      // 6. Snapshot the WS buffer and DELETE while the streamer awaits
+      //    begin-ack. Snapshot lets the predicates below ignore any WS
+      //    traffic emitted before the cancel.
+      const deleteSnapshot = harness.receivedWsMessages.length;
+      const cancelRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(cancelRes.status).toBe(200);
+      const cancelBody = (await cancelRes.json()) as { jobId: string; cancelled: boolean };
+      expect(cancelBody.cancelled).toBe(true);
+      expect(cancelBody.jobId).toBe(jobId);
+
+      // 7. flashJobFailed with reason='aborted' AND abortReason='aborted'.
+      //    The upload-cancel path runs through `failJob` (orchestrator
+      //    routes TransferError('aborted',...) → failJob with abortReason
+      //    populated), so both fields are stamped on the WS emit.
+      const failedEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string; reason?: string; abortReason?: string };
+      }>(
+        (m) => (m as { type?: unknown }).type === TransmissionType.flashJobFailed,
+        5000,
+        deleteSnapshot,
+      );
+      expect(failedEvent.data.jobId).toBe(jobId);
+      expect(failedEvent.data.reason).toBe('aborted');
+      expect(failedEvent.data.abortReason).toBe('aborted');
+
+      // The deferred POST resolves once the streamer rejects with the
+      // abort. Per controller mapping, `aborted` → 500. Drain the body
+      // so the connection isn't left dangling at suite teardown.
+      const flashRes = await flashPromise;
+      expect(flashRes.status).toBe(500);
+      await flashRes.json().catch(() => undefined);
+
+      // 8. Lock release via the cancel/failJob path (NOT the heartbeat path —
+      //    we never emit a post-deploy POLL_ACK in this test).
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        deleteSnapshot,
+      );
+      expect(lockReleased.locked).toBe(false);
+
+      // 9. GET → null (no active job after release).
+      const getRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(getRes.status).toBe(200);
+      const getBody: unknown = await getRes.json();
+      expect(getBody).toBeNull();
+
+      // 10. Worker stayed healthy. LAST so a Worker that died midway is
+      //     caught even if other assertions happened to pass.
+      expect(harness.workerErrors).toEqual([]);
+    },
+    30_000,
+  );
+
+  skipIfNotPosix(
+    'DELETE during deploy phase: deploy-unsub disposed → flashJobFailed{abortReason} + per-controller Failed → lock release',
+    async () => {
+      // 1. Boot harness + variant cache + upload (same as upload-cancel test).
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+      });
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+
+      // 2. autoAckUpload so the upload phase succeeds. NO scriptDeploy →
+      //    when the orchestrator sends FW_DEPLOY_BEGIN, the stub captures
+      //    it but emits no further frames. The deploy phase hangs
+      //    awaiting FW_DEPLOY_DONE.
+      harness.stub.autoAckUpload({});
+
+      // 3. POST flash.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as { jobId: string };
+
+      await harness.waitForWsMessage(
+        (m) => (m as { type?: unknown }).type === TransmissionType.flashJobStarted,
+        5000,
+      );
+
+      // 4. Wait until we know we're in the deploy phase. Signal: the stub
+      //    received FW_DEPLOY_BEGIN over the wire. Upload completes
+      //    sub-second under autoAckUpload, then orchestrator immediately
+      //    sends FW_DEPLOY_BEGIN — without this gate, a fast cancel could
+      //    land while the streamer is still running and we'd hit the
+      //    upload-cancel codepath instead.
+      await harness.stub.waitForFrame((f) => f.type === SerialMessageType.FW_DEPLOY_BEGIN, 10_000);
+
+      // 5. Snapshot + DELETE while deploy is hanging.
+      const deleteSnapshot = harness.receivedWsMessages.length;
+      const cancelRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(cancelRes.status).toBe(200);
+      const cancelBody = (await cancelRes.json()) as { jobId: string; cancelled: boolean };
+      expect(cancelBody.cancelled).toBe(true);
+      expect(cancelBody.jobId).toBe(flashBody.jobId);
+
+      // 6. flashJobFailed with abortReason='http' and NO `reason` field.
+      //    The deploy-cancel path emits inline (flash_orchestrator.ts:820-823),
+      //    bypassing `failJob` and its `reason` stamping.
+      const failedEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string; reason?: string; abortReason?: string };
+      }>(
+        (m) => (m as { type?: unknown }).type === TransmissionType.flashJobFailed,
+        5000,
+        deleteSnapshot,
+      );
+      expect(failedEvent.data.jobId).toBe(flashBody.jobId);
+      expect(failedEvent.data.abortReason).toBe('http');
+      expect(failedEvent.data.reason).toBeUndefined();
+
+      // 7. flashControllerResult emitted before flashJobFailed for the
+      //    master, transitioning Sending → Failed. Per orchestrator's
+      //    failNonTerminalControllers, the result event carries the
+      //    full ControllerFlashState with stage=Failed.
+      const controllerResult = harness.receivedWsMessages
+        .slice(deleteSnapshot)
+        .find((m) => (m as { type?: unknown }).type === TransmissionType.flashControllerResult) as
+        | { data?: { controller?: { stage?: FwStage } } }
+        | undefined;
+      expect(controllerResult).toBeDefined();
+      expect(controllerResult?.data?.controller?.stage).toBe(FwStage.Failed);
+
+      // 8. Lock release via the cancel codepath.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        deleteSnapshot,
+      );
+      expect(lockReleased.locked).toBe(false);
+
+      // 9. GET → null.
+      const getRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(getRes.status).toBe(200);
+      const getBody: unknown = await getRes.json();
+      expect(getBody).toBeNull();
+
+      // 10. Worker stayed healthy.
+      expect(harness.workerErrors).toEqual([]);
+    },
+    30_000,
+  );
+});

--- a/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
@@ -154,6 +154,8 @@ describe('integration: cancel during upload + deploy', () => {
       // 10. Worker stayed healthy. LAST so a Worker that died midway is
       //     caught even if other assertions happened to pass.
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     30_000,
   );
@@ -270,6 +272,8 @@ describe('integration: cancel during upload + deploy', () => {
 
       // 10. Worker stayed healthy.
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     30_000,
   );

--- a/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_cancel.integration.test.ts
@@ -1,4 +1,4 @@
-// Integration tests for c.6c.2 Task 7: cancel mechanism. Two cases — cancel
+// Integration tests for the cancel mechanism. Two cases — cancel
 // during upload phase, cancel during deploy phase. Each verifies the
 // corresponding orchestrator branch ends in `flashJobFailed` + lock release.
 //

--- a/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
@@ -1,6 +1,6 @@
-// Integration test for c.6c.2 Task 8: chunk NAK + Go-Back-N retransmit.
+// Integration test: chunk NAK + Go-Back-N retransmit.
 //
-// Validates the c.6b chunk_streamer's NAK handling end-to-end against a
+// Validates the chunk_streamer's NAK handling end-to-end against a
 // real serial wire. The stub master is configured with autoAckUpload({
 // failAtSeq: 2 }), which NAKs FW_CHUNK seq=2 exactly once with
 // lastGoodSeq=1, reasonCode='CRC' before resuming normal ACKing — so the
@@ -42,7 +42,7 @@ const PRE_FLASH_FW = '1.0.0';
 const POST_FLASH_FW = '1.5.0';
 // 5 chunks of 4096 bytes each — needed so failAtSeq: 2 actually fires.
 // The streamer's default chunkSizeBytes=4096 (chunk_streamer.ts:63), so a
-// 4096-byte blob (Task 5) is exactly 1 chunk; we need ≥3 to NAK seq=2.
+// 4096-byte blob would be exactly 1 chunk; we need ≥3 to NAK seq=2.
 const BLOB_SIZE = 5 * 4096;
 
 // FW_CHUNK payload (5 US-separated fields per generateFwChunk):
@@ -89,7 +89,7 @@ describe('integration: chunk NAK + Go-Back-N recovery', () => {
       // 4. Configure stub: autoAckUpload({failAtSeq:2}) NAKs seq=2 once
       //    with lastGoodSeq=1, reasonCode='CRC' then resumes ACKing.
       //    scriptDeploy: happy single-controller OK so the deploy phase
-      //    completes the same as the Task 5 happy-path baseline.
+      //    completes after the upload recovers.
       harness.stub.autoAckUpload({ failAtSeq: 2 });
       harness.stub.scriptDeploy({
         controllers: [

--- a/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
@@ -1,0 +1,179 @@
+// Integration test for c.6c.2 Task 8: chunk NAK + Go-Back-N retransmit.
+//
+// Validates the c.6b chunk_streamer's NAK handling end-to-end against a
+// real serial wire. The stub master is configured with autoAckUpload({
+// failAtSeq: 2 }), which NAKs FW_CHUNK seq=2 exactly once with
+// lastGoodSeq=1, reasonCode='CRC' before resuming normal ACKing — so the
+// streamer must rewind to seq=2 and retransmit for the upload to complete.
+//
+// Sequence covered:
+//   1. Pre-populate variantCache via stub POLL_ACK
+//   2. Pre-populate upload store with a 20KB firmware blob (5 chunks @ 4096B)
+//   3. autoAckUpload({ failAtSeq: 2 }) on stub
+//   4. POST /api/firmware/flash kind=upload (JWT-authenticated)
+//   5. Observe flashJobStarted
+//   6. Observe flashJobDone — only fires if streamer recovered from NAK
+//   7. Verify retransmit happened: count FW_CHUNK frames with seq=2 ≥ 2
+//   8. Heartbeat → lock release within ~1-2s (well before 15s timer fallback)
+//   9. workerErrors empty
+//
+// The orchestrator's onChunkNak handler is log-only (no WS event), so the
+// NAK assertion lives on the stub-side wire-frame buffer rather than on
+// WS events. The flashJobDone assertion is the load-bearing proof that the
+// streamer's retry logic works.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+import { SerialMessageType } from '../../serial/serial_message.js';
+import { MessageHelper } from '../../serial/message_helper.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+// Master's sentinel MAC per project_master_esp_sentinel_mac convention.
+// decidePostDeployHeartbeat filters on this exact string so the test must
+// match it bit-for-bit.
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const MASTER_VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+// 5 chunks of 4096 bytes each — needed so failAtSeq: 2 actually fires.
+// The streamer's default chunkSizeBytes=4096 (chunk_streamer.ts:63), so a
+// 4096-byte blob (Task 5) is exactly 1 chunk; we need ≥3 to NAK seq=2.
+const BLOB_SIZE = 5 * 4096;
+
+// FW_CHUNK payload (5 US-separated fields per generateFwChunk):
+//   transferId<US>seq<US>payloadLen<US>base64Bytes<US>crc16Hex
+// Returns the seq number for FW_CHUNK frames; null for malformed payloads.
+function chunkSeq(payload: string): number | null {
+  const parts = payload.split(MessageHelper.US);
+  if (parts.length < 2) return null;
+  const n = parseInt(parts[1], 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+describe('integration: chunk NAK + Go-Back-N recovery', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'autoAckUpload({failAtSeq:2}) → seq=2 NAK once → streamer retransmits → flashJobDone',
+    async () => {
+      // 1. Boot harness configured for the master only.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+      });
+
+      // 2. Pre-populate the controllerVariantCache via stub POLL_ACK.
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      // 3. Pre-populate the upload store with a 20KB firmware blob —
+      //    5 chunks @ 4096B so failAtSeq:2 has a seq=2 to fire on.
+      const binBytes = Buffer.alloc(BLOB_SIZE, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+
+      // 4. Configure stub: autoAckUpload({failAtSeq:2}) NAKs seq=2 once
+      //    with lastGoodSeq=1, reasonCode='CRC' then resumes ACKing.
+      //    scriptDeploy: happy single-controller OK so the deploy phase
+      //    completes the same as the Task 5 happy-path baseline.
+      harness.stub.autoAckUpload({ failAtSeq: 2 });
+      harness.stub.scriptDeploy({
+        controllers: [
+          {
+            id: MASTER_SENTINEL_MAC,
+            outcome: 'OK',
+            finalVersion: POST_FLASH_FW,
+            error: '',
+          },
+        ],
+      });
+
+      // 5. POST /api/firmware/flash.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as { jobId: string };
+      expect(flashBody.jobId).toBeTruthy();
+
+      // 6. flashJobStarted.
+      const startedEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobStarted, 5000);
+      expect(startedEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 7. flashJobDone — proves the streamer recovered from the NAK.
+      //    Allow 15s headroom for: 5 chunks + retransmit (Go-Back-N from
+      //    seq=2) + deploy walk on slow CI.
+      const doneEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobDone, 15_000);
+      expect(doneEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 8. Verify the retransmit actually happened: seq=2 chunk should
+      //    appear at least twice in stub.receivedFrames() — once
+      //    originally, at least once after the NAK as the streamer
+      //    rewinds and retransmits per Go-Back-N. We assert >=2 (not
+      //    ==2) because the streamer may retransmit additional times if
+      //    timing/window state warrants; the load-bearing claim is that
+      //    a retransmit happened at all.
+      const seq2Chunks = harness.stub
+        .receivedFrames()
+        .filter((f) => f.type === SerialMessageType.FW_CHUNK && chunkSeq(f.payload) === 2);
+      expect(seq2Chunks.length).toBeGreaterThanOrEqual(2);
+
+      // 9. Stub master emits POLL_ACK with the post-flash firmwareVersion.
+      //    decidePostDeployHeartbeat → 'fire' → lock release WELL BEFORE
+      //    the 15-sec reboot-timer fallback. Snapshot WS buffer length
+      //    BEFORE emitting so the wait below only sees the heartbeat-driven
+      //    release, not the connect-time lockStateChanged{locked:false}
+      //    snapshot the server sent on WS open.
+      const snapshot = harness.receivedWsMessages.length;
+      harness.stub.writePollAck({ firmwareVersion: POST_FLASH_FW });
+
+      // 10. lockStateChanged{locked:false} within 5s — if it takes 15+
+      //     seconds, the heartbeat path is broken and the timer fallback
+      //     is releasing instead.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
+      expect(lockReleased.locked).toBe(false);
+
+      // 11. Final assertion: the Worker stayed healthy through the whole
+      //     run. Placed LAST so a Worker that died midway is caught even
+      //     if other assertions happened to pass (stale message replay
+      //     could mask earlier breakage).
+      expect(harness.workerErrors).toEqual([]);
+    },
+    60_000, // generous: includes potential first-time `npm run build` + WS round-trips
+  );
+});

--- a/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
@@ -173,6 +173,13 @@ describe('integration: chunk NAK + Go-Back-N recovery', () => {
       //     if other assertions happened to pass (stale message replay
       //     could mask earlier breakage).
       expect(harness.workerErrors).toEqual([]);
+      // Diagnostic surfaces — empty in the happy path. Non-empty means
+      // wire-format drift between MessageGenerator and the stub's parsers
+      // (parsingErrors) or socat dying mid-test (unexpectedExits). Either
+      // way the test failure points at the actual cause instead of a
+      // mysterious downstream timeout.
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     60_000, // generous: includes potential first-time `npm run build` + WS round-trips
   );

--- a/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_chunk_nak.integration.test.ts
@@ -31,7 +31,7 @@ import { TransmissionType } from '../../models/enums.js';
 import { SerialMessageType } from '../../serial/serial_message.js';
 import { MessageHelper } from '../../serial/message_helper.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 // Master's sentinel MAC per project_master_esp_sentinel_mac convention.
 // decidePostDeployHeartbeat filters on this exact string so the test must
@@ -63,7 +63,7 @@ describe('integration: chunk NAK + Go-Back-N recovery', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'autoAckUpload({failAtSeq:2}) → seq=2 NAK once → streamer retransmits → flashJobDone',
     async () => {
       // 1. Boot harness configured for the master only.

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -101,6 +101,19 @@ describe('integration: concurrent flash rejection', () => {
       expect(conflictBody.error).toBe('job_already_running');
       expect(conflictBody.currentJobId).toBe(firstFlashBody.jobId);
 
+      // 5b. Prove the lock prevented a *ghost* second flash on the wire,
+      //     not just returned 409 to the client. Pre-lock work in the
+      //     orchestrator (e.g., emitting FW_TRANSFER_BEGIN before the
+      //     job-existence check) would let serial frames leak through
+      //     even though HTTP says 409 — visible to the master, invisible
+      //     to the rest of this assertion. The stub's receivedFrames()
+      //     buffer captures every server→master frame; for a single
+      //     in-flight flash there must be exactly one FW_TRANSFER_BEGIN.
+      const transferBeginFrames = harness.stub
+        .receivedFrames()
+        .filter((f) => f.type === SerialMessageType.FW_TRANSFER_BEGIN);
+      expect(transferBeginFrames).toHaveLength(1);
+
       // 6. Send a write-class WS message (SERVO_TEST, the only entry in
       //    WS_WRITE_CLASS_MESSAGE_TYPES) and expect a flashJobActive
       //    rejection frame back. Snapshot the buffer first so we don't

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -160,9 +160,7 @@ describe('integration: concurrent flash rejection', () => {
       await harness.waitForWsMessage(
         (m) => {
           const msg = m as { type?: unknown; data?: { abortReason?: unknown } };
-          return (
-            msg.type === TransmissionType.flashJobFailed && msg.data?.abortReason === 'http'
-          );
+          return msg.type === TransmissionType.flashJobFailed && msg.data?.abortReason === 'http';
         },
         5000,
         beforeCancelSnapshot,

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -1,0 +1,144 @@
+// Integration test for c.6c.2 Task 12: concurrent flash rejection.
+//
+// Two assertions in one test:
+//
+//   (a) HTTP 409: while the first flash is hanging in the deploy phase
+//       (autoAckUpload completes the upload, no scriptDeploy keeps the
+//       orchestrator awaiting FW_DEPLOY_DONE forever), a second POST
+//       returns 409 with { error: 'job_already_running', currentJobId }
+//       matching the first flash's jobId.
+//
+//   (b) WS flashJobActive: with the lock still held, a SERVO_TEST message
+//       (the only entry in WS_WRITE_CLASS_MESSAGE_TYPES) is rejected by
+//       rejectIfLocked, which emits a flashJobActive frame back to the
+//       originating client carrying error='flashJobActive' and
+//       rejectedMsgType='SERVO_TEST'.
+//
+// Cleanup: DELETE the in-flight flash at end-of-test so the lock releases
+// immediately rather than waiting 15s for the reboot timer.
+//
+// Tasks 5-11 all complete the flash cleanly; Task 12 is the only test
+// exercising the in-flight-flash rejection path.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+import { SerialMessageType } from '../../serial/serial_message.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const MASTER_VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+
+describe('integration: concurrent flash rejection', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'second POST during in-flight flash → 409; WS SERVO_TEST → flashJobActive frame',
+    async () => {
+      // 1. Boot + variant cache + upload seed.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+      });
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+
+      // 2. autoAckUpload completes the upload phase. NO scriptDeploy → the
+      //    orchestrator sends FW_DEPLOY_BEGIN and hangs awaiting
+      //    FW_DEPLOY_DONE, holding the lock the whole time.
+      harness.stub.autoAckUpload({});
+
+      // 3. POST first flash.
+      const firstFlashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(firstFlashRes.status).toBe(200);
+      const firstFlashBody = (await firstFlashRes.json()) as { jobId: string };
+
+      // 4. Wait for the deploy phase: stub receives FW_DEPLOY_BEGIN. Once
+      //    we observe it on the wire, we know the lock is held and the
+      //    orchestrator is hanging in the deploy waiter.
+      await harness.stub.waitForFrame((f) => f.type === SerialMessageType.FW_DEPLOY_BEGIN, 10_000);
+
+      // 5. Concurrent POST → 409 with currentJobId.
+      const secondFlashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(secondFlashRes.status).toBe(409);
+      const conflictBody = (await secondFlashRes.json()) as {
+        error: string;
+        currentJobId: string;
+      };
+      expect(conflictBody.error).toBe('job_already_running');
+      expect(conflictBody.currentJobId).toBe(firstFlashBody.jobId);
+
+      // 6. Send a write-class WS message (SERVO_TEST, the only entry in
+      //    WS_WRITE_CLASS_MESSAGE_TYPES) and expect a flashJobActive
+      //    rejection frame back. Snapshot the buffer first so we don't
+      //    match earlier flashJobActive frames if any landed.
+      const snapshot = harness.receivedWsMessages.length;
+      harness.wsClient.send(
+        JSON.stringify({
+          msgType: 'SERVO_TEST',
+          data: {
+            controllerAddress: MASTER_SENTINEL_MAC,
+            controllerName: 'master',
+            moduleSubType: 0,
+            moduleIdx: 0,
+            channelNumber: 0,
+            value: 0,
+          },
+        }),
+      );
+
+      const rejectionFrame = await harness.waitForWsMessage<{
+        type: number;
+        error: string;
+        rejectedMsgType: string;
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobActive, 5000, snapshot);
+      expect(rejectionFrame.error).toBe('flashJobActive');
+      expect(rejectionFrame.rejectedMsgType).toBe('SERVO_TEST');
+
+      // 7. Clean up: DELETE the in-flight flash so the lock releases now
+      //    rather than waiting 15s for the reboot timer.
+      const cancelRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(cancelRes.status).toBe(200);
+
+      // 8. Worker stayed healthy.
+      expect(harness.workerErrors).toEqual([]);
+    },
+    30_000,
+  );
+});

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -9,10 +9,10 @@
 //       matching the first flash's jobId.
 //
 //   (b) WS flashJobActive: with the lock still held, a SERVO_TEST message
-//       (the only entry in WS_WRITE_CLASS_MESSAGE_TYPES) is rejected by
-//       rejectIfLocked, which emits a flashJobActive frame back to the
-//       originating client carrying error='flashJobActive' and
-//       rejectedMsgType='SERVO_TEST'.
+//       (a write-class message in WS_WRITE_CLASS_MESSAGE_TYPES) is
+//       rejected by rejectIfLocked, which emits a flashJobActive frame
+//       back to the originating client carrying error='flashJobActive'
+//       and rejectedMsgType='SERVO_TEST'.
 //
 // Cleanup: DELETE the in-flight flash at end-of-test so the lock releases
 // immediately rather than waiting 15s for the reboot timer.
@@ -114,7 +114,7 @@ describe('integration: concurrent flash rejection', () => {
         .filter((f) => f.type === SerialMessageType.FW_TRANSFER_BEGIN);
       expect(transferBeginFrames).toHaveLength(1);
 
-      // 6. Send a write-class WS message (SERVO_TEST, the only entry in
+      // 6. Send a write-class WS message (SERVO_TEST, a member of
       //    WS_WRITE_CLASS_MESSAGE_TYPES) and expect a flashJobActive
       //    rejection frame back. Snapshot the buffer first so we don't
       //    match earlier flashJobActive frames if any landed.

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -28,7 +28,7 @@ import {
 import { TransmissionType } from '../../models/enums.js';
 import { SerialMessageType } from '../../serial/serial_message.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
 const MASTER_VARIANT = 'astros-controller-v1';
@@ -43,7 +43,7 @@ describe('integration: concurrent flash rejection', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'second POST during in-flight flash → 409; WS SERVO_TEST → flashJobActive frame',
     async () => {
       // 1. Boot + variant cache + upload seed.

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -130,11 +130,30 @@ describe('integration: concurrent flash rejection', () => {
 
       // 7. Clean up: DELETE the in-flight flash so the lock releases now
       //    rather than waiting 15s for the reboot timer.
+      const beforeCancelSnapshot = harness.receivedWsMessages.length;
       const cancelRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
         method: 'DELETE',
         headers: { authorization: `Bearer ${harness.authToken}` },
       });
       expect(cancelRes.status).toBe(200);
+
+      // 7b. Wait for the orchestrator to fully process the cancel before
+      //     letting afterEach run dispose/shutdown. The DELETE returns 200
+      //     synchronously, but per-controller cleanup + flashJobFailed
+      //     emit happen async after the response. Without this wait,
+      //     `afterEach` would terminate the Worker mid-cleanup and race
+      //     in-flight emitWs calls into a half-shut-down server — visible
+      //     as intermittent `workerErrors` under load.
+      await harness.waitForWsMessage(
+        (m) => {
+          const msg = m as { type?: unknown; data?: { abortReason?: unknown } };
+          return (
+            msg.type === TransmissionType.flashJobFailed && msg.data?.abortReason === 'http'
+          );
+        },
+        5000,
+        beforeCancelSnapshot,
+      );
 
       // 8. Worker stayed healthy.
       expect(harness.workerErrors).toEqual([]);

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -168,6 +168,8 @@ describe('integration: concurrent flash rejection', () => {
 
       // 8. Worker stayed healthy.
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     30_000,
   );

--- a/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_concurrent.integration.test.ts
@@ -1,4 +1,4 @@
-// Integration test for c.6c.2 Task 12: concurrent flash rejection.
+// Integration test: concurrent flash rejection.
 //
 // Two assertions in one test:
 //
@@ -17,8 +17,8 @@
 // Cleanup: DELETE the in-flight flash at end-of-test so the lock releases
 // immediately rather than waiting 15s for the reboot timer.
 //
-// Tasks 5-11 all complete the flash cleanly; Task 12 is the only test
-// exercising the in-flight-flash rejection path.
+// This is the only integration test exercising the in-flight-flash
+// rejection path — every other test completes the flash cleanly.
 
 import { describe, it, expect, afterEach } from 'vitest';
 import {

--- a/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
@@ -1,0 +1,215 @@
+// End-to-end integration test for the firmware OTA orchestrator's
+// `kind: 'github'` source path. Mirrors the upload-source happy path
+// (flash_happy_upload.integration.test.ts) but exercises the GitHub
+// release service + firmware cache code paths instead of the upload
+// store.
+//
+// Two interception points are needed for a hermetic run:
+//   1. GitHubReleaseService.getReleases() — intercepted by injecting a
+//      fake `fetch` via ApiServerOptions.firmwareReleaseFetcher. The
+//      fake returns canned release JSON for v1.5.0 with one asset
+//      matching the master's variant.
+//   2. FirmwareCache.fetch() — intercepted by pre-populating the on-disk
+//      cache so lookup() returns a hit and fetch() short-circuits
+//      without invoking its own downloader.
+//
+// Sequence covered:
+//   1. Pre-populate variantCache via stub POLL_ACK
+//   2. Pre-populate firmware cache with a 4KB blob for variant lolin_d32_pro
+//   3. POST /api/firmware/flash kind=github version=1.5.0 (JWT-auth)
+//   4. flashJobStarted carries a github-shaped source.displayName
+//   5. autoAckUpload drives FW_TRANSFER_BEGIN/CHUNK/END from cache.path
+//   6. scriptDeploy drives FW_PROGRESS + FW_DEPLOY_DONE
+//   7. flashJobDone fires
+//   8. Stub emits master POLL_ACK with deployed firmwareVersion
+//   9. Heartbeat path releases lock → lockStateChanged{locked:false}
+//  10. workerErrors is empty (Worker stayed healthy)
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+// Master's sentinel MAC per project_master_esp_sentinel_mac convention.
+// decidePostDeployHeartbeat filters on this exact string so the test must
+// match it bit-for-bit.
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+// Variant matches the github asset-name regex /^astros-esp-(.+)-([a-z][a-z0-9_]*)-app\.bin$/
+// — lowercase letters/digits/underscores only, no hyphens. The
+// upload-side test uses 'astros-controller-v1' which would fail the
+// regex; for github source we have to use a PlatformIO env name.
+const VARIANT = 'lolin_d32_pro';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+
+// Fake fetcher returning canned GitHub release JSON. The shape matches
+// GitHubReleaseDto (models/firmware/release.ts): tag_name with leading
+// 'v' (the service's stripLeadingV normalizes to '1.5.0'), draft/prerelease
+// false, one asset whose name+content_type pass extractFirmwareAssets's
+// filters.
+function buildFakeReleaseFetcher(releases: unknown[]): typeof fetch {
+  const fn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (!url.includes('api.github.com/repos/') || !url.includes('/releases')) {
+      throw new Error(`fake fetcher: unexpected URL ${url}`);
+    }
+    return new Response(JSON.stringify(releases), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  return fn as unknown as typeof fetch;
+}
+
+describe('integration: happy github flash + heartbeat release', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'POST /api/firmware/flash kind=github → flashJobDone → POLL_ACK heartbeat → lockStateChanged{locked:false}',
+    async () => {
+      // 1. Boot the harness with a fake release fetcher. The cache is
+      //    pre-seeded BEFORE the flash POST so FirmwareCache.lookup()
+      //    returns a hit and fetch() short-circuits — no download
+      //    attempted, no real network I/O.
+      const binBytes = Buffer.alloc(4096, 0x42);
+
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+        firmwareReleaseFetcher: buildFakeReleaseFetcher([
+          {
+            tag_name: `v${POST_FLASH_FW}`,
+            published_at: '2026-04-15T12:00:00Z',
+            draft: false,
+            prerelease: false,
+            assets: [
+              {
+                name: `astros-esp-${POST_FLASH_FW}-${VARIANT}-app.bin`,
+                browser_download_url: `https://example.test/astros-esp-${POST_FLASH_FW}-${VARIANT}-app.bin`,
+                size: binBytes.length,
+                content_type: 'application/octet-stream',
+              },
+            ],
+          },
+        ]),
+      });
+
+      // 2. Pre-populate the controllerVariantCache: stub emits POLL_ACK
+      //    so listFlashTargets() finds the master at flash time. Without
+      //    this the orchestrator rejects with `no_controllers`.
+      harness.stub.writePollAck();
+      await new Promise((r) => setTimeout(r, 300));
+
+      // 3. Seed the firmware cache. The helper writes the
+      //    .bin/.bin.sha256/.meta.json triple matching FirmwareCache's
+      //    layout so lookup() returns non-null on the first call.
+      const { sha256 } = await harness.populateFirmwareCache({
+        binBytes,
+        version: POST_FLASH_FW,
+        variant: VARIANT,
+      });
+      void sha256; // available for diagnostic if streamer fails
+
+      // 4. Configure stub master responses: defaults for upload, single
+      //    OK deploy outcome reporting POST_FLASH_FW.
+      harness.stub.autoAckUpload({});
+      harness.stub.scriptDeploy({
+        controllers: [
+          {
+            id: MASTER_SENTINEL_MAC,
+            outcome: 'OK',
+            finalVersion: POST_FLASH_FW,
+            error: '',
+          },
+        ],
+      });
+
+      // 5. POST /api/firmware/flash with the github source. The
+      //    orchestrator's resolveFlashSource calls
+      //    releaseService.getReleases() (intercepted by the fake
+      //    fetcher) → finds release v1.5.0 → finds the lolin_d32_pro
+      //    asset → calls cache.fetch() → cache.lookup() returns hit →
+      //    short-circuits. The version field matches because
+      //    stripLeadingV strips the 'v' from 'v1.5.0'.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'github', version: POST_FLASH_FW } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as {
+        jobId: string;
+        transferId: string;
+        targets: string[];
+      };
+      expect(flashBody.jobId).toBeTruthy();
+      expect(flashBody.targets).toEqual([MASTER_SENTINEL_MAC]);
+
+      // 6. flashJobStarted: WS frame is `{type, data}`. Assert the
+      //    github-shaped displayName per resolveFlashSource:
+      //    `astros-esp ${version} (${variant})`.
+      const startedEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string; source: { displayName: string } };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobStarted, 5000);
+      expect(startedEvent.data.jobId).toBe(flashBody.jobId);
+      expect(startedEvent.data.source.displayName).toBe(`astros-esp ${POST_FLASH_FW} (${VARIANT})`);
+
+      // 7. flashJobDone after upload (BEGIN/CHUNK/END auto-acks) +
+      //    deploy (FW_PROGRESS + FW_DEPLOY_DONE). Sub-second for a 4KB
+      //    blob; 10s headroom for slow CI.
+      const doneEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobDone, 10_000);
+      expect(doneEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 8. Stub emits POLL_ACK with the post-flash firmwareVersion.
+      //    decidePostDeployHeartbeat → 'fire' (sentinel MAC matches,
+      //    version matches deployed target) → orchestrator's
+      //    notifyMasterHeartbeat → lock release WELL BEFORE the 15-sec
+      //    reboot-timer fallback would fire.
+      harness.stub.writePollAck({ firmwareVersion: POST_FLASH_FW });
+
+      // 9. lockStateChanged is FLAT — `locked` sits at the top level
+      //    alongside `type`, not under `data`. Should arrive within
+      //    ~1-2 seconds of step 8; 15+ seconds means the heartbeat path
+      //    is broken and the timer fallback is releasing instead.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>((m) => {
+        const msg = m as { type?: unknown; locked?: unknown };
+        return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+      }, 5000);
+      expect(lockReleased.locked).toBe(false);
+
+      // 10. GET /api/firmware/flash → null (no active job after release).
+      const getRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(getRes.status).toBe(200);
+      const getBody: unknown = await getRes.json();
+      expect(getBody).toBeNull();
+
+      // 11. Worker stayed healthy — placed LAST so a Worker that died
+      //     midway is caught even if other assertions happened to pass
+      //     on stale message replay.
+      expect(harness.workerErrors).toEqual([]);
+    },
+    60_000, // generous: includes potential first-time `npm run build` + WS round-trips
+  );
+});

--- a/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
@@ -221,6 +221,8 @@ describe('integration: happy github flash + heartbeat release', () => {
       //     midway is caught even if other assertions happened to pass
       //     on stale message replay.
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     60_000, // generous: includes potential first-time `npm run build` + WS round-trips
   );

--- a/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
@@ -107,8 +107,11 @@ describe('integration: happy github flash + heartbeat release', () => {
       // 2. Pre-populate the controllerVariantCache: stub emits POLL_ACK
       //    so listFlashTargets() finds the master at flash time. Without
       //    this the orchestrator rejects with `no_controllers`.
+      //
+      //    Deterministic poll-wait instead of a fixed sleep — the latter
+      //    flakes under vitest's parallel-thread load.
       harness.stub.writePollAck();
-      await new Promise((r) => setTimeout(r, 300));
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, VARIANT);
 
       // 3. Seed the firmware cache. The helper writes the
       //    .bin/.bin.sha256/.meta.json triple matching FirmwareCache's
@@ -182,6 +185,11 @@ describe('integration: happy github flash + heartbeat release', () => {
       //    version matches deployed target) → orchestrator's
       //    notifyMasterHeartbeat → lock release WELL BEFORE the 15-sec
       //    reboot-timer fallback would fire.
+      //
+      //    Snapshot the WS buffer length BEFORE emitting so the wait below
+      //    only sees the heartbeat-driven release, not the connect-time
+      //    lockStateChanged{locked:false} snapshot the server sent on WS open.
+      const snapshot = harness.receivedWsMessages.length;
       harness.stub.writePollAck({ firmwareVersion: POST_FLASH_FW });
 
       // 9. lockStateChanged is FLAT — `locked` sits at the top level
@@ -191,10 +199,14 @@ describe('integration: happy github flash + heartbeat release', () => {
       const lockReleased = await harness.waitForWsMessage<{
         type: number;
         locked: boolean;
-      }>((m) => {
-        const msg = m as { type?: unknown; locked?: unknown };
-        return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
-      }, 5000);
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
       expect(lockReleased.locked).toBe(false);
 
       // 10. GET /api/firmware/flash → null (no active job after release).

--- a/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_github.integration.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../../test_harness/integration_harness.js';
 import { TransmissionType } from '../../models/enums.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 // Master's sentinel MAC per project_master_esp_sentinel_mac convention.
 // decidePostDeployHeartbeat filters on this exact string so the test must
@@ -73,7 +73,7 @@ describe('integration: happy github flash + heartbeat release', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'POST /api/firmware/flash kind=github → flashJobDone → POLL_ACK heartbeat → lockStateChanged{locked:false}',
     async () => {
       // 1. Boot the harness with a fake release fetcher. The cache is

--- a/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
@@ -57,9 +57,12 @@ describe('integration: happy upload flash + heartbeat release', () => {
       //    handlePollResponse populates the cache so listFlashTargets()
       //    returns this controller at flash time. Without this, the
       //    orchestrator would reject with `no_controllers`.
+      //
+      //    `waitForVariantCachePopulated` polls the cache deterministically
+      //    instead of relying on a fixed sleep, which flakes under vitest's
+      //    parallel-thread load.
       harness.stub.writePollAck();
-      // Allow the wire round-trip + Worker post → handlePollResponse to run.
-      await new Promise((r) => setTimeout(r, 300));
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
 
       // 3. Pre-populate the upload store with a small firmware blob. The
       //    helper writes the meta.json directly (bypassing the
@@ -136,6 +139,11 @@ describe('integration: happy upload flash + heartbeat release', () => {
       //    matches, version matches deployed target) → orchestrator's
       //    notifyMasterHeartbeat → lock release WELL BEFORE the 15-sec
       //    reboot-timer fallback would fire.
+      //
+      //    Snapshot the WS buffer length BEFORE emitting so the wait below
+      //    only sees the heartbeat-driven release, not the connect-time
+      //    lockStateChanged{locked:false} snapshot the server sent on WS open.
+      const snapshot = harness.receivedWsMessages.length;
       harness.stub.writePollAck({ firmwareVersion: POST_FLASH_FW });
 
       // 9. Wait for lockStateChanged{locked:false}. Should arrive within
@@ -148,10 +156,14 @@ describe('integration: happy upload flash + heartbeat release', () => {
       const lockReleased = await harness.waitForWsMessage<{
         type: number;
         locked: boolean;
-      }>((m) => {
-        const msg = m as { type?: unknown; locked?: unknown };
-        return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
-      }, 5000);
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
       expect(lockReleased.locked).toBe(false);
 
       // 10. GET /api/firmware/flash → null (no active job after release).

--- a/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../../test_harness/integration_harness.js';
 import { TransmissionType } from '../../models/enums.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 // Master's sentinel MAC per project_master_esp_sentinel_mac convention.
 // decidePostDeployHeartbeat filters on this exact string so the test must
@@ -40,7 +40,7 @@ describe('integration: happy upload flash + heartbeat release', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'POST /api/firmware/flash kind=upload → flashJobDone → POLL_ACK heartbeat → lockStateChanged{locked:false}',
     async () => {
       // 1. Boot harness configured for the master only. Pre-flash firmware

--- a/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
@@ -1,0 +1,173 @@
+// First end-to-end integration test for the firmware OTA orchestrator.
+// Drives a full upload-source flash through a real ApiServer + StubMaster
+// over a PTY-backed serial port and verifies the heartbeat path releases
+// the lock well before the 15-sec reboot-timer fallback would fire.
+//
+// Sequence covered:
+//   1. Pre-populate variantCache via stub POLL_ACK
+//   2. Pre-populate upload store with a 4KB firmware blob
+//   3. POST /api/firmware/flash kind=upload (JWT-authenticated)
+//   4. Observe flashJobStarted → autoAckUpload drives FW_TRANSFER_BEGIN/CHUNK/END
+//   5. scriptDeploy drives FW_PROGRESS + FW_DEPLOY_DONE
+//   6. flashJobDone fires
+//   7. Stub emits master POLL_ACK with deployed firmwareVersion
+//   8. Heartbeat path releases lock → lockStateChanged{locked:false}
+//   9. GET /api/firmware/flash returns null
+//  10. workerErrors is empty (Worker stayed healthy)
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+// Master's sentinel MAC per project_master_esp_sentinel_mac convention.
+// decidePostDeployHeartbeat filters on this exact string so the test must
+// match it bit-for-bit.
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const MASTER_VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+
+describe('integration: happy upload flash + heartbeat release', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'POST /api/firmware/flash kind=upload → flashJobDone → POLL_ACK heartbeat → lockStateChanged{locked:false}',
+    async () => {
+      // 1. Boot harness configured for the master only. Pre-flash firmware
+      //    version is what the variantCache POLL_ACK will carry; post-flash
+      //    is what the stub reports after the deploy completes.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+      });
+
+      // 2. Pre-populate the controllerVariantCache: stub emits a POLL_ACK
+      //    from the master sentinel MAC carrying the variant. ApiServer's
+      //    handlePollResponse populates the cache so listFlashTargets()
+      //    returns this controller at flash time. Without this, the
+      //    orchestrator would reject with `no_controllers`.
+      harness.stub.writePollAck();
+      // Allow the wire round-trip + Worker post → handlePollResponse to run.
+      await new Promise((r) => setTimeout(r, 300));
+
+      // 3. Pre-populate the upload store with a small firmware blob. The
+      //    helper writes the meta.json directly (bypassing the
+      //    esp_app_desc validation in `store()`) so we can use arbitrary
+      //    bytes as the fixture. The streamer reads bytes off disk and
+      //    chunk-streams them; the stub auto-ACKs each chunk.
+      const binBytes = Buffer.alloc(4096, 0x42);
+      const { sha256 } = await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+      // sha256 isn't asserted but is available for diagnostic use if the
+      // test fails (the streamer will fail with hash_mismatch if our sha
+      // sidecar diverges from the actual bytes).
+      void sha256;
+
+      // 4. Configure stub master responses for the upload + deploy phases.
+      //    autoAckUpload({}) uses defaults: windowSize=16, endStatus='OK',
+      //    no failAtSeq. scriptDeploy drives FW_PROGRESS frames + a single
+      //    FW_DEPLOY_DONE with outcome OK and finalVersion=POST_FLASH_FW.
+      harness.stub.autoAckUpload({});
+      harness.stub.scriptDeploy({
+        controllers: [
+          {
+            id: MASTER_SENTINEL_MAC,
+            outcome: 'OK',
+            finalVersion: POST_FLASH_FW,
+            error: '',
+          },
+        ],
+      });
+
+      // 5. POST /api/firmware/flash. Use Node's built-in fetch + the
+      //    harness's JWT auth token (express-jwt validates with the same
+      //    JWT_KEY the harness signed with).
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as {
+        jobId: string;
+        transferId: string;
+        targets: string[];
+      };
+      expect(flashBody.jobId).toBeTruthy();
+      expect(flashBody.targets).toEqual([MASTER_SENTINEL_MAC]);
+
+      // 6. Observe the WS event sequence. WS messages serialize the
+      //    TransmissionType numeric enum value, not the string name —
+      //    `m.type` is `12`, not `'flashJobStarted'`.
+      const startedEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobStarted, 5000);
+      expect(startedEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 7. Then flashJobDone after upload (BEGIN/CHUNK/END auto-acks) +
+      //    deploy (FW_PROGRESS + FW_DEPLOY_DONE). With a 4KB blob this
+      //    is sub-second; allow 10s of headroom for slow CI.
+      const doneEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobDone, 10_000);
+      expect(doneEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 8. Stub master emits a POLL_ACK with the post-flash firmwareVersion.
+      //    This triggers decidePostDeployHeartbeat → 'fire' (sentinel MAC
+      //    matches, version matches deployed target) → orchestrator's
+      //    notifyMasterHeartbeat → lock release WELL BEFORE the 15-sec
+      //    reboot-timer fallback would fire.
+      harness.stub.writePollAck({ firmwareVersion: POST_FLASH_FW });
+
+      // 9. Wait for lockStateChanged{locked:false}. Should arrive within
+      //    ~1-2 seconds of step 8. If it takes 15+ seconds, the heartbeat
+      //    path is broken and the timer fallback is releasing instead;
+      //    that's a real bug, not a flake.
+      // lockStateChanged is flat (not {type, data}) — buildLockStateResponse
+      // spreads LockState directly into the WS frame. The `locked` field
+      // sits at the top level, alongside `type`, `owner`, `since`.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>((m) => {
+        const msg = m as { type?: unknown; locked?: unknown };
+        return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+      }, 5000);
+      expect(lockReleased.locked).toBe(false);
+
+      // 10. GET /api/firmware/flash → null (no active job after release).
+      const getRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(getRes.status).toBe(200);
+      const getBody: unknown = await getRes.json();
+      expect(getBody).toBeNull();
+
+      // 11. Final assertion: the Worker stayed healthy through the whole
+      //     run. Placed LAST so a Worker that died midway is caught even
+      //     if other assertions happened to pass (stale message replay
+      //     could mask earlier breakage).
+      expect(harness.workerErrors).toEqual([]);
+    },
+    60_000, // generous: includes potential first-time `npm run build` + WS round-trips
+  );
+});

--- a/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_happy_upload.integration.test.ts
@@ -179,6 +179,8 @@ describe('integration: happy upload flash + heartbeat release', () => {
       //     if other assertions happened to pass (stale message replay
       //     could mask earlier breakage).
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     60_000, // generous: includes potential first-time `npm run build` + WS round-trips
   );

--- a/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
@@ -160,7 +160,10 @@ describe('integration: heartbeat vs reboot-timer', () => {
       expect(flashRes.status).toBe(200);
       const flashBody = (await flashRes.json()) as { jobId: string };
 
-      await harness.waitForWsMessage(
+      const doneEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string; endedAt: string };
+      }>(
         (m) =>
           (m as { type?: unknown }).type === TransmissionType.flashJobDone &&
           (m as { data?: { jobId?: unknown } }).data?.jobId === flashBody.jobId,
@@ -170,13 +173,23 @@ describe('integration: heartbeat vs reboot-timer', () => {
       // 4. Master heartbeat with WRONG version (still pre-flash).
       //    decidePostDeployHeartbeat returns 'version_mismatch'; orchestrator
       //    does NOT clear the reboot timer.
-      const wrongVersionAt = Date.now();
       const snapshot = harness.receivedWsMessages.length;
       harness.stub.writePollAck({ firmwareVersion: PRE_FLASH_FW }); // wrong version!
 
       // 5. Lock release should arrive via the timer fallback (~1s with our
       //    override). NOT before — this proves the wrong-version POLL_ACK
       //    was correctly ignored.
+      //
+      //    Reference timestamp is the server-side `endedAt` from the
+      //    flashJobDone payload, NOT `Date.now()` at WS-receive. The
+      //    orchestrator's `handleDeployDone` captures `endedAt` and arms
+      //    the reboot timer in the same synchronous block, so the timer's
+      //    notion of "now" matches `endedAt` to within a millisecond.
+      //    Using a client-side timestamp (e.g. `Date.now()` after
+      //    awaiting flashJobDone, or after writing the wrong-version
+      //    POLL_ACK) would undercount by however long WS delivery took
+      //    and could fail the lower bound on slow CI even when the timer
+      //    behaved correctly.
       const lockReleased = await harness.waitForWsMessage<{
         type: number;
         locked: boolean;
@@ -190,7 +203,8 @@ describe('integration: heartbeat vs reboot-timer', () => {
       );
       const releasedAt = Date.now();
       expect(lockReleased.locked).toBe(false);
-      const deltaMs = releasedAt - wrongVersionAt;
+      const doneAt = new Date(doneEvent.data.endedAt).getTime();
+      const deltaMs = releasedAt - doneAt;
       // Released via timer fallback — expected ~SHORT_REBOOT_TIMEOUT_MS
       // (1000ms). Generous lower bound (>= 800ms) to prove the heartbeat
       // didn't release; generous upper bound (< 4000ms) for CI slowness.

--- a/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
@@ -111,6 +111,8 @@ describe('integration: heartbeat vs reboot-timer', () => {
       expect(deltaMs).toBeLessThan(3000);
 
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     30_000,
   );
@@ -212,6 +214,8 @@ describe('integration: heartbeat vs reboot-timer', () => {
       expect(deltaMs).toBeLessThan(4000);
 
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     30_000,
   );

--- a/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
@@ -1,0 +1,204 @@
+// c.6c.2 Task 10 — heartbeat-vs-reboot-timer first-fire-wins integration tests.
+//
+// Two scenarios:
+//   1. matching-version POLL_ACK heartbeat releases the lock fast (well under
+//      the 15s reboot-timer threshold).
+//   2. wrong-version POLL_ACK heartbeat is filtered by
+//      decidePostDeployHeartbeat → the timer fallback is what releases the
+//      lock (asserted via wall-clock lower bound, the load-bearing piece).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const MASTER_VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+// Shrunk reboot timer so the wrong-version test's timer-fallback path
+// completes in ~1s rather than the production 15s.
+const SHORT_REBOOT_TIMEOUT_MS = 1000;
+
+describe('integration: heartbeat vs reboot-timer', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'matching-version POLL_ACK heartbeat releases lock well under reboot timer',
+    async () => {
+      // 1. Boot — production 15s reboot timer (default). Test asserts the
+      //    heartbeat fires before the timer.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+      });
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      // 2. Seed upload + configure stub for happy path.
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+      harness.stub.autoAckUpload({});
+      harness.stub.scriptDeploy({
+        controllers: [
+          {
+            id: MASTER_SENTINEL_MAC,
+            outcome: 'OK',
+            finalVersion: POST_FLASH_FW,
+            error: '',
+          },
+        ],
+      });
+
+      // 3. POST flash + wait for flashJobDone.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as { jobId: string };
+
+      const doneEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobDone, 10_000);
+      expect(doneEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 4. Snapshot the timestamp + WS index.
+      const heartbeatStartedAt = Date.now();
+      const snapshot = harness.receivedWsMessages.length;
+
+      // 5. Master heartbeat with matching version.
+      harness.stub.writePollAck({ firmwareVersion: POST_FLASH_FW });
+
+      // 6. Lock release — should arrive within ~1-2s, well below the
+      //    15-sec timer threshold. Assert delta < 3000ms (generous
+      //    headroom for slow CI). If this assertion fires, the
+      //    heartbeat path is broken and the timer fallback released
+      //    instead.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
+      const releasedAt = Date.now();
+      expect(lockReleased.locked).toBe(false);
+      const deltaMs = releasedAt - heartbeatStartedAt;
+      expect(deltaMs).toBeLessThan(3000);
+
+      expect(harness.workerErrors).toEqual([]);
+    },
+    30_000,
+  );
+
+  skipIfNotPosix(
+    'wrong-version POLL_ACK heartbeat is ignored → timer fallback releases lock',
+    async () => {
+      // 1. Boot with shrunken reboot timer so the timer-fallback path
+      //    completes in ~1s rather than 15s.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+        flashOrchestratorConfig: { rebootTimeoutMs: SHORT_REBOOT_TIMEOUT_MS },
+      });
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      // 2. Seed + happy stub setup (same as test 1).
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+      harness.stub.autoAckUpload({});
+      harness.stub.scriptDeploy({
+        controllers: [
+          {
+            id: MASTER_SENTINEL_MAC,
+            outcome: 'OK',
+            finalVersion: POST_FLASH_FW,
+            error: '',
+          },
+        ],
+      });
+
+      // 3. POST flash + wait for flashJobDone.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as { jobId: string };
+
+      await harness.waitForWsMessage(
+        (m) =>
+          (m as { type?: unknown }).type === TransmissionType.flashJobDone &&
+          (m as { data?: { jobId?: unknown } }).data?.jobId === flashBody.jobId,
+        10_000,
+      );
+
+      // 4. Master heartbeat with WRONG version (still pre-flash).
+      //    decidePostDeployHeartbeat returns 'version_mismatch'; orchestrator
+      //    does NOT clear the reboot timer.
+      const wrongVersionAt = Date.now();
+      const snapshot = harness.receivedWsMessages.length;
+      harness.stub.writePollAck({ firmwareVersion: PRE_FLASH_FW }); // wrong version!
+
+      // 5. Lock release should arrive via the timer fallback (~1s with our
+      //    override). NOT before — this proves the wrong-version POLL_ACK
+      //    was correctly ignored.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
+      const releasedAt = Date.now();
+      expect(lockReleased.locked).toBe(false);
+      const deltaMs = releasedAt - wrongVersionAt;
+      // Released via timer fallback — expected ~SHORT_REBOOT_TIMEOUT_MS
+      // (1000ms). Generous lower bound (>= 800ms) to prove the heartbeat
+      // didn't release; generous upper bound (< 4000ms) for CI slowness.
+      expect(deltaMs).toBeGreaterThanOrEqual(800);
+      expect(deltaMs).toBeLessThan(4000);
+
+      expect(harness.workerErrors).toEqual([]);
+    },
+    30_000,
+  );
+});

--- a/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
@@ -1,4 +1,4 @@
-// c.6c.2 Task 10 — heartbeat-vs-reboot-timer first-fire-wins integration tests.
+// Integration tests: heartbeat-vs-reboot-timer first-fire-wins.
 //
 // Two scenarios:
 //   1. matching-version POLL_ACK heartbeat releases the lock fast (well under

--- a/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_heartbeat_release.integration.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../test_harness/integration_harness.js';
 import { TransmissionType } from '../../models/enums.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
 const MASTER_VARIANT = 'astros-controller-v1';
@@ -32,7 +32,7 @@ describe('integration: heartbeat vs reboot-timer', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'matching-version POLL_ACK heartbeat releases lock well under reboot timer',
     async () => {
       // 1. Boot — production 15s reboot timer (default). Test asserts the
@@ -115,7 +115,7 @@ describe('integration: heartbeat vs reboot-timer', () => {
     30_000,
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'wrong-version POLL_ACK heartbeat is ignored → timer fallback releases lock',
     async () => {
       // 1. Boot with shrunken reboot timer so the timer-fallback path

--- a/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
@@ -1,0 +1,247 @@
+// Integration test for c.6c.2 Task 9: per-controller deploy mixed
+// OK/FAILED outcomes.
+//
+// Pins the orchestrator's `deriveJobLifecycle` contract: when every
+// controller reaches a terminal stage, the job lifecycle is `'done'`
+// regardless of the OK/Failed mix. The job-wide WS event is
+// `flashJobDone` — NOT `flashJobFailed`. Per-controller failures are
+// local to that controller's `flashControllerResult`; `flashJobFailed`
+// is reserved for job-wide aborts.
+//
+// Sequence covered:
+//   1. Pre-populate variantCache for BOTH master sentinel + one padawan
+//   2. Pre-populate upload store with a 4KB firmware blob
+//   3. POST /api/firmware/flash kind=upload with two targets
+//   4. Stub scriptDeploy emits FW_PROGRESS per controller, then a single
+//      FW_DEPLOY_DONE with results=[master OK, padawan FAILED]
+//   5. flashControllerResult fires twice: master VersionConfirmed,
+//      padawan Failed
+//   6. flashJobDone fires (load-bearing); flashJobFailed never fires
+//   7. Master POLL_ACK with deployed version → heartbeat releases lock
+//   8. workerErrors empty
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+import { FwStage } from '../../models/firmware/firmware_messages.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const PADAWAN_MAC = 'aa:bb:cc:dd:ee:ff';
+const VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+const PADAWAN_ERROR = 'crc_mismatch';
+
+describe('integration: per-controller deploy mixed OK/FAILED', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'master OK + padawan FAILED → flashJobDone (NOT failed) → master heartbeat releases lock',
+    async () => {
+      // 1. Boot harness configured for the master only. Both controllers
+      //    share the same variant; the padawan is introduced via a
+      //    second POLL_ACK below.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+      });
+
+      // 2. Pre-populate the controllerVariantCache for BOTH controllers.
+      //    All POLL_ACKs flow through the master end of the PTY on the
+      //    wire — we just override the `mac` arg per call so each frame
+      //    represents a different controller. The harness's
+      //    `waitForVariantCachePopulated` is keyed by MAC and lets us
+      //    deterministically wait for each insertion.
+      //
+      //    Insertion order matters: Map iteration is insertion-order in
+      //    JS, so master is inserted first → listFlashTargets() returns
+      //    [master, padawan] in that order. The test sorts both sides
+      //    of the targets assertion for tolerance.
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, VARIANT);
+      harness.stub.writePollAck({ mac: PADAWAN_MAC, variant: VARIANT });
+      await harness.waitForVariantCachePopulated(PADAWAN_MAC, VARIANT);
+
+      // 3. Seed the upload store. Same shape as the happy-path test;
+      //    the bytes are arbitrary because the streamer's hash check
+      //    sees the harness-written sidecar sha256.
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+
+      // 4. Configure stub responses. Upload succeeds for both
+      //    controllers (the binary is uploaded once to the master and
+      //    distributed). scriptDeploy carries mixed outcomes: master
+      //    OK with finalVersion, padawan FAILED with error. The stub
+      //    emits FW_PROGRESS frames per controller through the default
+      //    Sending → Verifying → Rebooting stage progression, then ONE
+      //    FW_DEPLOY_DONE whose results[] array has both entries.
+      harness.stub.autoAckUpload({});
+      harness.stub.scriptDeploy({
+        controllers: [
+          {
+            id: MASTER_SENTINEL_MAC,
+            outcome: 'OK',
+            finalVersion: POST_FLASH_FW,
+            error: '',
+          },
+          {
+            id: PADAWAN_MAC,
+            outcome: 'FAILED',
+            finalVersion: '',
+            error: PADAWAN_ERROR,
+          },
+        ],
+      });
+
+      // 5. POST flash. Targets order is variant-cache insertion order
+      //    (master first, padawan second). Sorting both sides of the
+      //    assertion keeps the test tolerant to a future change in
+      //    iteration order without losing the membership check.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as {
+        jobId: string;
+        targets: string[];
+      };
+      expect(flashBody.jobId).toBeTruthy();
+      expect(flashBody.targets.slice().sort()).toEqual(
+        [MASTER_SENTINEL_MAC, PADAWAN_MAC].slice().sort(),
+      );
+
+      // 6. flashJobStarted.
+      const startedEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobStarted, 5000);
+      expect(startedEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 7. flashJobDone — the load-bearing assertion. Mixed terminal
+      //    outcomes do NOT promote the job to flashJobFailed;
+      //    deriveJobLifecycle returns 'done' as long as every
+      //    controller is in a terminal stage. A regression that flipped
+      //    this to flashJobFailed would time out here.
+      const doneEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>((m) => (m as { type?: unknown }).type === TransmissionType.flashJobDone, 10_000);
+      expect(doneEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 8. Per-controller flashControllerResult events. Two terminal
+      //    transitions, one per controller:
+      //      * master  → VersionConfirmed (finalVersion=POST_FLASH_FW)
+      //      * padawan → Failed (error=PADAWAN_ERROR)
+      //
+      //    Note: scriptDeploy's per-stage FW_PROGRESS frames generate
+      //    `flashControllerUpdate` events (Sending/Verifying/Rebooting
+      //    × 2 controllers = 6 events on the WS bus); the terminal
+      //    transitions are the separate `flashControllerResult` stream.
+      type ControllerResult = {
+        type: number;
+        data: {
+          jobId: string;
+          controller: {
+            controllerId: string;
+            stage: FwStage;
+            error?: string;
+            finalVersion?: string;
+          };
+        };
+      };
+      const controllerResults = harness.receivedWsMessages.filter(
+        (m) => (m as { type?: unknown }).type === TransmissionType.flashControllerResult,
+      ) as ControllerResult[];
+
+      expect(controllerResults.length).toBe(2);
+
+      const masterResult = controllerResults.find(
+        (r) => r.data.controller.controllerId === MASTER_SENTINEL_MAC,
+      );
+      const padawanResult = controllerResults.find(
+        (r) => r.data.controller.controllerId === PADAWAN_MAC,
+      );
+
+      expect(masterResult).toBeDefined();
+      expect(masterResult?.data.controller.stage).toBe(FwStage.VersionConfirmed);
+      expect(masterResult?.data.controller.finalVersion).toBe(POST_FLASH_FW);
+
+      expect(padawanResult).toBeDefined();
+      expect(padawanResult?.data.controller.stage).toBe(FwStage.Failed);
+      expect(padawanResult?.data.controller.error).toBe(PADAWAN_ERROR);
+
+      // 9. NO flashJobFailed should have been emitted. This is the
+      //    second-most-load-bearing pin: a regression where mixed
+      //    terminal outcomes incorrectly trip flashJobFailed (e.g., a
+      //    naive "any controller Failed → job Failed" check) would
+      //    silently break only this assertion.
+      const failedEvents = harness.receivedWsMessages.filter(
+        (m) => (m as { type?: unknown }).type === TransmissionType.flashJobFailed,
+      );
+      expect(failedEvents).toEqual([]);
+
+      // 10. Heartbeat path. The master rebooted into POST_FLASH_FW;
+      //     emit POLL_ACK from the sentinel MAC carrying the deployed
+      //     version → decidePostDeployHeartbeat fires →
+      //     orchestrator.notifyMasterHeartbeat clears the reboot timer
+      //     and releases the lock. The padawan failed and didn't
+      //     reboot, so its POLL_ACK is irrelevant to the heartbeat
+      //     release decision (decidePostDeployHeartbeat filters on the
+      //     master sentinel MAC).
+      //
+      //     Snapshot the WS buffer before emitting so the wait below
+      //     only sees the heartbeat-driven release, not the connect-
+      //     time lockStateChanged{locked:false} the server sent on
+      //     WS open.
+      const snapshot = harness.receivedWsMessages.length;
+      harness.stub.writePollAck({ firmwareVersion: POST_FLASH_FW });
+
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
+      expect(lockReleased.locked).toBe(false);
+
+      // 11. GET /api/firmware/flash → null (no active job after release).
+      const getRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect(getRes.status).toBe(200);
+      const getBody: unknown = await getRes.json();
+      expect(getBody).toBeNull();
+
+      // 12. Worker stayed healthy through the run. LAST so a Worker
+      //     that died midway is caught even if other assertions
+      //     happened to pass on stale message replay.
+      expect(harness.workerErrors).toEqual([]);
+    },
+    30_000,
+  );
+});

--- a/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
@@ -240,6 +240,8 @@ describe('integration: per-controller deploy mixed OK/FAILED', () => {
       //     that died midway is caught even if other assertions
       //     happened to pass on stale message replay.
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     30_000,
   );

--- a/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
@@ -27,7 +27,7 @@ import {
 import { TransmissionType } from '../../models/enums.js';
 import { FwStage } from '../../models/firmware/firmware_messages.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
 const PADAWAN_MAC = 'aa:bb:cc:dd:ee:ff';
@@ -44,7 +44,7 @@ describe('integration: per-controller deploy mixed OK/FAILED', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'master OK + padawan FAILED → flashJobDone (NOT failed) → master heartbeat releases lock',
     async () => {
       // 1. Boot harness configured for the master only. Both controllers

--- a/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
@@ -1,5 +1,4 @@
-// Integration test for c.6c.2 Task 9: per-controller deploy mixed
-// OK/FAILED outcomes.
+// Integration test: per-controller deploy mixed OK/FAILED outcomes.
 //
 // Pins the orchestrator's `deriveJobLifecycle` contract: when every
 // controller reaches a terminal stage, the job lifecycle is `'done'`

--- a/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
@@ -1,0 +1,126 @@
+// c.6c.2 Task 11 — reboot-timer fallback when NO heartbeat arrives.
+//
+// Pins the recovery contract: if a flash succeeds but the master never
+// emits a heartbeat POLL_ACK (bricked, partitioned, or just slow), the
+// reboot timer is the only path to lock release. Without this, an
+// operator's next flash attempt would be permanently blocked.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const MASTER_VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+const SHORT_REBOOT_TIMEOUT_MS = 1000;
+
+describe('integration: reboot-timer fallback (no heartbeat)', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'no POLL_ACK after flashJobDone → timer fallback fires → lockStateChanged{locked:false}',
+    async () => {
+      // 1. Boot with shrunken reboot timer so the test completes in seconds.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+        flashOrchestratorConfig: { rebootTimeoutMs: SHORT_REBOOT_TIMEOUT_MS },
+      });
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      // 2. Seed upload + happy stub setup (same as Task 5 / Task 10 test 1).
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+      harness.stub.autoAckUpload({});
+      harness.stub.scriptDeploy({
+        controllers: [
+          {
+            id: MASTER_SENTINEL_MAC,
+            outcome: 'OK',
+            finalVersion: POST_FLASH_FW,
+            error: '',
+          },
+        ],
+      });
+
+      // 3. POST flash + wait for flashJobDone.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({ source: { kind: 'upload' } }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as { jobId: string };
+
+      const doneEvent = await harness.waitForWsMessage<{
+        type: number;
+        data: { jobId: string };
+      }>(
+        (m) =>
+          (m as { type?: unknown }).type === TransmissionType.flashJobDone &&
+          (m as { data?: { jobId?: unknown } }).data?.jobId === flashBody.jobId,
+        10_000,
+      );
+      expect(doneEvent.data.jobId).toBe(flashBody.jobId);
+
+      // 4. Snapshot the moment flashJobDone resolved + WS index.
+      //    DELIBERATELY emit NO POLL_ACK after this — the test pins the
+      //    timer-only release path.
+      const doneAt = Date.now();
+      const snapshot = harness.receivedWsMessages.length;
+
+      // 5. Wait for lock release. The reboot timer is the only path; with
+      //    SHORT_REBOOT_TIMEOUT_MS=1000, the lock should release ~1s after
+      //    flashJobDone. The lower bound of 800ms is the load-bearing
+      //    assertion: it proves the lock did NOT release immediately
+      //    (which would indicate the timer didn't arm or fired
+      //    prematurely). Upper bound 4000ms tolerates slow CI.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
+      const releasedAt = Date.now();
+      expect(lockReleased.locked).toBe(false);
+      const deltaMs = releasedAt - doneAt;
+      expect(deltaMs).toBeGreaterThanOrEqual(800);
+      expect(deltaMs).toBeLessThan(4000);
+
+      // 6. GET → null.
+      const getRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect((await getRes.json()) as unknown).toBeNull();
+
+      // 7. Worker stayed healthy.
+      expect(harness.workerErrors).toEqual([]);
+    },
+    30_000,
+  );
+});

--- a/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
@@ -128,6 +128,8 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
 
       // 7. Worker stayed healthy.
       expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
     },
     30_000,
   );

--- a/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
@@ -98,7 +98,7 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
       //    flashJobDone payload, NOT `Date.now()` at WS-receive. The
       //    orchestrator's `handleDeployDone` captures `endedAt` and arms
       //    the timer in the same synchronous block, so the timer's notion
-      //    of "now" matches `endedAt` to within microseconds. Using a
+      //    of "now" matches `endedAt` to within a millisecond. Using a
       //    client-side timestamp would undercount by however long WS
       //    delivery took and could fail the lower bound on slow CI even
       //    when the timer behaved correctly.

--- a/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
@@ -74,7 +74,7 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
 
       const doneEvent = await harness.waitForWsMessage<{
         type: number;
-        data: { jobId: string };
+        data: { jobId: string; endedAt: string };
       }>(
         (m) =>
           (m as { type?: unknown }).type === TransmissionType.flashJobDone &&
@@ -83,10 +83,8 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
       );
       expect(doneEvent.data.jobId).toBe(flashBody.jobId);
 
-      // 4. Snapshot the moment flashJobDone resolved + WS index.
-      //    DELIBERATELY emit NO POLL_ACK after this — the test pins the
-      //    timer-only release path.
-      const doneAt = Date.now();
+      // 4. Snapshot the WS index. DELIBERATELY emit NO POLL_ACK after this —
+      //    the test pins the timer-only release path.
       const snapshot = harness.receivedWsMessages.length;
 
       // 5. Wait for lock release. The reboot timer is the only path; with
@@ -95,6 +93,15 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
       //    assertion: it proves the lock did NOT release immediately
       //    (which would indicate the timer didn't arm or fired
       //    prematurely). Upper bound 4000ms tolerates slow CI.
+      //
+      //    Reference timestamp is the server-side `endedAt` from the
+      //    flashJobDone payload, NOT `Date.now()` at WS-receive. The
+      //    orchestrator's `handleDeployDone` captures `endedAt` and arms
+      //    the timer in the same synchronous block, so the timer's notion
+      //    of "now" matches `endedAt` to within microseconds. Using a
+      //    client-side timestamp would undercount by however long WS
+      //    delivery took and could fail the lower bound on slow CI even
+      //    when the timer behaved correctly.
       const lockReleased = await harness.waitForWsMessage<{
         type: number;
         locked: boolean;
@@ -108,6 +115,7 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
       );
       const releasedAt = Date.now();
       expect(lockReleased.locked).toBe(false);
+      const doneAt = new Date(doneEvent.data.endedAt).getTime();
       const deltaMs = releasedAt - doneAt;
       expect(deltaMs).toBeGreaterThanOrEqual(800);
       expect(deltaMs).toBeLessThan(4000);

--- a/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
@@ -1,4 +1,4 @@
-// c.6c.2 Task 11 — reboot-timer fallback when NO heartbeat arrives.
+// Integration test: reboot-timer fallback when NO heartbeat arrives.
 //
 // Pins the recovery contract: if a flash succeeds but the master never
 // emits a heartbeat POLL_ACK (bricked, partitioned, or just slow), the
@@ -41,7 +41,7 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
       harness.stub.writePollAck();
       await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
 
-      // 2. Seed upload + happy stub setup (same as Task 5 / Task 10 test 1).
+      // 2. Seed upload + happy stub setup so the flash reaches flashJobDone.
       const binBytes = Buffer.alloc(4096, 0x42);
       await harness.populateUpload({
         binBytes,

--- a/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_reboot_timer_fallback.integration.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../test_harness/integration_harness.js';
 import { TransmissionType } from '../../models/enums.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
 const MASTER_VARIANT = 'astros-controller-v1';
@@ -28,7 +28,7 @@ describe('integration: reboot-timer fallback (no heartbeat)', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'no POLL_ACK after flashJobDone → timer fallback fires → lockStateChanged{locked:false}',
     async () => {
       // 1. Boot with shrunken reboot timer so the test completes in seconds.

--- a/astros_api/src/guard/write_guard.test.ts
+++ b/astros_api/src/guard/write_guard.test.ts
@@ -175,6 +175,29 @@ describe('writeGuard', () => {
       }
     });
 
+    it('allows POST /firmware/flash so the orchestrator can return 409 with currentJobId', () => {
+      // The flash POST is allowlisted while a flash is active so the
+      // request reaches the orchestrator's synchronous lock-acquire check
+      // and surfaces the documented 409 `{ error: 'job_already_running',
+      // currentJobId }` payload — operators need currentJobId to
+      // distinguish "flash already running" from "you can't do this
+      // right now". Without the allowlist the route would return a
+      // generic 423 with no jobId.
+      const { status, lock } = activeFlash();
+      const { res, next } = call('POST', '/firmware/flash', status, lock);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('still blocks other POST paths even when /firmware/flash is allowlisted', () => {
+      const { status, lock } = activeFlash();
+      for (const p of ['/scripts/upload', '/locations/syncconfig', '/firmware/upload']) {
+        const { res, next } = call('POST', p, status, lock);
+        expect(next).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(423);
+      }
+    });
+
     it('blocks panicStop and panicClear with 423 (stricter than read-only mode)', () => {
       // Read-only allows panic so the user can halt motion during a server
       // outage; flash-active does NOT, because emitting a PANIC_STOP frame

--- a/astros_api/src/guard/write_guard.ts
+++ b/astros_api/src/guard/write_guard.ts
@@ -17,10 +17,20 @@ const ALLOWED_IN_READONLY: Array<{ method: string; path: string }> = [
 // and corrupt the in-flight transfer. Login / reauth still work so a fresh
 // session can attach to the live job. DELETE /firmware/flash is the cancel
 // path — it MUST be allowed during a flash, otherwise the cancel button is
-// unreachable while the orchestrator holds the lock.
+// unreachable while the orchestrator holds the lock. POST /firmware/flash is
+// allowed through so a second concurrent flash attempt reaches the orchestrator
+// and gets a 409 { error: 'job_already_running', currentJobId } rather than the
+// generic 423 — the operator UI needs currentJobId to distinguish "you're trying
+// to flash but a flash is already running" from "you can't do this right now".
+//
+// Note: read-only mode (ALLOWED_IN_READONLY) takes precedence over this list
+// when both gates fire simultaneously. That edge case (DB recovery + flash
+// active) is not reachable in practice — read-only is entered during bootstrap
+// before any flash job can exist — so the ordering is intentional.
 const ALLOWED_DURING_FLASH: Array<{ method: string; path: string }> = [
   { method: 'POST', path: '/login' },
   { method: 'POST', path: '/reauth' },
+  { method: 'POST', path: '/firmware/flash' },
   { method: 'DELETE', path: '/firmware/flash' },
 ];
 

--- a/astros_api/src/serial/serial_message_service.test.ts
+++ b/astros_api/src/serial/serial_message_service.test.ts
@@ -131,6 +131,155 @@ describe('SerialMessageService', () => {
       // Tracker should be removed (all controllers ACK'd)
       expect(service.messageTracker.has(msgId)).toBe(false);
     });
+
+    // ── FW_* response routing ────────────────────────────────
+    // Regression coverage for the bug where the handleMessage switch had no
+    // FW_* cases — inbound firmware response frames validated successfully but
+    // fell through, causing the worker to postMessage `{ type: UNKNOWN }` and
+    // the orchestrator to time out at begin_timeout. See
+    // fix(api/serial): route FW_* responses through serial_message_service.
+
+    it('routes FW_TRANSFER_BEGIN_ACK to handleFwTransferBeginAck', () => {
+      const service = new SerialMessageService(vi.fn());
+
+      const msg = buildMessage(
+        SerialMessageType.FW_TRANSFER_BEGIN_ACK,
+        'msg-fw-begin',
+        `xfer-1${US}OK`,
+      );
+
+      const result = service.handleMessage(msg);
+
+      expect(result.type).toBe(SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK);
+      if (result.type === SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK) {
+        expect(result.payload.transferId).toBe('xfer-1');
+        expect(result.payload.status).toBe('OK');
+      }
+    });
+
+    it('routes FW_CHUNK_ACK to handleFwChunkAck', () => {
+      const service = new SerialMessageService(vi.fn());
+
+      const msg = buildMessage(
+        SerialMessageType.FW_CHUNK_ACK,
+        'msg-fw-chunk-ack',
+        `xfer-1${US}5${US}6${US}10`,
+      );
+
+      const result = service.handleMessage(msg);
+
+      expect(result.type).toBe(SerialWorkerResponseType.FW_CHUNK_ACK);
+      if (result.type === SerialWorkerResponseType.FW_CHUNK_ACK) {
+        expect(result.payload.transferId).toBe('xfer-1');
+        expect(result.payload.highestContiguousSeq).toBe(5);
+        expect(result.payload.nextExpectedSeq).toBe(6);
+        expect(result.payload.windowRemaining).toBe(10);
+      }
+    });
+
+    it('routes FW_CHUNK_NAK to handleFwChunkNak', () => {
+      const service = new SerialMessageService(vi.fn());
+
+      const msg = buildMessage(
+        SerialMessageType.FW_CHUNK_NAK,
+        'msg-fw-chunk-nak',
+        `xfer-1${US}3${US}CRC`,
+      );
+
+      const result = service.handleMessage(msg);
+
+      expect(result.type).toBe(SerialWorkerResponseType.FW_CHUNK_NAK);
+      if (result.type === SerialWorkerResponseType.FW_CHUNK_NAK) {
+        expect(result.payload.transferId).toBe('xfer-1');
+        expect(result.payload.lastGoodSeq).toBe(3);
+        expect(result.payload.reasonCode).toBe('CRC');
+      }
+    });
+
+    it('routes FW_TRANSFER_END_ACK to handleFwTransferEndAck', () => {
+      const service = new SerialMessageService(vi.fn());
+
+      const sha = 'a'.repeat(64);
+      const msg = buildMessage(
+        SerialMessageType.FW_TRANSFER_END_ACK,
+        'msg-fw-end',
+        `xfer-1${US}OK${US}${sha}`,
+      );
+
+      const result = service.handleMessage(msg);
+
+      expect(result.type).toBe(SerialWorkerResponseType.FW_TRANSFER_END_ACK);
+      if (result.type === SerialWorkerResponseType.FW_TRANSFER_END_ACK) {
+        expect(result.payload.transferId).toBe('xfer-1');
+        expect(result.payload.status).toBe('OK');
+        expect(result.payload.computedSha256Hex).toBe(sha);
+      }
+    });
+
+    it('routes FW_PROGRESS to handleFwProgress', () => {
+      const service = new SerialMessageService(vi.fn());
+
+      const msg = buildMessage(
+        SerialMessageType.FW_PROGRESS,
+        'msg-fw-progress',
+        `xfer-1${US}ctrl-1${US}SENDING${US}1024${US}4096${US}detail-text`,
+      );
+
+      const result = service.handleMessage(msg);
+
+      expect(result.type).toBe(SerialWorkerResponseType.FW_PROGRESS);
+      if (result.type === SerialWorkerResponseType.FW_PROGRESS) {
+        expect(result.payload.transferId).toBe('xfer-1');
+        expect(result.payload.controllerId).toBe('ctrl-1');
+        expect(result.payload.stage).toBe('SENDING');
+        expect(result.payload.bytesSent).toBe(1024);
+        expect(result.payload.totalBytes).toBe(4096);
+        expect(result.payload.detail).toBe('detail-text');
+      }
+    });
+
+    it('routes FW_DEPLOY_DONE to handleFwDeployDone', () => {
+      const service = new SerialMessageService(vi.fn());
+
+      // Wire format: transferId<US>controllerId<US>outcome<US>finalVersion<US>error
+      // (single-controller, OK -> empty error)
+      const msg = buildMessage(
+        SerialMessageType.FW_DEPLOY_DONE,
+        'msg-fw-deploy-done',
+        `xfer-1${US}ctrl-1${US}OK${US}1.5.0${US}`,
+      );
+
+      const result = service.handleMessage(msg);
+
+      expect(result.type).toBe(SerialWorkerResponseType.FW_DEPLOY_DONE);
+      if (result.type === SerialWorkerResponseType.FW_DEPLOY_DONE) {
+        expect(result.payload.transferId).toBe('xfer-1');
+        expect(result.payload.results).toHaveLength(1);
+        expect(result.payload.results[0].controllerId).toBe('ctrl-1');
+        expect(result.payload.results[0].outcome).toBe('OK');
+        expect(result.payload.results[0].finalVersion).toBe('1.5.0');
+        expect(result.payload.results[0].error).toBe('');
+      }
+    });
+
+    it('routes FW_BACKPRESSURE to handleFwBackpressure', () => {
+      const service = new SerialMessageService(vi.fn());
+
+      const msg = buildMessage(
+        SerialMessageType.FW_BACKPRESSURE,
+        'msg-fw-bp',
+        `xfer-1${US}PAUSE${US}sd_busy`,
+      );
+
+      const result = service.handleMessage(msg);
+
+      expect(result.type).toBe(SerialWorkerResponseType.FW_BACKPRESSURE);
+      if (result.type === SerialWorkerResponseType.FW_BACKPRESSURE) {
+        expect(result.payload.transferId).toBe('xfer-1');
+        expect(result.payload.action).toBe('PAUSE');
+        expect(result.payload.reason).toBe('sd_busy');
+      }
+    });
   });
 
   // ── Tracker lifecycle ────────────────────────────────────────

--- a/astros_api/src/serial/serial_message_service.test.ts
+++ b/astros_api/src/serial/serial_message_service.test.ts
@@ -241,8 +241,11 @@ describe('SerialMessageService', () => {
     it('routes FW_DEPLOY_DONE to handleFwDeployDone', () => {
       const service = new SerialMessageService(vi.fn());
 
-      // Wire format: transferId<US>controllerId<US>outcome<US>finalVersion<US>error
-      // (single-controller, OK -> empty error)
+      // Wire format: transferId<US>result_1<RS>result_2<RS>...
+      // where each result is controllerId<US>outcome<US>finalVersion<US>error.
+      // The single-controller case below has no RS — the result list is just
+      // result_1 — so the bytes coincidentally read as a flat structure, but
+      // the protocol is hierarchical (see message_handler.ts:handleFwDeployDone).
       const msg = buildMessage(
         SerialMessageType.FW_DEPLOY_DONE,
         'msg-fw-deploy-done',

--- a/astros_api/src/serial/serial_message_service.ts
+++ b/astros_api/src/serial/serial_message_service.ts
@@ -89,6 +89,27 @@ export class SerialMessageService {
           validationResult.data,
         );
         break;
+      case SerialMessageType.FW_TRANSFER_BEGIN_ACK:
+        result = this.messageHandler.handleFwTransferBeginAck(validationResult.data);
+        break;
+      case SerialMessageType.FW_CHUNK_ACK:
+        result = this.messageHandler.handleFwChunkAck(validationResult.data);
+        break;
+      case SerialMessageType.FW_CHUNK_NAK:
+        result = this.messageHandler.handleFwChunkNak(validationResult.data);
+        break;
+      case SerialMessageType.FW_TRANSFER_END_ACK:
+        result = this.messageHandler.handleFwTransferEndAck(validationResult.data);
+        break;
+      case SerialMessageType.FW_PROGRESS:
+        result = this.messageHandler.handleFwProgress(validationResult.data);
+        break;
+      case SerialMessageType.FW_DEPLOY_DONE:
+        result = this.messageHandler.handleFwDeployDone(validationResult.data);
+        break;
+      case SerialMessageType.FW_BACKPRESSURE:
+        result = this.messageHandler.handleFwBackpressure(validationResult.data);
+        break;
     }
 
     if (validationResult.type !== SerialMessageType.POLL_ACK) {

--- a/astros_api/src/test_harness/global_setup.ts
+++ b/astros_api/src/test_harness/global_setup.ts
@@ -3,12 +3,11 @@
 //
 // Why globalSetup specifically: vitest's default pool runs test files in
 // parallel worker threads. If `bootIntegrationHarness` triggered the build
-// per-call, multiple workers could race on `npm run build` — and the build's
-// `prebuild` script (`rm -rf dist && eslint`) deletes dist/ from under any
-// worker that's mid-spawn or mid-load of the dist Worker file. Symptoms
-// range from ERR_MODULE_NOT_FOUND on a half-deleted dist tree to vacuous
-// passes when one worker finishes a build during another worker's mtime
-// check.
+// per-call, multiple workers could race on the rebuild — `rm -rf dist`
+// followed by `tsc` would delete dist/ from under any worker mid-spawn or
+// mid-load of the dist Worker file. Symptoms range from ERR_MODULE_NOT_FOUND
+// on a half-deleted dist tree to vacuous passes when one worker finishes a
+// build during another worker's mtime check.
 //
 // globalSetup eliminates the race by serializing: vitest invokes this in
 // its main process before any worker exists, so dist/ is stable for the
@@ -18,16 +17,18 @@
 // source file (see `newestCompiledMtime`) plus tsconfig.json / package.json,
 // so unit-only `npx vitest run` invocations don't pay the build cost.
 //
-// Not in the freshness check, intentionally: `.env` / `.env.test`. The build's
-// postbuild step copies them into dist/.env, but the integration harness
-// (integration_harness.ts) sets every env var the ApiServer reads directly
-// on process.env before bootstrap, and Dotenv.config is non-overwriting —
-// so dist/.env contents are unreachable from the integration suite. Adding
-// them to the check would force needless rebuilds when developers tweak
-// local .env files.
+// Not in the freshness check, intentionally: `.env` / `.env.test`. We invoke
+// `tsc` + `tsc-alias` directly here — bypassing `npm run build` precisely
+// so the gitignored `.env` isn't required — so globalSetup never even
+// produces a dist/.env. Even if a manual `npm run build` had populated one,
+// integration_harness.ts sets every env var the ApiServer reads directly on
+// process.env before bootstrap and Dotenv.config is non-overwriting, so
+// dist/.env contents are unreachable from the integration suite either way.
+// Adding `.env*` to the check would force needless rebuilds when developers
+// tweak local files.
 
 import { spawnSync } from 'child_process';
-import { readdirSync, statSync } from 'fs';
+import { readdirSync, rmSync, statSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -96,21 +97,39 @@ export default function setup(): void {
     // dist/ missing or stat failed; fall through to build.
   }
 
-  // Build it. `npm run build` runs the project's full pipeline (lint + tsc +
-  // tsc-alias). If lint fails, the build fails and the entire vitest run
-  // fails to start — that's correct: a failing lint should not silently
-  // produce a stale dist/.
-  const result = spawnSync('npm', ['run', 'build'], {
+  // Build it directly with tsc + tsc-alias instead of `npm run build`.
+  // `npm run build` invokes `postbuild` (`cp .env ./dist/.env`), which fails
+  // on any checkout without a local `.env` — `.env` is gitignored, so a
+  // clean clone or CI runner without one would fail integration tests at
+  // setup time. dist/.env is unreachable from the integration suite anyway:
+  // integration_harness.ts sets every env var the ApiServer reads directly
+  // on process.env before bootstrap, and Dotenv.config is non-overwriting.
+  //
+  // We mirror prebuild's `rm -rf dist` so renamed/deleted src files don't
+  // leave stale dist artifacts behind. Lint is intentionally skipped — it's
+  // a separate CI job and a pre-commit step, not vitest's responsibility.
+  rmSync(resolve(apiRoot, 'dist'), { recursive: true, force: true });
+
+  const tscResult = spawnSync('npx', ['tsc'], {
     cwd: apiRoot,
     stdio: 'inherit',
     env: process.env,
   });
-  if (result.status !== 0) {
+  if (tscResult.status !== 0) {
     throw new Error(
-      `vitest globalSetup: npm run build failed with code ${result.status}. ` +
+      `vitest globalSetup: npx tsc failed with code ${tscResult.status}. ` +
         `dist/ is required so integration tests can spawn the serial Worker — ` +
         `tsx's loader does not propagate to Worker threads.`,
     );
+  }
+
+  const aliasResult = spawnSync('npx', ['tsc-alias'], {
+    cwd: apiRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (aliasResult.status !== 0) {
+    throw new Error(`vitest globalSetup: npx tsc-alias failed with code ${aliasResult.status}.`);
   }
 
   // Verify the Worker file exists post-build.

--- a/astros_api/src/test_harness/global_setup.ts
+++ b/astros_api/src/test_harness/global_setup.ts
@@ -21,11 +21,11 @@
 // `tsc` + `tsc-alias` directly here — bypassing `npm run build` precisely
 // so the gitignored `.env` isn't required — so globalSetup never even
 // produces a dist/.env. Even if a manual `npm run build` had populated one,
-// integration_harness.ts sets every env var the ApiServer reads directly on
-// process.env before bootstrap and Dotenv.config is non-overwriting, so
-// dist/.env contents are unreachable from the integration suite either way.
-// Adding `.env*` to the check would force needless rebuilds when developers
-// tweak local files.
+// integration_harness.ts passes every per-test value through ApiServer's
+// `configOverrides` option, which takes precedence over both Dotenv-loaded
+// values and any pre-existing process.env entries. So dist/.env contents
+// are unreachable from the integration suite either way. Adding `.env*` to
+// the check would force needless rebuilds when developers tweak local files.
 
 import { spawnSync } from 'child_process';
 import { readdirSync, rmSync, statSync } from 'fs';

--- a/astros_api/src/test_harness/global_setup.ts
+++ b/astros_api/src/test_harness/global_setup.ts
@@ -23,6 +23,15 @@ import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 export default function setup(): void {
+  // The integration suite is Linux-only (see pty_pair.ts). Skip the build
+  // on every other platform so unit-only `npx vitest run` invocations on
+  // Windows still succeed — `npm run build`'s `prebuild` step uses
+  // `rm -rf dist` which fails on win32, and macOS's socat emits PTY paths
+  // pty_pair.ts's regex doesn't match anyway.
+  if (process.platform !== 'linux') {
+    return;
+  }
+
   // Resolve the astros_api root from this file's location.
   // here    -> .../astros_api/src/test_harness/global_setup.ts
   // apiRoot -> .../astros_api/

--- a/astros_api/src/test_harness/global_setup.ts
+++ b/astros_api/src/test_harness/global_setup.ts
@@ -1,0 +1,68 @@
+// vitest globalSetup hook — runs once in the main process before any worker
+// thread spawns, builds dist/ if the integration harness will need it.
+//
+// Why globalSetup specifically: vitest's default pool runs test files in
+// parallel worker threads. If `bootIntegrationHarness` triggered the build
+// per-call, multiple workers could race on `npm run build` — and the build's
+// `prebuild` script (`rm -rf dist && eslint`) deletes dist/ from under any
+// worker that's mid-spawn or mid-load of the dist Worker file. Symptoms
+// range from ERR_MODULE_NOT_FOUND on a half-deleted dist tree to vacuous
+// passes when one worker finishes a build during another worker's mtime
+// check.
+//
+// globalSetup eliminates the race by serializing: vitest invokes this in
+// its main process before any worker exists, so dist/ is stable for the
+// entire test run. Workers just resolve the URL — they never write to dist/.
+//
+// We still mtime-skip the build if dist/ is already fresh, so unit-only
+// `npx vitest run` invocations don't pay the build cost.
+
+import { spawnSync } from 'child_process';
+import { statSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+export default function setup(): void {
+  // Resolve the astros_api root from this file's location.
+  // here    -> .../astros_api/src/test_harness/global_setup.ts
+  // apiRoot -> .../astros_api/
+  const here = fileURLToPath(import.meta.url);
+  const apiRoot = resolve(dirname(here), '..', '..');
+  const distWorker = resolve(apiRoot, 'dist', 'background_tasks', 'serial_worker.js');
+  const srcWorker = resolve(apiRoot, 'src', 'background_tasks', 'serial_worker.js');
+
+  // Skip the build if dist/ is fresh (dist worker mtime >= src worker mtime).
+  try {
+    const distStat = statSync(distWorker);
+    const srcStat = statSync(srcWorker);
+    if (distStat.mtimeMs >= srcStat.mtimeMs) {
+      return;
+    }
+  } catch {
+    // dist/ missing or stat failed; fall through to build.
+  }
+
+  // Build it. `npm run build` runs the project's full pipeline (lint + tsc +
+  // tsc-alias). If lint fails, the build fails and the entire vitest run
+  // fails to start — that's correct: a failing lint should not silently
+  // produce a stale dist/.
+  const result = spawnSync('npm', ['run', 'build'], {
+    cwd: apiRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `vitest globalSetup: npm run build failed with code ${result.status}. ` +
+        `dist/ is required so integration tests can spawn the serial Worker — ` +
+        `tsx's loader does not propagate to Worker threads.`,
+    );
+  }
+
+  // Verify the Worker file exists post-build.
+  try {
+    statSync(distWorker);
+  } catch {
+    throw new Error(`vitest globalSetup: build completed but ${distWorker} is missing.`);
+  }
+}

--- a/astros_api/src/test_harness/global_setup.ts
+++ b/astros_api/src/test_harness/global_setup.ts
@@ -102,8 +102,9 @@ export default function setup(): void {
   // on any checkout without a local `.env` — `.env` is gitignored, so a
   // clean clone or CI runner without one would fail integration tests at
   // setup time. dist/.env is unreachable from the integration suite anyway:
-  // integration_harness.ts sets every env var the ApiServer reads directly
-  // on process.env before bootstrap, and Dotenv.config is non-overwriting.
+  // integration_harness.ts plumbs every per-instance value through
+  // ApiServer's `configOverrides` option, which takes precedence over both
+  // Dotenv-loaded values and any pre-existing process.env entries.
   //
   // We mirror prebuild's `rm -rf dist` so renamed/deleted src files don't
   // leave stale dist artifacts behind. Lint is intentionally skipped — it's

--- a/astros_api/src/test_harness/global_setup.ts
+++ b/astros_api/src/test_harness/global_setup.ts
@@ -14,13 +14,49 @@
 // its main process before any worker exists, so dist/ is stable for the
 // entire test run. Workers just resolve the URL — they never write to dist/.
 //
-// We still mtime-skip the build if dist/ is already fresh, so unit-only
-// `npx vitest run` invocations don't pay the build cost.
+// We still mtime-skip the build if dist/ is newer than every compilable
+// source file (see `newestCompiledMtime`) plus tsconfig.json / package.json,
+// so unit-only `npx vitest run` invocations don't pay the build cost.
+//
+// Not in the freshness check, intentionally: `.env` / `.env.test`. The build's
+// postbuild step copies them into dist/.env, but the integration harness
+// (integration_harness.ts) sets every env var the ApiServer reads directly
+// on process.env before bootstrap, and Dotenv.config is non-overwriting —
+// so dist/.env contents are unreachable from the integration suite. Adding
+// them to the check would force needless rebuilds when developers tweak
+// local .env files.
 
 import { spawnSync } from 'child_process';
-import { statSync } from 'fs';
+import { readdirSync, statSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
+
+// Walk a directory recursively and return the newest mtime among files that
+// would actually be compiled into dist/. Mirrors tsconfig.json's exclude list
+// (`**/*.test.ts`, `**/*.spec.ts`) so that editing a test file does not force
+// a rebuild — those files never end up in dist. If you change tsconfig.json's
+// exclude list, update this filter to match (and vice versa).
+//
+// Symlinks under src/ are intentionally skipped: `entry.isFile()` is false for
+// a symlink Dirent even when the target is a regular file, so they fall
+// through. There are none today, and skipping them avoids cyclic-symlink
+// recursion. If a future workflow needs them, switch to lstat + a realpath
+// visited-set guard.
+function newestCompiledMtime(dir: string): number {
+  let newest = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      newest = Math.max(newest, newestCompiledMtime(full));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) continue;
+    const m = statSync(full).mtimeMs;
+    if (m > newest) newest = m;
+  }
+  return newest;
+}
 
 export default function setup(): void {
   // The integration suite is Linux-only (see pty_pair.ts). Skip the build
@@ -37,14 +73,23 @@ export default function setup(): void {
   // apiRoot -> .../astros_api/
   const here = fileURLToPath(import.meta.url);
   const apiRoot = resolve(dirname(here), '..', '..');
+  const srcRoot = resolve(apiRoot, 'src');
   const distWorker = resolve(apiRoot, 'dist', 'background_tasks', 'serial_worker.js');
-  const srcWorker = resolve(apiRoot, 'src', 'background_tasks', 'serial_worker.js');
 
-  // Skip the build if dist/ is fresh (dist worker mtime >= src worker mtime).
+  // Skip the build only if dist/ is at least as new as every compilable source
+  // file plus tsconfig.json / package.json. The previous heuristic compared
+  // dist worker mtime to src worker mtime alone, which missed transitive deps
+  // — editing src/serial/serial_message_service.ts (imported by the worker)
+  // left dist stale while this check returned early. Walking src/ catches any
+  // change that would alter dist's contents; tsconfig.json and package.json
+  // are included because edits to either (compiler flags, TypeScript version)
+  // can also change dist output without touching any src/ file.
   try {
-    const distStat = statSync(distWorker);
-    const srcStat = statSync(srcWorker);
-    if (distStat.mtimeMs >= srcStat.mtimeMs) {
+    const distMtime = statSync(distWorker).mtimeMs;
+    const tsconfigMtime = statSync(resolve(apiRoot, 'tsconfig.json')).mtimeMs;
+    const packageMtime = statSync(resolve(apiRoot, 'package.json')).mtimeMs;
+    const newest = Math.max(newestCompiledMtime(srcRoot), tsconfigMtime, packageMtime);
+    if (distMtime >= newest) {
       return;
     }
   } catch {

--- a/astros_api/src/test_harness/integration_harness.test.ts
+++ b/astros_api/src/test_harness/integration_harness.test.ts
@@ -66,4 +66,33 @@ describe('integration harness', () => {
     },
     30_000, // generous timeout — first run may include a fresh build
   );
+
+  skipIfNotLinux(
+    'shutdown() completes promptly even when a WS client stays connected',
+    async () => {
+      // Pins the SIGTERM-doesn't-hang contract: ws.Server.close() refuses to
+      // invoke its callback until every client has disconnected, and
+      // http.Server.close() refuses to invoke its callback until every
+      // keep-alive connection drains. Without proactive teardown
+      // (terminate() on each ws client + closeAllConnections() on the
+      // http server), shutdown would hang indefinitely on any idle client.
+      //
+      // The other tests in this file go through `harness.dispose()`, which
+      // closes wsClient *before* invoking server.shutdown() — so they do
+      // not exercise the bug. Here we deliberately leave the client open
+      // and assert shutdown still completes within a generous bound.
+      harness = await bootIntegrationHarness();
+      expect(harness.wsClient.readyState).toBe(harness.wsClient.OPEN);
+
+      const start = Date.now();
+      await harness.server.shutdown();
+      const elapsed = Date.now() - start;
+
+      // Sub-second on a quiet machine; a few seconds covers slow CI. The
+      // bug was unbounded hang — anything in the seconds range proves the
+      // proactive-terminate path ran.
+      expect(elapsed).toBeLessThan(3000);
+    },
+    30_000,
+  );
 });

--- a/astros_api/src/test_harness/integration_harness.test.ts
+++ b/astros_api/src/test_harness/integration_harness.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { bootIntegrationHarness, type IntegrationHarness } from './integration_harness.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 describe('integration harness', () => {
   let harness: IntegrationHarness | undefined;
@@ -11,7 +11,7 @@ describe('integration harness', () => {
     harness = undefined;
   });
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'boots ApiServer + StubMaster, accepts WS, receives initial state, tears down',
     async () => {
       harness = await bootIntegrationHarness();
@@ -28,7 +28,7 @@ describe('integration harness', () => {
     30_000, // generous timeout — first boot includes a fresh `npm run build`
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'serial worker thread loads + does not error when receiving a POLL_ACK frame',
     async () => {
       harness = await bootIntegrationHarness();

--- a/astros_api/src/test_harness/integration_harness.test.ts
+++ b/astros_api/src/test_harness/integration_harness.test.ts
@@ -39,10 +39,12 @@ describe('integration harness', () => {
       // back through Worker postMessage to ApiServer.handleSerialWorkerMessage.
       //
       // We use a padawan MAC (NOT the master sentinel 00:00:..) so the frame
-      // exercises the controllers update path. The test's empty DB means no
-      // controller is registered, so the variant cache won't be populated,
-      // but the Worker must still parse and forward the message without
-      // crashing.
+      // exercises the controllers update path. The DB has no row for this
+      // MAC so handlePollResponse bails at the controller-existence check
+      // after the lookup, but the variant-cache `.set` and heartbeat-decision
+      // logic run *before* that lookup — so awaiting the cache entry proves
+      // the frame round-tripped through the Worker and was dispatched
+      // end-to-end, not just that the Worker didn't crash.
 
       harness.stub.writePollAck({
         mac: 'aa:bb:cc:dd:ee:ff',
@@ -50,17 +52,18 @@ describe('integration harness', () => {
         variant: 'astros-controller-v1',
       });
 
-      // Allow the wire round-trip to complete.
-      await new Promise((r) => setTimeout(r, 500));
+      // Deterministic wait: polls the variant cache instead of sleeping.
+      // Throws on timeout, so failure to dispatch surfaces clearly rather
+      // than as a no-op `expect.toEqual([])` pass.
+      await harness.waitForVariantCachePopulated('aa:bb:cc:dd:ee:ff', 'astros-controller-v1');
 
-      // The Worker MUST not have errored. An earlier vacuous version of this
-      // test passed despite ERR_MODULE_NOT_FOUND because it only checked
-      // `harness.server` was defined — anything could be defined. workerErrors
-      // is populated by ApiServer's onWorkerError callback whenever the Worker
-      // emits an 'error' event (e.g. failed to load, crashed processing the
-      // frame).
+      // Belt-and-suspenders: even after end-to-end dispatch succeeded, an
+      // earlier vacuous version of this test passed despite
+      // ERR_MODULE_NOT_FOUND because it only checked `harness.server` was
+      // defined. workerErrors is populated by ApiServer's onWorkerError
+      // callback whenever the Worker emits an 'error' event.
       expect(harness.workerErrors).toEqual([]);
     },
-    30_000, // bumped from 10s — first run includes a fresh `npm run build`
+    30_000, // generous timeout — first run may include a fresh build
   );
 });

--- a/astros_api/src/test_harness/integration_harness.test.ts
+++ b/astros_api/src/test_harness/integration_harness.test.ts
@@ -63,6 +63,13 @@ describe('integration harness', () => {
       // defined. workerErrors is populated by ApiServer's onWorkerError
       // callback whenever the Worker emits an 'error' event.
       expect(harness.workerErrors).toEqual([]);
+
+      // Also assert no stub-side parser errors. Wire-format drift between
+      // ApiServer's MessageGenerator and the stub's payload parsers would
+      // cause the stub to silently drop frames it can't ACK — tests would
+      // then time out with no hint why. Empty here is the load-bearing
+      // baseline; tests exercising FW_* paths should mirror this assertion.
+      expect(harness.stub.parsingErrors()).toEqual([]);
     },
     30_000, // generous timeout — first run may include a fresh build
   );

--- a/astros_api/src/test_harness/integration_harness.test.ts
+++ b/astros_api/src/test_harness/integration_harness.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { bootIntegrationHarness, type IntegrationHarness } from './integration_harness.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+describe('integration harness', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotPosix(
+    'boots ApiServer + StubMaster, accepts WS, receives initial state, tears down',
+    async () => {
+      harness = await bootIntegrationHarness();
+
+      // The server emits an initial `lockState` snapshot on WS connect (per
+      // api_server.ts websocket connection handler). Verify we receive it.
+      // Use loose matching: any message whose type field exists.
+      const msg = await harness.waitForWsMessage(
+        (m) => typeof (m as { type?: unknown })?.type !== 'undefined',
+        5000,
+      );
+      expect(msg).toBeDefined();
+    },
+    20_000, // generous timeout — first boot includes DB init + worker spawn
+  );
+});

--- a/astros_api/src/test_harness/integration_harness.test.ts
+++ b/astros_api/src/test_harness/integration_harness.test.ts
@@ -27,4 +27,44 @@ describe('integration harness', () => {
     },
     20_000, // generous timeout — first boot includes DB init + worker spawn
   );
+
+  skipIfNotPosix(
+    'serial worker thread loads + round-trips a POLL_ACK frame end-to-end',
+    async () => {
+      harness = await bootIntegrationHarness();
+
+      // The stub master emits a POLL_ACK on the master end of the PTY.
+      // It travels: stub serialport -> kernel PTY pair -> server-side serialport ->
+      // DelimiterParser -> serial_worker (PARSED via msgService.handleMessage) ->
+      // back through Worker postMessage to ApiServer.handleSerialWorkerMessage.
+      //
+      // If the Worker fails to load (e.g. ERR_MODULE_NOT_FOUND on `.ts`
+      // imports under tsx), the on('error') handler logs but the process
+      // doesn't crash — meaning the original smoke test passes even with a
+      // dead Worker. This test forces a wire-level round-trip so that a
+      // broken Worker would surface (the server would hold the PARSED-event
+      // promise indefinitely or never observe the frame).
+      //
+      // We use a padawan MAC (NOT the master sentinel 00:00:..) so the frame
+      // exercises the controllers update path. The test's empty DB means no
+      // controller is registered, so the variant cache won't be populated,
+      // but the Worker must still parse and forward the message without
+      // crashing.
+
+      harness.stub.writePollAck({
+        mac: 'aa:bb:cc:dd:ee:ff',
+        firmwareVersion: '1.5.0',
+        variant: 'astros-controller-v1',
+      });
+
+      // Allow the wire round-trip to complete.
+      await new Promise((r) => setTimeout(r, 500));
+
+      // The value of this test is purely "the Worker loaded and didn't
+      // crash on the first real frame". If the server is still alive and
+      // listening here, the Worker loaded successfully under tsx.
+      expect(harness.server).toBeDefined();
+    },
+    10_000,
+  );
 });

--- a/astros_api/src/test_harness/integration_harness.test.ts
+++ b/astros_api/src/test_harness/integration_harness.test.ts
@@ -25,11 +25,11 @@ describe('integration harness', () => {
       );
       expect(msg).toBeDefined();
     },
-    20_000, // generous timeout — first boot includes DB init + worker spawn
+    30_000, // generous timeout — first boot includes a fresh `npm run build`
   );
 
   skipIfNotPosix(
-    'serial worker thread loads + round-trips a POLL_ACK frame end-to-end',
+    'serial worker thread loads + does not error when receiving a POLL_ACK frame',
     async () => {
       harness = await bootIntegrationHarness();
 
@@ -37,13 +37,6 @@ describe('integration harness', () => {
       // It travels: stub serialport -> kernel PTY pair -> server-side serialport ->
       // DelimiterParser -> serial_worker (PARSED via msgService.handleMessage) ->
       // back through Worker postMessage to ApiServer.handleSerialWorkerMessage.
-      //
-      // If the Worker fails to load (e.g. ERR_MODULE_NOT_FOUND on `.ts`
-      // imports under tsx), the on('error') handler logs but the process
-      // doesn't crash — meaning the original smoke test passes even with a
-      // dead Worker. This test forces a wire-level round-trip so that a
-      // broken Worker would surface (the server would hold the PARSED-event
-      // promise indefinitely or never observe the frame).
       //
       // We use a padawan MAC (NOT the master sentinel 00:00:..) so the frame
       // exercises the controllers update path. The test's empty DB means no
@@ -60,11 +53,14 @@ describe('integration harness', () => {
       // Allow the wire round-trip to complete.
       await new Promise((r) => setTimeout(r, 500));
 
-      // The value of this test is purely "the Worker loaded and didn't
-      // crash on the first real frame". If the server is still alive and
-      // listening here, the Worker loaded successfully under tsx.
-      expect(harness.server).toBeDefined();
+      // The Worker MUST not have errored. An earlier vacuous version of this
+      // test passed despite ERR_MODULE_NOT_FOUND because it only checked
+      // `harness.server` was defined — anything could be defined. workerErrors
+      // is populated by ApiServer's onWorkerError callback whenever the Worker
+      // emits an 'error' event (e.g. failed to load, crashed processing the
+      // frame).
+      expect(harness.workerErrors).toEqual([]);
     },
-    10_000,
+    30_000, // bumped from 10s — first run includes a fresh `npm run build`
   );
 });

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -1,6 +1,6 @@
 // Boots a real ApiServer connected to a StubMaster via a PTY pair, exposes
 // HTTP + WebSocket clients for tests, and tears everything down cleanly on
-// dispose(). Linux/macOS only (inherits PTY pair platform constraint).
+// dispose(). Linux only (inherits PTY pair platform constraint).
 
 import { spawnSync } from 'child_process';
 import { createHash, randomUUID } from 'crypto';

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -1,0 +1,247 @@
+// Boots a real ApiServer connected to a StubMaster via a PTY pair, exposes
+// HTTP + WebSocket clients for tests, and tears everything down cleanly on
+// dispose(). Linux/macOS only (inherits PTY pair platform constraint).
+
+import { createServer } from 'net';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { WebSocket } from 'ws';
+
+import { ApiServer } from '../api_server.js';
+import { createPtyPair, type PtyPair } from './pty_pair.js';
+import { StubMaster } from './stub_master.js';
+
+export interface BootIntegrationHarnessOpts {
+  masterFirmwareVersion?: string; // default '1.0.0'
+  masterVariant?: string; // default 'astros-master-test-variant'
+  masterMac?: string; // default '00:00:00:00:00:00' (sentinel)
+  masterFingerprint?: string; // default 'master-stub'
+}
+
+export interface IntegrationHarness {
+  server: ApiServer;
+  stub: StubMaster;
+  pty: PtyPair;
+  httpBaseUrl: string;
+  wsClient: WebSocket;
+  receivedWsMessages: readonly unknown[];
+  waitForWsMessage<T = unknown>(
+    predicate: (msg: unknown) => boolean,
+    timeoutMs?: number,
+  ): Promise<T>;
+  dispose(): Promise<void>;
+}
+
+async function findFreePort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((err) => {
+        if (err) reject(err);
+        else if (port === 0) reject(new Error('findFreePort: failed to allocate'));
+        else resolve(port);
+      });
+    });
+  });
+}
+
+export async function bootIntegrationHarness(
+  opts: BootIntegrationHarnessOpts = {},
+): Promise<IntegrationHarness> {
+  // 1. PTY pair
+  const pty = await createPtyPair();
+
+  // 2. Random ports
+  const apiPort = await findFreePort();
+  const wsPort = await findFreePort();
+
+  // 3. Temp DB directory (so tests don't pollute ~/.config/astrosserver)
+  const dbDir = await mkdtemp(join(tmpdir(), 'astros-integration-'));
+
+  // 4. Set env vars for the ApiServer's bootstrap.
+  // NOTE: process.env is process-global, so concurrent harness boots in the
+  // same process would race. vitest doesn't run tests within the same file
+  // in parallel by default; each test sequentially boots+disposes.
+  const prevEnv = {
+    SERIAL_PORT: process.env.SERIAL_PORT,
+    BAUD_RATE: process.env.BAUD_RATE,
+    API_PORT: process.env.API_PORT,
+    WEBSOCKET_PORT: process.env.WEBSOCKET_PORT,
+    JWT_KEY: process.env.JWT_KEY,
+    DATABASE_PATH: process.env.DATABASE_PATH,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+  process.env.SERIAL_PORT = pty.serverPath;
+  process.env.BAUD_RATE = '9600';
+  process.env.API_PORT = String(apiPort);
+  process.env.WEBSOCKET_PORT = String(wsPort);
+  process.env.JWT_KEY = process.env.JWT_KEY ?? 'test-jwt-key';
+  process.env.DATABASE_PATH = dbDir;
+  // Important: do NOT set NODE_ENV='test' — that would skip setupSerialPort,
+  // which is the very thing we want to exercise. Override to undefined if it
+  // was set by vitest globals.
+  delete process.env.NODE_ENV;
+
+  let server: ApiServer | undefined;
+  let stub: StubMaster | undefined;
+  let wsClient: WebSocket | undefined;
+
+  try {
+    // 5. Boot ApiServer.
+    server = await ApiServer.bootstrap();
+
+    // 6. Construct + start StubMaster on the master end.
+    stub = new StubMaster({
+      ptyPath: pty.masterPath,
+      masterMac: opts.masterMac,
+      masterFingerprint: opts.masterFingerprint,
+      masterFirmwareVersion: opts.masterFirmwareVersion,
+      masterVariant: opts.masterVariant,
+    });
+    await stub.start();
+
+    // 7. Connect WS client + buffer messages. The message listener must be
+    // attached BEFORE the connection completes, because the server sends its
+    // initial `systemStatus` + `lockState` snapshot inside its 'connection'
+    // handler (which fires on handshake completion). If we awaited 'open'
+    // first and then registered the listener, those frames would emit before
+    // any consumer was listening and would be lost.
+    wsClient = new WebSocket(`ws://127.0.0.1:${wsPort}`);
+
+    const receivedWsMessages: unknown[] = [];
+    type Listener = (msg: unknown) => void;
+    const listeners: Listener[] = [];
+    wsClient.on('message', (data) => {
+      try {
+        const parsed: unknown = JSON.parse(data.toString());
+        receivedWsMessages.push(parsed);
+        for (const l of [...listeners]) l(parsed);
+      } catch {
+        // Ignore non-JSON frames (shouldn't happen — server emits JSON).
+      }
+    });
+
+    const ws = wsClient;
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', () => resolve());
+      ws.once('error', reject);
+    });
+
+    const waitForWsMessage = <T = unknown>(
+      predicate: (msg: unknown) => boolean,
+      timeoutMs = 5000,
+    ): Promise<T> => {
+      const existing = receivedWsMessages.find(predicate);
+      if (existing !== undefined) return Promise.resolve(existing as T);
+
+      return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const idx = listeners.indexOf(handler);
+          if (idx >= 0) listeners.splice(idx, 1);
+          const recent = receivedWsMessages
+            .slice(-10)
+            .map((m) => (m as { type?: unknown })?.type ?? '<no type>');
+          reject(
+            new Error(
+              `waitForWsMessage timed out after ${timeoutMs}ms. ` +
+                `Recent message types: ${JSON.stringify(recent)}`,
+            ),
+          );
+        }, timeoutMs);
+
+        const handler: Listener = (msg) => {
+          if (!predicate(msg)) return;
+          clearTimeout(timer);
+          const idx = listeners.indexOf(handler);
+          if (idx >= 0) listeners.splice(idx, 1);
+          resolve(msg as T);
+        };
+        listeners.push(handler);
+      });
+    };
+
+    const dispose = async (): Promise<void> => {
+      // Reverse-order teardown. Resilient: each step in its own try/catch so
+      // a failure in one doesn't leak the others.
+      try {
+        wsClient?.close();
+      } catch {
+        /* ignore */
+      }
+      try {
+        await stub?.dispose();
+      } catch {
+        /* ignore */
+      }
+      try {
+        await server?.shutdown();
+      } catch {
+        /* ignore */
+      }
+      try {
+        await pty.dispose();
+      } catch {
+        /* ignore */
+      }
+      try {
+        await rm(dbDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+
+      // Restore env vars to prevent leakage to other tests.
+      for (const [key, value] of Object.entries(prevEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    };
+
+    return {
+      server,
+      stub,
+      pty,
+      httpBaseUrl: `http://127.0.0.1:${apiPort}`,
+      wsClient,
+      receivedWsMessages,
+      waitForWsMessage,
+      dispose,
+    };
+  } catch (bootErr) {
+    // If anything fails mid-boot, tear down what we did set up.
+    try {
+      wsClient?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await stub?.dispose();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await server?.shutdown();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await pty.dispose();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await rm(dbDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+    for (const [key, value] of Object.entries(prevEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    throw bootErr;
+  }
+}

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -104,13 +104,17 @@ export interface IntegrationHarness {
     timeoutMs?: number,
     fromIndex?: number,
   ): Promise<T>;
-  // Seeds the FirmwareUploadStore (FIRMWARE_CACHE_PATH/uploads/) with a
-  // valid `upload-<uuid>.bin` + `.bin.sha256` + `.meta.json` triple so a
+  // Seeds the FirmwareUploadStore (under the harness's per-instance
+  // `firmwareCachePath` override / FIRMWARE_CACHE_PATH in production,
+  // plus the `/uploads` subdir) with a valid
+  // `upload-<uuid>.bin` + `.bin.sha256` + `.meta.json` triple so a
   // subsequent flash with `kind: 'upload'` resolves without going through
   // `store()` (which requires a real esp_app_desc_t header). Returns the
   // generated uploadId + sha256 so callers can cross-reference if needed.
   populateUpload(args: PopulateUploadArgs): Promise<{ uploadId: string; sha256: string }>;
-  // Seeds the FirmwareCache (FIRMWARE_CACHE_PATH/github/) with a valid
+  // Seeds the FirmwareCache (under the harness's per-instance
+  // `firmwareCachePath` override / FIRMWARE_CACHE_PATH in production,
+  // plus the `/github` subdir) with a valid
   // `astros-esp-<version>-<variant>-app.{bin,bin.sha256,meta.json}` triple so
   // a subsequent flash with `kind: 'github'` resolves via cache hit and
   // never attempts a download. Returns the computed sha256 so callers can

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -22,6 +22,13 @@ export interface BootIntegrationHarnessOpts {
   masterVariant?: string; // default 'astros-master-test-variant'
   masterMac?: string; // default '00:00:00:00:00:00' (sentinel)
   masterFingerprint?: string; // default 'master-stub'
+  /**
+   * Tests targeting `kind: 'github'` flashes inject a fake fetch that returns
+   * canned GitHub release JSON. Combined with `populateFirmwareCache` (below),
+   * this lets the test exercise the github source-resolution path without
+   * any network I/O.
+   */
+  firmwareReleaseFetcher?: typeof fetch;
 }
 
 // Args for `harness.populateUpload(...)` — used by integration tests that
@@ -37,6 +44,22 @@ export interface PopulateUploadArgs {
   originalFilename: string; // e.g. 'astros-esp-1.5.0.bin'
   version: string; // semver string in meta
   projectName?: string; // default 'AstrOs.ESP'
+}
+
+// Args for `harness.populateFirmwareCache(...)` — used by integration tests
+// that exercise the `kind: 'github'` source path. Pre-seeds the on-disk
+// firmware cache so `FirmwareCache.lookup()` returns a hit and `fetch()`
+// short-circuits without any download attempt. Mirrors the cache layout
+// produced by a real `fetch(release, asset)` so `lookup()`'s validations
+// (SHA256_HEX_RE on the .sha256 sidecar, isValidMeta on the .meta.json)
+// pass.
+export interface PopulateFirmwareCacheArgs {
+  binBytes: Buffer; // raw firmware bytes
+  version: string; // semver, e.g. '1.5.0' (no leading 'v')
+  variant: string; // PlatformIO env name, e.g. 'lolin_d32_pro'
+  tag?: string; // default `v${version}` (mirrors GitHub convention)
+  publishedAt?: string; // default new Date().toISOString()
+  sourceUrl?: string; // default a synthetic example.test URL
 }
 
 export interface IntegrationHarness {
@@ -65,6 +88,13 @@ export interface IntegrationHarness {
   // `store()` (which requires a real esp_app_desc_t header). Returns the
   // generated uploadId + sha256 so callers can cross-reference if needed.
   populateUpload(args: PopulateUploadArgs): Promise<{ uploadId: string; sha256: string }>;
+  // Seeds the FirmwareCache (FIRMWARE_CACHE_PATH/github/) with a valid
+  // `astros-esp-<version>-<variant>-app.{bin,bin.sha256,meta.json}` triple so
+  // a subsequent flash with `kind: 'github'` resolves via cache hit and
+  // never attempts a download. Returns the computed sha256 so callers can
+  // cross-reference if needed (the streamer will fail with hash_mismatch
+  // if the fixture's sidecar diverges from the actual bytes).
+  populateFirmwareCache(args: PopulateFirmwareCacheArgs): Promise<{ sha256: string }>;
   dispose(): Promise<void>;
 }
 
@@ -219,6 +249,7 @@ export async function bootIntegrationHarness(
     server = await ApiServer.bootstrap({
       workerScriptUrl,
       onWorkerError: (err) => workerErrors.push(err),
+      firmwareReleaseFetcher: opts?.firmwareReleaseFetcher,
     });
 
     // 6. Construct + start StubMaster on the master end.
@@ -321,6 +352,44 @@ export async function bootIntegrationHarness(
       return { uploadId, sha256 };
     };
 
+    // Closure over firmwareCacheDir, mirroring populateUpload's shape.
+    // Layout per firmware_cache.ts:
+    //   <cache>/github/astros-esp-<version>-<variant>-app.bin
+    //   <cache>/github/astros-esp-<version>-<variant>-app.bin.sha256
+    //   <cache>/github/astros-esp-<version>-<variant>-app.meta.json
+    // The sidecar contents satisfy lookup()'s SHA256_HEX_RE + isValidMeta
+    // checks so a subsequent FirmwareCache.fetch() short-circuits via
+    // lookup() without ever invoking its injected fetcher.
+    const populateFirmwareCache = async (
+      args: PopulateFirmwareCacheArgs,
+    ): Promise<{ sha256: string }> => {
+      const githubDir = join(firmwareCacheDir, 'github');
+      await mkdir(githubDir, { recursive: true });
+
+      const sha256 = createHash('sha256').update(args.binBytes).digest('hex');
+      const baseName = `astros-esp-${args.version}-${args.variant}-app`;
+      const tag = args.tag ?? `v${args.version}`;
+      const publishedAt = args.publishedAt ?? new Date().toISOString();
+      const sourceUrl = args.sourceUrl ?? `https://example.test/${baseName}.bin`;
+
+      await writeFile(join(githubDir, `${baseName}.bin`), args.binBytes);
+      await writeFile(join(githubDir, `${baseName}.bin.sha256`), sha256);
+      await writeFile(
+        join(githubDir, `${baseName}.meta.json`),
+        JSON.stringify({
+          tag,
+          version: args.version,
+          variant: args.variant,
+          downloadedAt: new Date().toISOString(),
+          publishedAt,
+          sourceUrl,
+          sizeBytes: args.binBytes.length,
+        }),
+      );
+
+      return { sha256 };
+    };
+
     const dispose = async (): Promise<void> => {
       // Reverse-order teardown. Resilient: each step in its own try/catch so
       // a failure in one doesn't leak the others.
@@ -373,6 +442,7 @@ export async function bootIntegrationHarness(
       workerErrors,
       waitForWsMessage,
       populateUpload,
+      populateFirmwareCache,
       dispose,
     };
   } catch (bootErr) {

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -29,6 +29,16 @@ export interface BootIntegrationHarnessOpts {
    * any network I/O.
    */
   firmwareReleaseFetcher?: typeof fetch;
+  /**
+   * Override the FlashJobOrchestrator's reboot-timeout / throttle-window to
+   * keep timer-fallback tests fast. Default reboot timeout is 15000ms;
+   * Task 10 / 11 set this to a small value (e.g. 1000ms) so a wrong-version
+   * heartbeat or no-heartbeat scenario doesn't burn 15 seconds of wall-clock.
+   */
+  flashOrchestratorConfig?: {
+    rebootTimeoutMs?: number;
+    throttleWindowMs?: number;
+  };
 }
 
 // Args for `harness.populateUpload(...)` — used by integration tests that
@@ -277,6 +287,7 @@ export async function bootIntegrationHarness(
       workerScriptUrl,
       onWorkerError: (err) => workerErrors.push(err),
       firmwareReleaseFetcher: opts?.firmwareReleaseFetcher,
+      flashOrchestratorConfig: opts?.flashOrchestratorConfig,
     });
 
     // 6. Construct + start StubMaster on the master end.

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -3,9 +3,11 @@
 // dispose(). Linux/macOS only (inherits PTY pair platform constraint).
 
 import { spawnSync } from 'child_process';
+import { createHash, randomUUID } from 'crypto';
 import { statSync } from 'fs';
 import { createServer } from 'net';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import jsonwebtoken from 'jsonwebtoken';
 import { tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -22,11 +24,30 @@ export interface BootIntegrationHarnessOpts {
   masterFingerprint?: string; // default 'master-stub'
 }
 
+// Args for `harness.populateUpload(...)` — used by integration tests that
+// need to seed the FirmwareUploadStore's single-slot directory directly
+// (bypassing the validate-and-promote path of `store()`). The triple
+// written to disk satisfies `FirmwareUploadStore.latest()`'s 4 cross-checks:
+//   1. UPLOAD_META_RE matches `upload-<uuidv4>.meta.json`
+//   2. .sha256 contents match `/^[0-9a-f]{64}$/`
+//   3. parsed.uploadId === uuid in filename
+//   4. parsed.sizeBytes === bin file size
+export interface PopulateUploadArgs {
+  binBytes: Buffer; // raw firmware bytes (test fixture content)
+  originalFilename: string; // e.g. 'astros-esp-1.5.0.bin'
+  version: string; // semver string in meta
+  projectName?: string; // default 'AstrOs.ESP'
+}
+
 export interface IntegrationHarness {
   server: ApiServer;
   stub: StubMaster;
   pty: PtyPair;
   httpBaseUrl: string;
+  // JWT signed with the same JWT_KEY the ApiServer reads from env, valid
+  // for 7 days. Tests pass `Authorization: Bearer ${authToken}` on
+  // protected routes (everything under /api except /api/auth/*).
+  authToken: string;
   wsClient: WebSocket;
   receivedWsMessages: readonly unknown[];
   // Errors emitted by the spawned serial Worker thread. Tests assert this is
@@ -38,6 +59,12 @@ export interface IntegrationHarness {
     predicate: (msg: unknown) => boolean,
     timeoutMs?: number,
   ): Promise<T>;
+  // Seeds the FirmwareUploadStore (FIRMWARE_CACHE_PATH/uploads/) with a
+  // valid `upload-<uuid>.bin` + `.bin.sha256` + `.meta.json` triple so a
+  // subsequent flash with `kind: 'upload'` resolves without going through
+  // `store()` (which requires a real esp_app_desc_t header). Returns the
+  // generated uploadId + sha256 so callers can cross-reference if needed.
+  populateUpload(args: PopulateUploadArgs): Promise<{ uploadId: string; sha256: string }>;
   dispose(): Promise<void>;
 }
 
@@ -132,6 +159,12 @@ export async function bootIntegrationHarness(
   // 3. Temp DB directory (so tests don't pollute ~/.config/astrosserver)
   const dbDir = await mkdtemp(join(tmpdir(), 'astros-integration-'));
 
+  // 3b. Temp firmware-cache directory. FirmwareCache + FirmwareUploadStore
+  //     are constructed during ApiServer.bootstrap and read this env var
+  //     at construction time, so it must be set BEFORE bootstrap is called.
+  //     Cleaned up in dispose alongside dbDir.
+  const firmwareCacheDir = await mkdtemp(join(tmpdir(), 'astros-fwcache-'));
+
   // 4. Set env vars for the ApiServer's bootstrap.
   // NOTE: process.env is process-global, so concurrent harness boots in the
   // same process would race. vitest doesn't run tests within the same file
@@ -143,18 +176,34 @@ export async function bootIntegrationHarness(
     WEBSOCKET_PORT: process.env.WEBSOCKET_PORT,
     JWT_KEY: process.env.JWT_KEY,
     DATABASE_PATH: process.env.DATABASE_PATH,
+    FIRMWARE_CACHE_PATH: process.env.FIRMWARE_CACHE_PATH,
     NODE_ENV: process.env.NODE_ENV,
   };
   process.env.SERIAL_PORT = pty.serverPath;
   process.env.BAUD_RATE = '9600';
   process.env.API_PORT = String(apiPort);
   process.env.WEBSOCKET_PORT = String(wsPort);
-  process.env.JWT_KEY = process.env.JWT_KEY ?? 'test-jwt-key';
+  const jwtKey = process.env.JWT_KEY ?? 'test-jwt-key';
+  process.env.JWT_KEY = jwtKey;
   process.env.DATABASE_PATH = dbDir;
+  process.env.FIRMWARE_CACHE_PATH = firmwareCacheDir;
   // Important: do NOT set NODE_ENV='test' — that would skip setupSerialPort,
   // which is the very thing we want to exercise. Override to undefined if it
   // was set by vitest globals.
   delete process.env.NODE_ENV;
+
+  // 4b. Generate a long-lived JWT signed with the same JWT_KEY the
+  //     ApiServer reads. Mirrors `User.generateJwt()` in models/users.ts so
+  //     the express-jwt middleware on /api routes accepts it identically.
+  //     Done before bootstrap so the harness can return the token even if
+  //     bootstrap fails partway (the token itself doesn't depend on server
+  //     state — it's just a signed envelope).
+  const jwtExpiry = new Date();
+  jwtExpiry.setDate(jwtExpiry.getDate() + 7);
+  const authToken = jsonwebtoken.sign(
+    { name: 'integration-test', exp: jwtExpiry.getTime() / 1000 },
+    jwtKey,
+  );
 
   let server: ApiServer | undefined;
   let stub: StubMaster | undefined;
@@ -242,6 +291,36 @@ export async function bootIntegrationHarness(
       });
     };
 
+    // Closure over firmwareCacheDir: each test gets a fresh harness with a
+    // fresh cache dir, so populateUpload always writes into the dir the
+    // ApiServer's FirmwareUploadStore is reading from.
+    const populateUpload = async (
+      args: PopulateUploadArgs,
+    ): Promise<{ uploadId: string; sha256: string }> => {
+      const uploadId = randomUUID();
+      const uploadsDir = join(firmwareCacheDir, 'uploads');
+      await mkdir(uploadsDir, { recursive: true });
+
+      const sha256 = createHash('sha256').update(args.binBytes).digest('hex');
+      const baseName = `upload-${uploadId}`;
+
+      await writeFile(join(uploadsDir, `${baseName}.bin`), args.binBytes);
+      await writeFile(join(uploadsDir, `${baseName}.bin.sha256`), sha256);
+      await writeFile(
+        join(uploadsDir, `${baseName}.meta.json`),
+        JSON.stringify({
+          uploadId,
+          originalFilename: args.originalFilename,
+          projectName: args.projectName ?? 'AstrOs.ESP',
+          version: args.version,
+          uploadedAt: new Date().toISOString(),
+          sizeBytes: args.binBytes.length,
+        }),
+      );
+
+      return { uploadId, sha256 };
+    };
+
     const dispose = async (): Promise<void> => {
       // Reverse-order teardown. Resilient: each step in its own try/catch so
       // a failure in one doesn't leak the others.
@@ -270,6 +349,11 @@ export async function bootIntegrationHarness(
       } catch {
         /* ignore */
       }
+      try {
+        await rm(firmwareCacheDir, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
 
       // Restore env vars to prevent leakage to other tests.
       for (const [key, value] of Object.entries(prevEnv)) {
@@ -283,10 +367,12 @@ export async function bootIntegrationHarness(
       stub,
       pty,
       httpBaseUrl: `http://127.0.0.1:${apiPort}`,
+      authToken,
       wsClient,
       receivedWsMessages,
       workerErrors,
       waitForWsMessage,
+      populateUpload,
       dispose,
     };
   } catch (bootErr) {
@@ -313,6 +399,11 @@ export async function bootIntegrationHarness(
     }
     try {
       await rm(dbDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+    try {
+      await rm(firmwareCacheDir, { recursive: true, force: true });
     } catch {
       /* ignore */
     }

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -180,46 +180,38 @@ export async function bootIntegrationHarness(
   // 2. Temp DB directory (so tests don't pollute ~/.config/astrosserver)
   const dbDir = await mkdtemp(join(tmpdir(), 'astros-integration-'));
 
-  // 2b. Temp firmware-cache directory. FirmwareCache + FirmwareUploadStore
-  //     are constructed during ApiServer.bootstrap and read this env var
-  //     at construction time, so it must be set BEFORE bootstrap is called.
-  //     Cleaned up in dispose alongside dbDir.
+  // 2b. Temp firmware-cache directory. Passed via configOverrides below so
+  //     the harness doesn't need to mutate process.env. Cleaned up in
+  //     dispose alongside dbDir.
   const firmwareCacheDir = await mkdtemp(join(tmpdir(), 'astros-fwcache-'));
 
-  // 3. Set env vars for the ApiServer's bootstrap.
-  // NOTE: process.env is process-global, so concurrent harness boots in the
-  // same process would race. vitest doesn't run tests within the same file
-  // in parallel by default; each test sequentially boots+disposes.
+  // 3. Per-instance test config, passed to ApiServer via `configOverrides`.
+  //    The harness deliberately does NOT mutate process.env: env mutations
+  //    are process-global, so two harnesses booting concurrently (in any
+  //    test pool that shares process.env across workers, today or in the
+  //    future) would clobber each other's SERIAL_PORT / DATABASE_PATH /
+  //    etc. Plumbing the values through configOverrides keeps each
+  //    ApiServer instance hermetic.
   //
-  // API_PORT='0' / WEBSOCKET_PORT='0' tells ApiServer to ask the kernel for
-  // an ephemeral port. The harness reads back the actual ports via
-  // server.getBoundApiPort()/getBoundWebsocketPort() AFTER bootstrap. This
-  // avoids a TOCTOU race: a "find free port, then bind it later" scheme
-  // closes the probe socket before the real bind, leaving a window for any
-  // other process (or sibling vitest worker) to grab the port and cause
-  // EADDRINUSE on bootstrap.
-  const prevEnv = {
-    SERIAL_PORT: process.env.SERIAL_PORT,
-    BAUD_RATE: process.env.BAUD_RATE,
-    API_PORT: process.env.API_PORT,
-    WEBSOCKET_PORT: process.env.WEBSOCKET_PORT,
-    JWT_KEY: process.env.JWT_KEY,
-    DATABASE_PATH: process.env.DATABASE_PATH,
-    FIRMWARE_CACHE_PATH: process.env.FIRMWARE_CACHE_PATH,
-    NODE_ENV: process.env.NODE_ENV,
-  };
-  process.env.SERIAL_PORT = pty.serverPath;
-  process.env.BAUD_RATE = '9600';
-  process.env.API_PORT = '0';
-  process.env.WEBSOCKET_PORT = '0';
+  //    apiPort/websocketPort = 0 ask the kernel for ephemeral ports; the
+  //    harness reads back the actual ports via getBoundApiPort/
+  //    getBoundWebsocketPort after bootstrap completes (this also closes
+  //    the TOCTOU race a "find free port, then bind later" scheme has).
+  //
+  //    skipSerialSetup is set explicitly to false. Vitest defaults
+  //    NODE_ENV='test', which would otherwise short-circuit serial-port
+  //    setup — the very thing this harness is exercising.
   const jwtKey = process.env.JWT_KEY ?? 'test-jwt-key';
-  process.env.JWT_KEY = jwtKey;
-  process.env.DATABASE_PATH = dbDir;
-  process.env.FIRMWARE_CACHE_PATH = firmwareCacheDir;
-  // Important: do NOT set NODE_ENV='test' — that would skip setupSerialPort,
-  // which is the very thing we want to exercise. Override to undefined if it
-  // was set by vitest globals.
-  delete process.env.NODE_ENV;
+  const configOverrides = {
+    serialPort: pty.serverPath,
+    baudRate: 9600,
+    apiPort: 0,
+    websocketPort: 0,
+    jwtKey,
+    databasePath: join(dbDir, 'database.sqlite3'),
+    firmwareCachePath: firmwareCacheDir,
+    skipSerialSetup: false,
+  };
 
   // 3b. Generate a long-lived JWT signed with the same JWT_KEY the
   //     ApiServer reads. Mirrors `User.generateJwt()` in models/users.ts so
@@ -252,6 +244,7 @@ export async function bootIntegrationHarness(
       onWorkerError: (err) => workerErrors.push(err),
       firmwareReleaseFetcher: opts?.firmwareReleaseFetcher,
       flashOrchestratorConfig: opts?.flashOrchestratorConfig,
+      configOverrides,
     });
 
     // 4b. Read back the kernel-assigned ports (we asked for 0). These are
@@ -439,12 +432,6 @@ export async function bootIntegrationHarness(
       } catch {
         /* ignore */
       }
-
-      // Restore env vars to prevent leakage to other tests.
-      for (const [key, value] of Object.entries(prevEnv)) {
-        if (value === undefined) delete process.env[key];
-        else process.env[key] = value;
-      }
     };
 
     const waitForVariantCachePopulated = async (
@@ -522,10 +509,6 @@ export async function bootIntegrationHarness(
       await rm(firmwareCacheDir, { recursive: true, force: true });
     } catch {
       /* ignore */
-    }
-    for (const [key, value] of Object.entries(prevEnv)) {
-      if (value === undefined) delete process.env[key];
-      else process.env[key] = value;
     }
     throw bootErr;
   }

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -2,10 +2,13 @@
 // HTTP + WebSocket clients for tests, and tears everything down cleanly on
 // dispose(). Linux/macOS only (inherits PTY pair platform constraint).
 
+import { spawnSync } from 'child_process';
+import { statSync } from 'fs';
 import { createServer } from 'net';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { WebSocket } from 'ws';
 
 import { ApiServer } from '../api_server.js';
@@ -26,11 +29,73 @@ export interface IntegrationHarness {
   httpBaseUrl: string;
   wsClient: WebSocket;
   receivedWsMessages: readonly unknown[];
+  // Errors emitted by the spawned serial Worker thread. Tests assert this is
+  // empty so a Worker that fails to load (e.g. ERR_MODULE_NOT_FOUND) surfaces
+  // as a test failure rather than a silent log line. Mutated in-place by the
+  // ApiServer's onWorkerError callback during the harness lifetime.
+  workerErrors: readonly Error[];
   waitForWsMessage<T = unknown>(
     predicate: (msg: unknown) => boolean,
     timeoutMs?: number,
   ): Promise<T>;
   dispose(): Promise<void>;
+}
+
+/**
+ * The integration harness boots a real ApiServer which spawns a serial Worker.
+ * Worker threads under vitest+tsx cannot resolve the `.js`-style imports in
+ * src/background_tasks/serial_worker.js — the tsx loader hooks do not propagate
+ * to Worker threads. Workaround: build dist/ first and point the Worker at the
+ * compiled JS instead.
+ *
+ * The build is only run if dist/background_tasks/serial_worker.js is missing
+ * or older than its src/ counterpart. Warm rebuilds are skipped so subsequent
+ * test runs don't pay the build cost.
+ */
+function ensureDistBuilt(): URL {
+  // Resolve the astros_api root from this file's location.
+  // here     -> .../astros_api/src/test_harness/integration_harness.ts
+  // apiRoot  -> .../astros_api/
+  const here = fileURLToPath(import.meta.url);
+  const apiRoot = resolve(dirname(here), '..', '..');
+  const distWorker = resolve(apiRoot, 'dist', 'background_tasks', 'serial_worker.js');
+  const srcWorker = resolve(apiRoot, 'src', 'background_tasks', 'serial_worker.js');
+
+  // Skip the build if dist/ is fresh (dist worker mtime >= src worker mtime).
+  try {
+    const distStat = statSync(distWorker);
+    const srcStat = statSync(srcWorker);
+    if (distStat.mtimeMs >= srcStat.mtimeMs) {
+      return pathToFileURL(distWorker);
+    }
+  } catch {
+    // dist/ missing or stat failed; fall through to build.
+  }
+
+  // Build it. `npm run build` runs the project's full pipeline (lint + tsc +
+  // tsc-alias). If lint fails, the build fails and the harness fails to
+  // boot — that's correct: a failing lint should not silently produce a
+  // stale dist/.
+  const result = spawnSync('npm', ['run', 'build'], {
+    cwd: apiRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Integration harness: npm run build failed with code ${result.status}. ` +
+        `dist/ is required to spawn the serial Worker because tsx's loader does ` +
+        `not propagate to Worker threads.`,
+    );
+  }
+
+  // Verify the Worker file exists post-build.
+  try {
+    statSync(distWorker);
+  } catch {
+    throw new Error(`Integration harness: build completed but ${distWorker} is missing.`);
+  }
+  return pathToFileURL(distWorker);
 }
 
 async function findFreePort(): Promise<number> {
@@ -53,6 +118,10 @@ async function findFreePort(): Promise<number> {
 export async function bootIntegrationHarness(
   opts: BootIntegrationHarnessOpts = {},
 ): Promise<IntegrationHarness> {
+  // 0. Ensure dist/ is built so the spawned serial Worker can actually load
+  //    its imports under vitest+tsx. See ensureDistBuilt() for rationale.
+  const workerScriptUrl = ensureDistBuilt();
+
   // 1. PTY pair
   const pty = await createPtyPair();
 
@@ -91,9 +160,17 @@ export async function bootIntegrationHarness(
   let stub: StubMaster | undefined;
   let wsClient: WebSocket | undefined;
 
+  // Captures any 'error' events from the spawned serial Worker thread. The
+  // round-trip test asserts this stays empty: a Worker that died with
+  // ERR_MODULE_NOT_FOUND would otherwise pass test assertions silently.
+  const workerErrors: Error[] = [];
+
   try {
     // 5. Boot ApiServer.
-    server = await ApiServer.bootstrap();
+    server = await ApiServer.bootstrap({
+      workerScriptUrl,
+      onWorkerError: (err) => workerErrors.push(err),
+    });
 
     // 6. Construct + start StubMaster on the master end.
     stub = new StubMaster({
@@ -208,6 +285,7 @@ export async function bootIntegrationHarness(
       httpBaseUrl: `http://127.0.0.1:${apiPort}`,
       wsClient,
       receivedWsMessages,
+      workerErrors,
       waitForWsMessage,
       dispose,
     };

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -2,7 +2,6 @@
 // HTTP + WebSocket clients for tests, and tears everything down cleanly on
 // dispose(). Linux only (inherits PTY pair platform constraint).
 
-import { spawnSync } from 'child_process';
 import { createHash, randomUUID } from 'crypto';
 import { statSync } from 'fs';
 import { createServer } from 'net';
@@ -137,58 +136,33 @@ export interface IntegrationHarness {
 }
 
 /**
- * The integration harness boots a real ApiServer which spawns a serial Worker.
- * Worker threads under vitest+tsx cannot resolve the `.js`-style imports in
- * src/background_tasks/serial_worker.js — the tsx loader hooks do not propagate
- * to Worker threads. Workaround: build dist/ first and point the Worker at the
- * compiled JS instead.
+ * Resolve the dist Worker URL the harness will pass to ApiServer. The build
+ * itself happens in vitest's globalSetup (see global_setup.ts) so it runs
+ * once in the main process before any worker thread spawns; this function
+ * is read-only.
  *
- * The build is only run if dist/background_tasks/serial_worker.js is missing
- * or older than its src/ counterpart. Warm rebuilds are skipped so subsequent
- * test runs don't pay the build cost.
+ * Why a separate globalSetup instead of building here: vitest runs test
+ * files in parallel worker threads, and `npm run build` includes a
+ * `prebuild` step that does `rm -rf dist`. If two workers raced on the
+ * build, one would delete dist/ while another was mid-spawn of the Worker
+ * pointing at it — ERR_MODULE_NOT_FOUND on a half-deleted tree.
  */
-function ensureDistBuilt(): URL {
+function resolveDistWorkerUrl(): URL {
   // Resolve the astros_api root from this file's location.
   // here     -> .../astros_api/src/test_harness/integration_harness.ts
   // apiRoot  -> .../astros_api/
   const here = fileURLToPath(import.meta.url);
   const apiRoot = resolve(dirname(here), '..', '..');
   const distWorker = resolve(apiRoot, 'dist', 'background_tasks', 'serial_worker.js');
-  const srcWorker = resolve(apiRoot, 'src', 'background_tasks', 'serial_worker.js');
 
-  // Skip the build if dist/ is fresh (dist worker mtime >= src worker mtime).
-  try {
-    const distStat = statSync(distWorker);
-    const srcStat = statSync(srcWorker);
-    if (distStat.mtimeMs >= srcStat.mtimeMs) {
-      return pathToFileURL(distWorker);
-    }
-  } catch {
-    // dist/ missing or stat failed; fall through to build.
-  }
-
-  // Build it. `npm run build` runs the project's full pipeline (lint + tsc +
-  // tsc-alias). If lint fails, the build fails and the harness fails to
-  // boot — that's correct: a failing lint should not silently produce a
-  // stale dist/.
-  const result = spawnSync('npm', ['run', 'build'], {
-    cwd: apiRoot,
-    stdio: 'inherit',
-    env: process.env,
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `Integration harness: npm run build failed with code ${result.status}. ` +
-        `dist/ is required to spawn the serial Worker because tsx's loader does ` +
-        `not propagate to Worker threads.`,
-    );
-  }
-
-  // Verify the Worker file exists post-build.
   try {
     statSync(distWorker);
   } catch {
-    throw new Error(`Integration harness: build completed but ${distWorker} is missing.`);
+    throw new Error(
+      `Integration harness: ${distWorker} is missing. ` +
+        `vitest's globalSetup (src/test_harness/global_setup.ts) should have built it; ` +
+        `if you're running the harness outside vitest, run \`npm run build\` first.`,
+    );
   }
   return pathToFileURL(distWorker);
 }
@@ -213,9 +187,10 @@ async function findFreePort(): Promise<number> {
 export async function bootIntegrationHarness(
   opts: BootIntegrationHarnessOpts = {},
 ): Promise<IntegrationHarness> {
-  // 0. Ensure dist/ is built so the spawned serial Worker can actually load
-  //    its imports under vitest+tsx. See ensureDistBuilt() for rationale.
-  const workerScriptUrl = ensureDistBuilt();
+  // 0. Resolve the dist Worker URL. The build itself runs in vitest's
+  //    globalSetup before any worker thread spawns; we just point the
+  //    spawned ApiServer at the existing artifact here.
+  const workerScriptUrl = resolveDistWorkerUrl();
 
   // 1. PTY pair
   const pty = await createPtyPair();

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -78,9 +78,22 @@ export interface IntegrationHarness {
   // as a test failure rather than a silent log line. Mutated in-place by the
   // ApiServer's onWorkerError callback during the harness lifetime.
   workerErrors: readonly Error[];
+  /**
+   * Resolves with the next inbound WS frame matching `predicate`, or rejects
+   * after `timeoutMs` (default 5s) listing the last 10 received message types.
+   *
+   * Pass `fromIndex` to ignore everything already in `receivedWsMessages` up
+   * to (but not including) that index. Used to avoid matching connection-time
+   * snapshots when the test wants the result of an action it just initiated.
+   * Pattern:
+   *   const snapshot = harness.receivedWsMessages.length;
+   *   harness.stub.writePollAck({ firmwareVersion: '1.5.0' });
+   *   const released = await harness.waitForWsMessage(predicate, 5000, snapshot);
+   */
   waitForWsMessage<T = unknown>(
     predicate: (msg: unknown) => boolean,
     timeoutMs?: number,
+    fromIndex?: number,
   ): Promise<T>;
   // Seeds the FirmwareUploadStore (FIRMWARE_CACHE_PATH/uploads/) with a
   // valid `upload-<uuid>.bin` + `.bin.sha256` + `.meta.json` triple so a
@@ -95,6 +108,20 @@ export interface IntegrationHarness {
   // cross-reference if needed (the streamer will fail with hash_mismatch
   // if the fixture's sidecar diverges from the actual bytes).
   populateFirmwareCache(args: PopulateFirmwareCacheArgs): Promise<{ sha256: string }>;
+  /**
+   * Poll-waits up to `timeoutMs` for the ApiServer's controllerVariantCache
+   * to contain `mac` with the expected `variant`. The cache is populated
+   * asynchronously by handlePollResponse after a POLL_ACK arrives; under
+   * vitest's parallel-thread load, an arbitrary sleep after `stub.writePollAck`
+   * isn't reliable. This helper is the deterministic alternative.
+   *
+   * Throws on timeout (default 3000ms).
+   */
+  waitForVariantCachePopulated(
+    mac: string,
+    expectedVariant: string,
+    timeoutMs?: number,
+  ): Promise<void>;
   dispose(): Promise<void>;
 }
 
@@ -292,9 +319,17 @@ export async function bootIntegrationHarness(
     const waitForWsMessage = <T = unknown>(
       predicate: (msg: unknown) => boolean,
       timeoutMs = 5000,
+      fromIndex = 0,
     ): Promise<T> => {
-      const existing = receivedWsMessages.find(predicate);
-      if (existing !== undefined) return Promise.resolve(existing as T);
+      // Existing-scan ignores anything before fromIndex so a test waiting for
+      // the result of an action it just initiated doesn't match a connect-time
+      // snapshot frame (e.g. the WS server emits lockStateChanged{locked:false}
+      // on connect — without fromIndex, a post-flash heartbeat-release wait
+      // would resolve immediately on that buffered frame).
+      for (let i = fromIndex; i < receivedWsMessages.length; i++) {
+        const msg = receivedWsMessages[i];
+        if (predicate(msg)) return Promise.resolve(msg as T);
+      }
 
       return new Promise<T>((resolve, reject) => {
         const timer = setTimeout(() => {
@@ -431,6 +466,35 @@ export async function bootIntegrationHarness(
       }
     };
 
+    const waitForVariantCachePopulated = async (
+      mac: string,
+      expectedVariant: string,
+      timeoutMs = 3000,
+    ): Promise<void> => {
+      const startedAt = Date.now();
+      // 25ms poll: the round-trip (PTY → DelimiterParser → Worker postMessage
+      // → handlePollResponse → cache.set) is sub-millisecond on a quiet
+      // machine but can stretch under vitest's parallel-thread load.
+      const pollIntervalMs = 25;
+      // Bind the server reference here — the outer `server` is reassigned
+      // by the bootstrap path so TS can't narrow the closure capture.
+      const apiServer = server;
+      if (apiServer === undefined) {
+        throw new Error('waitForVariantCachePopulated: harness server not bootstrapped');
+      }
+      while (Date.now() - startedAt < timeoutMs) {
+        if (apiServer.getVariantForControllerForTest(mac) === expectedVariant) {
+          return;
+        }
+        await new Promise((r) => setTimeout(r, pollIntervalMs));
+      }
+      const actual = apiServer.getVariantForControllerForTest(mac);
+      throw new Error(
+        `waitForVariantCachePopulated: cache for mac=${mac} did not reach variant=${expectedVariant} within ${timeoutMs}ms ` +
+          `(actual=${actual === undefined ? '<missing>' : actual})`,
+      );
+    };
+
     return {
       server,
       stub,
@@ -443,6 +507,7 @@ export async function bootIntegrationHarness(
       waitForWsMessage,
       populateUpload,
       populateFirmwareCache,
+      waitForVariantCachePopulated,
       dispose,
     };
   } catch (bootErr) {

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -4,7 +4,6 @@
 
 import { createHash, randomUUID } from 'crypto';
 import { statSync } from 'fs';
-import { createServer } from 'net';
 import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import jsonwebtoken from 'jsonwebtoken';
 import { tmpdir } from 'os';
@@ -167,23 +166,6 @@ function resolveDistWorkerUrl(): URL {
   return pathToFileURL(distWorker);
 }
 
-async function findFreePort(): Promise<number> {
-  return new Promise<number>((resolve, reject) => {
-    const server = createServer();
-    server.unref();
-    server.on('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address();
-      const port = typeof address === 'object' && address ? address.port : 0;
-      server.close((err) => {
-        if (err) reject(err);
-        else if (port === 0) reject(new Error('findFreePort: failed to allocate'));
-        else resolve(port);
-      });
-    });
-  });
-}
-
 export async function bootIntegrationHarness(
   opts: BootIntegrationHarnessOpts = {},
 ): Promise<IntegrationHarness> {
@@ -195,23 +177,27 @@ export async function bootIntegrationHarness(
   // 1. PTY pair
   const pty = await createPtyPair();
 
-  // 2. Random ports
-  const apiPort = await findFreePort();
-  const wsPort = await findFreePort();
-
-  // 3. Temp DB directory (so tests don't pollute ~/.config/astrosserver)
+  // 2. Temp DB directory (so tests don't pollute ~/.config/astrosserver)
   const dbDir = await mkdtemp(join(tmpdir(), 'astros-integration-'));
 
-  // 3b. Temp firmware-cache directory. FirmwareCache + FirmwareUploadStore
+  // 2b. Temp firmware-cache directory. FirmwareCache + FirmwareUploadStore
   //     are constructed during ApiServer.bootstrap and read this env var
   //     at construction time, so it must be set BEFORE bootstrap is called.
   //     Cleaned up in dispose alongside dbDir.
   const firmwareCacheDir = await mkdtemp(join(tmpdir(), 'astros-fwcache-'));
 
-  // 4. Set env vars for the ApiServer's bootstrap.
+  // 3. Set env vars for the ApiServer's bootstrap.
   // NOTE: process.env is process-global, so concurrent harness boots in the
   // same process would race. vitest doesn't run tests within the same file
   // in parallel by default; each test sequentially boots+disposes.
+  //
+  // API_PORT='0' / WEBSOCKET_PORT='0' tells ApiServer to ask the kernel for
+  // an ephemeral port. The harness reads back the actual ports via
+  // server.getBoundApiPort()/getBoundWebsocketPort() AFTER bootstrap. This
+  // avoids a TOCTOU race: a "find free port, then bind it later" scheme
+  // closes the probe socket before the real bind, leaving a window for any
+  // other process (or sibling vitest worker) to grab the port and cause
+  // EADDRINUSE on bootstrap.
   const prevEnv = {
     SERIAL_PORT: process.env.SERIAL_PORT,
     BAUD_RATE: process.env.BAUD_RATE,
@@ -224,8 +210,8 @@ export async function bootIntegrationHarness(
   };
   process.env.SERIAL_PORT = pty.serverPath;
   process.env.BAUD_RATE = '9600';
-  process.env.API_PORT = String(apiPort);
-  process.env.WEBSOCKET_PORT = String(wsPort);
+  process.env.API_PORT = '0';
+  process.env.WEBSOCKET_PORT = '0';
   const jwtKey = process.env.JWT_KEY ?? 'test-jwt-key';
   process.env.JWT_KEY = jwtKey;
   process.env.DATABASE_PATH = dbDir;
@@ -235,7 +221,7 @@ export async function bootIntegrationHarness(
   // was set by vitest globals.
   delete process.env.NODE_ENV;
 
-  // 4b. Generate a long-lived JWT signed with the same JWT_KEY the
+  // 3b. Generate a long-lived JWT signed with the same JWT_KEY the
   //     ApiServer reads. Mirrors `User.generateJwt()` in models/users.ts so
   //     the express-jwt middleware on /api routes accepts it identically.
   //     Done before bootstrap so the harness can return the token even if
@@ -258,7 +244,9 @@ export async function bootIntegrationHarness(
   const workerErrors: Error[] = [];
 
   try {
-    // 5. Boot ApiServer.
+    // 4. Boot ApiServer. bootstrap() awaits both binds (HTTP listen + WS
+    //    'listening'), so it rejects on EADDRINUSE rather than returning a
+    //    server that's mid-bind.
     server = await ApiServer.bootstrap({
       workerScriptUrl,
       onWorkerError: (err) => workerErrors.push(err),
@@ -266,7 +254,13 @@ export async function bootIntegrationHarness(
       flashOrchestratorConfig: opts?.flashOrchestratorConfig,
     });
 
-    // 6. Construct + start StubMaster on the master end.
+    // 4b. Read back the kernel-assigned ports (we asked for 0). These are
+    //     used to construct httpBaseUrl and the WS client URL below; before
+    //     bootstrap returned they would have been 0, useless to the caller.
+    const apiPort = server.getBoundApiPort();
+    const wsPort = server.getBoundWebsocketPort();
+
+    // 5. Construct + start StubMaster on the master end.
     stub = new StubMaster({
       ptyPath: pty.masterPath,
       masterMac: opts.masterMac,
@@ -276,7 +270,7 @@ export async function bootIntegrationHarness(
     });
     await stub.start();
 
-    // 7. Connect WS client + buffer messages. The message listener must be
+    // 6. Connect WS client + buffer messages. The message listener must be
     // attached BEFORE the connection completes, because the server sends its
     // initial `systemStatus` + `lockState` snapshot inside its 'connection'
     // handler (which fires on handshake completion). If we awaited 'open'

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -32,8 +32,9 @@ export interface BootIntegrationHarnessOpts {
   /**
    * Override the FlashJobOrchestrator's reboot-timeout / throttle-window to
    * keep timer-fallback tests fast. Default reboot timeout is 15000ms;
-   * Task 10 / 11 set this to a small value (e.g. 1000ms) so a wrong-version
-   * heartbeat or no-heartbeat scenario doesn't burn 15 seconds of wall-clock.
+   * tests exercising the timer fallback set this to a small value (e.g.
+   * 1000ms) so a wrong-version-heartbeat or no-heartbeat scenario doesn't
+   * burn 15 seconds of wall-clock.
    */
   flashOrchestratorConfig?: {
     rebootTimeoutMs?: number;

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -201,7 +201,13 @@ export async function bootIntegrationHarness(
   //    skipSerialSetup is set explicitly to false. Vitest defaults
   //    NODE_ENV='test', which would otherwise short-circuit serial-port
   //    setup — the very thing this harness is exercising.
-  const jwtKey = process.env.JWT_KEY ?? 'test-jwt-key';
+  // Hardcoded fixed test key. We deliberately do NOT read process.env.JWT_KEY
+  // here — that read was the last surface in the harness coupling test boot
+  // to the process-global env. The harness signs its own JWT with this same
+  // value (just below) and passes it to ApiServer via configOverrides.jwtKey,
+  // so the value only needs to be self-consistent across the boot, not match
+  // anything outside it.
+  const jwtKey = 'test-jwt-key';
   const configOverrides = {
     serialPort: pty.serverPath,
     baudRate: 9600,

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -241,6 +241,20 @@ export async function bootIntegrationHarness(
   // ERR_MODULE_NOT_FOUND would otherwise pass test assertions silently.
   const workerErrors: Error[] = [];
 
+  // Resilient teardown helper used by both the happy-path `dispose()` and
+  // the boot-error cleanup. Logs the failing step instead of swallowing —
+  // real cleanup failures (leaked socat, stuck WS, dirty DB) need to be
+  // visible diagnostically rather than surfacing as the next test's
+  // mysterious EADDRINUSE / polluted-DB / orphaned-tmp.
+  const safeRun = async (label: string, fn: () => void | Promise<void>): Promise<void> => {
+    try {
+      await fn();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`harness ${label} failed: ${msg}`);
+    }
+  };
+
   try {
     // 4. Boot ApiServer. bootstrap() awaits both binds (HTTP listen + WS
     //    'listening'), so it rejects on EADDRINUSE rather than returning a
@@ -406,38 +420,24 @@ export async function bootIntegrationHarness(
     };
 
     const dispose = async (): Promise<void> => {
-      // Reverse-order teardown. Resilient: each step in its own try/catch so
-      // a failure in one doesn't leak the others.
-      try {
-        wsClient?.close();
-      } catch {
-        /* ignore */
-      }
-      try {
+      // Reverse-order teardown. Resilient: each step is wrapped in safeRun
+      // (defined just above) so a failure in one doesn't leak the others —
+      // but unlike a bare `catch {}`, safeRun logs the failing step. Real
+      // cleanup failures (leaked socat, dirty DB, stuck WS) need to surface
+      // diagnostically; the next test seeing EADDRINUSE or a polluted DB
+      // shouldn't be the first signal that something went wrong.
+      await safeRun('wsClient.close', () => wsClient?.close());
+      await safeRun('stub.dispose', async () => {
         await stub?.dispose();
-      } catch {
-        /* ignore */
-      }
-      try {
+      });
+      await safeRun('server.shutdown', async () => {
         await server?.shutdown();
-      } catch {
-        /* ignore */
-      }
-      try {
-        await pty.dispose();
-      } catch {
-        /* ignore */
-      }
-      try {
-        await rm(dbDir, { recursive: true, force: true });
-      } catch {
-        /* ignore */
-      }
-      try {
-        await rm(firmwareCacheDir, { recursive: true, force: true });
-      } catch {
-        /* ignore */
-      }
+      });
+      await safeRun('pty.dispose', () => pty.dispose());
+      await safeRun('rm dbDir', () => rm(dbDir, { recursive: true, force: true }));
+      await safeRun('rm firmwareCacheDir', () =>
+        rm(firmwareCacheDir, { recursive: true, force: true }),
+      );
     };
 
     const waitForVariantCachePopulated = async (
@@ -485,37 +485,20 @@ export async function bootIntegrationHarness(
       dispose,
     };
   } catch (bootErr) {
-    // If anything fails mid-boot, tear down what we did set up.
-    try {
-      wsClient?.close();
-    } catch {
-      /* ignore */
-    }
-    try {
+    // If anything fails mid-boot, tear down what we did set up. Same
+    // resilient pattern as `dispose()` — log via safeRun, never swallow.
+    await safeRun('wsClient.close (boot-fail)', () => wsClient?.close());
+    await safeRun('stub.dispose (boot-fail)', async () => {
       await stub?.dispose();
-    } catch {
-      /* ignore */
-    }
-    try {
+    });
+    await safeRun('server.shutdown (boot-fail)', async () => {
       await server?.shutdown();
-    } catch {
-      /* ignore */
-    }
-    try {
-      await pty.dispose();
-    } catch {
-      /* ignore */
-    }
-    try {
-      await rm(dbDir, { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
-    try {
-      await rm(firmwareCacheDir, { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
+    });
+    await safeRun('pty.dispose (boot-fail)', () => pty.dispose());
+    await safeRun('rm dbDir (boot-fail)', () => rm(dbDir, { recursive: true, force: true }));
+    await safeRun('rm firmwareCacheDir (boot-fail)', () =>
+      rm(firmwareCacheDir, { recursive: true, force: true }),
+    );
     throw bootErr;
   }
 }

--- a/astros_api/src/test_harness/pty_pair.test.ts
+++ b/astros_api/src/test_harness/pty_pair.test.ts
@@ -22,9 +22,15 @@ describe('createPtyPair', () => {
     const pty = await createPtyPair();
     const path = pty.serverPath;
     await pty.dispose();
-    // After dispose, the PTY device should be gone (kernel reaps when socat exits).
-    // Allow brief grace for the kernel close.
-    await new Promise((r) => setTimeout(r, 100));
+    // After dispose, the PTY device should be gone (kernel reaps when socat
+    // exits). Cleanup is kernel-async — usually completes in <50ms but can
+    // exceed 100ms on a loaded CI runner. Poll instead of sleeping a fixed
+    // duration so the test's wall-clock cost stays minimal on a quiet
+    // machine while tolerating slow runners up to the 2s ceiling.
+    const deadline = Date.now() + 2000;
+    while (existsSync(path) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
     expect(existsSync(path)).toBe(false);
   });
 });

--- a/astros_api/src/test_harness/pty_pair.test.ts
+++ b/astros_api/src/test_harness/pty_pair.test.ts
@@ -18,6 +18,35 @@ describe('createPtyPair', () => {
     }
   });
 
+  skipIfNotLinux('records unexpected socat death in unexpectedExits', async () => {
+    // Pins the diagnostic surface for socat dying mid-test (OOM, parent
+    // SIGHUP, segfault under log pressure). Without the post-startup exit
+    // listener, the death would surface as a mysterious downstream
+    // timeout — the listener inside `await ready` short-circuits once
+    // both PTY paths are captured.
+    const pty = await createPtyPair();
+    expect(pty.unexpectedExits).toEqual([]);
+    expect(pty.pid).toBeDefined();
+
+    // Provoke an unexpected exit: SIGKILL the socat process from outside.
+    // dispose() sets `disposing = true` first, so anything that bypasses
+    // dispose (like this kill) hits the post-startup listener path.
+    process.kill(pty.pid as number, 'SIGKILL');
+
+    // Poll for the exit event (kernel signal delivery + Node's exit-event
+    // dispatch is sub-ms but not synchronous).
+    const deadline = Date.now() + 2000;
+    while (pty.unexpectedExits.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+
+    expect(pty.unexpectedExits).toHaveLength(1);
+    expect(pty.unexpectedExits[0].signal).toBe('SIGKILL');
+
+    // dispose is idempotent against an already-dead child.
+    await pty.dispose();
+  });
+
   skipIfNotLinux('dispose() releases the socat process and PTY paths', async () => {
     const pty = await createPtyPair();
     const path = pty.serverPath;

--- a/astros_api/src/test_harness/pty_pair.test.ts
+++ b/astros_api/src/test_harness/pty_pair.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { existsSync } from 'fs';
 import { createPtyPair } from './pty_pair.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 describe('createPtyPair', () => {
-  skipIfNotPosix('emits two distinct PTY paths under /dev/pts/', async () => {
+  skipIfNotLinux('emits two distinct PTY paths under /dev/pts/', async () => {
     const pty = await createPtyPair();
     try {
       expect(pty.serverPath).toMatch(/^\/dev\/pts\/\d+$/);
@@ -18,7 +18,7 @@ describe('createPtyPair', () => {
     }
   });
 
-  skipIfNotPosix('dispose() releases the socat process and PTY paths', async () => {
+  skipIfNotLinux('dispose() releases the socat process and PTY paths', async () => {
     const pty = await createPtyPair();
     const path = pty.serverPath;
     await pty.dispose();

--- a/astros_api/src/test_harness/pty_pair.test.ts
+++ b/astros_api/src/test_harness/pty_pair.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'fs';
+import { createPtyPair } from './pty_pair.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+describe('createPtyPair', () => {
+  skipIfNotPosix('emits two distinct PTY paths under /dev/pts/', async () => {
+    const pty = await createPtyPair();
+    try {
+      expect(pty.serverPath).toMatch(/^\/dev\/pts\/\d+$/);
+      expect(pty.masterPath).toMatch(/^\/dev\/pts\/\d+$/);
+      expect(pty.serverPath).not.toBe(pty.masterPath);
+      expect(existsSync(pty.serverPath)).toBe(true);
+      expect(existsSync(pty.masterPath)).toBe(true);
+    } finally {
+      await pty.dispose();
+    }
+  });
+
+  skipIfNotPosix('dispose() releases the socat process and PTY paths', async () => {
+    const pty = await createPtyPair();
+    const path = pty.serverPath;
+    await pty.dispose();
+    // After dispose, the PTY device should be gone (kernel reaps when socat exits).
+    // Allow brief grace for the kernel close.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(existsSync(path)).toBe(false);
+  });
+});

--- a/astros_api/src/test_harness/pty_pair.ts
+++ b/astros_api/src/test_harness/pty_pair.ts
@@ -10,8 +10,15 @@ const PTY_LINE_REGEX = /N PTY is (\/dev\/pts\/\d+)/;
 const SOCAT_STARTUP_TIMEOUT_MS = 5000;
 
 export async function createPtyPair(): Promise<PtyPair> {
-  if (process.platform === 'win32') {
-    throw new Error('PtyPair: socat-based PTYs are not supported on Windows');
+  // Linux-only: PTY_LINE_REGEX matches the `/dev/pts/N` paths Linux's socat
+  // emits. macOS socat produces `/dev/ttysNNN`-style paths, so the regex
+  // would silently miss matches and the timeout would fire 5s later. Rather
+  // than maintain a per-platform regex matrix for a developer convenience
+  // we don't have hardware to test on, gate the whole helper to Linux.
+  if (process.platform !== 'linux') {
+    throw new Error(
+      `PtyPair: socat-based PTYs are only supported on Linux (got ${process.platform})`,
+    );
   }
 
   const child = spawn('socat', ['-d', '-d', 'pty,raw,echo=0', 'pty,raw,echo=0'], {

--- a/astros_api/src/test_harness/pty_pair.ts
+++ b/astros_api/src/test_harness/pty_pair.ts
@@ -34,14 +34,31 @@ export async function createPtyPair(): Promise<PtyPair> {
       reject(new Error(`socat did not emit PTY paths within ${SOCAT_STARTUP_TIMEOUT_MS}ms`));
     }, SOCAT_STARTUP_TIMEOUT_MS);
 
-    if (!child.stderr) {
+    const stderr = child.stderr;
+    if (!stderr) {
       clearTimeout(timer);
       reject(new Error('socat process has no stderr stream (unexpected)'));
       return;
     }
 
-    child.stderr.on('data', (chunk: Buffer) => {
-      for (const line of chunk.toString('utf8').split('\n')) {
+    // Node stream chunks are not guaranteed to align to newlines, so a
+    // PTY line like `... N PTY is /dev/pts/3` can split across two 'data'
+    // events. Splitting each chunk in isolation would miss the line in
+    // both halves and the helper would flap on SOCAT_STARTUP_TIMEOUT_MS.
+    // Buffer text across chunks; pop the trailing element back into the
+    // buffer because it may be a partial line (or empty if the chunk
+    // ended on '\n').
+    //
+    // Once both PTY paths are captured we detach the listener and clear
+    // the buffer. socat run with `-d -d` keeps logging through the
+    // harness lifetime (data-transfer-loop notices, etc.); leaving the
+    // listener attached would accumulate that output indefinitely.
+    let stderrBuffer = '';
+    const onStderrData = (chunk: Buffer): void => {
+      stderrBuffer += chunk.toString('utf8');
+      const lines = stderrBuffer.split('\n');
+      stderrBuffer = lines.pop() ?? '';
+      for (const line of lines) {
         const match = line.match(PTY_LINE_REGEX);
         if (!match) continue;
         if (serverPath === undefined) {
@@ -49,10 +66,13 @@ export async function createPtyPair(): Promise<PtyPair> {
         } else if (masterPath === undefined) {
           masterPath = match[1];
           clearTimeout(timer);
+          stderr.off('data', onStderrData);
+          stderrBuffer = '';
           resolve();
         }
       }
-    });
+    };
+    stderr.on('data', onStderrData);
 
     child.on('exit', (code, signal) => {
       if (serverPath === undefined || masterPath === undefined) {

--- a/astros_api/src/test_harness/pty_pair.ts
+++ b/astros_api/src/test_harness/pty_pair.ts
@@ -1,10 +1,15 @@
 import { spawn } from 'child_process';
 
+export interface SocatExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
 export interface PtyPair {
-  serverPath: string; // /dev/pts/N — server-side ApiServer opens this
-  masterPath: string; // /dev/pts/M — stub master opens this
+  readonly serverPath: string; // /dev/pts/N — server-side ApiServer opens this
+  readonly masterPath: string; // /dev/pts/M — stub master opens this
   /** socat's process pid (for diagnostics; undefined if spawn failed). */
-  pid: number | undefined;
+  readonly pid?: number;
   /**
    * Records every socat exit that wasn't initiated by `dispose()`. Stays
    * empty in the happy case. Tests should assert empty after each scenario
@@ -12,7 +17,7 @@ export interface PtyPair {
    * crashed under -d -d log buffer pressure, etc.), which would otherwise
    * surface as a mysterious 5-second `waitForX` timeout with no diagnostic.
    */
-  unexpectedExits: ReadonlyArray<{ code: number | null; signal: NodeJS.Signals | null }>;
+  readonly unexpectedExits: ReadonlyArray<SocatExit>;
   dispose(): Promise<void>;
 }
 

--- a/astros_api/src/test_harness/pty_pair.ts
+++ b/astros_api/src/test_harness/pty_pair.ts
@@ -1,0 +1,92 @@
+import { spawn } from 'child_process';
+
+export interface PtyPair {
+  serverPath: string; // /dev/pts/N — server-side ApiServer opens this
+  masterPath: string; // /dev/pts/M — stub master opens this
+  dispose(): Promise<void>;
+}
+
+const PTY_LINE_REGEX = /N PTY is (\/dev\/pts\/\d+)/;
+const SOCAT_STARTUP_TIMEOUT_MS = 5000;
+
+export async function createPtyPair(): Promise<PtyPair> {
+  if (process.platform === 'win32') {
+    throw new Error('PtyPair: socat-based PTYs are not supported on Windows');
+  }
+
+  const child = spawn('socat', ['-d', '-d', 'pty,raw,echo=0', 'pty,raw,echo=0'], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+
+  let serverPath: string | undefined;
+  let masterPath: string | undefined;
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`socat did not emit PTY paths within ${SOCAT_STARTUP_TIMEOUT_MS}ms`));
+    }, SOCAT_STARTUP_TIMEOUT_MS);
+
+    if (!child.stderr) {
+      clearTimeout(timer);
+      reject(new Error('socat process has no stderr stream (unexpected)'));
+      return;
+    }
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      for (const line of chunk.toString('utf8').split('\n')) {
+        const match = line.match(PTY_LINE_REGEX);
+        if (!match) continue;
+        if (serverPath === undefined) {
+          serverPath = match[1];
+        } else if (masterPath === undefined) {
+          masterPath = match[1];
+          clearTimeout(timer);
+          resolve();
+        }
+      }
+    });
+
+    child.on('exit', (code, signal) => {
+      if (serverPath === undefined || masterPath === undefined) {
+        clearTimeout(timer);
+        reject(
+          new Error(`socat exited before emitting both PTY paths (code=${code}, signal=${signal})`),
+        );
+      }
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `socat spawn failed: ${err.message}. Is socat installed? Try \`apt-get install socat\` or \`brew install socat\`.`,
+        ),
+      );
+    });
+  });
+
+  await ready;
+
+  const dispose = async (): Promise<void> => {
+    if (child.exitCode !== null) return;
+    child.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve();
+      }, 1000);
+      child.on('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  };
+
+  // Both paths are guaranteed set by the time `ready` resolves.
+  // The conditional guard satisfies TypeScript without non-null assertions.
+  if (serverPath === undefined || masterPath === undefined) {
+    throw new Error('socat PTY paths were not captured (internal error)');
+  }
+
+  return { serverPath, masterPath, dispose };
+}

--- a/astros_api/src/test_harness/pty_pair.ts
+++ b/astros_api/src/test_harness/pty_pair.ts
@@ -23,6 +23,7 @@ export async function createPtyPair(): Promise<PtyPair> {
 
   const ready = new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => {
+      child.kill('SIGTERM');
       reject(new Error(`socat did not emit PTY paths within ${SOCAT_STARTUP_TIMEOUT_MS}ms`));
     }, SOCAT_STARTUP_TIMEOUT_MS);
 

--- a/astros_api/src/test_harness/pty_pair.ts
+++ b/astros_api/src/test_harness/pty_pair.ts
@@ -3,6 +3,16 @@ import { spawn } from 'child_process';
 export interface PtyPair {
   serverPath: string; // /dev/pts/N — server-side ApiServer opens this
   masterPath: string; // /dev/pts/M — stub master opens this
+  /** socat's process pid (for diagnostics; undefined if spawn failed). */
+  pid: number | undefined;
+  /**
+   * Records every socat exit that wasn't initiated by `dispose()`. Stays
+   * empty in the happy case. Tests should assert empty after each scenario
+   * — a non-empty list means socat died mid-test (OOM kill, parent SIGHUP,
+   * crashed under -d -d log buffer pressure, etc.), which would otherwise
+   * surface as a mysterious 5-second `waitForX` timeout with no diagnostic.
+   */
+  unexpectedExits: ReadonlyArray<{ code: number | null; signal: NodeJS.Signals | null }>;
   dispose(): Promise<void>;
 }
 
@@ -95,7 +105,22 @@ export async function createPtyPair(): Promise<PtyPair> {
 
   await ready;
 
+  // Permanent exit listener attached AFTER startup completes. The listener
+  // inside the `ready` Promise short-circuits once both paths are captured,
+  // so it would silently no-op on a mid-test socat death — the test would
+  // then hit some `waitForWsMessage` / `waitForFrame` timeout with no
+  // indication that the PTY pair vanished. This separate listener records
+  // exits that weren't initiated by `dispose()` so tests can assert empty
+  // and surface socat crashes diagnostically.
+  let disposing = false;
+  const unexpectedExits: Array<{ code: number | null; signal: NodeJS.Signals | null }> = [];
+  child.on('exit', (code, signal) => {
+    if (disposing) return;
+    unexpectedExits.push({ code, signal });
+  });
+
   const dispose = async (): Promise<void> => {
+    disposing = true;
     if (child.exitCode !== null) return;
     child.kill('SIGTERM');
     await new Promise<void>((resolve) => {
@@ -103,7 +128,7 @@ export async function createPtyPair(): Promise<PtyPair> {
         child.kill('SIGKILL');
         resolve();
       }, 1000);
-      child.on('exit', () => {
+      child.once('exit', () => {
         clearTimeout(timer);
         resolve();
       });
@@ -116,5 +141,5 @@ export async function createPtyPair(): Promise<PtyPair> {
     throw new Error('socat PTY paths were not captured (internal error)');
   }
 
-  return { serverPath, masterPath, dispose };
+  return { serverPath, masterPath, pid: child.pid, unexpectedExits, dispose };
 }

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -498,6 +498,45 @@ describe('StubMaster (PTY-backed)', () => {
   );
 
   skipIfNotLinux(
+    'scriptDeploy: surfaces parse error when FW_DEPLOY_BEGIN requests a controller not scripted for',
+    async () => {
+      // Symmetric to the "scripted but not requested" check. Without this
+      // validation, the dispatcher emits FW_DEPLOY_DONE with results
+      // missing for the unscripted controller, the server treats it as
+      // never-finishing, and the test hangs at a downstream waitForWsMessage
+      // with no diagnostic.
+      const { stub, serverPort, dispose } = await setupBothEnds();
+      try {
+        stub.scriptDeploy({
+          controllers: [{ id: 'ctrl-A', outcome: 'OK', finalVersion: '1.5.0' }],
+          // ctrl-B is requested by the orchestrator below but NOT scripted
+        });
+
+        const generator = new MessageGenerator();
+        const deployData: FwDeployBegin = {
+          transferId: 'xfer-1',
+          order: ['ctrl-A', 'ctrl-B'],
+        };
+        const header = generator.generateHeader(SerialMessageType.FW_DEPLOY_BEGIN, 'd1');
+        const { msg } = generator.generateFwDeployBegin(header, deployData);
+
+        const drainPromise = collectFrames(serverPort, 5).catch(() => []);
+        serverPort.write(msg);
+        await drainPromise;
+        await new Promise((r) => setTimeout(r, 50));
+
+        const errs = stub.parsingErrors();
+        expect(errs.length).toBeGreaterThan(0);
+        const missingErr = errs.find((e) => e.note.includes('missing'));
+        expect(missingErr).toBeDefined();
+        expect(missingErr?.note).toContain('ctrl-B');
+      } finally {
+        await dispose();
+      }
+    },
+  );
+
+  skipIfNotLinux(
     'scriptDeploy: surfaces parse error when scripted controller is not in FW_DEPLOY_BEGIN order',
     async () => {
       // Pins the diagnostic for a misconfigured test: scripting a deploy

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -9,6 +9,7 @@ import { MessageHandler } from '../serial/message_handler.js';
 import { SerialMessageType } from '../serial/serial_message.js';
 import { SerialWorkerResponseType } from '../serial/serial_worker_response.js';
 import {
+  FW_SERIAL_SLIDING_WINDOW,
   FwStage,
   type FwTransferBegin,
   type FwChunk,
@@ -570,4 +571,34 @@ describe('StubMaster (PTY-backed)', () => {
       }
     },
   );
+
+  // -------------------------------------------------------------------------
+  // autoAckUpload input validation — protects against frames the server
+  // would categorically parse as UNKNOWN. No PTY needed: the validation
+  // runs synchronously inside autoAckUpload() before any wire I/O.
+  // -------------------------------------------------------------------------
+
+  it('autoAckUpload: rejects windowSize > FW_SERIAL_SLIDING_WINDOW', () => {
+    const stub = new StubMaster({ ptyPath: '/dev/null' });
+    expect(() => stub.autoAckUpload({ windowSize: FW_SERIAL_SLIDING_WINDOW + 1 })).toThrow(
+      /windowSize must be in/,
+    );
+  });
+
+  it('autoAckUpload: rejects windowSize <= 0', () => {
+    const stub = new StubMaster({ ptyPath: '/dev/null' });
+    expect(() => stub.autoAckUpload({ windowSize: 0 })).toThrow(/windowSize must be in/);
+    expect(() => stub.autoAckUpload({ windowSize: -1 })).toThrow(/windowSize must be in/);
+  });
+
+  it('autoAckUpload: rejects failAtSeq <= 0 (would emit invalid lastGoodSeq)', () => {
+    const stub = new StubMaster({ ptyPath: '/dev/null' });
+    expect(() => stub.autoAckUpload({ failAtSeq: 0 })).toThrow(/failAtSeq must be > 0/);
+    expect(() => stub.autoAckUpload({ failAtSeq: -5 })).toThrow(/failAtSeq must be > 0/);
+  });
+
+  it('autoAckUpload: accepts windowSize at the FW_SERIAL_SLIDING_WINDOW boundary', () => {
+    const stub = new StubMaster({ ptyPath: '/dev/null' });
+    expect(() => stub.autoAckUpload({ windowSize: FW_SERIAL_SLIDING_WINDOW })).not.toThrow();
+  });
 });

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -98,7 +98,7 @@ function requireFrame(frames: ValidatedFrame[], index: number): ValidatedFrame {
 
 describe('StubMaster (PTY-backed)', () => {
   // -------------------------------------------------------------------------
-  // Task 2 — raw I/O round-trips
+  // Raw I/O round-trips
   // -------------------------------------------------------------------------
 
   skipIfNotPosix(
@@ -227,7 +227,7 @@ describe('StubMaster (PTY-backed)', () => {
   );
 
   // -------------------------------------------------------------------------
-  // Task 3 — scripted-response API
+  // Scripted-response API
   // -------------------------------------------------------------------------
 
   skipIfNotPosix(

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -17,7 +17,7 @@ import {
   type FwDeployBegin,
 } from '../models/firmware/firmware_messages.js';
 
-const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
 
 // ---------------------------------------------------------------------------
 // Shared setup helper — avoids 20+ lines of PTY/port/stub boilerplate per
@@ -102,7 +102,7 @@ describe('StubMaster (PTY-backed)', () => {
   // Raw I/O round-trips
   // -------------------------------------------------------------------------
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'inbound: server-side write of FW_TRANSFER_BEGIN is parsed by the stub master',
     async () => {
       const pty = await createPtyPair();
@@ -162,7 +162,7 @@ describe('StubMaster (PTY-backed)', () => {
     },
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'outbound: stub master writes FW_TRANSFER_BEGIN_ACK that the server-side handler accepts',
     async () => {
       const pty = await createPtyPair();
@@ -231,7 +231,7 @@ describe('StubMaster (PTY-backed)', () => {
   // Scripted-response API
   // -------------------------------------------------------------------------
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'autoAckUpload: auto-ACKs FW_TRANSFER_BEGIN, three FW_CHUNKs, and FW_TRANSFER_END',
     async () => {
       const { stub, serverPort, dispose } = await setupBothEnds();
@@ -325,7 +325,7 @@ describe('StubMaster (PTY-backed)', () => {
     },
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'autoAckUpload with failAtSeq=2: NAKs once then resumes normal ACKing',
     async () => {
       const { stub, serverPort, dispose } = await setupBothEnds();
@@ -414,7 +414,7 @@ describe('StubMaster (PTY-backed)', () => {
     },
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'scriptDeploy: walks FW_PROGRESS stages then emits FW_DEPLOY_DONE with per-controller outcomes',
     async () => {
       const { stub, serverPort, dispose } = await setupBothEnds();
@@ -497,7 +497,7 @@ describe('StubMaster (PTY-backed)', () => {
     },
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'writePollAck: emits POLL_ACK parseable by MessageHandler.handlePollAck',
     async () => {
       const { stub, serverPort, dispose } = await setupBothEnds();
@@ -534,7 +534,7 @@ describe('StubMaster (PTY-backed)', () => {
     },
   );
 
-  skipIfNotPosix(
+  skipIfNotLinux(
     'disable("autoAckUpload"): no response is written after FW_TRANSFER_BEGIN',
     async () => {
       const { stub, serverPort, dispose } = await setupBothEnds();

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -498,6 +498,51 @@ describe('StubMaster (PTY-backed)', () => {
   );
 
   skipIfNotLinux(
+    'scriptDeploy: surfaces parse error when scripted controller is not in FW_DEPLOY_BEGIN order',
+    async () => {
+      // Pins the diagnostic for a misconfigured test: scripting a deploy
+      // result for a controller the orchestrator never requested. Without
+      // the validation, the stub would happily emit FW_PROGRESS /
+      // FW_DEPLOY_DONE for that controller; the orchestrator would then
+      // produce a confusing "result for unknown controller" failure that's
+      // hard to trace back to the test config.
+      const { stub, serverPort, dispose } = await setupBothEnds();
+      try {
+        stub.scriptDeploy({
+          controllers: [
+            { id: 'ctrl-A', outcome: 'OK', finalVersion: '1.5.0' },
+            { id: 'ghost-B', outcome: 'OK', finalVersion: '1.5.0' },
+          ],
+        });
+
+        const generator = new MessageGenerator();
+        const deployData: FwDeployBegin = {
+          transferId: 'xfer-1',
+          order: ['ctrl-A'], // ghost-B is NOT requested
+        };
+        const header = generator.generateHeader(SerialMessageType.FW_DEPLOY_BEGIN, 'd1');
+        const { msg } = generator.generateFwDeployBegin(header, deployData);
+
+        // Drain whatever frames the stub emits in response (we don't assert
+        // on shape here — the existing scriptDeploy test covers that path).
+        const drainPromise = collectFrames(serverPort, 5).catch(() => []);
+        serverPort.write(msg);
+        await drainPromise;
+
+        // Give the stub's inbound dispatch a tick to record the error.
+        await new Promise((r) => setTimeout(r, 50));
+
+        const errs = stub.parsingErrors();
+        expect(errs.length).toBeGreaterThan(0);
+        expect(errs[0].note).toContain('ghost-B');
+        expect(errs[0].note).toContain('not in FW_DEPLOY_BEGIN order');
+      } finally {
+        await dispose();
+      }
+    },
+  );
+
+  skipIfNotLinux(
     'writePollAck: emits POLL_ACK parseable by MessageHandler.handlePollAck',
     async () => {
       const { stub, serverPort, dispose } = await setupBothEnds();

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -8,10 +8,7 @@ import { MessageGenerator } from '../serial/message_generator.js';
 import { MessageHandler } from '../serial/message_handler.js';
 import { SerialMessageType } from '../serial/serial_message.js';
 import { SerialWorkerResponseType } from '../serial/serial_worker_response.js';
-import {
-  FW_SERIAL_SLIDING_WINDOW,
-  type FwTransferBegin,
-} from '../models/firmware/firmware_messages.js';
+import { type FwTransferBegin } from '../models/firmware/firmware_messages.js';
 
 const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
 
@@ -110,7 +107,7 @@ describe('StubMaster (PTY-backed)', () => {
 
         stub.writeFwTransferBeginAck({
           transferId: 'xfer-1',
-          windowSize: FW_SERIAL_SLIDING_WINDOW,
+          status: 'OK',
           msgId: 'm1',
         });
 
@@ -125,9 +122,7 @@ describe('StubMaster (PTY-backed)', () => {
         expect(response.type).toBe(SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK);
         if (response.type === SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK) {
           expect(response.payload.transferId).toBe('xfer-1');
-          // The fake serializes windowSize as the status field; round-trip
-          // here just confirms it survives the wire intact.
-          expect(response.payload.status).toBe(String(FW_SERIAL_SLIDING_WINDOW));
+          expect(response.payload.status).toBe('OK');
         }
       } finally {
         await stub.dispose();

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -8,11 +8,99 @@ import { MessageGenerator } from '../serial/message_generator.js';
 import { MessageHandler } from '../serial/message_handler.js';
 import { SerialMessageType } from '../serial/serial_message.js';
 import { SerialWorkerResponseType } from '../serial/serial_worker_response.js';
-import { type FwTransferBegin } from '../models/firmware/firmware_messages.js';
+import {
+  FwStage,
+  type FwTransferBegin,
+  type FwChunk,
+  type FwTransferEnd,
+  type FwDeployBegin,
+} from '../models/firmware/firmware_messages.js';
 
 const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
 
+// ---------------------------------------------------------------------------
+// Shared setup helper — avoids 20+ lines of PTY/port/stub boilerplate per
+// test. Returns all three live handles. Caller must tear down in `finally`.
+// ---------------------------------------------------------------------------
+
+interface TestEnds {
+  stub: StubMaster;
+  serverPort: SerialPort;
+  dispose: () => Promise<void>;
+}
+
+async function setupBothEnds(): Promise<TestEnds> {
+  const pty = await createPtyPair();
+  const stub = new StubMaster({ ptyPath: pty.masterPath });
+  const serverPort = new SerialPort({ path: pty.serverPath, baudRate: 9600, autoOpen: false });
+
+  await stub.start();
+  await new Promise<void>((resolve, reject) => {
+    serverPort.open((err) => (err ? reject(err) : resolve()));
+  });
+
+  const dispose = async (): Promise<void> => {
+    await stub.dispose();
+    await new Promise<void>((resolve) => {
+      if (serverPort.isOpen) {
+        serverPort.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+    await pty.dispose();
+  };
+
+  return { stub, serverPort, dispose };
+}
+
+type ValidatedFrame = ReturnType<MessageHandler['validateMessage']>;
+
+// Collect N frames from the server side of the PTY by parsing each line.
+function collectFrames(
+  serverPort: SerialPort,
+  count: number,
+  timeoutMs = 3000,
+): Promise<ValidatedFrame[]> {
+  return new Promise((resolve, reject) => {
+    const handler = new MessageHandler();
+    const frames: ValidatedFrame[] = [];
+    const timer = setTimeout(
+      () =>
+        reject(
+          new Error(`collectFrames: timed out waiting for ${count} frames, got ${frames.length}`),
+        ),
+      timeoutMs,
+    );
+    const parser = serverPort.pipe(new DelimiterParser({ delimiter: '\n' }));
+    parser.on('data', (chunk: Buffer) => {
+      const validation = handler.validateMessage(chunk.toString('utf8'));
+      frames.push(validation);
+      if (frames.length >= count) {
+        clearTimeout(timer);
+        resolve(frames);
+      }
+    });
+  });
+}
+
+// Assert that a frame at a given index exists and return it, so callers
+// don't need non-null assertions. Throws a descriptive error if the frame
+// is missing (which should only happen if collectFrames resolves with fewer
+// frames than expected — a test-setup bug, not a product bug).
+function requireFrame(frames: ValidatedFrame[], index: number): ValidatedFrame {
+  const f = frames[index];
+  if (f === undefined) {
+    throw new Error(`requireFrame: no frame at index ${index} (got ${frames.length} total)`);
+  }
+  return f;
+}
+
 describe('StubMaster (PTY-backed)', () => {
+  // -------------------------------------------------------------------------
+  // Task 2 — raw I/O round-trips
+  // -------------------------------------------------------------------------
+
   skipIfNotPosix(
     'inbound: server-side write of FW_TRANSFER_BEGIN is parsed by the stub master',
     async () => {
@@ -134,6 +222,351 @@ describe('StubMaster (PTY-backed)', () => {
           }
         });
         await pty.dispose();
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Task 3 — scripted-response API
+  // -------------------------------------------------------------------------
+
+  skipIfNotPosix(
+    'autoAckUpload: auto-ACKs FW_TRANSFER_BEGIN, three FW_CHUNKs, and FW_TRANSFER_END',
+    async () => {
+      const { stub, serverPort, dispose } = await setupBothEnds();
+      try {
+        stub.autoAckUpload();
+
+        const generator = new MessageGenerator();
+        const SHA = 'b'.repeat(64);
+        const XFER = 'xfer-upload-1';
+
+        // 5 frames expected back: 1 begin-ack + 3 chunk-acks + 1 end-ack.
+        const framesPromise = collectFrames(serverPort, 5);
+
+        // Write FW_TRANSFER_BEGIN
+        const beginHeader = generator.generateHeader(SerialMessageType.FW_TRANSFER_BEGIN, 'b1');
+        const { msg: beginMsg } = generator.generateFwTransferBegin(beginHeader, {
+          transferId: XFER,
+          totalSize: 300,
+          sha256Hex: SHA,
+          chunkSize: 100,
+          targets: ['master'],
+        });
+        serverPort.write(beginMsg);
+
+        // Write 3 FW_CHUNKs (seq 0, 1, 2)
+        for (let seq = 0; seq < 3; seq++) {
+          const chunkData: FwChunk = {
+            transferId: XFER,
+            seq,
+            payloadLen: 4,
+            base64Bytes: 'AAAA',
+            crc16Hex: '00ff',
+          };
+          const chunkHeader = generator.generateHeader(SerialMessageType.FW_CHUNK, `c${seq}`);
+          const { msg: chunkMsg } = generator.generateFwChunk(chunkHeader, chunkData);
+          serverPort.write(chunkMsg);
+        }
+
+        // Write FW_TRANSFER_END
+        const endData: FwTransferEnd = {
+          transferId: XFER,
+          totalChunks: 3,
+          finalSha256Hex: SHA,
+        };
+        const endHeader = generator.generateHeader(SerialMessageType.FW_TRANSFER_END, 'e1');
+        const { msg: endMsg } = generator.generateFwTransferEnd(endHeader, endData);
+        serverPort.write(endMsg);
+
+        const frames = await framesPromise;
+        const handler = new MessageHandler();
+
+        // Frame 0: FW_TRANSFER_BEGIN_ACK with status='OK'
+        const f0 = requireFrame(frames, 0);
+        expect(f0.valid).toBe(true);
+        expect(f0.type).toBe(SerialMessageType.FW_TRANSFER_BEGIN_ACK);
+        const beginAck = handler.handleFwTransferBeginAck(f0.data);
+        expect(beginAck.type).toBe(SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK);
+        if (beginAck.type === SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK) {
+          expect(beginAck.payload.transferId).toBe(XFER);
+          expect(beginAck.payload.status).toBe('OK');
+        }
+
+        // Frames 1-3: FW_CHUNK_ACK with advancing highestContiguousSeq / nextExpectedSeq
+        for (let seq = 0; seq < 3; seq++) {
+          const f = requireFrame(frames, seq + 1);
+          expect(f.valid).toBe(true);
+          expect(f.type).toBe(SerialMessageType.FW_CHUNK_ACK);
+          const ack = handler.handleFwChunkAck(f.data);
+          expect(ack.type).toBe(SerialWorkerResponseType.FW_CHUNK_ACK);
+          if (ack.type === SerialWorkerResponseType.FW_CHUNK_ACK) {
+            expect(ack.payload.transferId).toBe(XFER);
+            expect(ack.payload.highestContiguousSeq).toBe(seq);
+            expect(ack.payload.nextExpectedSeq).toBe(seq + 1);
+          }
+        }
+
+        // Frame 4: FW_TRANSFER_END_ACK echoing the SHA
+        const f4 = requireFrame(frames, 4);
+        expect(f4.valid).toBe(true);
+        expect(f4.type).toBe(SerialMessageType.FW_TRANSFER_END_ACK);
+        const endAck = handler.handleFwTransferEndAck(f4.data);
+        expect(endAck.type).toBe(SerialWorkerResponseType.FW_TRANSFER_END_ACK);
+        if (endAck.type === SerialWorkerResponseType.FW_TRANSFER_END_ACK) {
+          expect(endAck.payload.transferId).toBe(XFER);
+          expect(endAck.payload.status).toBe('OK');
+          expect(endAck.payload.computedSha256Hex).toBe(SHA);
+        }
+      } finally {
+        await dispose();
+      }
+    },
+  );
+
+  skipIfNotPosix(
+    'autoAckUpload with failAtSeq=2: NAKs once then resumes normal ACKing',
+    async () => {
+      const { stub, serverPort, dispose } = await setupBothEnds();
+      try {
+        stub.autoAckUpload({ failAtSeq: 2 });
+
+        const generator = new MessageGenerator();
+        const XFER = 'xfer-nak-test';
+
+        // Sequence: seq 0 → ACK, seq 1 → ACK, seq 2 → NAK, seq 2 (retry) → ACK, seq 3 → ACK
+        // 5 responses total.
+        const framesPromise = collectFrames(serverPort, 5);
+
+        const writeChunk = (seq: number): void => {
+          const chunkData: FwChunk = {
+            transferId: XFER,
+            seq,
+            payloadLen: 4,
+            base64Bytes: 'AAAA',
+            crc16Hex: '00ff',
+          };
+          const header = generator.generateHeader(SerialMessageType.FW_CHUNK, `c${seq}`);
+          const { msg } = generator.generateFwChunk(header, chunkData);
+          serverPort.write(msg);
+        };
+
+        // seq 0, 1, 2 (triggers NAK), 2 (retry → ACK), 3
+        writeChunk(0);
+        writeChunk(1);
+        writeChunk(2);
+        writeChunk(2); // retransmit after NAK
+        writeChunk(3);
+
+        const frames = await framesPromise;
+        const handler = new MessageHandler();
+
+        // seq 0 → ACK
+        const fn0 = requireFrame(frames, 0);
+        expect(fn0.type).toBe(SerialMessageType.FW_CHUNK_ACK);
+        const ack0 = handler.handleFwChunkAck(fn0.data);
+        if (ack0.type === SerialWorkerResponseType.FW_CHUNK_ACK) {
+          expect(ack0.payload.highestContiguousSeq).toBe(0);
+          expect(ack0.payload.nextExpectedSeq).toBe(1);
+        }
+
+        // seq 1 → ACK
+        const fn1 = requireFrame(frames, 1);
+        expect(fn1.type).toBe(SerialMessageType.FW_CHUNK_ACK);
+        const ack1 = handler.handleFwChunkAck(fn1.data);
+        if (ack1.type === SerialWorkerResponseType.FW_CHUNK_ACK) {
+          expect(ack1.payload.highestContiguousSeq).toBe(1);
+          expect(ack1.payload.nextExpectedSeq).toBe(2);
+        }
+
+        // seq 2 (first occurrence) → NAK with lastGoodSeq=1, reasonCode='CRC'
+        const fn2 = requireFrame(frames, 2);
+        expect(fn2.type).toBe(SerialMessageType.FW_CHUNK_NAK);
+        const nak = handler.handleFwChunkNak(fn2.data);
+        expect(nak.type).toBe(SerialWorkerResponseType.FW_CHUNK_NAK);
+        if (nak.type === SerialWorkerResponseType.FW_CHUNK_NAK) {
+          expect(nak.payload.transferId).toBe(XFER);
+          expect(nak.payload.lastGoodSeq).toBe(1);
+          expect(nak.payload.reasonCode).toBe('CRC');
+        }
+
+        // seq 2 (retransmit) → ACK
+        const fn3 = requireFrame(frames, 3);
+        expect(fn3.type).toBe(SerialMessageType.FW_CHUNK_ACK);
+        const ack2retry = handler.handleFwChunkAck(fn3.data);
+        if (ack2retry.type === SerialWorkerResponseType.FW_CHUNK_ACK) {
+          expect(ack2retry.payload.highestContiguousSeq).toBe(2);
+          expect(ack2retry.payload.nextExpectedSeq).toBe(3);
+        }
+
+        // seq 3 → ACK
+        const fn4 = requireFrame(frames, 4);
+        expect(fn4.type).toBe(SerialMessageType.FW_CHUNK_ACK);
+        const ack3 = handler.handleFwChunkAck(fn4.data);
+        if (ack3.type === SerialWorkerResponseType.FW_CHUNK_ACK) {
+          expect(ack3.payload.highestContiguousSeq).toBe(3);
+          expect(ack3.payload.nextExpectedSeq).toBe(4);
+        }
+      } finally {
+        await dispose();
+      }
+    },
+  );
+
+  skipIfNotPosix(
+    'scriptDeploy: walks FW_PROGRESS stages then emits FW_DEPLOY_DONE with per-controller outcomes',
+    async () => {
+      const { stub, serverPort, dispose } = await setupBothEnds();
+      try {
+        stub.scriptDeploy({
+          controllers: [
+            { id: 'ctrl-A', outcome: 'OK', finalVersion: '1.5.0' },
+            { id: 'ctrl-B', outcome: 'FAILED', error: 'crc_mismatch' },
+          ],
+        });
+
+        const generator = new MessageGenerator();
+        const XFER = 'xfer-1';
+
+        // 3 stages × 2 controllers + 1 FW_DEPLOY_DONE = 7 frames
+        const framesPromise = collectFrames(serverPort, 7);
+
+        const deployData: FwDeployBegin = {
+          transferId: XFER,
+          order: ['ctrl-A', 'ctrl-B'],
+        };
+        const header = generator.generateHeader(SerialMessageType.FW_DEPLOY_BEGIN, 'd1');
+        const { msg } = generator.generateFwDeployBegin(header, deployData);
+        serverPort.write(msg);
+
+        const frames = await framesPromise;
+        const handler = new MessageHandler();
+
+        const defaultStages = [FwStage.Sending, FwStage.Verifying, FwStage.Rebooting];
+
+        // Frames 0-2: FW_PROGRESS for ctrl-A (Sending, Verifying, Rebooting)
+        for (let i = 0; i < 3; i++) {
+          const f = requireFrame(frames, i);
+          expect(f.type).toBe(SerialMessageType.FW_PROGRESS);
+          const prog = handler.handleFwProgress(f.data);
+          expect(prog.type).toBe(SerialWorkerResponseType.FW_PROGRESS);
+          if (prog.type === SerialWorkerResponseType.FW_PROGRESS) {
+            expect(prog.payload.transferId).toBe(XFER);
+            expect(prog.payload.controllerId).toBe('ctrl-A');
+            expect(prog.payload.stage).toBe(defaultStages[i]);
+            expect(prog.payload.bytesSent).toBe(0);
+            expect(prog.payload.totalBytes).toBe(0);
+          }
+        }
+
+        // Frames 3-5: FW_PROGRESS for ctrl-B (Sending, Verifying, Rebooting)
+        for (let i = 0; i < 3; i++) {
+          const f = requireFrame(frames, i + 3);
+          expect(f.type).toBe(SerialMessageType.FW_PROGRESS);
+          const prog = handler.handleFwProgress(f.data);
+          expect(prog.type).toBe(SerialWorkerResponseType.FW_PROGRESS);
+          if (prog.type === SerialWorkerResponseType.FW_PROGRESS) {
+            expect(prog.payload.transferId).toBe(XFER);
+            expect(prog.payload.controllerId).toBe('ctrl-B');
+            expect(prog.payload.stage).toBe(defaultStages[i]);
+          }
+        }
+
+        // Frame 6: FW_DEPLOY_DONE with both controller outcomes
+        const f6 = requireFrame(frames, 6);
+        expect(f6.type).toBe(SerialMessageType.FW_DEPLOY_DONE);
+        const done = handler.handleFwDeployDone(f6.data);
+        expect(done.type).toBe(SerialWorkerResponseType.FW_DEPLOY_DONE);
+        if (done.type === SerialWorkerResponseType.FW_DEPLOY_DONE) {
+          expect(done.payload.transferId).toBe(XFER);
+          expect(done.payload.results).toHaveLength(2);
+          const [rA, rB] = done.payload.results;
+          expect(rA?.controllerId).toBe('ctrl-A');
+          expect(rA?.outcome).toBe('OK');
+          expect(rA?.finalVersion).toBe('1.5.0');
+          expect(rA?.error).toBe('');
+          expect(rB?.controllerId).toBe('ctrl-B');
+          expect(rB?.outcome).toBe('FAILED');
+          expect(rB?.finalVersion).toBe('');
+          expect(rB?.error).toBe('crc_mismatch');
+        }
+      } finally {
+        await dispose();
+      }
+    },
+  );
+
+  skipIfNotPosix(
+    'writePollAck: emits POLL_ACK parseable by MessageHandler.handlePollAck',
+    async () => {
+      const { stub, serverPort, dispose } = await setupBothEnds();
+      try {
+        const framesPromise = collectFrames(serverPort, 1);
+
+        stub.writePollAck({
+          mac: 'AA:BB:CC:DD:EE:FF',
+          fingerprint: 'fp-test',
+          firmwareVersion: '2.3.4',
+          variant: 'astros-padawan-test',
+          msgId: 'poll-m1',
+        });
+
+        const frames = await framesPromise;
+        const handler = new MessageHandler();
+
+        const fp0 = requireFrame(frames, 0);
+        expect(fp0.valid).toBe(true);
+        expect(fp0.type).toBe(SerialMessageType.POLL_ACK);
+        expect(fp0.id).toBe('poll-m1');
+
+        const resp = handler.handlePollAck(fp0.data);
+        expect(resp.type).toBe(SerialWorkerResponseType.POLL);
+        if (resp.type === SerialWorkerResponseType.POLL) {
+          expect(resp.controller?.address).toBe('AA:BB:CC:DD:EE:FF');
+          expect(resp.controller?.fingerprint).toBe('fp-test');
+          expect(resp.controller?.firmwareVersion).toBe('2.3.4');
+          expect(resp.controller?.variant).toBe('astros-padawan-test');
+        }
+      } finally {
+        await dispose();
+      }
+    },
+  );
+
+  skipIfNotPosix(
+    'disable("autoAckUpload"): no response is written after FW_TRANSFER_BEGIN',
+    async () => {
+      const { stub, serverPort, dispose } = await setupBothEnds();
+      try {
+        stub.autoAckUpload();
+        stub.disable('autoAckUpload');
+
+        const generator = new MessageGenerator();
+
+        // Race: if any frame arrives within 200ms the test fails; timeout is a pass.
+        const noResponsePromise = new Promise<'timeout' | 'got-frame'>((resolve) => {
+          const timer = setTimeout(() => resolve('timeout'), 200);
+          const parser = serverPort.pipe(new DelimiterParser({ delimiter: '\n' }));
+          parser.once('data', () => {
+            clearTimeout(timer);
+            resolve('got-frame');
+          });
+        });
+
+        const beginHeader = generator.generateHeader(SerialMessageType.FW_TRANSFER_BEGIN, 'b-dis');
+        const { msg: beginMsg } = generator.generateFwTransferBegin(beginHeader, {
+          transferId: 'xfer-disabled',
+          totalSize: 100,
+          sha256Hex: 'c'.repeat(64),
+          chunkSize: 100,
+          targets: ['master'],
+        });
+        serverPort.write(beginMsg);
+
+        const result = await noResponsePromise;
+        expect(result).toBe('timeout');
+      } finally {
+        await dispose();
       }
     },
   );

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { SerialPort } from 'serialport';
+import { DelimiterParser } from '@serialport/parser-delimiter';
+
+import { createPtyPair } from './pty_pair.js';
+import { StubMaster } from './stub_master.js';
+import { MessageGenerator } from '../serial/message_generator.js';
+import { MessageHandler } from '../serial/message_handler.js';
+import { SerialMessageType } from '../serial/serial_message.js';
+import { SerialWorkerResponseType } from '../serial/serial_worker_response.js';
+import {
+  FW_SERIAL_SLIDING_WINDOW,
+  type FwTransferBegin,
+} from '../models/firmware/firmware_messages.js';
+
+const skipIfNotPosix = process.platform === 'win32' ? it.skip : it;
+
+describe('StubMaster (PTY-backed)', () => {
+  skipIfNotPosix(
+    'inbound: server-side write of FW_TRANSFER_BEGIN is parsed by the stub master',
+    async () => {
+      const pty = await createPtyPair();
+      const stub = new StubMaster({ ptyPath: pty.masterPath });
+
+      // Server side opens the *server* PTY end and writes a real
+      // FW_TRANSFER_BEGIN frame using the production MessageGenerator.
+      const serverPort = new SerialPort({
+        path: pty.serverPath,
+        baudRate: 9600,
+        autoOpen: false,
+      });
+
+      try {
+        await stub.start();
+        await new Promise<void>((resolve, reject) => {
+          serverPort.open((err) => (err ? reject(err) : resolve()));
+        });
+
+        const generator = new MessageGenerator();
+        const beginPayload: FwTransferBegin = {
+          transferId: 'xfer-abc',
+          totalSize: 1024,
+          sha256Hex: 'a'.repeat(64),
+          chunkSize: 256,
+          targets: ['ctrl-1', 'ctrl-2'],
+        };
+        const header = generator.generateHeader(SerialMessageType.FW_TRANSFER_BEGIN, 'msg-1');
+        const { msg } = generator.generateFwTransferBegin(header, beginPayload);
+        serverPort.write(msg);
+
+        const frame = await stub.waitForFrame(
+          (f) => f.type === SerialMessageType.FW_TRANSFER_BEGIN,
+          3000,
+        );
+
+        expect(frame.type).toBe(SerialMessageType.FW_TRANSFER_BEGIN);
+        expect(frame.msgId).toBe('msg-1');
+        expect(frame.payload).toContain('xfer-abc');
+        expect(frame.payload).toContain('ctrl-1');
+
+        // Snapshot view should include the same frame.
+        const seen = stub.receivedFrames();
+        expect(seen.length).toBeGreaterThanOrEqual(1);
+        expect(seen[0]?.msgId).toBe('msg-1');
+      } finally {
+        await stub.dispose();
+        await new Promise<void>((resolve) => {
+          if (serverPort.isOpen) {
+            serverPort.close(() => resolve());
+          } else {
+            resolve();
+          }
+        });
+        await pty.dispose();
+      }
+    },
+  );
+
+  skipIfNotPosix(
+    'outbound: stub master writes FW_TRANSFER_BEGIN_ACK that the server-side handler accepts',
+    async () => {
+      const pty = await createPtyPair();
+      const stub = new StubMaster({ ptyPath: pty.masterPath });
+
+      const serverPort = new SerialPort({
+        path: pty.serverPath,
+        baudRate: 9600,
+        autoOpen: false,
+      });
+
+      try {
+        await stub.start();
+        await new Promise<void>((resolve, reject) => {
+          serverPort.open((err) => (err ? reject(err) : resolve()));
+        });
+
+        // Wire up a parser on the server side and capture exactly one line.
+        const handler = new MessageHandler();
+        const linePromise = new Promise<string>((resolve, reject) => {
+          const timer = setTimeout(
+            () => reject(new Error('Server did not receive a frame within 3000ms')),
+            3000,
+          );
+          const parser = serverPort.pipe(new DelimiterParser({ delimiter: '\n' }));
+          parser.once('data', (chunk: Buffer) => {
+            clearTimeout(timer);
+            resolve(chunk.toString('utf8'));
+          });
+        });
+
+        stub.writeFwTransferBeginAck({
+          transferId: 'xfer-1',
+          windowSize: FW_SERIAL_SLIDING_WINDOW,
+          msgId: 'm1',
+        });
+
+        const line = await linePromise;
+        const validation = handler.validateMessage(line);
+
+        expect(validation.valid).toBe(true);
+        expect(validation.type).toBe(SerialMessageType.FW_TRANSFER_BEGIN_ACK);
+        expect(validation.id).toBe('m1');
+
+        const response = handler.handleFwTransferBeginAck(validation.data);
+        expect(response.type).toBe(SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK);
+        if (response.type === SerialWorkerResponseType.FW_TRANSFER_BEGIN_ACK) {
+          expect(response.payload.transferId).toBe('xfer-1');
+          // The fake serializes windowSize as the status field; round-trip
+          // here just confirms it survives the wire intact.
+          expect(response.payload.status).toBe(String(FW_SERIAL_SLIDING_WINDOW));
+        }
+      } finally {
+        await stub.dispose();
+        await new Promise<void>((resolve) => {
+          if (serverPort.isOpen) {
+            serverPort.close(() => resolve());
+          } else {
+            resolve();
+          }
+        });
+        await pty.dispose();
+      }
+    },
+  );
+});

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -533,8 +533,12 @@ export class StubMaster {
   // receipt, the stub emits FW_PROGRESS for each controller's stages then
   // emits FW_DEPLOY_DONE with the configured per-controller outcomes.
   //
-  // Validation is done at call time (not response time) so misconfigured tests
-  // fail fast rather than producing a mysterious protocol error mid-test.
+  // Argument-shape validation (outcome/finalVersion/error invariants) runs
+  // at call time so misconfigured options fail fast rather than producing
+  // mysterious protocol errors mid-test. Cross-frame validation against the
+  // FW_DEPLOY_BEGIN order (controllers scripted-but-not-requested or
+  // requested-but-not-scripted) happens at dispatch time and is recorded in
+  // `parseErrors` for tests asserting `parsingErrors().toEqual([])`.
   scriptDeploy(opts: ScriptDeployOpts): void {
     const controllers: ScriptDeployControllerCfg[] = opts.controllers.map((c) => {
       if (c.outcome === 'OK' && !c.finalVersion) {

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -62,6 +62,20 @@ const DEFAULT_MASTER_VARIANT = 'astros-master-test-variant';
 // Inbound frame shape (parsed from server-emitted lines)
 // ---------------------------------------------------------------------------
 
+/**
+ * Diagnostic record for a payload the scripted-response dispatcher could
+ * not parse, or where scriptDeploy controllers don't match
+ * FW_DEPLOY_BEGIN's order. Tests assert `stub.parsingErrors()` is empty —
+ * a non-empty list means a wire-format drift / test misconfig that would
+ * otherwise surface as a mysterious downstream timeout.
+ */
+export interface StubParseError {
+  readonly type: SerialMessageType;
+  readonly msgId: string;
+  readonly payload: string;
+  readonly note: string;
+}
+
 export interface InboundFrame {
   type: SerialMessageType;
   msgId: string;
@@ -254,12 +268,7 @@ export class StubMaster {
   // ApiServer's MessageGenerator and the stub's parsers would make every
   // ACK silently never get sent, and tests would time out without a hint
   // why. Tests should assert empty (the harness re-exposes this).
-  private readonly parseErrors: Array<{
-    type: SerialMessageType;
-    msgId: string;
-    payload: string;
-    note: string;
-  }> = [];
+  private readonly parseErrors: StubParseError[] = [];
 
   // Scripted-response configuration. Both are null when the feature
   // is not enabled; set by autoAckUpload() / scriptDeploy(); cleared by
@@ -347,12 +356,7 @@ export class StubMaster {
    * list means a wire-format drift between MessageGenerator and the stub
    * has silently broken every ACK on that frame type.
    */
-  parsingErrors(): readonly Readonly<{
-    type: SerialMessageType;
-    msgId: string;
-    payload: string;
-    note: string;
-  }>[] {
+  parsingErrors(): ReadonlyArray<StubParseError> {
     return this.parseErrors;
   }
 
@@ -844,7 +848,7 @@ function parseFwTransferEndPayload(
 //   transferId<US>controllerId_1<RS>controllerId_2<RS>...
 function parseFwDeployBeginPayload(
   payload: string,
-): { transferId: string; order: string[] } | null {
+): { readonly transferId: string; readonly order: readonly string[] } | null {
   const firstUs = payload.indexOf(MessageHelper.US);
   if (firstUs < 0) return null;
   const transferId = payload.substring(0, firstUs);

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -715,9 +715,9 @@ export class StubMaster {
         // frames so tests don't hang at a downstream waitForWsMessage —
         // the diagnostic is the value-add, not a hard fail.
         const requestedSet = new Set(requestedOrder);
-        const extras = deployCfg.controllers
-          .map((ctrl) => ctrl.id)
-          .filter((id) => !requestedSet.has(id));
+        const scriptedIds = deployCfg.controllers.map((ctrl) => ctrl.id);
+        const scriptedSet = new Set(scriptedIds);
+        const extras = scriptedIds.filter((id) => !requestedSet.has(id));
         if (extras.length > 0) {
           this.parseErrors.push({
             type: frame.type,
@@ -726,6 +726,23 @@ export class StubMaster {
             note:
               `scriptDeploy includes controller(s) not in FW_DEPLOY_BEGIN order: ` +
               `extras=[${extras.join(',')}], requested=[${requestedOrder.join(',')}]`,
+          });
+        }
+        // Symmetric: orchestrator requested a controller that scriptDeploy
+        // didn't script for. The dispatcher would still emit a
+        // FW_DEPLOY_DONE, but with results missing for that controller —
+        // the server then treats it as never-finishing and the test hangs
+        // at a downstream waitForWsMessage with no diagnostic. Surface
+        // here so the misconfig is visible.
+        const missing = requestedOrder.filter((id) => !scriptedSet.has(id));
+        if (missing.length > 0) {
+          this.parseErrors.push({
+            type: frame.type,
+            msgId: frame.msgId,
+            payload: frame.payload,
+            note:
+              `scriptDeploy missing controller(s) requested in FW_DEPLOY_BEGIN: ` +
+              `missing=[${missing.join(',')}], scripted=[${scriptedIds.join(',')}]`,
           });
         }
 

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -702,7 +702,33 @@ export class StubMaster {
           });
           break;
         }
-        const { transferId } = deployParsed;
+        const { transferId, order: requestedOrder } = deployParsed;
+
+        // Validate that every scripted controller appears in the
+        // FW_DEPLOY_BEGIN order. Tests that accidentally script results
+        // for a controller the orchestrator never requested would
+        // otherwise emit FW_PROGRESS/FW_DEPLOY_DONE with controller IDs
+        // the orchestrator can't match, producing confusing
+        // "result for unknown controller" failures downstream. Surface
+        // the mismatch here so it's visible in stub.parsingErrors()
+        // before that failure mode kicks in. We still emit the existing
+        // frames so tests don't hang at a downstream waitForWsMessage —
+        // the diagnostic is the value-add, not a hard fail.
+        const requestedSet = new Set(requestedOrder);
+        const extras = deployCfg.controllers
+          .map((ctrl) => ctrl.id)
+          .filter((id) => !requestedSet.has(id));
+        if (extras.length > 0) {
+          this.parseErrors.push({
+            type: frame.type,
+            msgId: frame.msgId,
+            payload: frame.payload,
+            note:
+              `scriptDeploy includes controller(s) not in FW_DEPLOY_BEGIN order: ` +
+              `extras=[${extras.join(',')}], requested=[${requestedOrder.join(',')}]`,
+          });
+        }
+
         // Walk each controller through its stage progression then emit
         // FW_DEPLOY_DONE. No artificial delay between frames — the
         // orchestrator's per-controller throttle (250ms / 4Hz) means

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -74,15 +74,12 @@ export interface InboundFrame {
 
 export interface FwTransferBeginAckArgs {
   transferId: string;
-  // The handler accepts an open-ended status string (per protocol.md), but
-  // for the test fake we expose a `windowSize` knob and serialize it as the
-  // status field's stand-in. In practice firmware sends "OK" + a separate
-  // window-size advertisement on the FW_CHUNK_ACK stream; this fake compresses
-  // both into the begin-ack so tests can declare the window upfront.
-  // NOTE: this matches how serial_bus_response_test.ts and the streamer's
-  // begin-ack consumer treat the field — they just record `status` as a
-  // string and ignore its content, so any value works for round-trip tests.
-  windowSize?: number;
+  // The wire-format `status` field is open-ended (the handler accepts any
+  // string), but per chunk_streamer.ts the only value that lets the transfer
+  // proceed is 'OK'; any other value aborts with reason 'transfer-rejected'.
+  // Tests default to 'OK' (happy path); failure-mode tests pass an explicit
+  // value like 'sd_full' to drive the rejection branch.
+  status?: string;
   msgId?: string;
 }
 
@@ -311,8 +308,8 @@ export class StubMaster {
   // -------------------------------------------------------------------------
 
   writeFwTransferBeginAck(args: FwTransferBeginAckArgs): void {
-    const window = args.windowSize ?? FW_SERIAL_SLIDING_WINDOW;
-    const payload = [args.transferId, String(window)].join(MessageHelper.US);
+    const status = args.status ?? 'OK';
+    const payload = [args.transferId, status].join(MessageHelper.US);
     this.writeFrame(SerialMessageType.FW_TRANSFER_BEGIN_ACK, args.msgId, payload);
   }
 

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -5,7 +5,9 @@
 // during tests. It is a *test fake*, not a behavior simulator — real
 // firmware behavior simulation lives in AstrOs.ESP.
 //
-// Task 2 covered the raw read/write skeleton:
+// Two layers of API:
+//
+// Raw read/write skeleton:
 //   - Opens a SerialPort + DelimiterParser on the master end of a PTY.
 //   - Parses inbound (server-emitted) frames into `{ type, msgId, payload }`.
 //   - Exposes typed outbound writers for every master→server message family
@@ -15,7 +17,7 @@
 //   - Exposes a `waitForFrame()` synchronization helper for deterministic
 //     test orchestration.
 //
-// Task 3 (this file) adds the scripted-response API on top:
+// Scripted-response API on top:
 //   - autoAckUpload(): auto-ACK FW_TRANSFER_BEGIN / FW_CHUNK / FW_TRANSFER_END.
 //     Supports failAtSeq for one-shot NAK injection (Go-Back-N).
 //   - scriptDeploy(opts): on FW_DEPLOY_BEGIN, walk each controller through
@@ -64,8 +66,8 @@ export interface InboundFrame {
   type: SerialMessageType;
   msgId: string;
   // Raw payload bytes after the GS separator, unparsed. Tests can match on
-  // this directly (e.g. assert it contains a transferId substring); Task 3
-  // will layer per-type field decoding for the scripted-response API.
+  // this directly (e.g. assert it contains a transferId substring); the
+  // scripted-response API layers per-type field decoding on top.
   payload: string;
 }
 
@@ -162,7 +164,7 @@ export interface PollAckArgs {
 }
 
 // ---------------------------------------------------------------------------
-// Scripted-response API argument shapes (Task 3)
+// Scripted-response API argument shapes
 // ---------------------------------------------------------------------------
 
 export interface AutoAckUploadOpts {
@@ -247,7 +249,7 @@ export class StubMaster {
   private readonly inbound: InboundFrame[] = [];
   private readonly waiters: FrameWaiter[] = [];
 
-  // Scripted-response configuration (Task 3). Both are null when the feature
+  // Scripted-response configuration. Both are null when the feature
   // is not enabled; set by autoAckUpload() / scriptDeploy(); cleared by
   // disable().
   private autoAckUploadCfg: AutoAckUploadCfg | null = null;
@@ -456,7 +458,7 @@ export class StubMaster {
   }
 
   // -------------------------------------------------------------------------
-  // Scripted-response API (Task 3)
+  // Scripted-response API
   // -------------------------------------------------------------------------
 
   // Configure the stub to automatically respond to FW_TRANSFER_BEGIN,
@@ -679,7 +681,7 @@ function parseInbound(line: string): InboundFrame | null {
 }
 
 // ---------------------------------------------------------------------------
-// Narrow file-scope payload parsers for inbound server→master frames (Task 3).
+// Narrow file-scope payload parsers for inbound server→master frames.
 //
 // These are intentionally separate from MessageHandler, which parses the
 // master→server direction. Field counts and separator choice are verified

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -1,0 +1,451 @@
+// Scriptable wire-protocol responder for the firmware OTA integration test
+// harness. The stub master opens one end of a PTY pair (created by
+// `createPtyPair`) and mimics just enough of the AstrOs ESP32 master
+// firmware's wire-protocol surface to satisfy the orchestrator/streamer
+// during tests. It is a *test fake*, not a behavior simulator — real
+// firmware behavior simulation lives in AstrOs.ESP.
+//
+// Task 2 (this file) covers the raw read/write skeleton:
+//   - Opens a SerialPort + DelimiterParser on the master end of a PTY.
+//   - Parses inbound (server-emitted) frames into `{ type, msgId, payload }`.
+//   - Exposes typed outbound writers for every master→server message family
+//     in the protocol (FW_TRANSFER_BEGIN_ACK, FW_CHUNK_ACK, FW_CHUNK_NAK,
+//     FW_TRANSFER_END_ACK, FW_PROGRESS, FW_DEPLOY_DONE, FW_BACKPRESSURE,
+//     POLL_ACK).
+//   - Exposes a `waitForFrame()` synchronization helper for deterministic
+//     test orchestration.
+//
+// The scripted-response API (auto-ack of uploads, deploy scripting) is a
+// separate concern and lands in Task 3 — keep this module focused on raw
+// I/O so Task 3 can layer on top without touching the wire format.
+
+import { SerialPort } from 'serialport';
+import { DelimiterParser } from '@serialport/parser-delimiter';
+import { v4 as uuid_v4 } from 'uuid';
+
+import { MessageHelper } from '../serial/message_helper.js';
+import { SerialMessageType } from '../serial/serial_message.js';
+import {
+  FW_SERIAL_SLIDING_WINDOW,
+  type FwBackpressureAction,
+  type FwChunkNakReason,
+  type FwStage,
+  type FwTransferEndStatus,
+} from '../models/firmware/firmware_messages.js';
+
+// ---------------------------------------------------------------------------
+// Construction options
+// ---------------------------------------------------------------------------
+
+export interface StubMasterOpts {
+  ptyPath: string;
+  // Sentinel MAC for the master per project convention (per
+  // project_master_esp_sentinel_mac memory). Real firmware always reports
+  // POLL_ACK with this address from the master; padawans send their own MACs.
+  masterMac?: string;
+  masterFingerprint?: string;
+  masterFirmwareVersion?: string;
+  masterVariant?: string;
+}
+
+const DEFAULT_MASTER_MAC = '00:00:00:00:00:00';
+const DEFAULT_MASTER_FINGERPRINT = 'master-stub';
+const DEFAULT_MASTER_FIRMWARE_VERSION = '1.0.0';
+const DEFAULT_MASTER_VARIANT = 'astros-master-test-variant';
+
+// ---------------------------------------------------------------------------
+// Inbound frame shape (parsed from server-emitted lines)
+// ---------------------------------------------------------------------------
+
+export interface InboundFrame {
+  type: SerialMessageType;
+  msgId: string;
+  // Raw payload bytes after the GS separator, unparsed. Tests can match on
+  // this directly (e.g. assert it contains a transferId substring); Task 3
+  // will layer per-type field decoding for the scripted-response API.
+  payload: string;
+}
+
+// ---------------------------------------------------------------------------
+// Outbound writer argument shapes. Each maps 1:1 to a single wire frame
+// addressed to the server. Field layouts mirror the parsers in
+// MessageHandler — that file is the source of truth for count + order.
+// ---------------------------------------------------------------------------
+
+export interface FwTransferBeginAckArgs {
+  transferId: string;
+  // The handler accepts an open-ended status string (per protocol.md), but
+  // for the test fake we expose a `windowSize` knob and serialize it as the
+  // status field's stand-in. In practice firmware sends "OK" + a separate
+  // window-size advertisement on the FW_CHUNK_ACK stream; this fake compresses
+  // both into the begin-ack so tests can declare the window upfront.
+  // NOTE: this matches how serial_bus_response_test.ts and the streamer's
+  // begin-ack consumer treat the field — they just record `status` as a
+  // string and ignore its content, so any value works for round-trip tests.
+  windowSize?: number;
+  msgId?: string;
+}
+
+export interface FwChunkAckArgs {
+  transferId: string;
+  highestContiguousSeq: number;
+  // Handler reads this as `nextExpectedSeq`, not bytesSent — see
+  // MessageHandler.handleFwChunkAck. The 4-field layout is:
+  //   transferId<US>highestContiguousSeq<US>nextExpectedSeq<US>windowRemaining
+  nextExpectedSeq: number;
+  windowRemaining?: number;
+  msgId?: string;
+}
+
+export interface FwChunkNakArgs {
+  transferId: string;
+  lastGoodSeq: number;
+  // Reason codes come from FW_CHUNK_NAK_REASONS in firmware_messages.ts —
+  // that const tuple is the protocol source of truth. Allowed values:
+  // 'CRC' | 'SIZE' | 'OUT_OF_ORDER' | 'FLASH_FULL'.
+  reasonCode: FwChunkNakReason;
+  msgId?: string;
+}
+
+export interface FwTransferEndAckArgs {
+  transferId: string;
+  // Status enum from FW_TRANSFER_END_STATUSES: 'OK' | 'HASH_MISMATCH' |
+  // 'IO_ERROR'.
+  status: FwTransferEndStatus;
+  // 64 lowercase hex chars — the handler's parseSha256Hex enforces that.
+  computedSha256Hex: string;
+  msgId?: string;
+}
+
+export interface FwProgressArgs {
+  transferId: string;
+  controllerId: string;
+  stage: FwStage;
+  bytesSent: number;
+  totalBytes: number;
+  detail?: string;
+  msgId?: string;
+}
+
+export interface FwDeployDoneResultArg {
+  controllerId: string;
+  outcome: 'OK' | 'FAILED';
+  // Cross-field invariant from protocol.md (also enforced by the server's
+  // handler at handleFwDeployDone): if outcome === 'OK' then error MUST
+  // be ''. The fake does not police this — callers are expected to honor
+  // the invariant; emitting OK + non-empty error will produce an UNKNOWN
+  // response on the server side.
+  finalVersion: string;
+  error: string;
+}
+
+export interface FwDeployDoneArgs {
+  transferId: string;
+  results: FwDeployDoneResultArg[];
+  msgId?: string;
+}
+
+export interface FwBackpressureArgs {
+  transferId: string;
+  // 'PAUSE' | 'RESUME' (FW_BACKPRESSURE_ACTIONS).
+  action: FwBackpressureAction;
+  reason: string;
+  msgId?: string;
+}
+
+export interface PollAckArgs {
+  mac?: string;
+  fingerprint?: string;
+  firmwareVersion?: string;
+  variant?: string;
+  msgId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: pending waitForFrame subscriber bookkeeping
+// ---------------------------------------------------------------------------
+
+interface FrameWaiter {
+  predicate: (frame: InboundFrame) => boolean;
+  resolve: (frame: InboundFrame) => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+// ---------------------------------------------------------------------------
+// StubMaster — open the PTY, parse inbound, write outbound.
+// ---------------------------------------------------------------------------
+
+export class StubMaster {
+  private readonly opts: Required<StubMasterOpts>;
+  private port: SerialPort | null = null;
+  private parser: DelimiterParser | null = null;
+  private readonly inbound: InboundFrame[] = [];
+  private readonly waiters: FrameWaiter[] = [];
+
+  constructor(opts: StubMasterOpts) {
+    this.opts = {
+      ptyPath: opts.ptyPath,
+      masterMac: opts.masterMac ?? DEFAULT_MASTER_MAC,
+      masterFingerprint: opts.masterFingerprint ?? DEFAULT_MASTER_FINGERPRINT,
+      masterFirmwareVersion: opts.masterFirmwareVersion ?? DEFAULT_MASTER_FIRMWARE_VERSION,
+      masterVariant: opts.masterVariant ?? DEFAULT_MASTER_VARIANT,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    if (this.port !== null) {
+      // start() is idempotent — calling twice without a dispose() is a
+      // programming error, but we no-op rather than crash so a test with
+      // overzealous setup doesn't blow up before its assertion runs.
+      return;
+    }
+
+    const port = new SerialPort({
+      path: this.opts.ptyPath,
+      baudRate: 9600,
+      autoOpen: false,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      port.open((err) => {
+        if (err) {
+          reject(new Error(`StubMaster: failed to open PTY ${this.opts.ptyPath}: ${err.message}`));
+          return;
+        }
+        resolve();
+      });
+    });
+
+    const parser = port.pipe(new DelimiterParser({ delimiter: '\n' }));
+    parser.on('data', (chunk: Buffer) => this.handleInboundLine(chunk.toString('utf8')));
+
+    this.port = port;
+    this.parser = parser;
+  }
+
+  async dispose(): Promise<void> {
+    // Reject any outstanding waiters so tests don't hang on a closed port.
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      if (!waiter) break;
+      clearTimeout(waiter.timer);
+      waiter.reject(new Error('StubMaster: disposed before frame arrived'));
+    }
+
+    const port = this.port;
+    this.port = null;
+    this.parser = null;
+
+    if (port === null) return;
+    if (!port.isOpen) return;
+
+    await new Promise<void>((resolve) => {
+      port.close(() => resolve());
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Inbound observation
+  // -------------------------------------------------------------------------
+
+  receivedFrames(): readonly InboundFrame[] {
+    return this.inbound;
+  }
+
+  async waitForFrame(
+    predicate: (frame: InboundFrame) => boolean,
+    timeoutMs = 2000,
+  ): Promise<InboundFrame> {
+    // Fast-path: scan already-buffered frames first so a test that calls
+    // waitForFrame() after the matching frame has already arrived doesn't
+    // hang for the full timeout.
+    for (const frame of this.inbound) {
+      if (predicate(frame)) {
+        return frame;
+      }
+    }
+
+    return new Promise<InboundFrame>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = this.waiters.findIndex((w) => w.timer === timer);
+        if (idx >= 0) this.waiters.splice(idx, 1);
+        const recent = this.inbound.slice(-5).map((f) => ({
+          type: SerialMessageType[f.type] ?? f.type,
+          msgId: f.msgId,
+          payloadPreview: f.payload.slice(0, 80),
+        }));
+        reject(
+          new Error(
+            `StubMaster.waitForFrame: timed out after ${timeoutMs}ms. ` +
+              `Recent frames (last 5 of ${this.inbound.length}): ` +
+              JSON.stringify(recent),
+          ),
+        );
+      }, timeoutMs);
+
+      this.waiters.push({ predicate, resolve, reject, timer });
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Raw write
+  // -------------------------------------------------------------------------
+
+  writeRaw(line: string): void {
+    if (this.port === null || !this.port.isOpen) {
+      throw new Error('StubMaster.writeRaw: port is not open (call start() first)');
+    }
+    this.port.write(line);
+  }
+
+  // -------------------------------------------------------------------------
+  // Outbound writers — each builds a properly framed line and writes it.
+  //
+  // Frame format (mirrors MessageGenerator.generateHeader):
+  //   {type}{RS}{validationToken}{RS}{msgId}{GS}{payload}{EOL}
+  // -------------------------------------------------------------------------
+
+  writeFwTransferBeginAck(args: FwTransferBeginAckArgs): void {
+    const window = args.windowSize ?? FW_SERIAL_SLIDING_WINDOW;
+    const payload = [args.transferId, String(window)].join(MessageHelper.US);
+    this.writeFrame(SerialMessageType.FW_TRANSFER_BEGIN_ACK, args.msgId, payload);
+  }
+
+  writeFwChunkAck(args: FwChunkAckArgs): void {
+    const window = args.windowRemaining ?? FW_SERIAL_SLIDING_WINDOW;
+    const payload = [
+      args.transferId,
+      String(args.highestContiguousSeq),
+      String(args.nextExpectedSeq),
+      String(window),
+    ].join(MessageHelper.US);
+    this.writeFrame(SerialMessageType.FW_CHUNK_ACK, args.msgId, payload);
+  }
+
+  writeFwChunkNak(args: FwChunkNakArgs): void {
+    const payload = [args.transferId, String(args.lastGoodSeq), args.reasonCode].join(
+      MessageHelper.US,
+    );
+    this.writeFrame(SerialMessageType.FW_CHUNK_NAK, args.msgId, payload);
+  }
+
+  writeFwTransferEndAck(args: FwTransferEndAckArgs): void {
+    const payload = [args.transferId, args.status, args.computedSha256Hex].join(MessageHelper.US);
+    this.writeFrame(SerialMessageType.FW_TRANSFER_END_ACK, args.msgId, payload);
+  }
+
+  writeFwProgress(args: FwProgressArgs): void {
+    const payload = [
+      args.transferId,
+      args.controllerId,
+      args.stage,
+      String(args.bytesSent),
+      String(args.totalBytes),
+      args.detail ?? '',
+    ].join(MessageHelper.US);
+    this.writeFrame(SerialMessageType.FW_PROGRESS, args.msgId, payload);
+  }
+
+  writeFwDeployDone(args: FwDeployDoneArgs): void {
+    if (args.results.length === 0) {
+      // The handler splits resultListStr on RS and then validates each result
+      // has 4 US-separated fields. An empty results list would yield a single
+      // empty-string entry that fails the field-count check. The fake refuses
+      // to produce a frame the handler will reject as UNKNOWN — surface the
+      // error at write-time so tests don't get a silent UNKNOWN response.
+      throw new Error('StubMaster.writeFwDeployDone: results must contain at least one entry');
+    }
+
+    const resultStrs = args.results.map((r) =>
+      [r.controllerId, r.outcome, r.finalVersion, r.error].join(MessageHelper.US),
+    );
+    const payload = [args.transferId, resultStrs.join(MessageHelper.RS)].join(MessageHelper.US);
+    this.writeFrame(SerialMessageType.FW_DEPLOY_DONE, args.msgId, payload);
+  }
+
+  writeFwBackpressure(args: FwBackpressureArgs): void {
+    const payload = [args.transferId, args.action, args.reason].join(MessageHelper.US);
+    this.writeFrame(SerialMessageType.FW_BACKPRESSURE, args.msgId, payload);
+  }
+
+  writePollAck(args?: PollAckArgs): void {
+    const mac = args?.mac ?? this.opts.masterMac;
+    const fingerprint = args?.fingerprint ?? this.opts.masterFingerprint;
+    const firmwareVersion = args?.firmwareVersion ?? this.opts.masterFirmwareVersion;
+    const variant = args?.variant ?? this.opts.masterVariant;
+    // 5-field POLL_ACK: mac, name, fingerprint, firmwareVersion, variant.
+    // Real master firmware sends the MAC as the "name" field (per
+    // project_master_esp_sentinel_mac); we mirror that.
+    const payload = [mac, mac, fingerprint, firmwareVersion, variant].join(MessageHelper.US);
+    this.writeFrame(SerialMessageType.POLL_ACK, args?.msgId, payload);
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  private writeFrame(type: SerialMessageType, msgId: string | undefined, payload: string): void {
+    if (this.port === null || !this.port.isOpen) {
+      throw new Error(
+        `StubMaster.writeFrame(${SerialMessageType[type]}): port is not open (call start() first)`,
+      );
+    }
+    const validation = MessageHelper.ValidationMap.get(type);
+    if (validation === undefined) {
+      throw new Error(`StubMaster.writeFrame: no validation token for type ${type}`);
+    }
+    const id = msgId ?? uuid_v4();
+    const line = `${type}${MessageHelper.RS}${validation}${MessageHelper.RS}${id}${MessageHelper.GS}${payload}${MessageHelper.MessageEOL}`;
+    this.port.write(line);
+  }
+
+  private handleInboundLine(line: string): void {
+    // The DelimiterParser strips '\n', so `line` here has no trailing newline.
+    const frame = parseInbound(line);
+    if (frame === null) return;
+    this.inbound.push(frame);
+
+    // Notify any waiter whose predicate now matches. Use a copy of the array
+    // so a waiter that calls waitForFrame again from inside its resolution
+    // doesn't disturb iteration.
+    const matched: FrameWaiter[] = [];
+    for (let i = this.waiters.length - 1; i >= 0; i--) {
+      const waiter = this.waiters[i];
+      if (waiter.predicate(frame)) {
+        matched.push(waiter);
+        this.waiters.splice(i, 1);
+      }
+    }
+    for (const waiter of matched) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(frame);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inbound parser. Matches the shape MessageHandler.validateMessage expects.
+// Returns null for any unparseable line so the caller can drop it silently.
+// ---------------------------------------------------------------------------
+
+function parseInbound(line: string): InboundFrame | null {
+  const groups = line.split(MessageHelper.GS);
+  if (groups.length !== 2) return null;
+
+  const headerParts = groups[0].split(MessageHelper.RS);
+  if (headerParts.length !== 3) return null;
+
+  const type = parseInt(headerParts[0], 10);
+  if (Number.isNaN(type)) return null;
+
+  return {
+    type: type as SerialMessageType,
+    msgId: headerParts[2],
+    payload: groups[1],
+  };
+}

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -172,12 +172,6 @@ export interface AutoAckUploadOpts {
   // streamer's bookkeeping is what matters; fake in-flight tracking would add
   // complexity without test value.
   windowSize?: number;
-  // Only 'every' is supported: ACK each FW_CHUNK individually. 'window'-level
-  // batching is unused for now; the union is kept narrow to avoid misleading
-  // callers. This field is accepted but not read at runtime — the implicit
-  // behavior IS 'every', so passing it is a no-op. It exists so tests can
-  // document intent explicitly without breaking when 'window' is added later.
-  ackCadence?: 'every';
   // Status field for FW_TRANSFER_END_ACK. Default 'OK' (happy path).
   endStatus?: FwTransferEndStatus;
   // If set, NAK exactly once when the first FW_CHUNK with seq === failAtSeq
@@ -572,8 +566,10 @@ export class StubMaster {
     switch (frame.type) {
       case SerialMessageType.FW_TRANSFER_BEGIN: {
         if (cfg === null) break;
+        const transferId = extractTransferId(frame.payload);
+        if (transferId === null) break; // Malformed payload; drop silently — would have produced a malformed ACK.
         this.writeFwTransferBeginAck({
-          transferId: extractTransferId(frame.payload),
+          transferId,
           status: 'OK',
         });
         break;
@@ -693,9 +689,9 @@ function parseInbound(line: string): InboundFrame | null {
 
 // Extract transferId from any payload whose first US-separated field is the
 // transferId. Used for FW_TRANSFER_BEGIN where we only need the ID.
-function extractTransferId(payload: string): string {
+function extractTransferId(payload: string): string | null {
   const idx = payload.indexOf(MessageHelper.US);
-  return idx < 0 ? payload : payload.substring(0, idx);
+  return idx < 0 ? null : payload.substring(0, idx);
 }
 
 // FW_CHUNK payload (5 US-separated fields per generateFwChunk):

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -248,6 +248,18 @@ export class StubMaster {
   private parser: DelimiterParser | null = null;
   private readonly inbound: InboundFrame[] = [];
   private readonly waiters: FrameWaiter[] = [];
+  // Records every payload the scripted-response dispatcher couldn't parse.
+  // Stays empty in the happy case. A non-empty list is exactly the bug
+  // class the harness exists to catch — wire-format drift between the
+  // ApiServer's MessageGenerator and the stub's parsers would make every
+  // ACK silently never get sent, and tests would time out without a hint
+  // why. Tests should assert empty (the harness re-exposes this).
+  private readonly parseErrors: Array<{
+    type: SerialMessageType;
+    msgId: string;
+    payload: string;
+    note: string;
+  }> = [];
 
   // Scripted-response configuration. Both are null when the feature
   // is not enabled; set by autoAckUpload() / scriptDeploy(); cleared by
@@ -327,6 +339,21 @@ export class StubMaster {
 
   receivedFrames(): readonly InboundFrame[] {
     return this.inbound;
+  }
+
+  /**
+   * Records of payloads the scripted-response dispatcher couldn't parse.
+   * Tests should assert this is empty after each scenario — a non-empty
+   * list means a wire-format drift between MessageGenerator and the stub
+   * has silently broken every ACK on that frame type.
+   */
+  parsingErrors(): readonly Readonly<{
+    type: SerialMessageType;
+    msgId: string;
+    payload: string;
+    note: string;
+  }>[] {
+    return this.parseErrors;
   }
 
   async waitForFrame(
@@ -591,7 +618,15 @@ export class StubMaster {
       case SerialMessageType.FW_TRANSFER_BEGIN: {
         if (cfg === null) break;
         const transferId = extractTransferId(frame.payload);
-        if (transferId === null) break; // Malformed payload; drop silently — would have produced a malformed ACK.
+        if (transferId === null) {
+          this.parseErrors.push({
+            type: frame.type,
+            msgId: frame.msgId,
+            payload: frame.payload,
+            note: 'extractTransferId returned null — no FW_TRANSFER_BEGIN_ACK emitted',
+          });
+          break;
+        }
         this.writeFwTransferBeginAck({
           transferId,
           status: 'OK',
@@ -602,7 +637,15 @@ export class StubMaster {
       case SerialMessageType.FW_CHUNK: {
         if (cfg === null) break;
         const chunkParsed = parseFwChunkPayload(frame.payload);
-        if (chunkParsed === null) break;
+        if (chunkParsed === null) {
+          this.parseErrors.push({
+            type: frame.type,
+            msgId: frame.msgId,
+            payload: frame.payload,
+            note: 'parseFwChunkPayload returned null — no FW_CHUNK_ACK/NAK emitted',
+          });
+          break;
+        }
         const { transferId, seq } = chunkParsed;
         // Inject exactly one NAK when this seq matches failAtSeq and we
         // haven't already failed. After that, resume normal ACKing
@@ -628,7 +671,15 @@ export class StubMaster {
       case SerialMessageType.FW_TRANSFER_END: {
         if (cfg === null) break;
         const endParsed = parseFwTransferEndPayload(frame.payload);
-        if (endParsed === null) break;
+        if (endParsed === null) {
+          this.parseErrors.push({
+            type: frame.type,
+            msgId: frame.msgId,
+            payload: frame.payload,
+            note: 'parseFwTransferEndPayload returned null — no FW_TRANSFER_END_ACK emitted',
+          });
+          break;
+        }
         this.writeFwTransferEndAck({
           transferId: endParsed.transferId,
           status: cfg.endStatus,
@@ -642,7 +693,15 @@ export class StubMaster {
         const deployCfg = this.scriptDeployCfg;
         if (deployCfg === null) break;
         const deployParsed = parseFwDeployBeginPayload(frame.payload);
-        if (deployParsed === null) break;
+        if (deployParsed === null) {
+          this.parseErrors.push({
+            type: frame.type,
+            msgId: frame.msgId,
+            payload: frame.payload,
+            note: 'parseFwDeployBeginPayload returned null — no FW_DEPLOY_DONE/PROGRESS emitted',
+          });
+          break;
+        }
         const { transferId } = deployParsed;
         // Walk each controller through its stage progression then emit
         // FW_DEPLOY_DONE. No artificial delay between frames — the

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -5,7 +5,7 @@
 // during tests. It is a *test fake*, not a behavior simulator — real
 // firmware behavior simulation lives in AstrOs.ESP.
 //
-// Task 2 (this file) covers the raw read/write skeleton:
+// Task 2 covered the raw read/write skeleton:
 //   - Opens a SerialPort + DelimiterParser on the master end of a PTY.
 //   - Parses inbound (server-emitted) frames into `{ type, msgId, payload }`.
 //   - Exposes typed outbound writers for every master→server message family
@@ -15,9 +15,12 @@
 //   - Exposes a `waitForFrame()` synchronization helper for deterministic
 //     test orchestration.
 //
-// The scripted-response API (auto-ack of uploads, deploy scripting) is a
-// separate concern and lands in Task 3 — keep this module focused on raw
-// I/O so Task 3 can layer on top without touching the wire format.
+// Task 3 (this file) adds the scripted-response API on top:
+//   - autoAckUpload(): auto-ACK FW_TRANSFER_BEGIN / FW_CHUNK / FW_TRANSFER_END.
+//     Supports failAtSeq for one-shot NAK injection (Go-Back-N).
+//   - scriptDeploy(opts): on FW_DEPLOY_BEGIN, walk each controller through
+//     stage FW_PROGRESS frames then emit FW_DEPLOY_DONE.
+//   - disable(feature): turn off a scripted response for timeout tests.
 
 import { SerialPort } from 'serialport';
 import { DelimiterParser } from '@serialport/parser-delimiter';
@@ -27,9 +30,9 @@ import { MessageHelper } from '../serial/message_helper.js';
 import { SerialMessageType } from '../serial/serial_message.js';
 import {
   FW_SERIAL_SLIDING_WINDOW,
+  FwStage,
   type FwBackpressureAction,
   type FwChunkNakReason,
-  type FwStage,
   type FwTransferEndStatus,
 } from '../models/firmware/firmware_messages.js';
 
@@ -159,6 +162,76 @@ export interface PollAckArgs {
 }
 
 // ---------------------------------------------------------------------------
+// Scripted-response API argument shapes (Task 3)
+// ---------------------------------------------------------------------------
+
+export interface AutoAckUploadOpts {
+  // Sliding window size to advertise in FW_CHUNK_ACK.windowRemaining.
+  // Defaults to FW_SERIAL_SLIDING_WINDOW (16). The stub doesn't track actual
+  // in-flight count — `windowRemaining` always echoes this value because the
+  // streamer's bookkeeping is what matters; fake in-flight tracking would add
+  // complexity without test value.
+  windowSize?: number;
+  // Only 'every' is supported: ACK each FW_CHUNK individually. 'window'-level
+  // batching is unused for now; the union is kept narrow to avoid misleading
+  // callers. This field is accepted but not read at runtime — the implicit
+  // behavior IS 'every', so passing it is a no-op. It exists so tests can
+  // document intent explicitly without breaking when 'window' is added later.
+  ackCadence?: 'every';
+  // Status field for FW_TRANSFER_END_ACK. Default 'OK' (happy path).
+  endStatus?: FwTransferEndStatus;
+  // If set, NAK exactly once when the first FW_CHUNK with seq === failAtSeq
+  // arrives (reasonCode='CRC', lastGoodSeq=failAtSeq-1). Subsequent chunks —
+  // including the retransmitted failAtSeq — are ACKed normally.
+  failAtSeq?: number;
+}
+
+export interface ScriptDeployControllerOpts {
+  // Controller MAC — must match what the orchestrator sent in
+  // FW_DEPLOY_BEGIN.order so progress frames are attributed correctly.
+  id: string;
+  outcome: 'OK' | 'FAILED';
+  // Required when outcome === 'OK'. Validated at scriptDeploy() call time.
+  finalVersion?: string;
+  // Required when outcome === 'FAILED'. Validated at scriptDeploy() call time.
+  error?: string;
+  // FW_PROGRESS stages to emit for this controller before FW_DEPLOY_DONE.
+  // Default [Sending, Verifying, Rebooting]. Terminal stages (VersionConfirmed
+  // / Failed) come from FW_DEPLOY_DONE, not a final FW_PROGRESS, so they
+  // should NOT appear here.
+  stages?: FwStage[];
+}
+
+export interface ScriptDeployOpts {
+  controllers: ScriptDeployControllerOpts[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal: scripted-response configuration state
+// ---------------------------------------------------------------------------
+
+interface AutoAckUploadCfg {
+  windowSize: number;
+  endStatus: FwTransferEndStatus;
+  failAtSeq: number | undefined;
+  // Mutable flag: true after the first NAK is emitted for failAtSeq.
+  // Reset to false each time autoAckUpload() is called.
+  hasFailedOnce: boolean;
+}
+
+interface ScriptDeployControllerCfg {
+  id: string;
+  outcome: 'OK' | 'FAILED';
+  finalVersion: string;
+  error: string;
+  stages: FwStage[];
+}
+
+interface ScriptDeployCfg {
+  controllers: ScriptDeployControllerCfg[];
+}
+
+// ---------------------------------------------------------------------------
 // Internal: pending waitForFrame subscriber bookkeeping
 // ---------------------------------------------------------------------------
 
@@ -179,6 +252,12 @@ export class StubMaster {
   private parser: DelimiterParser | null = null;
   private readonly inbound: InboundFrame[] = [];
   private readonly waiters: FrameWaiter[] = [];
+
+  // Scripted-response configuration (Task 3). Both are null when the feature
+  // is not enabled; set by autoAckUpload() / scriptDeploy(); cleared by
+  // disable().
+  private autoAckUploadCfg: AutoAckUploadCfg | null = null;
+  private scriptDeployCfg: ScriptDeployCfg | null = null;
 
   constructor(opts: StubMasterOpts) {
     this.opts = {
@@ -383,6 +462,64 @@ export class StubMaster {
   }
 
   // -------------------------------------------------------------------------
+  // Scripted-response API (Task 3)
+  // -------------------------------------------------------------------------
+
+  // Configure the stub to automatically respond to FW_TRANSFER_BEGIN,
+  // FW_CHUNK, and FW_TRANSFER_END. The auto-responses fire BEFORE waiter
+  // notifications, so a test that waitForFrame(FW_TRANSFER_BEGIN) will see the
+  // ACK already written when its promise resolves.
+  autoAckUpload(opts?: AutoAckUploadOpts): void {
+    this.autoAckUploadCfg = {
+      windowSize: opts?.windowSize ?? FW_SERIAL_SLIDING_WINDOW,
+      endStatus: opts?.endStatus ?? 'OK',
+      failAtSeq: opts?.failAtSeq,
+      // Reset the "failed once" flag on each fresh autoAckUpload() call so
+      // re-use across tests within a single StubMaster instance works cleanly.
+      hasFailedOnce: false,
+    };
+  }
+
+  // Configure the stub to automatically respond to FW_DEPLOY_BEGIN. On
+  // receipt, the stub emits FW_PROGRESS for each controller's stages then
+  // emits FW_DEPLOY_DONE with the configured per-controller outcomes.
+  //
+  // Validation is done at call time (not response time) so misconfigured tests
+  // fail fast rather than producing a mysterious protocol error mid-test.
+  scriptDeploy(opts: ScriptDeployOpts): void {
+    const controllers: ScriptDeployControllerCfg[] = opts.controllers.map((c) => {
+      if (c.outcome === 'OK' && !c.finalVersion) {
+        throw new Error(
+          `StubMaster.scriptDeploy: controller '${c.id}' has outcome 'OK' but finalVersion is missing`,
+        );
+      }
+      if (c.outcome === 'FAILED' && !c.error) {
+        throw new Error(
+          `StubMaster.scriptDeploy: controller '${c.id}' has outcome 'FAILED' but error is missing`,
+        );
+      }
+      return {
+        id: c.id,
+        outcome: c.outcome,
+        finalVersion: c.finalVersion ?? '',
+        error: c.error ?? '',
+        stages: c.stages ?? [FwStage.Sending, FwStage.Verifying, FwStage.Rebooting],
+      };
+    });
+    this.scriptDeployCfg = { controllers };
+  }
+
+  // Disable a scripted-response feature. Useful for tests that need to drive
+  // protocol-level timeouts (the absence of a response is the assertion).
+  disable(feature: 'autoAckUpload' | 'scriptDeploy'): void {
+    if (feature === 'autoAckUpload') {
+      this.autoAckUploadCfg = null;
+    } else {
+      this.scriptDeployCfg = null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // Internal helpers
   // -------------------------------------------------------------------------
 
@@ -407,6 +544,11 @@ export class StubMaster {
     if (frame === null) return;
     this.inbound.push(frame);
 
+    // Fire scripted responses BEFORE notifying waiters. Order matters: a test
+    // that waitForFrame(FW_TRANSFER_BEGIN) should see the auto-ACK already
+    // written on the wire when its promise resolves.
+    this.dispatchScriptedResponse(frame);
+
     // Notify any waiter whose predicate now matches. Use a copy of the array
     // so a waiter that calls waitForFrame again from inside its resolution
     // doesn't disturb iteration.
@@ -421,6 +563,99 @@ export class StubMaster {
     for (const waiter of matched) {
       clearTimeout(waiter.timer);
       waiter.resolve(frame);
+    }
+  }
+
+  private dispatchScriptedResponse(frame: InboundFrame): void {
+    const cfg = this.autoAckUploadCfg;
+
+    switch (frame.type) {
+      case SerialMessageType.FW_TRANSFER_BEGIN: {
+        if (cfg === null) break;
+        this.writeFwTransferBeginAck({
+          transferId: extractTransferId(frame.payload),
+          status: 'OK',
+        });
+        break;
+      }
+
+      case SerialMessageType.FW_CHUNK: {
+        if (cfg === null) break;
+        const chunkParsed = parseFwChunkPayload(frame.payload);
+        if (chunkParsed === null) break;
+        const { transferId, seq } = chunkParsed;
+        // Inject exactly one NAK when this seq matches failAtSeq and we
+        // haven't already failed. After that, resume normal ACKing
+        // (including for the retransmitted failAtSeq chunk).
+        if (cfg.failAtSeq !== undefined && seq === cfg.failAtSeq && !cfg.hasFailedOnce) {
+          cfg.hasFailedOnce = true;
+          this.writeFwChunkNak({
+            transferId,
+            lastGoodSeq: seq - 1,
+            reasonCode: 'CRC',
+          });
+        } else {
+          this.writeFwChunkAck({
+            transferId,
+            highestContiguousSeq: seq,
+            nextExpectedSeq: seq + 1,
+            windowRemaining: cfg.windowSize,
+          });
+        }
+        break;
+      }
+
+      case SerialMessageType.FW_TRANSFER_END: {
+        if (cfg === null) break;
+        const endParsed = parseFwTransferEndPayload(frame.payload);
+        if (endParsed === null) break;
+        this.writeFwTransferEndAck({
+          transferId: endParsed.transferId,
+          status: cfg.endStatus,
+          // Echo the hash the server sent so the streamer's hash check passes.
+          computedSha256Hex: endParsed.finalSha256Hex,
+        });
+        break;
+      }
+
+      case SerialMessageType.FW_DEPLOY_BEGIN: {
+        const deployCfg = this.scriptDeployCfg;
+        if (deployCfg === null) break;
+        const deployParsed = parseFwDeployBeginPayload(frame.payload);
+        if (deployParsed === null) break;
+        const { transferId } = deployParsed;
+        // Walk each controller through its stage progression then emit
+        // FW_DEPLOY_DONE. No artificial delay between frames — the
+        // orchestrator's per-controller throttle (250ms / 4Hz) means
+        // coalescing is acceptable in tests.
+        for (const ctrl of deployCfg.controllers) {
+          for (const stage of ctrl.stages) {
+            this.writeFwProgress({
+              transferId,
+              controllerId: ctrl.id,
+              stage,
+              // No actual bytes flow after FW_DEPLOY_BEGIN; using 0 here
+              // is correct. Tests asserting on bytesSent should use
+              // writeFwProgress directly.
+              bytesSent: 0,
+              totalBytes: 0,
+            });
+          }
+        }
+        this.writeFwDeployDone({
+          transferId,
+          results: deployCfg.controllers.map((ctrl) => ({
+            controllerId: ctrl.id,
+            outcome: ctrl.outcome,
+            finalVersion: ctrl.finalVersion,
+            error: ctrl.error,
+          })),
+        });
+        break;
+      }
+
+      default:
+        break;
     }
   }
 }
@@ -445,4 +680,53 @@ function parseInbound(line: string): InboundFrame | null {
     msgId: headerParts[2],
     payload: groups[1],
   };
+}
+
+// ---------------------------------------------------------------------------
+// Narrow file-scope payload parsers for inbound server→master frames (Task 3).
+//
+// These are intentionally separate from MessageHandler, which parses the
+// master→server direction. Field counts and separator choice are verified
+// against MessageGenerator.generateFwChunk / generateFwTransferEnd /
+// generateFwDeployBegin (the runtime generators are the source of truth).
+// ---------------------------------------------------------------------------
+
+// Extract transferId from any payload whose first US-separated field is the
+// transferId. Used for FW_TRANSFER_BEGIN where we only need the ID.
+function extractTransferId(payload: string): string {
+  const idx = payload.indexOf(MessageHelper.US);
+  return idx < 0 ? payload : payload.substring(0, idx);
+}
+
+// FW_CHUNK payload (5 US-separated fields per generateFwChunk):
+//   transferId<US>seq<US>payloadLen<US>base64Bytes<US>crc16Hex
+function parseFwChunkPayload(payload: string): { transferId: string; seq: number } | null {
+  const parts = payload.split(MessageHelper.US);
+  if (parts.length !== 5) return null;
+  const seq = parseInt(parts[1], 10);
+  if (Number.isNaN(seq)) return null;
+  return { transferId: parts[0], seq };
+}
+
+// FW_TRANSFER_END payload (3 US-separated fields per generateFwTransferEnd):
+//   transferId<US>totalChunks<US>finalSha256Hex
+function parseFwTransferEndPayload(
+  payload: string,
+): { transferId: string; finalSha256Hex: string } | null {
+  const parts = payload.split(MessageHelper.US);
+  if (parts.length !== 3) return null;
+  return { transferId: parts[0], finalSha256Hex: parts[2] };
+}
+
+// FW_DEPLOY_BEGIN payload (per generateFwDeployBegin):
+//   transferId<US>controllerId_1<RS>controllerId_2<RS>...
+function parseFwDeployBeginPayload(
+  payload: string,
+): { transferId: string; order: string[] } | null {
+  const firstUs = payload.indexOf(MessageHelper.US);
+  if (firstUs < 0) return null;
+  const transferId = payload.substring(0, firstUs);
+  const orderStr = payload.substring(firstUs + 1);
+  const order = orderStr.split(MessageHelper.RS);
+  return { transferId, order };
 }

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -466,8 +466,30 @@ export class StubMaster {
   // notifications, so a test that waitForFrame(FW_TRANSFER_BEGIN) will see the
   // ACK already written when its promise resolves.
   autoAckUpload(opts?: AutoAckUploadOpts): void {
+    // Validate at call time so misconfigured tests fail fast rather than
+    // emitting frames the server categorically parses as UNKNOWN.
+    //   - windowSize > FW_SERIAL_SLIDING_WINDOW: handleFwChunkAck rejects
+    //     `windowRemaining` exceeding the configured sliding window
+    //     (message_handler.ts:225-230). Every FW_CHUNK_ACK would route to
+    //     UNKNOWN and the streamer would never advance.
+    //   - failAtSeq <= 0: lastGoodSeq=failAtSeq-1 would serialize as a
+    //     negative integer, which parseUint rejects in handleFwChunkNak.
+    //     The streamer would never see the NAK so the retransmit branch
+    //     wouldn't exercise.
+    const windowSize = opts?.windowSize ?? FW_SERIAL_SLIDING_WINDOW;
+    if (windowSize <= 0 || windowSize > FW_SERIAL_SLIDING_WINDOW) {
+      throw new Error(
+        `StubMaster.autoAckUpload: windowSize must be in (0, ${FW_SERIAL_SLIDING_WINDOW}]; got ${windowSize}`,
+      );
+    }
+    if (opts?.failAtSeq !== undefined && opts.failAtSeq <= 0) {
+      throw new Error(
+        `StubMaster.autoAckUpload: failAtSeq must be > 0 (got ${opts.failAtSeq}); a NAK at seq=0 would emit lastGoodSeq=-1, which the server parses as UNKNOWN`,
+      );
+    }
+
     this.autoAckUploadCfg = {
-      windowSize: opts?.windowSize ?? FW_SERIAL_SLIDING_WINDOW,
+      windowSize,
       endStatus: opts?.endStatus ?? 'OK',
       failAtSeq: opts?.failAtSeq,
       // Reset the "failed once" flag on each fresh autoAckUpload() call so

--- a/astros_api/tsconfig.json
+++ b/astros_api/tsconfig.json
@@ -37,6 +37,10 @@
       "jest"
     ]
   },
+  // When adding a new src/-resident pattern here, mirror it in
+  // src/test_harness/global_setup.ts:newestCompiledMtime — the vitest
+  // globalSetup walker filters this list by hand to decide whether dist/
+  // is stale before integration tests run.
   "exclude": [
     "./vitest.config.ts",
     "./vitest.config.js",

--- a/astros_api/vitest.config.ts
+++ b/astros_api/vitest.config.ts
@@ -1,8 +1,13 @@
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-    test:{
-        
-    }
+  test: {
+    // Run once in the main process before any worker thread spawns. Builds
+    // dist/ if stale so the integration harness's spawned serial Worker
+    // can load its `.js`-style imports (tsx's loader doesn't propagate to
+    // Worker threads). See src/test_harness/global_setup.ts for the full
+    // rationale + the race condition that motivated centralizing this here
+    // rather than running it per-harness-boot.
+    globalSetup: ['./src/test_harness/global_setup.ts'],
+  },
 });


### PR DESCRIPTION
## Summary

c.6c.2 — PTY-stub integration test harness for the firmware OTA orchestrator + 3 production fixes surfaced by the harness exercising c.6c.1's full HTTP/WS/Worker/serial stack end-to-end.

A real `ApiServer` boots against a `socat`-backed PTY pair driven by an in-process `StubMaster` (a scriptable wire-protocol responder, NOT a firmware simulator — real firmware behavior simulation lives in AstrOs.ESP). 8 integration test files cover the full operator-facing flow: happy-path upload + github sources, cancel during upload + deploy, chunk NAK + Go-Back-N retransmit, mixed OK/FAILED outcomes, heartbeat-vs-timer first-fire-wins, reboot-timer fallback, and concurrent-flash rejection.

## Production bugs found and fixed

The harness exercises code paths c.6c.1's unit tests bypassed via `FakeSerialBus`. Three real bugs surfaced — each would have manifested in production:

1. **`serial_message_service.ts` — missing FW_* response routing** (`489f6cb`). The `handleMessage` switch had no cases for any of the 7 FW_* response types. Inbound FW_TRANSFER_BEGIN_ACK / FW_CHUNK_ACK / FW_PROGRESS / etc. arrived at the worker, validated successfully, then fell through and the worker postMessaged `{ type: UNKNOWN }` back. The streamer never observed any firmware-side response → any real flash command would have timed out at `begin_timeout` after 1500ms. Unit tests passed because `FakeSerialBus` directly emits typed `SerialWorkerResponseType.FW_*` responses, bypassing the worker entirely.

2. **`write_guard.ts` — `POST /firmware/flash` not in `ALLOWED_DURING_FLASH`** (bundled into `9af6baf`). Concurrent flash POSTs were short-circuited to a generic 423 by `writeGuard` before reaching the orchestrator. The fix passes them through so the orchestrator's synchronous lock-acquire check produces the documented `409 { error: 'job_already_running', currentJobId }` — operators need `currentJobId` to distinguish "flash already running" from "you can't do this right now."

3. **`api_server.ts` — refactored for testability** (`67b2d37`, `4592da5`). `shutdown()` is now async (no more `process.exit()`), the auto-bootstrap is gated on a main-module check (so `import { ApiServer }` from tests doesn't spawn a default server), and the HTTP server reference is captured for clean shutdown. Plus 4 test-only constructor opts (`workerScriptUrl`, `onWorkerError`, `firmwareReleaseFetcher`, `flashOrchestratorConfig`), all defaulting cleanly to production behavior when undefined. Production runs (the IIFE at the bottom of api_server.ts) are unchanged.

## What's new

### Harness primitives (`astros_api/src/test_harness/`)

- **`pty_pair.ts`** — spawns `socat -d -d pty,raw,echo=0 pty,raw,echo=0`, parses two `/dev/pts/N` paths from stderr, returns `{ serverPath, masterPath, dispose() }`. Linux only.
- **`stub_master.ts`** — opens one PTY end via `serialport`, parses inbound server frames, exposes 8 typed outbound writers (FW_TRANSFER_BEGIN_ACK / FW_CHUNK_ACK / FW_CHUNK_NAK / FW_TRANSFER_END_ACK / FW_PROGRESS / FW_DEPLOY_DONE / FW_BACKPRESSURE / POLL_ACK), plus a scripted-response API: `autoAckUpload({ failAtSeq? })`, `scriptDeploy({ controllers })`, `disable(feature)`, `waitForFrame(predicate)`.
- **`integration_harness.ts`** — boots a real `ApiServer` on random ports against a PTY-backed serial port, exposes HTTP base URL + JWT auth token + WS client + buffered messages + `waitForWsMessage(predicate, timeoutMs?, fromIndex?)` + `populateUpload` / `populateFirmwareCache` / `waitForVariantCachePopulated` helpers + `workerErrors[]` capture (asserted empty in every test). Reverse-order resilient `dispose()`.

### Integration tests (`astros_api/src/firmware/integration/`)

| File | Pins |
|---|---|
| `flash_happy_upload` | POST `kind=upload` → flashJobDone → master POLL_ACK heartbeat → lock release in ~1-2s |
| `flash_happy_github` | POST `kind=github version=1.5.0` with injected fake fetcher; cache hit short-circuits download |
| `flash_cancel` | DELETE during upload (AbortController) AND during deploy (inline cleanup); two distinct codepaths |
| `flash_chunk_nak` | `failAtSeq:2` → seq=2 NAK once → streamer rewinds → seq=2 received twice → flashJobDone |
| `flash_partial_failure` | Master OK + padawan FAILED → flashJobDone (NOT failed) per `deriveJobLifecycle` |
| `flash_heartbeat_release` | Heartbeat-released delta < 3000ms; wrong-version POLL_ACK ignored → timer fallback |
| `flash_reboot_timer_fallback` | No heartbeat → timer fires; lower bound 800ms proves no spurious release |
| `flash_concurrent` | Second POST during in-flight → 409 with currentJobId; WS SERVO_TEST → flashJobActive frame |

### Tooling

- `npm run test:integration` script for fast targeted re-runs (`vitest run src/firmware/integration`)
- QA plan extended: `.docs/qa/firmware-ota-flash.md` now lists what's automated vs what still needs manual verification (real hardware, real GitHub API, Vue UI)

## Test plan

- [ ] `cd astros_api && npx vitest run` — 725 tests pass cleanly (~22 sec wall clock)
- [ ] `cd astros_api && npm run test:integration` — 10 integration tests pass cleanly (~14 sec wall clock; first run includes a `dist/` build the harness triggers)
- [ ] `cd astros_api && npm run prettier:write && npm run lint:fix && npm run build` — all clean
- [ ] Run the full suite 3+ times — confirm stable (no flakes; verified locally at 13+ consecutive clean runs)
- [ ] Bench-rig smoke: flash a real firmware against the c.6c.1 + c.6c.2 server. **This is the load-bearing manual test** — proves the FW_* routing fix unblocks real-hardware flashes that were silently broken on `develop`.
- [ ] Optional: `apt-get install socat` on the CI runner (if not already present); the harness skips on Windows

## Notes for reviewers

- **Stability evidence**: the integration suite was stress-tested at 13+ consecutive full-suite runs after the `7bec649` flake fix (`waitForVariantCachePopulated` deterministic poll + `fromIndex` parameter on `waitForWsMessage` to avoid matching connect-time WS snapshots).
- **The 3 production fixes** are necessary, not opportunistic. Each was caught by the integration suite specifically because it exercises code paths the unit-test FakeSerialBus bypassed. Reviewing them as drive-by refactors would mis-frame their value.
- **Worker can't load TS source under vitest+tsx** — Worker threads don't inherit tsx's loader. The harness builds `dist/` first and points `ApiServer`'s Worker at the compiled JS via the new `workerScriptUrl` opt. Production behavior unchanged.
- **No new runtime dependencies**. The harness uses `serialport` (existing), `ws` (existing), `jsonwebtoken` (existing), and shells out to `socat` (system package).

## Suggested follow-ups (non-blocking)

From the final review pass — flagged for a future session:

- Capture `doneEvent.data.endedAt` from the orchestrator's emit rather than `Date.now()` post-await for tighter wall-clock-delta assertions in Tasks 10/11
- Await `lockStateChanged{locked:false}` after the cleanup DELETE in `flash_concurrent` for cleaner shutdown
- Add FW_BACKPRESSURE PAUSE/RESUME integration coverage (writer + handler exist; no current test)
- `ensureDistBuilt` could check transitive imports' mtime, not just the worker file directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
