### PR TITLE
OTA Firmware - Page Chrome

### DIFF
--- a/.docs/plans/20260507-2153-firmware-ota-d-1-page-chrome.md
+++ b/.docs/plans/20260507-2153-firmware-ota-d-1-page-chrome.md
@@ -1,0 +1,50 @@
+# d.1 — Firmware page chrome + nav
+
+## Context
+
+First PR of the **phase d** roadmap (`./20260507-2153-firmware-ota-d-vue-firmware-view.md`). Lands the empty `/firmware` route + nav entry + page chrome + design tokens + i18n keys. The page renders only the header + subtitle + empty content area in this PR — actual content (SourceStrip, Topology, Controllers panel) lands in d.2–d.5.
+
+Risk surface is tiny: no business logic, no WS, no HTTP. Reviewers sign off on visual fidelity to `ModulesView` chrome and the design handoff header spec.
+
+## Tasks
+
+- [ ] Add `/firmware` route to `astros_vue/src/router/index.ts` — auth-guarded by default (no `meta.public`), positioned consistently with Modules.
+- [ ] Add nav entry in `astros_vue/src/components/common/layout/AstrosLayout.vue` between Modules and Utility — text from `nav.firmware` i18n key.
+- [ ] Add i18n keys to `astros_vue/src/locales/enUS.json`: `nav.firmware`, `firmware_view.title`, `firmware_view.subtitle.select`, `firmware_view.subtitle.flashing`, `firmware_view.subtitle.done`, `firmware_view.subtitle.failed`. Copy verbatim from design handoff §Subtitle.
+- [ ] Add design-handoff CSS vars to `astros_vue/src/assets/styles.css`: state extras (idle/queued/updating/done/failed × bg/fg/dot per design handoff §State extras) under a `.firmware-view` selector or as scoped CSS custom properties.
+- [ ] Scope Inter font to firmware view via `@fontsource/inter` (add to `astros_vue/package.json`); import only inside `FirmwareView.vue` so the rest of the app keeps the existing system stack.
+- [ ] Create `astros_vue/src/views/FirmwareView.vue` — page shell mirroring `ModulesView` chrome:
+  - Header with `r2XLight` background, 14×20 padding, 1px bottom border, page title at 22px / 700.
+  - Subtitle line at 13px / `inkSoft` driven by a local `phase` ref (default `'select'`); the subtitle text comes from `firmware_view.subtitle.{phase}`.
+  - Content area uses `base200` background, `padding: 20px 24px`, `max-width: 1100px`, centered, vertical gap 16px.
+  - In this PR the content area is empty (placeholder comment for d.2–d.5).
+  - Wraps everything in a `.firmware-view` class for the Inter font scoping.
+- [ ] Verify Lighthouse a11y ≥ 95 on `/firmware` (manual check via Chrome devtools).
+- [ ] `npm run prettier:write` then `npm run lint:fix` then `npm run build` then `npm run test:unit` — all green.
+- [ ] Run `superpowers:requesting-code-review` on the diff against `develop`.
+
+## Acceptance criteria
+
+- `/firmware` reachable, auth-guarded; redirects to login if not authenticated.
+- Nav link appears between Modules and Utility.
+- Header chrome matches `ModulesView` pixel-for-pixel.
+- Subtitle copy matches design handoff §Subtitle for `select` phase.
+- No console errors / warnings.
+- Lighthouse a11y ≥ 95 on the empty page.
+
+## Out of scope (lands in later PRs)
+
+- SourceStrip, Topology, Controllers panel, StagesList — d.2–d.5.
+- WS dispatcher, firmwareStore, lock-aware integration — d.6.
+- Storybook stories — d.1 is just chrome; d.2+ adds component stories.
+- Real subtitle phase machine — d.5 wires this to the firmwareStore; in d.1 the local `phase` ref is hardcoded to `'select'`.
+
+## Files touched
+
+- `astros_vue/src/views/FirmwareView.vue` (new)
+- `astros_vue/src/router/index.ts` (modified)
+- `astros_vue/src/components/common/layout/AstrosLayout.vue` (modified)
+- `astros_vue/src/locales/enUS.json` (modified)
+- `astros_vue/src/assets/styles.css` (modified)
+- `astros_vue/package.json` (modified — `@fontsource/inter` dependency)
+- `astros_vue/package-lock.json` (regenerated)

--- a/.docs/plans/20260507-2153-firmware-ota-d-1-page-chrome.md
+++ b/.docs/plans/20260507-2153-firmware-ota-d-1-page-chrome.md
@@ -8,20 +8,15 @@ Risk surface is tiny: no business logic, no WS, no HTTP. Reviewers sign off on v
 
 ## Tasks
 
-- [ ] Add `/firmware` route to `astros_vue/src/router/index.ts` — auth-guarded by default (no `meta.public`), positioned consistently with Modules.
-- [ ] Add nav entry in `astros_vue/src/components/common/layout/AstrosLayout.vue` between Modules and Utility — text from `nav.firmware` i18n key.
-- [ ] Add i18n keys to `astros_vue/src/locales/enUS.json`: `nav.firmware`, `firmware_view.title`, `firmware_view.subtitle.select`, `firmware_view.subtitle.flashing`, `firmware_view.subtitle.done`, `firmware_view.subtitle.failed`. Copy verbatim from design handoff §Subtitle.
-- [ ] Add design-handoff CSS vars to `astros_vue/src/assets/styles.css`: state extras (idle/queued/updating/done/failed × bg/fg/dot per design handoff §State extras) under a `.firmware-view` selector or as scoped CSS custom properties.
-- [ ] Scope Inter font to firmware view via `@fontsource/inter` (add to `astros_vue/package.json`); import only inside `FirmwareView.vue` so the rest of the app keeps the existing system stack.
-- [ ] Create `astros_vue/src/views/FirmwareView.vue` — page shell mirroring `ModulesView` chrome:
-  - Header with `r2XLight` background, 14×20 padding, 1px bottom border, page title at 22px / 700.
-  - Subtitle line at 13px / `inkSoft` driven by a local `phase` ref (default `'select'`); the subtitle text comes from `firmware_view.subtitle.{phase}`.
-  - Content area uses `base200` background, `padding: 20px 24px`, `max-width: 1100px`, centered, vertical gap 16px.
-  - In this PR the content area is empty (placeholder comment for d.2–d.5).
-  - Wraps everything in a `.firmware-view` class for the Inter font scoping.
-- [ ] Verify Lighthouse a11y ≥ 95 on `/firmware` (manual check via Chrome devtools).
-- [ ] `npm run prettier:write` then `npm run lint:fix` then `npm run build` then `npm run test:unit` — all green.
-- [ ] Run `superpowers:requesting-code-review` on the diff against `develop`.
+- [x] Add `/firmware` route to `astros_vue/src/router/index.ts` — auth-guarded by default (no `meta.public`), positioned consistently with Modules.
+- [x] Add nav entry in `astros_vue/src/components/common/layout/AstrosLayout.vue` between Modules and Utility — text from `nav.firmware` i18n key.
+- [x] Add i18n keys to `astros_vue/src/locales/enUS.json`: `nav.firmware`, `firmware_view.title`, `firmware_view.subtitle.select`, `firmware_view.subtitle.flashing`, `firmware_view.subtitle.done`, `firmware_view.subtitle.failed`. Copy verbatim from design handoff §Subtitle.
+- [x] Add design-handoff CSS vars to `astros_vue/src/assets/styles.css`: state extras (idle/queued/updating/done/failed × bg/fg/dot per design handoff §State extras) under a `.firmware-view` selector.
+- [x] Scope Inter font to firmware view via `@fontsource/inter` (add to `astros_vue/package.json`); import only inside `FirmwareView.vue` so the rest of the app keeps the existing system stack.
+- [x] Create `astros_vue/src/views/FirmwareView.vue` — page shell mirroring `ModulesView` chrome.
+- [ ] Verify Lighthouse a11y ≥ 95 on `/firmware` (manual check via Chrome devtools — needs running API for auth; do during pre-PR QA).
+- [x] `npm run prettier:write` then `npm run lint:fix` then `npm run build` then `npm run test:unit` — all green.
+- [x] Run `superpowers:requesting-code-review` on the diff against `develop` — clean, no Critical/Important findings.
 
 ## Acceptance criteria
 

--- a/.docs/plans/20260507-2153-firmware-ota-d-vue-firmware-view.md
+++ b/.docs/plans/20260507-2153-firmware-ota-d-vue-firmware-view.md
@@ -1,0 +1,169 @@
+# Phase d — Vue Firmware View (master roadmap)
+
+## Context
+
+The AstrOs firmware-OTA feature is complete on the server side: `c.0`–`c.6c.2` shipped via PRs #72–#77, the integration harness merged, and operators can drive a flash via `curl` against `/api/firmware/flash`. The only remaining piece in the master decomposition (`./20260427-2202-firmware-ota-decomposition.md`) is **§d — Vue UI**. The QA plan (`../qa/firmware-ota-flash.md:75`) explicitly notes the UI is "not yet wired."
+
+Phase d closes the user-facing loop: a top-level `/firmware` route lets an operator pick a source (GitHub release or local upload), pick controllers, see a live topology + per-controller stage progression, and react to success/failure — without leaving the app or hitting the API directly. The design source of truth is `../design_handoff_firmware_update/` (Direction C, the topology console).
+
+Server-side WS events + HTTP routes already exist and are stable. **Exception: a server-side firmware-upload route does not yet exist.** Only `POST/DELETE/GET /api/firmware/flash` is registered; the flash route accepts `source: { kind: 'upload' }` but expects an upload to already be on disk. Building that route is being broken out as its own **pre-d phase** (separate plan, separate PR) and is a prerequisite for Upload mode to be functional. Phase d will design the Upload-mode UI in d.2 but it ships decoratively until pre-d lands.
+
+This roadmap covers all of phase d. Each PR has its own focused plan file (`20260507-XXXX-firmware-ota-d-N-...md`) committed to its own feature branch. This file lives on `develop` and serves as the cross-PR reference.
+
+---
+
+## Phase split — 6 PRs
+
+CLAUDE.md scope guard says >8 tasks or 3+ layers should be split. Phase d has ~10 task-units across 4 layers; further splitting into Storybook-friendly slices keeps each PR review window small and concentrates the WS-lifecycle hazards into a single final PR (d.6) where the pre-push branch review can be applied rigorously.
+
+| Phase | What ships | Layer focus | Risk surface | Branch |
+|---|---|---|---|---|
+| **d.1** | Route + nav + chrome + design tokens + i18n + empty `FirmwareView` | UI scaffold | Tiny | `feature/firmware-ota-d-1-page-chrome` |
+| **d.2** | `SourceStrip` + `FwBtn` + GitHub releases API call + Storybook | Presentational | Low | `feature/firmware-ota-d-2-source-strip` |
+| **d.3** | `Topology` SVG + CSS keyframes + Storybook | Presentational | Low | `feature/firmware-ota-d-3-topology` |
+| **d.4** | `ControllersPanel` + `ControllerRow` + `VersionDelta` + `compareTags` + `FwStatusPill` + Storybook | Presentational + tiny logic | Low | `feature/firmware-ota-d-4-controllers-panel` |
+| **d.5** | `StagesList` + `ConfirmModal` + page assembly + skeleton `firmwareStore` (UI-state only) + flash POST + Storybook | Page integration with mocked store | Medium (HTTP errors, modal a11y) | `feature/firmware-ota-d-5-page-assembly` |
+| **d.6** | WS dispatcher + live `firmwareStore` + late-join replay + lock-aware `AstrosWriteButton` + lock banner + e2e test | WS lifecycle + concurrency | High — the FMI surface | `feature/firmware-ota-d-6-live-wiring` |
+
+Each PR ≤ ~5–8 files. d.1–d.4 are pure presentational; reviewers sign off on Storybook stories alone. d.5 is the first PR where the page is end-to-end demoable, but only against mocked store state — no harness setup needed for review. d.6 is the only PR with WS lifecycle hazards; run `/pr-review-toolkit:review-pr` before pushing it.
+
+---
+
+## WebSocket event contract (verified against server)
+
+Source: `astros_api/src/firmware/flash_orchestrator.ts:323-344` (the `FlashOrchestratorWsMessage` discriminated union) + `astros_api/src/models/enums.ts:82` (TransmissionType numeric values).
+
+| `type` (numeric) | Name | Envelope | Payload |
+|---|---|---|---|
+| 11 | `flashJobActive` | flat | rejection echo for write-class WS messages sent during a flash; UI doesn't subscribe |
+| 12 | `flashJobStarted` | `{type, data}` | `FlashJobState` — `{ jobId, source, controllers[], startedAt, endedAt?, abortReason? }` |
+| 13 | `flashControllerUpdate` | `{type, data}` | `ControllerFlashState` — discriminated union by `stage` |
+| 14 | `flashControllerResult` | `{type, data}` | `{ jobId, controller: ControllerFlashState }` |
+| 15 | `flashJobDone` | `{type, data}` | `{ jobId, endedAt }` |
+| 16 | `flashJobFailed` | `{type, data}` | `FlashJobFailedData` — `{ jobId, reason, endedAt, abortReason?, detail? }` |
+
+`FwStage` enum (string literals): `'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING' | 'VERSION_CONFIRMED' | 'FAILED'`.
+
+`lockStateChanged` (type=10) is already wired and is **flat** (`{type, locked, owner, since}`) — no change.
+
+Late-join: `astros_api/src/api_server.ts:652-660` sends one `flashJobStarted` snapshot on connect when a job is in flight; `firmwareStore.applyJobStarted` must be idempotent.
+
+---
+
+## firmwareStore shape (Pinia composition) — d.5 + d.6
+
+```ts
+// Server-pushed state (WS is the single writer in d.6; in d.5 these are mock-set)
+currentJob: ref<FlashJobState | null>(null)
+controllerStates: ref<Map<string, ControllerFlashState>>(new Map())
+phase: ref<'idle' | 'select' | 'flashing' | 'done' | 'failed'>('idle')
+abortReason: ref<string | null>(null)
+lastError: ref<{ reason?: string, detail?: string } | null>(null)
+
+// UI selection state
+sourceMode: ref<'github' | 'upload'>('github')
+selectedReleaseVersion: ref<string | null>(null)
+uploadedFilename: ref<string | null>(null)
+selectedControllerIds: ref<Set<string>>(new Set())
+releases: ref<ReleaseSummary[]>([])
+confirmOpen: ref(false)
+
+// Getters
+target: computed(...)
+canFlash: computed(...)
+isJobInFlight: computed(...)
+
+// WS handlers (stubs in d.5, real in d.6)
+applyJobStarted, applyControllerUpdate, applyControllerResult, applyJobDone, applyJobFailed
+resetToSelect()
+
+// HTTP actions
+async fetchReleases(): Promise<void>             // d.2
+async startFlash(): Promise<void>                // d.5
+async cancelFlash(reason: string): Promise<void> // d.5
+async fetchCurrentJob(): Promise<void>           // d.6 — cold-load resync
+```
+
+**Hard rule (enforced from d.6):** WS dispatcher is the sole writer of server-pushed fields. HTTP responses surface only synchronous validation; WS is the truth source for in-flight state.
+
+---
+
+## Server-stage to UI-stage mapping (d.6)
+
+Server `FwStage` has 7 values; design handoff defines 5 stages (download / transfer / flash / verify / reboot). Define `mapServerStageToUiStage(stage: FwStage): UiStageKey` in `firmwareStore` (with unit tests in d.6):
+
+| Server `FwStage` | UI stage key | Notes |
+|---|---|---|
+| `QUEUED` | (no UI stage; row shows status pill `queued`) | |
+| `UPLOADING_TO_MASTER` | `download` | "Master receives file" |
+| `SENDING` | `transfer` (and implicitly `flash` during send) | |
+| `VERIFYING` | `verify` | |
+| `REBOOTING` | `reboot` | |
+| `VERSION_CONFIRMED` | (terminal success — all stages checked) | |
+| `FAILED` | (terminal failure — current stage shows `!`) | UI-stage derived from per-controller `error` + last-known stage progression |
+
+Don't add a "flash" stage to the server enum.
+
+---
+
+## Lock-aware UI integration (d.6)
+
+- No global lock-banner component exists today; write-blocking is per-button via `AstrosWriteButton` reading `systemStatus.readOnly`.
+- d.6 extends `AstrosWriteButton` to OR-in `useJobLockStore().locked`. Tooltip key: `firmware_view.lock_active`. Existing `systemStatus.readOnly` test must keep passing; new test asserts disable when only `jobLock.locked` is true.
+- d.6 adds a passive page-level banner in `AstrosLayout.vue` (next to existing system-status banner) that appears when `useJobLockStore().locked === true` reading "Firmware update in progress — write actions disabled."
+- `FirmwareView`: when `lockStore.locked` and the lock owner doesn't match our in-flight job, render a `role="alert"` region with the lock owner; disable Flash button. When the lock owner matches, the flashing UI takes over.
+
+---
+
+## FMI inventory (d.6 surface)
+
+All concurrency hazards land in d.6. Apply `/pr-review-toolkit:review-pr` before pushing.
+
+| Hazard | Risk | Coverage |
+|---|---|---|
+| **Concurrency: late-join + cold-load fetch race** | Both `firmwareStore.fetchCurrentJob()` (HTTP GET on mount) and the WS replay `flashJobStarted` could fire on view enter | `applyJobStarted` is idempotent; HTTP GET sets state only if `currentJob === null`; explicit unit test |
+| **Concurrency: WS reconnect during flash** | `useWebsocket` reconnects every 3s; server sends `flashJobStarted` snapshot on reconnect | `applyJobStarted` *replaces* (not merges) `controllerStates`; explicit unit test |
+| **Resource lifecycle: tab-close mid-flash** | Browser navigation/close is NOT a flash-cancel signal — server holds the lock until heartbeat or 15s timer | UI must NOT trigger cancel on `beforeunload`; on return, WS state remains authoritative; FirmwareView mount/unmount test |
+| **Resource lifecycle: stale `controllerStates` after job ends** | After `flashJobDone`/`flashJobFailed`, the next flash could inherit stale per-controller stages | `resetToSelect()` clears `controllerStates`; called when operator clicks "Done" in result bar |
+| **Operability: enum drift between Vue and server** | Vue's `WebsocketMessageType` is a hand-maintained mirror; if server adds a value, the Vue switch silently misroutes | Comment cross-reference at top of Vue enum; runtime `default:` warn-on-unknown in `handleMessage` (already present) |
+| **Operability: WS handler errors swallow real bugs** | Existing handlers catch+log; firmware handlers must follow that pattern but also reset `phase` to `idle` on `flashJobFailed` so the UI doesn't lock | Explicit unit test that `applyJobFailed` clears `currentJob` + sets `lastError` even if payload is malformed |
+
+---
+
+## Risks / open questions
+
+1. **Inter font scope.** Design specifies Inter; existing app uses DaisyUI's default sans-system stack. **Default in d.1: scope Inter to `.firmware-view` selector via `@fontsource/inter`**, not globally. Revisit if it looks visually inconsistent next to the rest of the app.
+
+2. **Server-stage mapping is approximate.** Resolution: `mapServerStageToUiStage` helper in `firmwareStore` with unit tests in d.6.
+
+3. **Decomposition mentions `POST /firmware/jobs`** at line 366; shipped path is `POST /firmware/flash`. Already accounted for.
+
+4. **`ConfirmModal` focus management isn't specified in the design handoff.** CLAUDE.md a11y rules require focus trap + ESC + restore. d.5 must add this; visual design unaffected.
+
+5. **Topology stroke animation prefixing.** Verify Vite's autoprefixer is enabled before assuming WebKit/Safari work without `-webkit-` prefixes (check during d.3).
+
+6. **Pre-d phase (server-side upload route) is a prerequisite for Upload mode functionality.** d.2 ships Upload mode UI as decorative; the route is broken out as a separate plan + PR. d.2 will render Upload mode but clicking "Browse files…" won't post anywhere yet.
+
+---
+
+## Critical files
+
+- **Server-side WS contract (read-only):** `astros_api/src/firmware/flash_orchestrator.ts:323-344`, `astros_api/src/models/firmware/flash_job_state.ts`, `astros_api/src/models/enums.ts:82`.
+- **Server-side HTTP contract (read-only):** `astros_api/src/controllers/firmware_flash_controller.ts`.
+- **Late-join entry point (read-only):** `astros_api/src/api_server.ts:652-660`.
+- **Vue patterns to mirror:** `astros_vue/src/stores/jobLock.ts`, `astros_vue/src/composables/useWebsocket.ts`, `astros_vue/src/views/ModulesView.vue` (chrome).
+- **Design source of truth:** `../design_handoff_firmware_update/README.md` + `firmwareDirectionC.jsx` + `firmwareShared.jsx`.
+- **Existing lock-aware button:** `astros_vue/src/components/common/AstrosWriteButton.vue` (extension point for d.6).
+
+---
+
+## Per-PR plan files
+
+- d.1 → `20260507-XXXX-firmware-ota-d-1-page-chrome.md`
+- d.2 → `20260507-XXXX-firmware-ota-d-2-source-strip.md`
+- d.3 → `20260507-XXXX-firmware-ota-d-3-topology.md`
+- d.4 → `20260507-XXXX-firmware-ota-d-4-controllers-panel.md`
+- d.5 → `20260507-XXXX-firmware-ota-d-5-page-assembly.md`
+- d.6 → `20260507-XXXX-firmware-ota-d-6-live-wiring.md`
+
+(Filenames will be assigned at the time each PR is started; timestamps reflect creation, not roadmap commit time.)

--- a/astros_vue/package-lock.json
+++ b/astros_vue/package-lock.json
@@ -8,6 +8,7 @@
       "name": "astros_vue",
       "version": "1.0.0-dev.5",
       "dependencies": {
+        "@fontsource/inter": "^5.2.8",
         "@headlessui/vue": "^1.7.23",
         "axios": "^1.13.2",
         "oh-vue-icons": "^1.0.0-rc3",
@@ -1367,6 +1368,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@headlessui/vue": {

--- a/astros_vue/package.json
+++ b/astros_vue/package.json
@@ -21,6 +21,7 @@
     "start:server": "cd ../astros_api &&  npm run-script start"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
     "@headlessui/vue": "^1.7.23",
     "axios": "^1.13.2",
     "oh-vue-icons": "^1.0.0-rc3",

--- a/astros_vue/src/assets/styles.css
+++ b/astros_vue/src/assets/styles.css
@@ -46,3 +46,32 @@
   background-color: #f49446 !important;
   color: black !important;
 }
+
+/* Tokens scoped to .firmware-view so the rest of the app keeps the existing palette; values from .docs/design_handoff_firmware_update/. */
+.firmware-view {
+  --fw-ink: #0e1726;
+  --fw-ink-soft: #4b5b73;
+  --fw-border: #d6e0e6;
+  --fw-border-strong: #9bb1bd;
+  --fw-success: #3aa676;
+  --fw-warn: #e5a93a;
+  --fw-danger: #cf4242;
+
+  --fw-state-idle-bg: #e6edf2;
+  --fw-state-idle-fg: #4b5b73;
+  --fw-state-idle-dot: #9bb1bd;
+  --fw-state-queued-bg: #e8eef7;
+  --fw-state-queued-fg: #3a4a6b;
+  --fw-state-queued-dot: #7d92b8;
+  --fw-state-updating-bg: #fff3dc;
+  --fw-state-updating-fg: #7d5a14;
+  --fw-state-updating-dot: #e5a93a;
+  --fw-state-done-bg: #dcf2e6;
+  --fw-state-done-fg: #1f6e44;
+  --fw-state-done-dot: #3aa676;
+  --fw-state-failed-bg: #fbe0e0;
+  --fw-state-failed-fg: #9a2828;
+  --fw-state-failed-dot: #cf4242;
+
+  font-family: 'Inter', system-ui, sans-serif;
+}

--- a/astros_vue/src/components/common/layout/AstrosLayout.vue
+++ b/astros_vue/src/components/common/layout/AstrosLayout.vue
@@ -102,6 +102,9 @@ function logout() {
               <router-link to="/modules">{{ $t('nav.modules') }}</router-link>
             </li>
             <li>
+              <router-link to="/firmware">{{ $t('nav.firmware') }}</router-link>
+            </li>
+            <li>
               <router-link to="/utility">{{ $t('nav.utility') }}</router-link>
             </li>
             <li>

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -38,8 +38,18 @@
     "playlists": "Playlists",
     "remote": "Remote",
     "modules": "Modules",
+    "firmware": "Firmware",
     "utility": "Utility",
     "logout": "Logout"
+  },
+  "firmware_view": {
+    "title": "Firmware",
+    "subtitle": {
+      "select": "Push firmware to your ESP fleet. The master receives the file then forwards to padawans over ESP-NOW.",
+      "flashing": "Update in progress — keep all controllers powered until reboot completes",
+      "done": "Update complete — all selected controllers are running the target firmware",
+      "failed": "Update finished with errors — review the failure below"
+    }
   },
   "placeholder": {
     "username": "username",

--- a/astros_vue/src/router/index.ts
+++ b/astros_vue/src/router/index.ts
@@ -57,6 +57,11 @@ const router = createRouter({
       component: () => import('../views/ModulesView.vue'),
     },
     {
+      path: '/firmware',
+      name: 'firmware',
+      component: () => import('../views/FirmwareView.vue'),
+    },
+    {
       path: '/utility',
       name: 'utility',
       component: () => import('../views/UtilityView.vue'),

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { AstrosLayout } from '@/components';
+
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/inter/700.css';
+
+const { t } = useI18n();
+
+type Phase = 'select' | 'flashing' | 'done' | 'failed';
+
+const phase = ref<Phase>('select');
+
+const subtitle = computed(() => t(`firmware_view.subtitle.${phase.value}`));
+</script>
+
+<template>
+  <AstrosLayout>
+    <template v-slot:main>
+      <main
+        class="firmware-view flex flex-col bg-base-200"
+        style="height: calc(100vh - 64px)"
+      >
+        <header class="firmware-view__header bg-r2-xlight">
+          <h1 class="firmware-view__title">{{ $t('firmware_view.title') }}</h1>
+        </header>
+        <div class="firmware-view__content">
+          <p class="firmware-view__subtitle">{{ subtitle }}</p>
+        </div>
+      </main>
+    </template>
+  </AstrosLayout>
+</template>
+
+<style scoped>
+.firmware-view__header {
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--fw-border);
+  flex-shrink: 0;
+}
+
+.firmware-view__title {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--fw-ink);
+}
+
+.firmware-view__subtitle {
+  font-size: 13px;
+  color: var(--fw-ink-soft);
+  margin: 0;
+}
+
+.firmware-view__content {
+  flex: 1;
+  padding: 20px 24px;
+  max-width: 1100px;
+  width: 100%;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-sizing: border-box;
+}
+</style>

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -20,35 +20,22 @@ const subtitle = computed(() => t(`firmware_view.subtitle.${phase.value}`));
 <template>
   <AstrosLayout>
     <template v-slot:main>
-      <main
-        class="firmware-view flex flex-col bg-base-200"
+      <div
+        class="flex flex-col overflow-hidden"
         style="height: calc(100vh - 64px)"
       >
-        <header class="firmware-view__header bg-r2-xlight">
-          <h1 class="firmware-view__title">{{ $t('firmware_view.title') }}</h1>
-        </header>
-        <div class="firmware-view__content">
+        <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0 mb-4">
+          <h1 class="text-2xl font-bold">{{ $t('firmware_view.title') }}</h1>
+        </div>
+        <div class="firmware-view firmware-view__content">
           <p class="firmware-view__subtitle">{{ subtitle }}</p>
         </div>
-      </main>
+      </div>
     </template>
   </AstrosLayout>
 </template>
 
 <style scoped>
-.firmware-view__header {
-  padding: 14px 20px;
-  border-bottom: 1px solid var(--fw-border);
-  flex-shrink: 0;
-}
-
-.firmware-view__title {
-  font-size: 22px;
-  font-weight: 700;
-  margin: 0;
-  color: var(--fw-ink);
-}
-
 .firmware-view__subtitle {
   font-size: 13px;
   color: var(--fw-ink-soft);


### PR DESCRIPTION
# Summary

  - First slice of the **phase d** firmware-OTA roadmap
  (`.docs/plans/20260507-2153-firmware-ota-d-vue-firmware-view.md`). Lands the empty `/firmware` route, nav entry
  between Modules and Utility, page chrome mirroring `ModulesView`, design-handoff CSS tokens scoped to
  `.firmware-view`, and i18n keys for the four phase subtitles.
  - No business logic, no WS, no HTTP — the page renders only the header + a phase-driven subtitle + an empty content
  area. SourceStrip, Topology, Controllers panel, and the firmwareStore land in d.2–d.6.
  - Inter font and design tokens are deliberately scoped to the firmware view so the rest of the app keeps its
  existing palette and font stack.

  ## Test plan

  - [ ] `/firmware` reachable when logged in; redirects to login when not authenticated.
  - [ ] Nav link appears between Modules and Utility, highlights active correctly.
  - [ ] Header chrome visually matches `ModulesView` (padding, border, title size).
  - [ ] Subtitle renders the `select`-phase copy from the design handoff.
  - [ ] No console errors / warnings on page load.
  - [ ] Lighthouse a11y ≥ 95 on `/firmware` (Chrome DevTools, with API running).
  - [x] `npm run prettier:write && npm run lint:fix && npm run build && npm run test:unit` — all green.
  - [x] `superpowers:requesting-code-review` on diff vs `develop` — no Critical/Important findings.

  ## Out of scope (later PRs in phase d)

  - d.2 — SourceStrip
  - d.3 — Topology
  - d.4 — Controllers panel + StagesList
  - d.5 — Subtitle phase machine wired to firmwareStore
  - d.6 — WS dispatcher + lock-aware integration