### PR TITLE
Feature/firmware ota d 4 controllers panel

### DIFF
--- a/.docs/plans/20260511-0811-firmware-ota-d-4-controllers-panel.md
+++ b/.docs/plans/20260511-0811-firmware-ota-d-4-controllers-panel.md
@@ -67,13 +67,20 @@ export type FirmwareStatusPillKind =
 
 ```ts
 // State
-const controllers = ref<FirmwareControllerView[]>([]);            // d.4: stories set this; d.5: action populates from controllers store
-const selectedControllerIds = ref<Set<string>>(new Set());
+const controllers = ref<FirmwareControllerView[]>([]);
+const selectedControllerIds = ref<ReadonlySet<string>>(new Set());
 
-// Selection actions
-function toggle(id: string): void { /* in-place mutate then replace ref to trigger reactivity */ }
-function selectAll(): void { selectedControllerIds.value = new Set(controllers.value.filter(/* not blocked */).map(c => c.id)); }
+// Selection actions — always build a fresh Set and assign; never mutate in place.
+function toggle(id: string): void {
+  const next = new Set(selectedControllerIds.value);
+  if (next.has(id)) next.delete(id); else next.add(id);
+  selectedControllerIds.value = next;
+}
+function selectAll(): void { /* fresh Set of non-blocked ids */ }
 function clear(): void { selectedControllerIds.value = new Set(); }
+
+// Reconcile: prune orphan selected ids when controllers is reassigned.
+watch(controllers, ...);
 
 // Computeds
 const target = computed<string | null>(() =>
@@ -83,22 +90,22 @@ const anyDowngradeBlocked = computed(() => /* iterate selected, check compareTag
 const canFlash = computed(() => target.value !== null && selectedControllerIds.value.size > 0 && !anyDowngradeBlocked.value);
 ```
 
-**Reactivity note:** `toggle` cannot mutate the Set in place — Vue tracks the ref value, not Set methods. Pattern: build a fresh Set from the prior one, then assign. (Same lesson as d.3 — captured in `feedback_safe_feature_branch_creation.md` …er, that one's about git, but the prop-shape memory from the d.3 round-2 review applies here too.)
+**Reactivity note:** `toggle/selectAll/clear` cannot mutate the Set in place — Vue tracks the ref value, not Set methods. Pattern: build a fresh Set from the prior one, then assign. The d.3 round-2 review surfaced this gotcha; d.4 applies the same fix and pins it with three reference-replacement tests.
 
 ---
 
 ## Tasks
 
-- [ ] Add i18n keys under `firmware_view.controllers.*`: `eyebrow_title`, `select_all`, `clear`, `master_pill`, `up_to_date`, `offline`, `downgrade_pill`, `action_bar.no_source`, `action_bar.no_selection`, `action_bar.push_summary` (named-interp), `action_bar.downgrade_blocked`, `action_bar.flash_button`, `result_bar.all_updated` (named-interp), `result_bar.failed_summary` (named-interp), `result_bar.view_logs`, `result_bar.done`, plus per-pill labels and status-dot aria-labels.
-- [ ] Define `FirmwareControllerView`, `ControllerOnlineStatus`, `FirmwareStatusPillKind` in `types/firmware.ts`.
-- [ ] Extend `firmwareStore`: `controllers`, `selectedControllerIds`, `target` computed, `anyDowngradeBlocked` computed, `canFlash` computed, `toggle/selectAll/clear` actions. Write unit tests covering the Set-replacement reactivity, downgrade detection, and canFlash combinatorics.
-- [ ] Implement `AstrosFirmwareStatusPill` (types.ts + .vue + stories). Single prop: `kind: FirmwareStatusPillKind` + slot for text.
-- [ ] Implement `AstrosFirmwareVersionDelta` (types.ts + .vue + stories + unit tests). Props: `current: string`, `target: string | null`. Renders `current · up to date` or `current → target` with conditional downgrade styling + pill.
-- [ ] Implement `AstrosFirmwareControllerRow` (types.ts + .vue + stories). Props: `controller: FirmwareControllerView`, `target: string | null`, `mode: 'select' | 'progress'`, `selected: boolean`, optional `status?: FirmwareStatusPillKind` for progress mode. Emits `@toggle`.
-- [ ] Implement `AstrosFirmwareControllersPanel` (.vue + stories). Reads from firmwareStore (`controllers`, `selectedControllerIds`, `target`, `canFlash`, `anyDowngradeBlocked`, current `phase` — note: `phase` not in store yet; pass as prop for d.4, hook to store in d.5). Renders header, rows, action/result bar.
-- [ ] Barrel export from `components/firmware/index.ts`.
-- [ ] Pre-commit gates: prettier, lint, build, vitest run, then commit (per CLAUDE.md "Code Review" workflow — invoke `superpowers:requesting-code-review` on diff vs prior commit before committing).
-- [ ] Pre-push: `/pr-review-toolkit:review-pr` (mandatory per the updated CLAUDE.md rule). Address Critical/Important findings before push.
+- [x] Add i18n keys under `firmware_view.controllers.*` (eyebrow, select-all/clear, master pill, downgrade pill, up-to-date suffix, status-dot aria, pill labels, action-bar copy, result-bar copy).
+- [x] Define `FirmwareControllerView`, `ControllerOnlineStatus`, `FirmwareStatusPillKind` in `types/firmware.ts`.
+- [x] Extend `firmwareStore`: `controllers`, `selectedControllerIds` (`ReadonlySet<string>`), `target`/`anyDowngradeBlocked`/`canFlash` computeds, `toggle/selectAll/clear` actions, plus a `watch(controllers)` reconciler that prunes orphan selected ids. Unit tests cover Set-replacement reactivity (all three actions), downgrade detection (NaN + cmp===0 boundary), canFlash combinatorics, and the reconciler.
+- [x] Implement `AstrosFirmwareStatusPill` (.vue + stories). Single prop: `kind: FirmwareStatusPillKind`.
+- [x] Implement `AstrosFirmwareVersionDelta` (.vue + stories + unit tests). Props: `current`, `target`. Renders `current · up to date` or `current → target` with conditional downgrade styling + pill.
+- [x] Implement `AstrosFirmwareControllerRow` (types.ts + .vue + stories). Props: `controller`, `target`, `mode: 'select' | 'progress'`, `selected: boolean`, optional `progressStatus`/`stageLabel` for progress mode. Emits `@toggle`. The select-mode right-column pill (`selectModePillKind`) is extracted to a sibling pure module with its own unit-test matrix (offline > downgrade > upToDate > null priority).
+- [x] Implement `AstrosFirmwareControllersPanel` (.vue + stories). Reads from firmwareStore (controllers, selectedControllerIds, target, canFlash, anyDowngradeBlocked). Takes `phase` as a prop (d.5 will move it to the store). Dev-mode `watchEffect` warns on null target / missing progress entries in non-select phases. Renders header, rows, action/result bar. Emits `@flash` / `@view-logs` / `@done`.
+- [x] Barrel export from `components/firmware/index.ts`.
+- [x] Pre-commit gates: prettier, lint, build, vitest run, per-commit `pr-review-toolkit:code-reviewer` agent pass, then commit.
+- [x] Pre-push: `/pr-review-toolkit:review-pr` 5-agent pass. Critical: 0. Important: addressed in a fixup commit (reconciler, dev warnings, JSDoc tightening, selectModePillKind extraction + tests, cmp===0 boundary test, dead i18n keys dropped, task-history comment removed, SelectTargetNoSelection story).
 
 ---
 

--- a/.docs/plans/20260511-0811-firmware-ota-d-4-controllers-panel.md
+++ b/.docs/plans/20260511-0811-firmware-ota-d-4-controllers-panel.md
@@ -1,0 +1,166 @@
+# d.4 — Controllers panel (`AstrosFirmwareControllersPanel`)
+
+Phase d, PR 4 of 6. Builds the right-column controllers panel per Direction C: header with select-all/clear, per-controller rows with version-delta + selection checkbox + status pill, and the bottom action/result bar.
+
+Includes four presentational components plus a small wire-up into `firmwareStore` for selection state.
+
+Roadmap reference: `20260507-2153-firmware-ota-d-vue-firmware-view.md`. Design source: `.docs/design_handoff_firmware_update/README.md:176-213` ("Component: `Controllers` panel") + `firmwareDirectionC.jsx:224-380` + `firmwareShared.jsx`.
+
+---
+
+## Scope decisions (confirmed with user)
+
+1. **Action/result bar bundled into d.4** — `ControllersPanel` renders Flash/View-logs/Done buttons. d.5 wires the click handlers to the flash POST and ConfirmModal.
+2. **Selection state lives in `firmwareStore`** — `selectedControllerIds: ref<Set<string>>` + `selectAll()`/`clear()`/`toggle(id)` actions. ControllerRow's checkbox v-models against the store. d.5/d.6 inherit a working selection model.
+3. **Mock controllers in d.4** — fleet data is hardcoded in Storybook (Body up v1.3.0, Core up v1.4.0, Dome down v1.4.0). d.5 wires the real `stores/controller` Controller list → `FirmwareControllerView` adapter.
+
+---
+
+## Components shipping in d.4
+
+| Component | Folder | Role |
+|---|---|---|
+| `AstrosFirmwareStatusPill` | `firmware/firmwareStatusPill/` | Small inline pill showing per-controller status (idle/queued/updating/done/failed + select-mode kinds: up-to-date/offline/downgrade). |
+| `AstrosFirmwareVersionDelta` | `firmware/firmwareVersionDelta/` | Renders `from → to` with downgrade detection via `compareTags`. Falls back to `current · up to date` when target is null or equal. |
+| `AstrosFirmwareControllerRow` | `firmware/firmwareControllerRow/` | One row: checkbox (select mode) or status pill (progress mode), badge, name + master pill + online-status dot, version delta below. |
+| `AstrosFirmwareControllersPanel` | `firmware/firmwareControllersPanel/` | Card with header (eyebrow + select-all/clear ghost buttons), rows, action/result bar. |
+
+Plus:
+- New `FirmwareControllerView` type in `types/firmware.ts` — the presentation-layer shape (id, label, current version, online status, master flag).
+- `firmwareStore` additions: `controllers`, `selectedControllerIds`, `selectAll`, `clear`, `toggle`, `target` computed (derived from `selectedReleaseTag` or `uploadedFilename` per `sourceMode`), `anyDowngradeBlocked` computed, `canFlash` computed.
+- New i18n keys under `firmware_view.controllers.*`.
+- Barrel exports for all four components + the `FirmwareControllerView` type.
+
+---
+
+## Type shape (draft for `types/firmware.ts`)
+
+```ts
+export type ControllerOnlineStatus = 'up' | 'down' | 'needsSynced';
+
+/** Presentation-layer view of a controller for the firmware-update flow. */
+export interface FirmwareControllerView {
+  id: string;
+  label: string;            // 'Body' / 'Core' / 'Dome'
+  glyph: string;            // single-letter badge: 'B', 'C', 'D'
+  current: string;          // semver tag, e.g. 'v1.4.0'
+  status: ControllerOnlineStatus;
+  isMaster: boolean;
+}
+
+export type FirmwareStatusPillKind =
+  | 'idle'
+  | 'queued'
+  | 'updating'
+  | 'done'
+  | 'failed'
+  | 'upToDate'
+  | 'offline'
+  | 'downgrade';
+```
+
+`FirmwareControllerView` deliberately mirrors `TopologyController`'s minimalism but adds version + status (which TopologyController doesn't need). d.5 will define the `Controller → FirmwareControllerView` adapter; d.4 ships only the type.
+
+---
+
+## firmwareStore additions
+
+```ts
+// State
+const controllers = ref<FirmwareControllerView[]>([]);            // d.4: stories set this; d.5: action populates from controllers store
+const selectedControllerIds = ref<Set<string>>(new Set());
+
+// Selection actions
+function toggle(id: string): void { /* in-place mutate then replace ref to trigger reactivity */ }
+function selectAll(): void { selectedControllerIds.value = new Set(controllers.value.filter(/* not blocked */).map(c => c.id)); }
+function clear(): void { selectedControllerIds.value = new Set(); }
+
+// Computeds
+const target = computed<string | null>(() =>
+  sourceMode.value === 'github' ? selectedReleaseTag.value : (uploadedFilename.value ? 'local-build' : null)
+);
+const anyDowngradeBlocked = computed(() => /* iterate selected, check compareTags(current, target) > 0 */);
+const canFlash = computed(() => target.value !== null && selectedControllerIds.value.size > 0 && !anyDowngradeBlocked.value);
+```
+
+**Reactivity note:** `toggle` cannot mutate the Set in place — Vue tracks the ref value, not Set methods. Pattern: build a fresh Set from the prior one, then assign. (Same lesson as d.3 — captured in `feedback_safe_feature_branch_creation.md` …er, that one's about git, but the prop-shape memory from the d.3 round-2 review applies here too.)
+
+---
+
+## Tasks
+
+- [ ] Add i18n keys under `firmware_view.controllers.*`: `eyebrow_title`, `select_all`, `clear`, `master_pill`, `up_to_date`, `offline`, `downgrade_pill`, `action_bar.no_source`, `action_bar.no_selection`, `action_bar.push_summary` (named-interp), `action_bar.downgrade_blocked`, `action_bar.flash_button`, `result_bar.all_updated` (named-interp), `result_bar.failed_summary` (named-interp), `result_bar.view_logs`, `result_bar.done`, plus per-pill labels and status-dot aria-labels.
+- [ ] Define `FirmwareControllerView`, `ControllerOnlineStatus`, `FirmwareStatusPillKind` in `types/firmware.ts`.
+- [ ] Extend `firmwareStore`: `controllers`, `selectedControllerIds`, `target` computed, `anyDowngradeBlocked` computed, `canFlash` computed, `toggle/selectAll/clear` actions. Write unit tests covering the Set-replacement reactivity, downgrade detection, and canFlash combinatorics.
+- [ ] Implement `AstrosFirmwareStatusPill` (types.ts + .vue + stories). Single prop: `kind: FirmwareStatusPillKind` + slot for text.
+- [ ] Implement `AstrosFirmwareVersionDelta` (types.ts + .vue + stories + unit tests). Props: `current: string`, `target: string | null`. Renders `current · up to date` or `current → target` with conditional downgrade styling + pill.
+- [ ] Implement `AstrosFirmwareControllerRow` (types.ts + .vue + stories). Props: `controller: FirmwareControllerView`, `target: string | null`, `mode: 'select' | 'progress'`, `selected: boolean`, optional `status?: FirmwareStatusPillKind` for progress mode. Emits `@toggle`.
+- [ ] Implement `AstrosFirmwareControllersPanel` (.vue + stories). Reads from firmwareStore (`controllers`, `selectedControllerIds`, `target`, `canFlash`, `anyDowngradeBlocked`, current `phase` — note: `phase` not in store yet; pass as prop for d.4, hook to store in d.5). Renders header, rows, action/result bar.
+- [ ] Barrel export from `components/firmware/index.ts`.
+- [ ] Pre-commit gates: prettier, lint, build, vitest run, then commit (per CLAUDE.md "Code Review" workflow — invoke `superpowers:requesting-code-review` on diff vs prior commit before committing).
+- [ ] Pre-push: `/pr-review-toolkit:review-pr` (mandatory per the updated CLAUDE.md rule). Address Critical/Important findings before push.
+
+---
+
+## Out of scope
+
+- `ConfirmModal` — d.5.
+- `StagesList` — d.5.
+- Page assembly (mounting in `FirmwareView`) — d.5.
+- Flash POST + ConfirmModal flow — d.5.
+- Wire `firmwareStore.controllers` from the real `stores/controller` Controller list — d.5 needs to define the adapter.
+- WS dispatcher / live in-flight rendering — d.6.
+- `compareTags` helper — already shipped in d.2 (`utils/version.ts`).
+- `AstrosFirmwareButton` (FwBtn) — already shipped in d.2.
+
+---
+
+## Verification
+
+1. `npm run build` (type-check).
+2. `npx vitest run` — new tests for `firmwareStore` selection / downgrade computeds + `AstrosFirmwareVersionDelta` downgrade rendering must pass; existing 56 tests must keep passing.
+3. `npm run storybook` — visually confirm each component renders across its stories:
+   - `AstrosFirmwareStatusPill`: one story per `kind` (8 stories).
+   - `AstrosFirmwareVersionDelta`: `UpToDate`, `Upgrade`, `Downgrade`, `NoTarget`.
+   - `AstrosFirmwareControllerRow`: `SelectModeUpToDate`, `SelectModeUpgrade`, `SelectModeDowngrade`, `SelectModeOffline`, `ProgressModeQueued`, `ProgressModeUpdating`, `ProgressModeDone`, `ProgressModeFailed`.
+   - `AstrosFirmwareControllersPanel`: `SelectInitial`, `SelectWithTarget`, `SelectAllSelected`, `SelectWithDowngrade`, `Flashing`, `Done`, `FailedCore`.
+4. Pre-push: `/pr-review-toolkit:review-pr` 5-agent pass; address Critical/Important.
+
+---
+
+## FMI inventory — skipped
+
+This is a presentational + small-store-mutation PR. No filesystem state, concurrency, network I/O, or crash recovery to inventory. Standard CRUD-shape changes only.
+
+---
+
+## Risks
+
+1. **`firmwareStore.controllers` shape leaking ahead of d.5's controllers-store adapter.** Mitigation: `FirmwareControllerView` is named to make the presentation-layer nature obvious; d.5's adapter is a small known piece of d.5 work. If the controllers store adds firmware-version metadata before d.5 ships, this view shape may converge with it — that's fine.
+2. **Set reactivity (same gotcha as d.3 round-2).** Mitigation: `toggle/selectAll/clear` actions always replace the Set, never mutate in place. Unit-test that mutating the store from outside the actions triggers the expected re-render (or fails closed in a documented way).
+3. **`AstrosFirmwareControllersPanel` reads `phase` as a prop (not store) in d.4.** d.5 will move it to the store. Risk: d.5 has to update the prop wiring. Mitigation: document the prop as `// TODO(d.5): read from firmwareStore.phase` and use the prop name `phase` matching the eventual store field.
+4. **Downgrade detection on malformed tags.** `compareTags` returns NaN on malformed input and `NaN > 0` is false — a malformed `current` silently passes the downgrade guard. Mitigation: `AstrosFirmwareVersionDelta` uses `Number.isNaN(compareTags(...))` and shows neither upgrade nor downgrade styling in that case (still renders the bare strings). Unit-test the NaN path.
+5. **i18n key explosion.** ~16 new keys for one component family. Mitigation: group them under `firmware_view.controllers.*` and `firmware_view.controllers.action_bar.*` / `result_bar.*` namespaces.
+
+---
+
+## Critical files
+
+- `.docs/design_handoff_firmware_update/README.md:176-213` — Controllers panel spec.
+- `.docs/design_handoff_firmware_update/firmwareDirectionC.jsx:224-380` — JSX reference (ControllerRow, panel container, action bar).
+- `.docs/design_handoff_firmware_update/firmwareShared.jsx` — `FwStatusPill`, `CtrlStatusDot`, `VersionDelta`, sample fleet data.
+- `astros_vue/src/stores/firmware.ts` — extension point.
+- `astros_vue/src/utils/version.ts` — `compareTags` already exists; do NOT re-implement.
+- `astros_vue/src/components/firmware/firmwareButton/AstrosFirmwareButton.vue` — primary/secondary/ghost button (use for action bar).
+- `astros_vue/src/components/firmware/firmwareTopology/` — naming + folder convention reference.
+
+---
+
+## Per-PR plan files (Phase D index)
+
+- d.1 → `20260507-2153-firmware-ota-d-1-page-chrome.md` ✅ merged
+- d.2 → `20260509-1716-firmware-ota-d-2-source-strip.md` ✅ merged
+- d.3 → `20260511-0651-firmware-ota-d-3-topology.md` ✅ on develop
+- d.4 → **this file**
+- d.5 → TBD
+- d.6 → TBD

--- a/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.stories.ts
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import AstrosFirmwareControllerRow from './AstrosFirmwareControllerRow.vue';
+import type { FirmwareControllerView } from '@/types/firmware';
+
+const body: FirmwareControllerView = {
+  id: 'body',
+  label: 'Body',
+  glyph: 'B',
+  current: 'v1.3.0',
+  status: 'up',
+  isMaster: true,
+};
+const core: FirmwareControllerView = {
+  id: 'core',
+  label: 'Core',
+  glyph: 'C',
+  current: 'v1.4.0',
+  status: 'up',
+  isMaster: false,
+};
+const domeOffline: FirmwareControllerView = {
+  id: 'dome',
+  label: 'Dome',
+  glyph: 'D',
+  current: 'v1.4.0',
+  status: 'down',
+  isMaster: false,
+};
+
+const meta = {
+  title: 'Components/Firmware/AstrosFirmwareControllerRow',
+  component: AstrosFirmwareControllerRow,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template:
+        '<div style="background: #fff; max-width: 480px; border: 1px solid #d6e0e6; border-radius: 6px;"><story /></div>',
+    }),
+  ],
+} satisfies Meta<typeof AstrosFirmwareControllerRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SelectModeMasterUpgrade: Story = {
+  args: { controller: body, target: 'v1.4.2', mode: 'select', selected: true },
+};
+
+export const SelectModePadawanUpgrade: Story = {
+  args: { controller: core, target: 'v1.4.2', mode: 'select', selected: false },
+};
+
+export const SelectModeUpToDate: Story = {
+  args: { controller: core, target: 'v1.4.0', mode: 'select', selected: false },
+};
+
+export const SelectModeNoTarget: Story = {
+  args: { controller: body, target: null, mode: 'select', selected: false },
+};
+
+export const SelectModeDowngrade: Story = {
+  args: { controller: core, target: 'v1.3.5', mode: 'select', selected: false },
+};
+
+export const SelectModeOffline: Story = {
+  args: { controller: domeOffline, target: 'v1.4.2', mode: 'select', selected: false },
+};
+
+export const ProgressModeQueued: Story = {
+  args: {
+    controller: body,
+    target: 'v1.4.2',
+    mode: 'progress',
+    selected: true,
+    progressStatus: 'queued',
+  },
+};
+
+export const ProgressModeUpdating: Story = {
+  args: {
+    controller: body,
+    target: 'v1.4.2',
+    mode: 'progress',
+    selected: true,
+    progressStatus: 'updating',
+    stageLabel: 'Transfer',
+  },
+};
+
+export const ProgressModeDone: Story = {
+  args: {
+    controller: core,
+    target: 'v1.4.2',
+    mode: 'progress',
+    selected: true,
+    progressStatus: 'done',
+  },
+};
+
+export const ProgressModeFailed: Story = {
+  args: {
+    controller: core,
+    target: 'v1.4.2',
+    mode: 'progress',
+    selected: true,
+    progressStatus: 'failed',
+  },
+};

--- a/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue
@@ -1,0 +1,241 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { compareTags } from '@/utils/version';
+import AstrosFirmwareVersionDelta from '../firmwareVersionDelta/AstrosFirmwareVersionDelta.vue';
+import AstrosFirmwareStatusPill from '../firmwareStatusPill/AstrosFirmwareStatusPill.vue';
+import type { FirmwareStatusPillKind } from '@/types/firmware';
+import type { ControllerRowProps } from './types';
+
+const props = defineProps<ControllerRowProps>();
+const emit = defineEmits<{ toggle: [id: string] }>();
+
+const { t } = useI18n();
+
+const isOffline = computed(() => props.controller.status === 'down');
+
+const isDowngrade = computed(() => {
+  if (props.target === null) return false;
+  const cmp = compareTags(props.controller.current, props.target);
+  if (Number.isNaN(cmp)) return false;
+  return cmp > 0;
+});
+
+const isUpToDate = computed(
+  () => props.target !== null && props.target === props.controller.current,
+);
+
+const blocked = computed(() => isOffline.value || isDowngrade.value);
+
+const selectModePillKind = computed<FirmwareStatusPillKind | null>(() => {
+  if (isOffline.value) return 'offline';
+  if (isDowngrade.value) return 'downgrade';
+  if (isUpToDate.value) return 'upToDate';
+  return null;
+});
+
+const statusDotAriaLabel = computed(() => {
+  const statusKey = `firmware_view.controllers.status_${
+    props.controller.status === 'needsSynced' ? 'needs_synced' : props.controller.status
+  }`;
+  return t('firmware_view.controllers.status_dot_aria', {
+    label: props.controller.label,
+    status: t(statusKey),
+  });
+});
+
+function onCheckboxChange() {
+  emit('toggle', props.controller.id);
+}
+</script>
+
+<template>
+  <div :class="['astros-firmware-controller-row', { 'is-blocked': mode === 'select' && blocked }]">
+    <label
+      v-if="mode === 'select'"
+      class="astros-firmware-controller-row__checkbox-wrap"
+    >
+      <input
+        type="checkbox"
+        class="astros-firmware-controller-row__checkbox"
+        :checked="selected"
+        :disabled="blocked"
+        :aria-label="t('firmware_view.controllers.row_select_aria', { label: controller.label })"
+        @change="onCheckboxChange"
+      />
+    </label>
+
+    <span
+      :class="[
+        'astros-firmware-controller-row__badge',
+        controller.isMaster
+          ? 'astros-firmware-controller-row__badge--master'
+          : 'astros-firmware-controller-row__badge--padawan',
+      ]"
+      aria-hidden="true"
+    >
+      {{ controller.glyph }}
+    </span>
+
+    <div class="astros-firmware-controller-row__middle">
+      <div class="astros-firmware-controller-row__top">
+        <span class="astros-firmware-controller-row__name">{{ controller.label }}</span>
+        <span
+          v-if="controller.isMaster"
+          class="astros-firmware-controller-row__master-pill"
+        >
+          {{ t('firmware_view.controllers.master_pill') }}
+        </span>
+        <span
+          :class="[
+            'astros-firmware-controller-row__status-dot',
+            `astros-firmware-controller-row__status-dot--${controller.status === 'needsSynced' ? 'needs-synced' : controller.status}`,
+          ]"
+          role="img"
+          :aria-label="statusDotAriaLabel"
+        />
+      </div>
+      <AstrosFirmwareVersionDelta
+        :current="controller.current"
+        :target="target"
+      />
+    </div>
+
+    <div class="astros-firmware-controller-row__right">
+      <template v-if="mode === 'select'">
+        <AstrosFirmwareStatusPill
+          v-if="selectModePillKind"
+          :kind="selectModePillKind"
+        />
+      </template>
+      <template v-else-if="progressStatus">
+        <AstrosFirmwareStatusPill :kind="progressStatus" />
+        <span
+          v-if="progressStatus === 'updating' && stageLabel"
+          class="astros-firmware-controller-row__stage"
+          >{{ stageLabel }}</span
+        >
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.astros-firmware-controller-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid #d6e0e6;
+  background: #ffffff;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.astros-firmware-controller-row.is-blocked {
+  opacity: 0.6;
+}
+
+.astros-firmware-controller-row__checkbox-wrap {
+  display: inline-flex;
+  align-items: center;
+}
+
+.astros-firmware-controller-row__checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: #2a5a97;
+  cursor: pointer;
+}
+
+.astros-firmware-controller-row__checkbox:disabled {
+  cursor: not-allowed;
+}
+
+.astros-firmware-controller-row__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 4px;
+  font-family: ui-monospace, 'SF Mono', monospace;
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.astros-firmware-controller-row__badge--master {
+  background: #2a5a97;
+  color: #ffffff;
+}
+
+.astros-firmware-controller-row__badge--padawan {
+  background: #cbdce1;
+  color: #2a5a97;
+}
+
+.astros-firmware-controller-row__middle {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 0;
+}
+
+.astros-firmware-controller-row__top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.astros-firmware-controller-row__name {
+  font-size: 13px;
+  font-weight: 700;
+  color: #0e1726;
+}
+
+.astros-firmware-controller-row__master-pill {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: #e8eef7;
+  color: #2a5a97;
+}
+
+.astros-firmware-controller-row__status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px #ffffff;
+}
+
+.astros-firmware-controller-row__status-dot--up {
+  background: #3aa676;
+}
+
+.astros-firmware-controller-row__status-dot--down {
+  background: #cf4242;
+}
+
+.astros-firmware-controller-row__status-dot--needs-synced {
+  background: #e5a93a;
+}
+
+.astros-firmware-controller-row__right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.astros-firmware-controller-row__stage {
+  font-family: ui-monospace, 'SF Mono', monospace;
+  font-size: 10px;
+  color: #4b5b73;
+}
+</style>

--- a/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { compareTags } from '@/utils/version';
 import AstrosFirmwareVersionDelta from '../firmwareVersionDelta/AstrosFirmwareVersionDelta.vue';
 import AstrosFirmwareStatusPill from '../firmwareStatusPill/AstrosFirmwareStatusPill.vue';
-import type { FirmwareStatusPillKind } from '@/types/firmware';
+import { selectModePillKind as computePillKind } from './selectModePillKind';
 import type { ControllerRowProps } from './types';
 
 const props = defineProps<ControllerRowProps>();
@@ -12,27 +11,11 @@ const emit = defineEmits<{ toggle: [id: string] }>();
 
 const { t } = useI18n();
 
-const isOffline = computed(() => props.controller.status === 'down');
-
-const isDowngrade = computed(() => {
-  if (props.target === null) return false;
-  const cmp = compareTags(props.controller.current, props.target);
-  if (Number.isNaN(cmp)) return false;
-  return cmp > 0;
-});
-
-const isUpToDate = computed(
-  () => props.target !== null && props.target === props.controller.current,
+const pillKind = computed(() =>
+  computePillKind({ controller: props.controller, target: props.target }),
 );
 
-const blocked = computed(() => isOffline.value || isDowngrade.value);
-
-const selectModePillKind = computed<FirmwareStatusPillKind | null>(() => {
-  if (isOffline.value) return 'offline';
-  if (isDowngrade.value) return 'downgrade';
-  if (isUpToDate.value) return 'upToDate';
-  return null;
-});
+const blocked = computed(() => pillKind.value === 'offline' || pillKind.value === 'downgrade');
 
 const statusDotAriaLabel = computed(() => {
   const statusKey = `firmware_view.controllers.status_${
@@ -104,8 +87,8 @@ function onCheckboxChange() {
     <div class="astros-firmware-controller-row__right">
       <template v-if="mode === 'select'">
         <AstrosFirmwareStatusPill
-          v-if="selectModePillKind"
-          :kind="selectModePillKind"
+          v-if="pillKind"
+          :kind="pillKind"
         />
       </template>
       <template v-else-if="progressStatus">

--- a/astros_vue/src/components/firmware/firmwareControllerRow/__tests__/selectModePillKind.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/__tests__/selectModePillKind.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { selectModePillKind } from '../selectModePillKind';
+import type { FirmwareControllerView } from '@/types/firmware';
+
+function ctrl(overrides: Partial<FirmwareControllerView> = {}): FirmwareControllerView {
+  return {
+    id: 'core',
+    label: 'Core',
+    glyph: 'C',
+    current: 'v1.4.0',
+    status: 'up',
+    isMaster: false,
+    ...overrides,
+  };
+}
+
+describe('selectModePillKind', () => {
+  it('returns offline when status is down, regardless of target', () => {
+    expect(selectModePillKind({ controller: ctrl({ status: 'down' }), target: null })).toBe(
+      'offline',
+    );
+    expect(selectModePillKind({ controller: ctrl({ status: 'down' }), target: 'v1.4.2' })).toBe(
+      'offline',
+    );
+  });
+
+  it('returns offline even when current === target (offline wins over upToDate)', () => {
+    // Mutation guard: if the priority order were inverted (upToDate first),
+    // an offline controller whose current happens to equal target would
+    // render as upToDate, hiding the connectivity issue.
+    expect(
+      selectModePillKind({
+        controller: ctrl({ status: 'down', current: 'v1.4.2' }),
+        target: 'v1.4.2',
+      }),
+    ).toBe('offline');
+  });
+
+  it('returns offline even on a would-be downgrade (offline wins over downgrade)', () => {
+    expect(
+      selectModePillKind({
+        controller: ctrl({ status: 'down', current: 'v1.5.0' }),
+        target: 'v1.4.2',
+      }),
+    ).toBe('offline');
+  });
+
+  it('returns downgrade when online and current > target', () => {
+    expect(selectModePillKind({ controller: ctrl({ current: 'v1.5.0' }), target: 'v1.4.2' })).toBe(
+      'downgrade',
+    );
+  });
+
+  it('returns upToDate when online and current === target', () => {
+    expect(selectModePillKind({ controller: ctrl({ current: 'v1.4.2' }), target: 'v1.4.2' })).toBe(
+      'upToDate',
+    );
+  });
+
+  it('returns null when online and target is null (no target chosen yet)', () => {
+    expect(selectModePillKind({ controller: ctrl(), target: null })).toBeNull();
+  });
+
+  it('returns null when online and current < target (typical upgrade-waiting-to-flash)', () => {
+    expect(
+      selectModePillKind({ controller: ctrl({ current: 'v1.3.0' }), target: 'v1.4.2' }),
+    ).toBeNull();
+  });
+
+  it('returns null for needsSynced + upgrade (only `down` triggers offline)', () => {
+    expect(
+      selectModePillKind({
+        controller: ctrl({ status: 'needsSynced', current: 'v1.3.0' }),
+        target: 'v1.4.2',
+      }),
+    ).toBeNull();
+  });
+
+  it('treats malformed current as not a downgrade (NaN > 0 is false)', () => {
+    expect(
+      selectModePillKind({ controller: ctrl({ current: 'not-a-version' }), target: 'v1.4.2' }),
+    ).toBeNull();
+  });
+});

--- a/astros_vue/src/components/firmware/firmwareControllerRow/selectModePillKind.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/selectModePillKind.ts
@@ -1,0 +1,26 @@
+import { compareTags } from '@/utils/version';
+import type { FirmwareControllerView, FirmwareStatusPillKind } from '@/types/firmware';
+
+export interface SelectModePillInput {
+  controller: FirmwareControllerView;
+  target: string | null;
+}
+
+/**
+ * Right-column pill in select mode. Priority: offline > downgrade > upToDate > none.
+ * Order matters — an offline controller whose current happens to equal target must
+ * render as offline (so the operator sees it can't participate), not upToDate.
+ *
+ * Returns null when the row should render no pill on the right (typical "upgrade
+ * waiting to be selected" state).
+ */
+export function selectModePillKind(input: SelectModePillInput): FirmwareStatusPillKind | null {
+  const { controller, target } = input;
+  if (controller.status === 'down') return 'offline';
+  if (target !== null) {
+    const cmp = compareTags(controller.current, target);
+    if (!Number.isNaN(cmp) && cmp > 0) return 'downgrade';
+    if (target === controller.current) return 'upToDate';
+  }
+  return null;
+}

--- a/astros_vue/src/components/firmware/firmwareControllerRow/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/types.ts
@@ -1,0 +1,15 @@
+import type { FirmwareControllerView, FirmwareStatusPillKind } from '@/types/firmware';
+
+export type ControllerRowMode = 'select' | 'progress';
+
+export interface ControllerRowProps {
+  controller: FirmwareControllerView;
+  target: string | null;
+  mode: ControllerRowMode;
+  /** Active in `select` mode. Ignored in `progress` mode. */
+  selected: boolean;
+  /** Status pill shown in `progress` mode. */
+  progressStatus?: FirmwareStatusPillKind;
+  /** Stage label rendered under the status pill in `progress` mode when updating. */
+  stageLabel?: string;
+}

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
@@ -51,6 +51,18 @@ export const SelectInitial: Story = {
   args: { phase: 'select' },
 };
 
+export const SelectTargetNoSelection: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: 'v1.4.2', selected: [] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: { phase: 'select' },
+};
+
 export const SelectWithTarget: Story = {
   render: (args) => ({
     components: { AstrosFirmwareControllersPanel },

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
@@ -1,0 +1,148 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { createPinia, setActivePinia } from 'pinia';
+import AstrosFirmwareControllersPanel from './AstrosFirmwareControllersPanel.vue';
+import { useFirmwareStore } from '@/stores/firmware';
+import type { FirmwareControllerView } from '@/types/firmware';
+
+const SAMPLE_CONTROLLERS: FirmwareControllerView[] = [
+  { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
+  { id: 'core', label: 'Core', glyph: 'C', current: 'v1.4.0', status: 'up', isMaster: false },
+  { id: 'dome', label: 'Dome', glyph: 'D', current: 'v1.4.0', status: 'down', isMaster: false },
+];
+
+function setupStore(opts: {
+  target?: string | null;
+  selected?: string[];
+  controllers?: FirmwareControllerView[];
+}) {
+  setActivePinia(createPinia());
+  const store = useFirmwareStore();
+  store.controllers = opts.controllers ?? SAMPLE_CONTROLLERS;
+  store.sourceMode = 'github';
+  store.selectedReleaseTag = opts.target ?? null;
+  store.selectedControllerIds = new Set(opts.selected ?? []);
+}
+
+const meta = {
+  title: 'Components/Firmware/AstrosFirmwareControllersPanel',
+  component: AstrosFirmwareControllersPanel,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template:
+        '<div style="background: #f2f7fa; padding: 24px; max-width: 560px;"><story /></div>',
+    }),
+  ],
+} satisfies Meta<typeof AstrosFirmwareControllersPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SelectInitial: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: null });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: { phase: 'select' },
+};
+
+export const SelectWithTarget: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: 'v1.4.2', selected: ['body'] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: { phase: 'select' },
+};
+
+export const SelectAllSelected: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: 'v1.4.2', selected: ['body', 'core'] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: { phase: 'select' },
+};
+
+export const SelectWithDowngrade: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: 'v1.3.5', selected: ['body', 'core'] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: { phase: 'select' },
+};
+
+export const Flashing: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: 'v1.4.2', selected: ['body', 'core'] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: {
+    phase: 'flashing',
+    progressByControllerId: {
+      body: { status: 'updating', stageLabel: 'Transfer' },
+      core: { status: 'queued' },
+      dome: { status: 'idle' },
+    },
+  },
+};
+
+export const Done: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: 'v1.4.2', selected: ['body', 'core'] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: {
+    phase: 'done',
+    doneCount: 2,
+    progressByControllerId: {
+      body: { status: 'done' },
+      core: { status: 'done' },
+      dome: { status: 'idle' },
+    },
+  },
+};
+
+export const FailedCore: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({ target: 'v1.4.2', selected: ['body', 'core'] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: {
+    phase: 'failed',
+    failedControllerLabel: 'Core',
+    failedStage: 'transfer',
+    progressByControllerId: {
+      body: { status: 'done' },
+      core: { status: 'failed' },
+      dome: { status: 'idle' },
+    },
+  },
+};

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
+import { useFirmwareStore } from '@/stores/firmware';
+import AstrosFirmwareControllerRow from '../firmwareControllerRow/AstrosFirmwareControllerRow.vue';
+import AstrosFirmwareButton from '../firmwareButton/AstrosFirmwareButton.vue';
+import type { ControllersPanelProps } from './types';
+
+const props = defineProps<ControllersPanelProps>();
+const emit = defineEmits<{
+  flash: [];
+  'view-logs': [];
+  done: [];
+}>();
+
+const { t } = useI18n();
+const firmware = useFirmwareStore();
+const { controllers, selectedControllerIds, target, canFlash, anyDowngradeBlocked } =
+  storeToRefs(firmware);
+
+const rowMode = computed<'select' | 'progress'>(() =>
+  props.phase === 'select' ? 'select' : 'progress',
+);
+
+const actionBarMessage = computed(() => {
+  if (target.value === null) return t('firmware_view.controllers.action_bar.no_source');
+  if (selectedControllerIds.value.size === 0)
+    return t('firmware_view.controllers.action_bar.no_selection');
+  return t('firmware_view.controllers.action_bar.push_summary', {
+    target: target.value,
+    count: selectedControllerIds.value.size,
+  });
+});
+</script>
+
+<template>
+  <section class="astros-firmware-controllers-panel">
+    <header class="astros-firmware-controllers-panel__header">
+      <span class="astros-firmware-controllers-panel__eyebrow">
+        {{ t('firmware_view.controllers.eyebrow_title') }}
+      </span>
+      <div
+        v-if="phase === 'select'"
+        class="astros-firmware-controllers-panel__header-actions"
+      >
+        <button
+          type="button"
+          class="astros-firmware-controllers-panel__ghost-btn"
+          @click="firmware.selectAll()"
+        >
+          {{ t('firmware_view.controllers.select_all') }}
+        </button>
+        <button
+          type="button"
+          class="astros-firmware-controllers-panel__ghost-btn"
+          @click="firmware.clear()"
+        >
+          {{ t('firmware_view.controllers.clear') }}
+        </button>
+      </div>
+    </header>
+
+    <ul class="astros-firmware-controllers-panel__rows">
+      <li
+        v-for="c in controllers"
+        :key="c.id"
+        class="astros-firmware-controllers-panel__row-wrap"
+      >
+        <AstrosFirmwareControllerRow
+          :controller="c"
+          :target="target"
+          :mode="rowMode"
+          :selected="selectedControllerIds.has(c.id)"
+          :progress-status="progressByControllerId?.[c.id]?.status"
+          :stage-label="progressByControllerId?.[c.id]?.stageLabel"
+          @toggle="firmware.toggle"
+        />
+      </li>
+    </ul>
+
+    <footer
+      v-if="phase === 'select'"
+      class="astros-firmware-controllers-panel__action-bar astros-firmware-controllers-panel__bar--select"
+    >
+      <div class="astros-firmware-controllers-panel__action-bar-text">
+        <span>{{ actionBarMessage }}</span>
+        <span
+          v-if="anyDowngradeBlocked"
+          class="astros-firmware-controllers-panel__action-bar-downgrade"
+        >
+          {{ t('firmware_view.controllers.action_bar.downgrade_blocked') }}
+        </span>
+      </div>
+      <AstrosFirmwareButton
+        kind="primary"
+        :disabled="!canFlash"
+        @click="emit('flash')"
+      >
+        {{ t('firmware_view.controllers.action_bar.flash_button') }}
+      </AstrosFirmwareButton>
+    </footer>
+
+    <footer
+      v-else-if="phase === 'done'"
+      class="astros-firmware-controllers-panel__action-bar astros-firmware-controllers-panel__bar--done"
+    >
+      <span
+        class="astros-firmware-controllers-panel__result-text astros-firmware-controllers-panel__result-text--done"
+      >
+        {{
+          t('firmware_view.controllers.result_bar.all_updated', {
+            count: doneCount ?? selectedControllerIds.size,
+          })
+        }}
+      </span>
+      <div class="astros-firmware-controllers-panel__action-bar-buttons">
+        <AstrosFirmwareButton
+          kind="secondary"
+          @click="emit('view-logs')"
+        >
+          {{ t('firmware_view.controllers.result_bar.view_logs') }}
+        </AstrosFirmwareButton>
+        <AstrosFirmwareButton
+          kind="primary"
+          @click="emit('done')"
+        >
+          {{ t('firmware_view.controllers.result_bar.done') }}
+        </AstrosFirmwareButton>
+      </div>
+    </footer>
+
+    <footer
+      v-else-if="phase === 'failed'"
+      class="astros-firmware-controllers-panel__action-bar astros-firmware-controllers-panel__bar--failed"
+    >
+      <span
+        class="astros-firmware-controllers-panel__result-text astros-firmware-controllers-panel__result-text--failed"
+      >
+        {{
+          t('firmware_view.controllers.result_bar.failed_summary', {
+            label: failedControllerLabel ?? '—',
+            stage: failedStage ?? '—',
+          })
+        }}
+      </span>
+      <div class="astros-firmware-controllers-panel__action-bar-buttons">
+        <AstrosFirmwareButton
+          kind="secondary"
+          @click="emit('view-logs')"
+        >
+          {{ t('firmware_view.controllers.result_bar.view_logs') }}
+        </AstrosFirmwareButton>
+        <AstrosFirmwareButton
+          kind="primary"
+          @click="emit('done')"
+        >
+          {{ t('firmware_view.controllers.result_bar.done') }}
+        </AstrosFirmwareButton>
+      </div>
+    </footer>
+  </section>
+</template>
+
+<style scoped>
+.astros-firmware-controllers-panel {
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border: 1px solid #d6e0e6;
+  border-radius: 6px;
+  align-self: flex-start;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.astros-firmware-controllers-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: #f6f9fb;
+  border-bottom: 1px solid #d6e0e6;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+}
+
+.astros-firmware-controllers-panel__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4b5b73;
+}
+
+.astros-firmware-controllers-panel__header-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.astros-firmware-controllers-panel__ghost-btn {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  color: #4b5b73;
+  padding: 6px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background 0.15s linear;
+}
+
+.astros-firmware-controllers-panel__ghost-btn:hover {
+  background: #eef3fa;
+}
+
+.astros-firmware-controllers-panel__ghost-btn:focus-visible {
+  outline: 2px solid #7d92b8;
+  outline-offset: 2px;
+}
+
+.astros-firmware-controllers-panel__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.astros-firmware-controllers-panel__row-wrap:last-child :deep(.astros-firmware-controller-row) {
+  border-bottom: none;
+}
+
+.astros-firmware-controllers-panel__action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px;
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+.astros-firmware-controllers-panel__bar--select {
+  background: #f6f9fb;
+  border-top: 1px solid #d6e0e6;
+}
+
+.astros-firmware-controllers-panel__bar--done {
+  background: #dcf2e6;
+  border-top: 1px solid #3aa67655;
+}
+
+.astros-firmware-controllers-panel__bar--failed {
+  background: #fbe0e0;
+  border-top: 1px solid #cf424255;
+}
+
+.astros-firmware-controllers-panel__action-bar-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+  color: #4b5b73;
+}
+
+.astros-firmware-controllers-panel__action-bar-downgrade {
+  font-size: 12px;
+  font-weight: 600;
+  color: #9a2828;
+}
+
+.astros-firmware-controllers-panel__action-bar-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.astros-firmware-controllers-panel__result-text {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.astros-firmware-controllers-panel__result-text--done {
+  color: #1f6e44;
+}
+
+.astros-firmware-controllers-panel__result-text--failed {
+  color: #9a2828;
+}
+</style>

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 import { useFirmwareStore } from '@/stores/firmware';
@@ -22,6 +22,37 @@ const { controllers, selectedControllerIds, target, canFlash, anyDowngradeBlocke
 const rowMode = computed<'select' | 'progress'>(() =>
   props.phase === 'select' ? 'select' : 'progress',
 );
+
+// Dev-only invariant warnings. Vite tree-shakes the block in production —
+// these surface wiring bugs during local dev / Storybook when the panel is
+// integrated with the WS dispatcher in d.5/d.6.
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.phase !== 'select' && target.value === null) {
+      console.warn(
+        `[AstrosFirmwareControllersPanel] target is null during phase="${props.phase}"; ` +
+          `parent should ensure a target is set whenever phase !== 'select'.`,
+      );
+    }
+    if (props.phase !== 'select' && props.progressByControllerId === undefined) {
+      console.warn(
+        `[AstrosFirmwareControllersPanel] progressByControllerId is undefined during ` +
+          `phase="${props.phase}"; rows will render with no status pill.`,
+      );
+    }
+    if (props.phase !== 'select' && props.progressByControllerId !== undefined) {
+      const missing = controllers.value
+        .filter((c) => props.progressByControllerId?.[c.id] === undefined)
+        .map((c) => c.id);
+      if (missing.length > 0) {
+        console.warn(
+          `[AstrosFirmwareControllersPanel] progressByControllerId is missing entries for ` +
+            `${missing.join(', ')} during phase="${props.phase}".`,
+        );
+      }
+    }
+  });
+}
 
 const actionBarMessage = computed(() => {
   if (target.value === null) return t('firmware_view.controllers.action_bar.no_source');
@@ -95,7 +126,7 @@ const actionBarMessage = computed(() => {
       <AstrosFirmwareButton
         kind="primary"
         :disabled="!canFlash"
-        @click="emit('flash')"
+        @click="canFlash && emit('flash')"
       >
         {{ t('firmware_view.controllers.action_bar.flash_button') }}
       </AstrosFirmwareButton>

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -10,12 +10,12 @@ export interface ControllerProgressEntry {
 
 export interface ControllersPanelProps {
   phase: ControllersPanelPhase;
-  /** Per-controller progress state keyed by controller id. Required for non-`select` phases. */
+  /** Per-controller progress state keyed by controller id; read in non-select phases. */
   progressByControllerId?: Record<string, ControllerProgressEntry>;
-  /** Result bar — `done` phase: count of controllers updated. */
+  /** Result bar count in `done` phase; falls back to `selectedControllerIds.size`. */
   doneCount?: number;
-  /** Result bar — `failed` phase: failing controller's label. */
+  /** Result bar label in `failed` phase. */
   failedControllerLabel?: string;
-  /** Result bar — `failed` phase: stage during which the failure occurred. */
+  /** Result bar stage name in `failed` phase. */
   failedStage?: string;
 }

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -1,0 +1,21 @@
+import type { FirmwareStatusPillKind } from '@/types/firmware';
+
+export type ControllersPanelPhase = 'select' | 'flashing' | 'done' | 'failed';
+
+export interface ControllerProgressEntry {
+  status: FirmwareStatusPillKind;
+  /** Stage label shown under the status pill when status === 'updating'. */
+  stageLabel?: string;
+}
+
+export interface ControllersPanelProps {
+  phase: ControllersPanelPhase;
+  /** Per-controller progress state keyed by controller id. Required for non-`select` phases. */
+  progressByControllerId?: Record<string, ControllerProgressEntry>;
+  /** Result bar — `done` phase: count of controllers updated. */
+  doneCount?: number;
+  /** Result bar — `failed` phase: failing controller's label. */
+  failedControllerLabel?: string;
+  /** Result bar — `failed` phase: stage during which the failure occurred. */
+  failedStage?: string;
+}

--- a/astros_vue/src/components/firmware/firmwareStatusPill/AstrosFirmwareStatusPill.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareStatusPill/AstrosFirmwareStatusPill.stories.ts
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import AstrosFirmwareStatusPill from './AstrosFirmwareStatusPill.vue';
+
+const meta = {
+  title: 'Components/Firmware/AstrosFirmwareStatusPill',
+  component: AstrosFirmwareStatusPill,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    kind: {
+      control: 'select',
+      options: ['idle', 'queued', 'updating', 'done', 'failed', 'upToDate', 'offline', 'downgrade'],
+    },
+  },
+} satisfies Meta<typeof AstrosFirmwareStatusPill>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = { args: { kind: 'idle' } };
+export const Queued: Story = { args: { kind: 'queued' } };
+export const Updating: Story = { args: { kind: 'updating' } };
+export const Done: Story = { args: { kind: 'done' } };
+export const Failed: Story = { args: { kind: 'failed' } };
+export const UpToDate: Story = { args: { kind: 'upToDate' } };
+export const Offline: Story = { args: { kind: 'offline' } };
+export const Downgrade: Story = { args: { kind: 'downgrade' } };

--- a/astros_vue/src/components/firmware/firmwareStatusPill/AstrosFirmwareStatusPill.vue
+++ b/astros_vue/src/components/firmware/firmwareStatusPill/AstrosFirmwareStatusPill.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { FirmwareStatusPillKind } from '@/types/firmware';
+
+const props = defineProps<{ kind: FirmwareStatusPillKind }>();
+
+const { t } = useI18n();
+
+const KIND_LABEL_KEY: Record<FirmwareStatusPillKind, string> = {
+  idle: 'firmware_view.controllers.pill.idle',
+  queued: 'firmware_view.controllers.pill.queued',
+  updating: 'firmware_view.controllers.pill.updating',
+  done: 'firmware_view.controllers.pill.done',
+  failed: 'firmware_view.controllers.pill.failed',
+  upToDate: 'firmware_view.controllers.pill.up_to_date',
+  offline: 'firmware_view.controllers.pill.offline',
+  downgrade: 'firmware_view.controllers.pill.downgrade',
+};
+
+const KIND_MODIFIER: Record<FirmwareStatusPillKind, string> = {
+  idle: 'idle',
+  queued: 'queued',
+  updating: 'updating',
+  done: 'done',
+  failed: 'failed',
+  upToDate: 'up-to-date',
+  offline: 'offline',
+  downgrade: 'downgrade',
+};
+
+const modifierClass = computed(() => `astros-firmware-status-pill--${KIND_MODIFIER[props.kind]}`);
+</script>
+
+<template>
+  <span :class="['astros-firmware-status-pill', modifierClass]">
+    {{ t(KIND_LABEL_KEY[kind]) }}
+  </span>
+</template>
+
+<style scoped>
+.astros-firmware-status-pill {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.astros-firmware-status-pill--idle {
+  background: #e6edf2;
+  color: #4b5b73;
+}
+
+.astros-firmware-status-pill--queued {
+  background: #e8eef7;
+  color: #3a4a6b;
+}
+
+.astros-firmware-status-pill--updating {
+  background: #fff3dc;
+  color: #7d5a14;
+}
+
+.astros-firmware-status-pill--done,
+.astros-firmware-status-pill--up-to-date {
+  background: #dcf2e6;
+  color: #1f6e44;
+}
+
+.astros-firmware-status-pill--failed,
+.astros-firmware-status-pill--offline,
+.astros-firmware-status-pill--downgrade {
+  background: #fbe0e0;
+  color: #9a2828;
+}
+</style>

--- a/astros_vue/src/components/firmware/firmwareVersionDelta/AstrosFirmwareVersionDelta.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareVersionDelta/AstrosFirmwareVersionDelta.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import AstrosFirmwareVersionDelta from './AstrosFirmwareVersionDelta.vue';
+
+const meta = {
+  title: 'Components/Firmware/AstrosFirmwareVersionDelta',
+  component: AstrosFirmwareVersionDelta,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof AstrosFirmwareVersionDelta>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NoTarget: Story = { args: { current: 'v1.4.0', target: null } };
+
+export const UpToDate: Story = { args: { current: 'v1.4.2', target: 'v1.4.2' } };
+
+export const Upgrade: Story = { args: { current: 'v1.3.0', target: 'v1.4.2' } };
+
+export const Downgrade: Story = { args: { current: 'v1.4.2', target: 'v1.3.0' } };
+
+export const MalformedCurrent: Story = {
+  args: { current: 'not-a-version', target: 'v1.4.2' },
+};

--- a/astros_vue/src/components/firmware/firmwareVersionDelta/AstrosFirmwareVersionDelta.vue
+++ b/astros_vue/src/components/firmware/firmwareVersionDelta/AstrosFirmwareVersionDelta.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { compareTags } from '@/utils/version';
+
+const props = defineProps<{
+  current: string;
+  target: string | null;
+}>();
+
+const { t } = useI18n();
+
+const upToDate = computed(() => props.target === null || props.target === props.current);
+
+// `compareTags` returns NaN for malformed input. `NaN > 0` is false, so a
+// malformed `current` would silently appear as an upgrade — explicit guard
+// here keeps the styling neutral instead of misleading.
+const downgrade = computed(() => {
+  if (upToDate.value || props.target === null) return false;
+  const cmp = compareTags(props.current, props.target);
+  if (Number.isNaN(cmp)) return false;
+  return cmp > 0;
+});
+</script>
+
+<template>
+  <span :class="['astros-firmware-version-delta', { 'is-downgrade': downgrade }]">
+    <span class="astros-firmware-version-delta__current">{{ current }}</span>
+    <template v-if="upToDate">
+      <span class="astros-firmware-version-delta__suffix">{{
+        t('firmware_view.controllers.up_to_date_suffix')
+      }}</span>
+    </template>
+    <template v-else>
+      <span
+        class="astros-firmware-version-delta__arrow"
+        aria-hidden="true"
+        >→</span
+      >
+      <span class="astros-firmware-version-delta__target">{{ target }}</span>
+      <span
+        v-if="downgrade"
+        class="astros-firmware-version-delta__pill"
+        >{{ t('firmware_view.controllers.downgrade_pill') }}</span
+      >
+    </template>
+  </span>
+</template>
+
+<style scoped>
+.astros-firmware-version-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: ui-monospace, 'SF Mono', monospace;
+  font-size: 11px;
+  color: #4b5b73;
+}
+
+.astros-firmware-version-delta__current,
+.astros-firmware-version-delta__target {
+  font-weight: 500;
+}
+
+.astros-firmware-version-delta__arrow {
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.astros-firmware-version-delta.is-downgrade .astros-firmware-version-delta__arrow,
+.astros-firmware-version-delta.is-downgrade .astros-firmware-version-delta__target {
+  color: #9a2828;
+}
+
+.astros-firmware-version-delta__suffix {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 11px;
+  color: #4b5b73;
+}
+
+.astros-firmware-version-delta__pill {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: #fbe0e0;
+  color: #9a2828;
+}
+</style>

--- a/astros_vue/src/components/firmware/firmwareVersionDelta/__tests__/AstrosFirmwareVersionDelta.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareVersionDelta/__tests__/AstrosFirmwareVersionDelta.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import AstrosFirmwareVersionDelta from '../AstrosFirmwareVersionDelta.vue';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: {
+    'en-US': {
+      firmware_view: {
+        controllers: {
+          up_to_date_suffix: '· up to date',
+          downgrade_pill: 'DOWNGRADE',
+        },
+      },
+    },
+  },
+});
+
+function render(current: string, target: string | null) {
+  return mount(AstrosFirmwareVersionDelta, {
+    props: { current, target },
+    global: { plugins: [i18n] },
+  });
+}
+
+describe('AstrosFirmwareVersionDelta', () => {
+  it('renders the up-to-date suffix when target is null', () => {
+    const w = render('v1.4.0', null);
+    expect(w.text()).toContain('v1.4.0');
+    expect(w.text()).toContain('up to date');
+    expect(w.text()).not.toContain('→');
+  });
+
+  it('renders the up-to-date suffix when current equals target', () => {
+    const w = render('v1.4.2', 'v1.4.2');
+    expect(w.text()).toContain('up to date');
+    expect(w.text()).not.toContain('→');
+  });
+
+  it('renders a from → to arrow on upgrade with no downgrade pill', () => {
+    const w = render('v1.3.0', 'v1.4.2');
+    expect(w.text()).toContain('v1.3.0');
+    expect(w.text()).toContain('v1.4.2');
+    expect(w.text()).toContain('→');
+    expect(w.text()).not.toContain('DOWNGRADE');
+    expect(w.classes()).not.toContain('is-downgrade');
+  });
+
+  it('renders the downgrade pill and is-downgrade class on downgrade', () => {
+    const w = render('v1.4.2', 'v1.3.0');
+    expect(w.text()).toContain('DOWNGRADE');
+    expect(w.classes()).toContain('is-downgrade');
+  });
+
+  it('renders neither downgrade pill nor up-to-date suffix when current is malformed', () => {
+    // NaN guard: compareTags returns NaN; we must NOT silently classify as
+    // upgrade or downgrade. The component shows the bare from → to.
+    const w = render('not-a-version', 'v1.4.2');
+    expect(w.text()).toContain('not-a-version');
+    expect(w.text()).toContain('v1.4.2');
+    expect(w.text()).toContain('→');
+    expect(w.text()).not.toContain('DOWNGRADE');
+    expect(w.classes()).not.toContain('is-downgrade');
+  });
+});

--- a/astros_vue/src/components/firmware/index.ts
+++ b/astros_vue/src/components/firmware/index.ts
@@ -1,5 +1,15 @@
 export { default as AstrosFirmwareButton } from './firmwareButton/AstrosFirmwareButton.vue';
 export { default as AstrosFirmwareSourceStrip } from './firmwareSourceStrip/AstrosFirmwareSourceStrip.vue';
 export { default as AstrosFirmwareTopology } from './firmwareTopology/AstrosFirmwareTopology.vue';
+export { default as AstrosFirmwareStatusPill } from './firmwareStatusPill/AstrosFirmwareStatusPill.vue';
+export { default as AstrosFirmwareVersionDelta } from './firmwareVersionDelta/AstrosFirmwareVersionDelta.vue';
+export { default as AstrosFirmwareControllerRow } from './firmwareControllerRow/AstrosFirmwareControllerRow.vue';
+export { default as AstrosFirmwareControllersPanel } from './firmwareControllersPanel/AstrosFirmwareControllersPanel.vue';
 export type { AstrosFirmwareButtonKind } from './firmwareButton/types';
 export type { TopologyController, TopologyFleet, TopologyPhase } from './firmwareTopology/types';
+export type { ControllerRowMode, ControllerRowProps } from './firmwareControllerRow/types';
+export type {
+  ControllerProgressEntry,
+  ControllersPanelPhase,
+  ControllersPanelProps,
+} from './firmwareControllersPanel/types';

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -76,6 +76,42 @@
       "role_padawan": "PADAWAN",
       "figure_aria_label": "Firmware update topology — master receives the file then forwards to padawan controllers over ESP-NOW",
       "node_title": "{label} ({role})"
+    },
+    "controllers": {
+      "eyebrow_title": "CONTROLLERS",
+      "select_all": "Select all",
+      "clear": "Clear",
+      "master_pill": "Master",
+      "downgrade_pill": "DOWNGRADE",
+      "up_to_date_suffix": "· up to date",
+      "status_dot_aria": "{label} is {status}",
+      "status_up": "online",
+      "status_down": "offline",
+      "status_needs_synced": "needs sync",
+      "row_select_aria": "Select {label} for firmware update",
+      "pill": {
+        "idle": "Idle",
+        "queued": "Queued",
+        "updating": "Updating",
+        "done": "Done",
+        "failed": "Failed",
+        "up_to_date": "Up to date",
+        "offline": "Offline",
+        "downgrade": "Downgrade"
+      },
+      "action_bar": {
+        "no_source": "Pick a source",
+        "no_selection": "Pick at least one controller",
+        "push_summary": "Will push {target} to {count} controller(s)",
+        "downgrade_blocked": "⛔ Downgrade blocked",
+        "flash_button": "Flash firmware"
+      },
+      "result_bar": {
+        "all_updated": "✓ All {count} controller(s) updated",
+        "failed_summary": "⚠ {label} failed during {stage}",
+        "view_logs": "View logs",
+        "done": "Done"
+      }
     }
   },
   "placeholder": {

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -273,6 +273,18 @@ describe('firmware store', () => {
       expect(store.anyDowngradeBlocked).toBe(true);
     });
 
+    it('treats current === target as not a downgrade (boundary: cmp === 0)', () => {
+      // Pins the strict-inequality `cmp > 0` semantics in isDowngrade. A
+      // mutation to `cmp >= 0` would flag an equal version as a downgrade
+      // and this test would fail.
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.0';
+      store.toggle('core'); // core is v1.4.0; target is v1.4.0
+      expect(store.anyDowngradeBlocked).toBe(false);
+    });
+
     it('treats a malformed current version as not a downgrade (NaN > 0 is false)', () => {
       const store = useFirmwareStore();
       store.controllers = [
@@ -289,6 +301,34 @@ describe('firmware store', () => {
       store.selectedReleaseTag = 'v1.4.2';
       store.toggle('weird');
       expect(store.anyDowngradeBlocked).toBe(false);
+    });
+  });
+
+  describe('controllers reconciler', () => {
+    it('prunes selected ids that no longer exist after controllers is reassigned', async () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.toggle('body');
+      store.toggle('core');
+      expect(store.selectedControllerIds.size).toBe(2);
+
+      // Reassign with dome removed and core renamed.
+      store.controllers = [
+        { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
+      ];
+      // watch is async; flush via microtask.
+      await Promise.resolve();
+      expect([...store.selectedControllerIds]).toEqual(['body']);
+    });
+
+    it('does not touch the Set when no ids are orphaned', async () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.toggle('body');
+      const before = store.selectedControllerIds;
+      store.controllers = [...sampleControllers]; // new reference, same ids
+      await Promise.resolve();
+      expect(store.selectedControllerIds).toBe(before);
     });
   });
 

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -9,7 +9,13 @@ vi.mock('@/api/apiService', () => ({
 
 import apiService from '@/api/apiService';
 import { useFirmwareStore } from '../firmware';
-import type { ReleaseInfo, ReleaseListResult } from '@/types/firmware';
+import type { FirmwareControllerView, ReleaseInfo, ReleaseListResult } from '@/types/firmware';
+
+const sampleControllers: FirmwareControllerView[] = [
+  { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
+  { id: 'core', label: 'Core', glyph: 'C', current: 'v1.4.0', status: 'up', isMaster: false },
+  { id: 'dome', label: 'Dome', glyph: 'D', current: 'v1.4.0', status: 'down', isMaster: false },
+];
 
 const apiGet = apiService.get as ReturnType<typeof vi.fn>;
 
@@ -155,6 +161,170 @@ describe('firmware store', () => {
       // Upload filename is preserved across mode switches per the design
       // handoff §Source toggle ("preserves their respective state").
       expect(store.uploadedFilename).toBe('custom-firmware.bin');
+    });
+  });
+
+  describe('target computed', () => {
+    it('returns the selected release tag in github mode', () => {
+      const store = useFirmwareStore();
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+      expect(store.target).toBe('v1.4.2');
+    });
+
+    it('returns null in github mode with no release selected', () => {
+      const store = useFirmwareStore();
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = null;
+      expect(store.target).toBeNull();
+    });
+
+    it("returns 'local-build' sentinel in upload mode with a filename", () => {
+      const store = useFirmwareStore();
+      store.sourceMode = 'upload';
+      store.uploadedFilename = 'custom.bin';
+      expect(store.target).toBe('local-build');
+    });
+
+    it('returns null in upload mode with no file', () => {
+      const store = useFirmwareStore();
+      store.sourceMode = 'upload';
+      store.uploadedFilename = null;
+      expect(store.target).toBeNull();
+    });
+  });
+
+  describe('selection actions', () => {
+    it('toggle adds an id when absent and removes it when present', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+
+      store.toggle('body');
+      expect([...store.selectedControllerIds]).toEqual(['body']);
+      store.toggle('core');
+      expect([...store.selectedControllerIds].sort()).toEqual(['body', 'core']);
+      store.toggle('body');
+      expect([...store.selectedControllerIds]).toEqual(['core']);
+    });
+
+    it('toggle replaces the Set reference so Vue reactivity observes the change', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      const before = store.selectedControllerIds;
+      store.toggle('body');
+      expect(store.selectedControllerIds).not.toBe(before);
+    });
+
+    it('selectAll picks every online, non-downgrade controller', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+
+      const before = store.selectedControllerIds;
+      store.selectAll();
+      // Body (v1.3.0 → v1.4.2: upgrade, online) included.
+      // Core (v1.4.0 → v1.4.2: upgrade, online) included.
+      // Dome offline → excluded.
+      expect([...store.selectedControllerIds].sort()).toEqual(['body', 'core']);
+      expect(store.selectedControllerIds).not.toBe(before);
+    });
+
+    it('selectAll skips controllers whose current version is newer than target (downgrade)', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.3.5';
+
+      store.selectAll();
+      // Body (v1.3.0 → v1.3.5: upgrade, online) included.
+      // Core (v1.4.0 → v1.3.5: downgrade) excluded.
+      // Dome offline excluded.
+      expect([...store.selectedControllerIds]).toEqual(['body']);
+    });
+
+    it('clear empties the selection and replaces the Set reference', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.toggle('body');
+      store.toggle('core');
+      const before = store.selectedControllerIds;
+      store.clear();
+      expect(store.selectedControllerIds.size).toBe(0);
+      expect(store.selectedControllerIds).not.toBe(before);
+    });
+  });
+
+  describe('anyDowngradeBlocked', () => {
+    it('returns false when nothing is selected', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.3.5';
+      expect(store.anyDowngradeBlocked).toBe(false);
+    });
+
+    it('returns true when a selected controller would downgrade', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.3.5';
+      store.toggle('core'); // core is v1.4.0; v1.4.0 > v1.3.5
+      expect(store.anyDowngradeBlocked).toBe(true);
+    });
+
+    it('treats a malformed current version as not a downgrade (NaN > 0 is false)', () => {
+      const store = useFirmwareStore();
+      store.controllers = [
+        {
+          id: 'weird',
+          label: 'Weird',
+          glyph: 'W',
+          current: 'not-a-version',
+          status: 'up',
+          isMaster: false,
+        },
+      ];
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+      store.toggle('weird');
+      expect(store.anyDowngradeBlocked).toBe(false);
+    });
+  });
+
+  describe('canFlash', () => {
+    it('is false with no target', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.toggle('body');
+      expect(store.canFlash).toBe(false);
+    });
+
+    it('is false with target but no selection', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+      expect(store.canFlash).toBe(false);
+    });
+
+    it('is true with target + at least one upgrade selection', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+      store.toggle('body');
+      expect(store.canFlash).toBe(true);
+    });
+
+    it('is false with target + selection but any selected controller would downgrade', () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.3.5';
+      store.toggle('body'); // upgrade
+      store.toggle('core'); // downgrade
+      expect(store.canFlash).toBe(false);
     });
   });
 });

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { defineStore } from 'pinia';
 import apiService from '@/api/apiService';
 import { FIRMWARE_RELEASES } from '@/api/endpoints';
@@ -11,10 +11,6 @@ import type {
   ReleasesLoadState,
 } from '@/types/firmware';
 
-// d.2 added: releases, sourceMode, selectedReleaseTag, uploadedFilename.
-// d.4 adds: controllers, selectedControllerIds, target/canFlash/anyDowngradeBlocked
-// computeds, toggle/selectAll/clear actions. currentJob, controllerStates,
-// phase land in d.5/d.6 with the WS dispatcher and flash POST.
 export const useFirmwareStore = defineStore('firmware', () => {
   const releases = ref<ReleaseInfo[]>([]);
   const releasesLoadState = ref<ReleasesLoadState>('idle');
@@ -26,6 +22,23 @@ export const useFirmwareStore = defineStore('firmware', () => {
 
   const controllers = ref<FirmwareControllerView[]>([]);
   const selectedControllerIds = ref<ReadonlySet<string>>(new Set());
+
+  // Reconcile selection against the fleet — when `controllers` is reassigned
+  // (e.g. by a WS-driven refresh), prune any selected ids that no longer
+  // refer to a known controller. Prevents orphan ids from silently passing
+  // `canFlash` (size > 0) and skipping the downgrade check (find returns
+  // undefined → not blocked).
+  watch(controllers, (next) => {
+    if (selectedControllerIds.value.size === 0) return;
+    const known = new Set(next.map((c) => c.id));
+    const filtered = new Set<string>();
+    for (const id of selectedControllerIds.value) {
+      if (known.has(id)) filtered.add(id);
+    }
+    if (filtered.size !== selectedControllerIds.value.size) {
+      selectedControllerIds.value = filtered;
+    }
+  });
 
   const target = computed<string | null>(() => {
     if (sourceMode.value === 'github') return selectedReleaseTag.value;

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -1,27 +1,77 @@
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 import apiService from '@/api/apiService';
 import { FIRMWARE_RELEASES } from '@/api/endpoints';
+import { compareTags } from '@/utils/version';
 import type {
+  FirmwareControllerView,
   FirmwareSourceMode,
   ReleaseInfo,
   ReleaseListResult,
   ReleasesLoadState,
 } from '@/types/firmware';
 
-// d.2 subset of the firmware view's UI state. Other fields described in
-// the umbrella plan (currentJob, controllerStates, phase, etc.) land in
-// d.5/d.6 when the WS dispatcher and flash POST arrive.
+// d.2 added: releases, sourceMode, selectedReleaseTag, uploadedFilename.
+// d.4 adds: controllers, selectedControllerIds, target/canFlash/anyDowngradeBlocked
+// computeds, toggle/selectAll/clear actions. currentJob, controllerStates,
+// phase land in d.5/d.6 with the WS dispatcher and flash POST.
 export const useFirmwareStore = defineStore('firmware', () => {
-  // Server-pushed
   const releases = ref<ReleaseInfo[]>([]);
   const releasesLoadState = ref<ReleasesLoadState>('idle');
   const staleSince = ref<string | null>(null);
 
-  // User selection
   const sourceMode = ref<FirmwareSourceMode>('github');
   const selectedReleaseTag = ref<string | null>(null);
   const uploadedFilename = ref<string | null>(null);
+
+  const controllers = ref<FirmwareControllerView[]>([]);
+  const selectedControllerIds = ref<ReadonlySet<string>>(new Set());
+
+  const target = computed<string | null>(() => {
+    if (sourceMode.value === 'github') return selectedReleaseTag.value;
+    return uploadedFilename.value ? 'local-build' : null;
+  });
+
+  function isDowngrade(controllerId: string): boolean {
+    const t = target.value;
+    if (t === null) return false;
+    const c = controllers.value.find((x) => x.id === controllerId);
+    if (!c) return false;
+    const cmp = compareTags(c.current, t);
+    return cmp > 0;
+  }
+
+  function isBlocked(controllerId: string): boolean {
+    const c = controllers.value.find((x) => x.id === controllerId);
+    if (!c) return false;
+    return c.status === 'down' || isDowngrade(controllerId);
+  }
+
+  const anyDowngradeBlocked = computed(() => [...selectedControllerIds.value].some(isDowngrade));
+
+  const canFlash = computed(
+    () =>
+      target.value !== null && selectedControllerIds.value.size > 0 && !anyDowngradeBlocked.value,
+  );
+
+  // Selection actions always replace the Set (not mutate in place) so Vue
+  // tracks the change — refs track value reassignment, not Set methods.
+  function toggle(id: string): void {
+    const next = new Set(selectedControllerIds.value);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    selectedControllerIds.value = next;
+  }
+
+  function selectAll(): void {
+    selectedControllerIds.value = new Set(
+      controllers.value.filter((c) => !isBlocked(c.id)).map((c) => c.id),
+    );
+  }
+
+  function clear(): void {
+    selectedControllerIds.value = new Set();
+  }
 
   async function fetchReleases(): Promise<void> {
     releasesLoadState.value = 'loading';
@@ -45,6 +95,14 @@ export const useFirmwareStore = defineStore('firmware', () => {
     sourceMode,
     selectedReleaseTag,
     uploadedFilename,
+    controllers,
+    selectedControllerIds,
+    target,
+    anyDowngradeBlocked,
+    canFlash,
+    toggle,
+    selectAll,
+    clear,
     fetchReleases,
   };
 });

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -30,3 +30,27 @@ export interface ReleaseListResult {
 export type ReleasesLoadState = 'idle' | 'loading' | 'loaded' | 'stale' | 'error';
 
 export type FirmwareSourceMode = 'github' | 'upload';
+
+export type ControllerOnlineStatus = 'up' | 'down' | 'needsSynced';
+
+/** Presentation-layer view of a controller for the firmware-update flow. */
+export interface FirmwareControllerView {
+  id: string;
+  label: string;
+  /** Single-letter badge glyph: 'B', 'C', 'D'. */
+  glyph: string;
+  /** Semver tag currently running on the controller, e.g. 'v1.4.0'. */
+  current: string;
+  status: ControllerOnlineStatus;
+  isMaster: boolean;
+}
+
+export type FirmwareStatusPillKind =
+  | 'idle'
+  | 'queued'
+  | 'updating'
+  | 'done'
+  | 'failed'
+  | 'upToDate'
+  | 'offline'
+  | 'downgrade';


### PR DESCRIPTION
## Summary

  - Builds the right-column **Controllers panel** for the firmware-update view per Direction C: status pill, version delta with downgrade detection, per-controller row, and the panel container with header (select-all/clear) and action/result bar.
  - Wires selection state into `firmwareStore` (`selectedControllerIds`, `target`/`canFlash`/`anyDowngradeBlocked` computeds,  `toggle`/`selectAll`/`clear` actions) plus a `watch(controllers)` reconciler so the WS-driven fleet refresh in d.5/d.6 can't silently leave orphan selections.
  - 33 new unit tests including a 9-case mutation-guarded `selectModePillKind` matrix and a `cmp === 0` boundary test for the downgrade guard. Panel rendering, animations, and visual layouts covered by Storybook (no TDD on UI layout per repo convention).

  ## What's in scope

  Components (all under `components/firmware/`):

  - `AstrosFirmwareStatusPill` — 8-kind pill (idle / queued / updating / done / failed / upToDate / offline / downgrade), one story per kind.
  - `AstrosFirmwareVersionDelta` — `current → target` with downgrade detection via `compareTags`. NaN-safe on malformed tags. 5 unit tests pin the rendering paths.
  - `AstrosFirmwareControllerRow` — checkbox (select mode) or status pill (progress mode), 30×30 badge, name + master pill + online-status dot, VersionDelta below. Emits `@toggle`. 11 stories. The select-mode right-column pill logic is extracted to `selectModePillKind.ts` (same pattern as d.3's `strokeFor`) with 9 unit tests covering the **offline > downgrade > upToDate > null** priority.
  - `AstrosFirmwareControllersPanel` — eyebrow + select-all/clear header, rows, and action/result bar reading `canFlash` / `anyDowngradeBlocked` from  the store. Dev-mode `watchEffect` warns on null `target` or missing progress entries in non-select phases. Emits `@flash` / `@view-logs` / `@done`. 7 stories covering `SelectInitial`, `SelectTargetNoSelection`, `SelectWithTarget`, `SelectAllSelected`, `SelectWithDowngrade`, `Flashing`,  `Done`, `FailedCore`.

  Store additions (`stores/firmware.ts`):

  - `controllers: ref<FirmwareControllerView[]>` (mock-set in stories; d.5 will wire from the controllers store).
  - `selectedControllerIds: ref<ReadonlySet<string>>` — actions always replace the Set (never mutate in place), pinning the Vue-reactivity gotcha from d.3 round 2.
  - `target` / `anyDowngradeBlocked` / `canFlash` computeds.
  - `toggle(id)` / `selectAll()` / `clear()` actions.
  - `watch(controllers)` reconciler — prunes orphan selected ids on fleet reassignment so `canFlash` (size > 0) and the downgrade guard can't silently misbehave.

  Types (`types/firmware.ts`):

  - `FirmwareControllerView` (id, label, glyph, current, status, isMaster).
  - `ControllerOnlineStatus` (up | down | needsSynced).
  - `FirmwareStatusPillKind` (8-value union).

  ## What's deferred

  - **ConfirmModal** → d.5.
  - **Page assembly** (mounting in `FirmwareView`) → d.5.
  - **Flash POST + cancel** → d.5.
  - **WS dispatcher / live in-flight rendering** → d.6.
  - **Discriminated-union prop tightening** (e.g., `ControllersPanelProps` keyed by `phase`, splitting `FirmwareStatusPillKind` into select/progress variants) → d.5 per the type-design-analyzer's recommendation — speculative until d.5's consumers exist.
  - **`controllers`-store → `FirmwareControllerView` adapter** → d.5.

  ## Test plan

  - [ ] `npm run build` succeeds (run from `astros_vue/`).
  - [ ] `npx vitest run` reports **89 tests passing**, including:
    - 22 firmware-store tests (was 6; +16 for d.4 + 2 reconciler + 1 boundary)
    - 5 `AstrosFirmwareVersionDelta` tests
    - 9 `selectModePillKind` tests
  - [ ] `npm run storybook` and visually verify all new stories at `http://localhost:6006/?path=/story/components-firmware-...`:
    - `AstrosFirmwareStatusPill`: 8 kind variants render with correct bg/fg per the design handoff color table.
    - `AstrosFirmwareVersionDelta`: `NoTarget`, `UpToDate`, `Upgrade` (gray arrow), `Downgrade` (red arrow + DOWNGRADE pill), `MalformedCurrent` (no pill, no up-to-date suffix).
    - `AstrosFirmwareControllerRow`: 11 stories — master + padawan upgrade rows, up-to-date, no-target, downgrade (red + opacity 0.6 + disabled checkbox), offline (opacity 0.6 + disabled checkbox), and 4 progress-mode states (queued, updating w/ stage label, done, failed).
    - `AstrosFirmwareControllersPanel`: 7 stories — verify the eyebrow + select-all/clear buttons appear only in `select` phase; action-bar text changes between `no_source`, `no_selection`, and `push_summary` with correct interpolated count; `Flash firmware` button is disabled until
  `canFlash` (target set + ≥1 selected + no downgrade); downgrade-blocked banner appears with a downgrade row selected; done/failed result bars show green/red backgrounds with View logs + Done buttons.
  - [ ] Open browser DevTools console while interacting with Storybook — no warnings except the **intentional dev-mode warnings** when a story passes  an inconsistent prop set (e.g., flashing phase with no `progressByControllerId`).
  - [ ] **Regression check:** d.3 topology stories (`SelectIdle`, `SelectAllSelected`, `Flashing`, `Done`, `FailedCore`, `FailedMaster`) still render  correctly — d.4 touches the store but should not affect topology rendering.
  - [ ] `firmware.spec.ts` reconciler test: confirm that reassigning `controllers` with an id removed correctly prunes that id from `selectedControllerIds` (covered by the test, manually re-run if confidence is needed).
  - [ ] Keyboard a11y spot check on the panel:
    - Tab through `Select all` / `Clear` ghost buttons → focus ring visible.
    - Tab into a row checkbox → `aria-label` reads "Select Body for firmware update" via screen reader.
    - Status dot has accessible `aria-label` reading e.g. "Body is online".
  - [ ] Reduced-motion check (unchanged from d.3): topology dashed-line animation halts under `prefers-reduced-motion: reduce` (DevTools → Rendering
  → Emulate CSS media).