### PR TITLE
OTA Firmware page assembly

### DIFF
--- a/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
+++ b/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
@@ -97,16 +97,16 @@ export interface FlashErrorEnvelope {
 
 ## Tasks
 
-- [ ] Add i18n keys: `firmware_view.stages.*` (label + hint per stage + `in_progress` badge), `firmware_view.confirm_modal.*` (title, body copy, cancel, confirm, power-warning), `firmware_view.flash_errors.*` (one entry per `FlashErrorReason`).
-- [ ] Add `FirmwarePhase`, `FirmwareStage`, `FlashErrorReason`, `FlashErrorEnvelope` to `types/firmware.ts`. Add `FIRMWARE_FLASH` constant to `api/endpoints.ts`.
-- [ ] Extend `firmwareStore`: add `phase`, `currentStage`, `flashError`, `failedController` refs; add `setPhase`, `resetToSelect`, `dismissError`, `startFlash`, `cancelFlash` actions. Initial phase is `'idle'`; transitions to `'select'` when `controllers.length > 0` (handled by the dev-mock populate or by d.6's WS-snapshot). Unit-test phase transitions + flash POST error mapping (success → flashing; 409 → flashError.reason='job_already_running'; network failure → flashError.reason='network_error').
-- [ ] Implement `AstrosFirmwareStagesList` (`types.ts` + `.vue` + stories). Props: `currentStage: FirmwareStage | null`, `phase: FirmwarePhase`, `failedStage?: FirmwareStage`. Renders 5 stage rows with state-driven styling. Stories: `Idle`, `Flashing` (currentStage='transfer'), `Done`, `Failed` (failedStage='transfer').
-- [ ] Implement `AstrosFirmwareConfirmModal` (`types.ts` + `.vue` + stories). Props: `open: boolean`, `target: string | null`, `selectedControllers: FirmwareControllerView[]`. Emits `cancel` / `confirm`. A11y: focus trap (use `vue-focus-trap` if present, else implement manually with a `Tab` key listener), ESC closes, click-backdrop closes, focus restore to trigger on close. `aria-modal="true"`, `role="dialog"`, `aria-labelledby` points at title. Stories: `OpenSingleController`, `OpenAllControllers`, `OpenUploadSource`.
-- [ ] Add **flash error banner** rendering inside `AstrosFirmwareControllersPanel`. Reads `firmwareStore.flashError`. Renders above the action bar when non-null. Includes localized error copy + a "Try again" / "Dismiss" affordance. Update the panel's stories with a `SelectWithFlashError` variant.
-- [ ] Update `FirmwareView.vue`: subtitle from store phase; two-column layout (`Topology + StagesList` left, `ControllersPanel` right); below 960px → single column; mount `ConfirmModal` and wire `@flash` → open modal → on confirm → `firmwareStore.startFlash()`; dev-only fleet mock in `onMounted`.
-- [ ] Barrel exports: add `AstrosFirmwareStagesList`, `AstrosFirmwareConfirmModal` + their types to `components/firmware/index.ts`.
-- [ ] Pre-commit gates: format, lint, type-check, vitest, per-commit `pr-review-toolkit:code-reviewer` agent.
-- [ ] Pre-push: `/pr-review-toolkit:review-pr` 5-agent pass (mandatory per CLAUDE.md). Address Critical/Important findings before push.
+- [x] i18n keys: stages.*, confirm_modal.*, flash_errors.*, flash_error_banner.*.
+- [x] Types in `types/firmware.ts`: `FirmwarePhase`, `FirmwareStage`, `FlashErrorReason`, `FlashErrorEnvelope`. `FIRMWARE_FLASH` endpoint constant. **Consolidated:** `TopologyPhase = FirmwarePhase` and `ControllersPanelPhase = Exclude<FirmwarePhase, 'idle'>` — single source of truth.
+- [x] `firmwareStore`: phase/currentStage/flashError/failedController refs; setPhase/resetToSelect/dismissError/startFlash/cancelFlash actions. Initial phase is `'idle'`; transitions to `'select'` when `controllers.length > 0`. 15 unit tests cover phase transitions, body shapes, error mapping (incl. retry-clears-error), double-click guard, cancel default reason, swallow-on-error.
+- [x] `AstrosFirmwareStagesList` (+ `stageRowState` helper + 8 unit tests covering all 5 phase × 5 stage combos). Dev-warn for null currentStage/failedStage in matching phases.
+- [x] `AstrosFirmwareConfirmModal` — native `<dialog>` element + `.showModal()` provides focus trap, ESC, and focus restore for free. No hand-rolled focus sentinels needed. Click on backdrop = `event.target === dialog`. 3 stories.
+- [x] Flash error banner in `AstrosFirmwareControllersPanel` reads `firmwareStore.flashError`. `role="alert"` + `aria-live="polite"`. Wired `currentJobId` and `detail` through named i18n interpolation. `SelectWithFlashError` story.
+- [x] `FirmwareView.vue` page assembly: store-driven subtitle, two-column grid (380px / flex 1), single-column below 960px, dev-only fleet bootstrap, modal mount, dev-warn for missing master.
+- [x] Barrel: `AstrosFirmwareStagesList`, `AstrosFirmwareConfirmModal` + types.
+- [x] Pre-commit: format, lint, type-check, 116-test vitest run, per-commit code-reviewer agent — 0 Critical / 0 Important.
+- [x] Pre-push `/pr-review-toolkit:review-pr` 5-agent pass. 2 Critical (no axios timeout, fragile DELETE bypass) + ~10 Important addressed in a fixup commit before push.
 
 ---
 
@@ -131,12 +131,7 @@ Row state derivation lives in `stageRowState(stage, currentStage, phase, failedS
 
 ### ConfirmModal a11y
 
-Per CLAUDE.md a11y rules:
-- `role="dialog" aria-modal="true" aria-labelledby="<title-id>"` on the card.
-- ESC keydown listener attached when `open === true` only (avoid leaking listeners).
-- Click on backdrop (NOT card) closes via Cancel emit.
-- **Focus trap:** when modal opens, focus first focusable element (Cancel button). Tab and Shift-Tab cycle within modal. On close, restore focus to the element that had focus when the modal opened (the Flash button).
-- Don't use `vue-focus-trap` if not already installed — implement manually with a `<div ref="firstFocus" tabindex="0">` sentinel at start/end of the modal and `keydown.tab` handler. ~25 lines.
+Shipped using the native `<dialog>` element + `.showModal()`. The browser provides focus trap, ESC handling, focus restore, and implicit `role="dialog"`/`aria-modal="true"` for free — no hand-rolled focus-trap code. `aria-labelledby` is set explicitly to the title id. Click on the backdrop fires `event.target === dialog`, which the component handles as a cancel. ESC fires the native `cancel` event, which the component preventDefaults and re-emits through `@cancel` so the parent's `open` ref drives close (keeping the close path single-sourced).
 
 ### Flash POST flow
 

--- a/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
+++ b/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
@@ -1,0 +1,270 @@
+# d.5 — Page assembly + `StagesList` + `ConfirmModal` + flash POST
+
+Phase d, PR 5 of 6. Wires d.1–d.4's presentational pieces into `FirmwareView`, adds the two remaining components (`StagesList`, `ConfirmModal`), moves the phase state machine into `firmwareStore`, and posts the flash request to the server. WS dispatcher (live in-flight rendering) defers to d.6.
+
+Roadmap reference: `20260507-2153-firmware-ota-d-vue-firmware-view.md`.
+Design source: `.docs/design_handoff_firmware_update/README.md:149-222` (StagesList + ConfirmModal) + `firmwareDirectionC.jsx:264-340` (StagesList) + `firmwareDirectionA.jsx:253-` (ConfirmModal reused).
+
+---
+
+## Scope decisions (confirmed with user)
+
+1. **Phase state moves to `firmwareStore`** in d.5. `phase: ref<FirmwarePhase>` (`'idle' | 'select' | 'flashing' | 'done' | 'failed'`) + transition actions. d.6 inherits a working state machine; FirmwareView drops its local `phase` ref.
+2. **Storybook-only stage progression.** Each panel/stage-list story is a snapshot of one phase. No timer-driven progression. d.6 wires real progression via WS.
+3. **Inline error banner** in `ControllersPanel` for flash POST failures. Server's typed error reasons (`job_already_running`, `release_not_found`, etc.) map to i18n keys; the banner shows the localized copy + a retry button. Phase stays `select` on error.
+4. **Dev-only fleet mock** in `FirmwareView.onMounted` populates `firmwareStore.controllers` with a sample fleet (Body / Core / Dome) when `import.meta.env.DEV` is true. d.6 replaces with the real `stores/controller` → `FirmwareControllerView` adapter.
+
+---
+
+## Scope
+
+### New components
+
+| Component | Folder | Role |
+|---|---|---|
+| `AstrosFirmwareStagesList` | `firmware/firmwareStagesList/` | Card listing 5 stages (download / transfer / flash / verify / reboot). State-driven row highlights: done (✓), current (yellow + "IN PROGRESS"), failed (! + red row), idle. |
+| `AstrosFirmwareConfirmModal` | `firmware/firmwareConfirmModal/` | Modal dialog triggered by Flash button. Lists source + target controllers, warns not to cut power. Cancel / Push firmware buttons. Focus trap + ESC + focus restore. |
+
+### Page assembly
+
+- `FirmwareView.vue` renamed concept: subtitle reads from `firmwareStore.phase`. Drops local `phase` ref. Mounts `SourceStrip` (always visible), `Topology` + `StagesList` (left column ~380px when flashing/done/failed; topology-only in select), `ControllersPanel` (right column, flex 1). Below 960px viewport, single column.
+- Dev-only `onMounted` populates `firmwareStore.controllers` with sample fleet.
+- Wires Flash button → opens `ConfirmModal` → on confirm calls `firmwareStore.startFlash()`.
+
+### `firmwareStore` additions
+
+```ts
+// State
+const phase = ref<FirmwarePhase>('idle');
+const currentStage = ref<FirmwareStage | null>(null);          // d.5: mocked via story args; d.6: WS-driven
+const flashError = ref<FlashErrorEnvelope | null>(null);
+const failedController = ref<{ id: string; label: string; stage: FirmwareStage } | null>(null);
+
+// Actions
+function setPhase(next: FirmwarePhase): void;
+function resetToSelect(): void;                                 // clears phase/currentStage/flashError/failedController
+function dismissError(): void;                                  // clears flashError only
+async function startFlash(): Promise<void>;                     // POST /api/firmware/flash; transitions phase on response
+async function cancelFlash(reason?: string): Promise<void>;     // DELETE /api/firmware/flash
+```
+
+### Types (`types/firmware.ts`)
+
+```ts
+export type FirmwarePhase = 'idle' | 'select' | 'flashing' | 'done' | 'failed';
+
+export type FirmwareStage = 'download' | 'transfer' | 'flash' | 'verify' | 'reboot';
+
+export type FlashErrorReason =
+  | 'invalid_body'
+  | 'job_already_running'
+  | 'no_controllers'
+  | 'variant_mismatch'
+  | 'variant_unknown'
+  | 'release_not_found'
+  | 'asset_not_found'
+  | 'no_upload'
+  | 'release_lookup_failed'
+  | 'source_resolution_failed'
+  | 'controllers_lookup_failed'
+  | 'subscriber_attach_failed'
+  | 'protocol_violation'
+  | 'streamer_unknown_error'
+  | 'internal_server_error'
+  | 'network_error';
+
+export interface FlashErrorEnvelope {
+  reason: FlashErrorReason;
+  detail?: string;
+  currentJobId?: string;
+}
+```
+
+`FlashErrorReason` is the union of server `FlashOrchestratorErrorReason` values that map to HTTP statuses the client cares about (400/409/500), plus `internal_server_error` (catch-all 500) and `network_error` (no response received). Post-streamer reasons (`hash_mismatch`, `chunk_retry_exhausted`, etc.) are deliberately omitted — those surface on WS in d.6, not via the HTTP error envelope.
+
+---
+
+## Out of scope
+
+- WS dispatcher / live in-flight rendering → d.6.
+- Real `controllers`-store → `FirmwareControllerView` adapter → d.6.
+- Lock-aware `AstrosWriteButton` extension → d.6.
+- Lock banner in `AstrosLayout` → d.6.
+- Discriminated-union prop tightening for `ControllersPanelProps` (deferred from d.4 review) → d.6 once consumers exist.
+- Upload-mode flash POST functionality — server-side upload route is its own pre-d phase; d.5 ships the UI but Browse Files won't post.
+
+---
+
+## Tasks
+
+- [ ] Add i18n keys: `firmware_view.stages.*` (label + hint per stage + `in_progress` badge), `firmware_view.confirm_modal.*` (title, body copy, cancel, confirm, power-warning), `firmware_view.flash_errors.*` (one entry per `FlashErrorReason`).
+- [ ] Add `FirmwarePhase`, `FirmwareStage`, `FlashErrorReason`, `FlashErrorEnvelope` to `types/firmware.ts`. Add `FIRMWARE_FLASH` constant to `api/endpoints.ts`.
+- [ ] Extend `firmwareStore`: add `phase`, `currentStage`, `flashError`, `failedController` refs; add `setPhase`, `resetToSelect`, `dismissError`, `startFlash`, `cancelFlash` actions. Initial phase is `'idle'`; transitions to `'select'` when `controllers.length > 0` (handled by the dev-mock populate or by d.6's WS-snapshot). Unit-test phase transitions + flash POST error mapping (success → flashing; 409 → flashError.reason='job_already_running'; network failure → flashError.reason='network_error').
+- [ ] Implement `AstrosFirmwareStagesList` (`types.ts` + `.vue` + stories). Props: `currentStage: FirmwareStage | null`, `phase: FirmwarePhase`, `failedStage?: FirmwareStage`. Renders 5 stage rows with state-driven styling. Stories: `Idle`, `Flashing` (currentStage='transfer'), `Done`, `Failed` (failedStage='transfer').
+- [ ] Implement `AstrosFirmwareConfirmModal` (`types.ts` + `.vue` + stories). Props: `open: boolean`, `target: string | null`, `selectedControllers: FirmwareControllerView[]`. Emits `cancel` / `confirm`. A11y: focus trap (use `vue-focus-trap` if present, else implement manually with a `Tab` key listener), ESC closes, click-backdrop closes, focus restore to trigger on close. `aria-modal="true"`, `role="dialog"`, `aria-labelledby` points at title. Stories: `OpenSingleController`, `OpenAllControllers`, `OpenUploadSource`.
+- [ ] Add **flash error banner** rendering inside `AstrosFirmwareControllersPanel`. Reads `firmwareStore.flashError`. Renders above the action bar when non-null. Includes localized error copy + a "Try again" / "Dismiss" affordance. Update the panel's stories with a `SelectWithFlashError` variant.
+- [ ] Update `FirmwareView.vue`: subtitle from store phase; two-column layout (`Topology + StagesList` left, `ControllersPanel` right); below 960px → single column; mount `ConfirmModal` and wire `@flash` → open modal → on confirm → `firmwareStore.startFlash()`; dev-only fleet mock in `onMounted`.
+- [ ] Barrel exports: add `AstrosFirmwareStagesList`, `AstrosFirmwareConfirmModal` + their types to `components/firmware/index.ts`.
+- [ ] Pre-commit gates: format, lint, type-check, vitest, per-commit `pr-review-toolkit:code-reviewer` agent.
+- [ ] Pre-push: `/pr-review-toolkit:review-pr` 5-agent pass (mandatory per CLAUDE.md). Address Critical/Important findings before push.
+
+---
+
+## Implementation notes
+
+### `StagesList` design
+
+Stages defined as a module constant:
+
+```ts
+// firmwareStagesList/stages.ts
+export const FIRMWARE_STAGES = ['download', 'transfer', 'flash', 'verify', 'reboot'] as const;
+```
+
+Index mapping by phase (per the design handoff's "Index mapping by phase"):
+- `phase === 'flashing'` → use `currentStage` prop (mocked in d.5 stories; WS-driven in d.6)
+- `phase === 'done'` → all 5 marked done
+- `phase === 'failed'` → `failedStage` prop is the failing one; earlier stages done; later stages idle
+- `phase === 'select' | 'idle'` → component not rendered at all (parent v-if)
+
+Row state derivation lives in `stageRowState(stage, currentStage, phase, failedStage)` pure helper → extract to a sibling module → unit-test all 5×4 = 20 combinations.
+
+### ConfirmModal a11y
+
+Per CLAUDE.md a11y rules:
+- `role="dialog" aria-modal="true" aria-labelledby="<title-id>"` on the card.
+- ESC keydown listener attached when `open === true` only (avoid leaking listeners).
+- Click on backdrop (NOT card) closes via Cancel emit.
+- **Focus trap:** when modal opens, focus first focusable element (Cancel button). Tab and Shift-Tab cycle within modal. On close, restore focus to the element that had focus when the modal opened (the Flash button).
+- Don't use `vue-focus-trap` if not already installed — implement manually with a `<div ref="firstFocus" tabindex="0">` sentinel at start/end of the modal and `keydown.tab` handler. ~25 lines.
+
+### Flash POST flow
+
+```ts
+async function startFlash(): Promise<void> {
+  if (!canFlash.value) return; // defense in depth; button is also disabled
+  flashError.value = null;
+  const body = sourceMode.value === 'github'
+    ? { source: { kind: 'github', version: selectedReleaseTag.value } }
+    : { source: { kind: 'upload' } };
+  try {
+    setPhase('flashing');
+    await apiService.post(FIRMWARE_FLASH, body);
+    // Note: HTTP 200 means orchestrator.start() resolved; the WS dispatcher
+    // owns subsequent state. In d.5 with no WS wired, we stay in 'flashing'
+    // until the user manually resets — that's why d.5 only ships static
+    // story snapshots, not a running app preview.
+  } catch (error) {
+    setPhase('select');
+    flashError.value = mapHttpErrorToEnvelope(error);
+  }
+}
+```
+
+`mapHttpErrorToEnvelope` is a small helper in `firmwareStore` that:
+- Parses axios error.response.status + error.response.data into a `FlashErrorEnvelope`.
+- Falls back to `{ reason: 'network_error' }` on no-response.
+- Falls back to `{ reason: 'internal_server_error' }` on unrecognized response shape.
+
+### Dev-only fleet mock
+
+```ts
+// FirmwareView.vue
+onMounted(async () => {
+  await firmware.fetchReleases();
+  if (import.meta.env.DEV && firmware.controllers.length === 0) {
+    firmware.controllers = [
+      { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
+      { id: 'core', label: 'Core', glyph: 'C', current: 'v1.4.0', status: 'up', isMaster: false },
+      { id: 'dome', label: 'Dome', glyph: 'D', current: 'v1.4.0', status: 'up', isMaster: false },
+    ];
+  }
+  // Transition idle → select once controllers are loaded.
+  if (firmware.controllers.length > 0 && firmware.phase === 'idle') {
+    firmware.setPhase('select');
+  }
+});
+```
+
+The mock is gated by `import.meta.env.DEV` — Vite strips the entire block in production. d.6 replaces this with the real adapter.
+
+---
+
+## A11y (forward-looking — per project memory `project_a11y_pass`)
+
+- `ConfirmModal` is the first modal in this feature flow; the a11y discipline above is load-bearing for the upcoming a11y pass.
+- `StagesList` rows have semantic structure: each row has `role="listitem"` inside a `role="list"` wrapper; the current/failed rows include `aria-current="step"` or `aria-invalid="true"` respectively.
+- Flash error banner: `role="alert"` (so screen readers announce on appearance) + `aria-live="polite"`.
+
+---
+
+## Verification
+
+1. `npm run build` succeeds.
+2. `npx vitest run` — new tests for `firmwareStore` phase transitions, flash-error mapping, and `stageRowState` helper must pass; existing 89 tests keep passing.
+3. `npm run storybook` — visually confirm each new story:
+   - `AstrosFirmwareStagesList`: `Idle`, `Flashing`, `Done`, `Failed`.
+   - `AstrosFirmwareConfirmModal`: open, all three source variants render correctly; ESC + click-backdrop close; focus trap holds.
+   - `AstrosFirmwareControllersPanel.SelectWithFlashError`: red banner above action bar with retry.
+4. Dev preview: `npm run dev`, navigate to `/firmware`, verify:
+   - SourceStrip + Topology + ControllersPanel render with mock fleet.
+   - Picking a release and selecting controllers enables the Flash button.
+   - Clicking Flash opens the modal; Cancel returns to select; Confirm POSTs to the API and either:
+     - On success (200): the page transitions to `flashing` and stays there (d.6 will wire live progression).
+     - On failure (4xx/5xx): the page stays in `select` and shows the localized error banner.
+5. A11y spot check: keyboard-only navigation through the page, ESC closes modal, focus returns to the Flash button after modal close, screen reader announces flash error banner.
+6. Pre-push toolkit: 5-agent pass; address Critical/Important.
+
+---
+
+## FMI inventory — required (per CLAUDE.md)
+
+This PR touches **network I/O** (flash POST) and **modal lifecycle** (ConfirmModal listeners). Filling in the failure-mode inventory:
+
+| Hazard | Risk | Coverage |
+|---|---|---|
+| **Network**: POST /flash hangs forever | UI stuck in `flashing` with no recovery | axios timeout config (check existing apiService default); on timeout, set phase back to `select` with `network_error` envelope |
+| **Network**: POST returns unexpected payload shape | `mapHttpErrorToEnvelope` mis-classifies | helper falls back to `internal_server_error`; explicit unit test for malformed responses |
+| **Concurrency**: User double-clicks Flash | Two POSTs in flight | `startFlash` returns early when `phase === 'flashing'`; button disabled while in flight; explicit test |
+| **Modal lifecycle**: ESC handler leaks after unmount | Memory leak / stray listener | listener attached/detached in `watchEffect` keyed on `open` prop; explicit unit test |
+| **Modal lifecycle**: Focus restore fails when trigger is unmounted | Focus stuck on body | `restoreFocus()` checks `triggerEl.isConnected` before refocusing |
+| **State**: User navigates away during `flashing` | View unmount discards phase state | acceptable — phase lives in Pinia store, survives route change; flash continues server-side |
+| **State**: Story Pinia setup leaks across renders | Stories show stale state | reuse the `setupStore()` pattern from d.4 stories (verified working) |
+
+---
+
+## Risks
+
+1. **Modal focus management** is hand-rolled. If `vue-focus-trap` (or similar) is already in deps, prefer it. Check `package.json` before writing manual implementation.
+2. **`startFlash` HTTP error mapping** depends on the server returning a stable `error` field. The server controller is stable on develop (we just read it). Document any drift in the d.6 plan.
+3. **`phase` initial state.** Setting `phase = 'idle'` and transitioning to `'select'` in `FirmwareView.onMounted` couples the state machine to the view's lifecycle. If d.6 needs the store to enter `'flashing'` on cold-load with a job in flight (the late-join scenario from the master roadmap §"Late-join"), the store must be able to start in non-idle state. Mitigation: `fetchCurrentJob()` (d.6 work) is the natural place to set the initial phase from server state — d.5's idle→select transition is just the bootstrap path.
+4. **Dev fleet mock** could leak into prod if `import.meta.env.DEV` is mis-evaluated. Verify Vite strips the block in a production build (`npm run build`, then grep `dist/` for "Body / Core / Dome").
+5. **Responsive single-column** at <960px — design handoff line 247 calls it out but says "not expected to be mobile-friendly, but should not break." Implement with a CSS `@media` query; verify in DevTools responsive mode.
+6. **`StagesList` rendering when `phase === 'failed'` and `failedStage` is null** — design handoff doesn't explicitly say. Default behavior: treat as all-idle with no failure highlight. Add a dev-mode `console.warn` mirror of d.4's pattern when this combo happens.
+
+---
+
+## Critical files
+
+- `astros_vue/src/views/FirmwareView.vue` — page assembly target.
+- `astros_vue/src/stores/firmware.ts` — phase state + actions go here.
+- `astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue` — flash error banner addition.
+- `astros_api/src/controllers/firmware_flash_controller.ts:1-115` — error response shape (read-only; do not modify).
+- `astros_api/src/models/firmware/flash_orchestrator.ts:17-19` — `FlashRequest` body shape.
+- `.docs/design_handoff_firmware_update/README.md:149-222` — StagesList + ConfirmModal spec.
+- `astros_vue/src/api/apiService.ts` — axios instance for the POST/DELETE calls.
+
+---
+
+## Per-PR plan files (Phase D index)
+
+- d.1 → `20260507-2153-firmware-ota-d-1-page-chrome.md` ✅ merged
+- d.2 → `20260509-1716-firmware-ota-d-2-source-strip.md` ✅ merged
+- d.3 → `20260511-0651-firmware-ota-d-3-topology.md` ✅ merged
+- d.4 → `20260511-0811-firmware-ota-d-4-controllers-panel.md` ✅ merged
+- d.5 → **this file**
+- d.6 → TBD (WS dispatcher + live wiring + lock-aware UI + e2e)
+
+## QA test plan
+
+Per user direction (see roadmap doc): the comprehensive manual QA plan lives at `.docs/qa/firmware-ota-flash-ui.md` and is written at **d.6 completion** when the feature is end-to-end testable in the running app. d.5's verification section (above) covers d.5's own scope; the operator-flow QA waits.

--- a/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
+++ b/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
@@ -161,10 +161,12 @@ async function startFlash(): Promise<void> {
 }
 ```
 
-`mapHttpErrorToEnvelope` is a small helper in `firmwareStore` that:
-- Parses axios error.response.status + error.response.data into a `FlashErrorEnvelope`.
+`mapHttpErrorToFlashEnvelope` lives in `utils/firmwareFlashError.ts` (extracted to a pure module for unit-testability — same pattern as d.3's `strokeFor` and d.4's `selectModePillKind`). It:
+- Parses axios `error.response.status` + `error.response.data` into a `FlashErrorEnvelope`.
 - Falls back to `{ reason: 'network_error' }` on no-response.
 - Falls back to `{ reason: 'internal_server_error' }` on unrecognized response shape.
+
+6 unit tests in `utils/__tests__/firmwareFlashError.spec.ts` cover the no-response, malformed-response, recognized-reason, detail/currentJobId-preservation, and unknown-reason-fallback paths.
 
 ### Dev-only fleet mock
 

--- a/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
+++ b/.docs/plans/20260511-2217-firmware-ota-d-5-page-assembly.md
@@ -99,13 +99,13 @@ export interface FlashErrorEnvelope {
 
 - [x] i18n keys: stages.*, confirm_modal.*, flash_errors.*, flash_error_banner.*.
 - [x] Types in `types/firmware.ts`: `FirmwarePhase`, `FirmwareStage`, `FlashErrorReason`, `FlashErrorEnvelope`. `FIRMWARE_FLASH` endpoint constant. **Consolidated:** `TopologyPhase = FirmwarePhase` and `ControllersPanelPhase = Exclude<FirmwarePhase, 'idle'>` — single source of truth.
-- [x] `firmwareStore`: phase/currentStage/flashError/failedController refs; setPhase/resetToSelect/dismissError/startFlash/cancelFlash actions. Initial phase is `'idle'`; transitions to `'select'` when `controllers.length > 0`. 15 unit tests cover phase transitions, body shapes, error mapping (incl. retry-clears-error), double-click guard, cancel default reason, swallow-on-error.
+- [x] `firmwareStore`: phase/currentStage/flashError/failedController refs; setPhase/resetToSelect/dismissError/startFlash/cancelFlash actions. Initial phase is `'idle'`; transitions to `'select'` when `controllers.length > 0`. Unit tests cover phase transitions, body shapes, error mapping (incl. retry-clears + retry-replaces), double-click guard, cancel default reason, swallow-on-error.
 - [x] `AstrosFirmwareStagesList` (+ `stageRowState` helper + 8 unit tests covering all 5 phase × 5 stage combos). Dev-warn for null currentStage/failedStage in matching phases.
 - [x] `AstrosFirmwareConfirmModal` — native `<dialog>` element + `.showModal()` provides focus trap, ESC, and focus restore for free. No hand-rolled focus sentinels needed. Click on backdrop = `event.target === dialog`. 3 stories.
 - [x] Flash error banner in `AstrosFirmwareControllersPanel` reads `firmwareStore.flashError`. `role="alert"` + `aria-live="polite"`. Wired `currentJobId` and `detail` through named i18n interpolation. `SelectWithFlashError` story.
 - [x] `FirmwareView.vue` page assembly: store-driven subtitle, two-column grid (380px / flex 1), single-column below 960px, dev-only fleet bootstrap, modal mount, dev-warn for missing master.
 - [x] Barrel: `AstrosFirmwareStagesList`, `AstrosFirmwareConfirmModal` + types.
-- [x] Pre-commit: format, lint, type-check, 116-test vitest run, per-commit code-reviewer agent — 0 Critical / 0 Important.
+- [x] Pre-commit: format, lint, type-check, full vitest run, per-commit code-reviewer agent — 0 Critical / 0 Important.
 - [x] Pre-push `/pr-review-toolkit:review-pr` 5-agent pass. 2 Critical (no axios timeout, fragile DELETE bypass) + ~10 Important addressed in a fixup commit before push.
 
 ---
@@ -135,26 +135,12 @@ Shipped using the native `<dialog>` element + `.showModal()`. The browser provid
 
 ### Flash POST flow
 
-```ts
-async function startFlash(): Promise<void> {
-  if (!canFlash.value) return; // defense in depth; button is also disabled
-  flashError.value = null;
-  const body = sourceMode.value === 'github'
-    ? { source: { kind: 'github', version: selectedReleaseTag.value } }
-    : { source: { kind: 'upload' } };
-  try {
-    setPhase('flashing');
-    await apiService.post(FIRMWARE_FLASH, body);
-    // Note: HTTP 200 means orchestrator.start() resolved; the WS dispatcher
-    // owns subsequent state. In d.5 with no WS wired, we stay in 'flashing'
-    // until the user manually resets — that's why d.5 only ships static
-    // story snapshots, not a running app preview.
-  } catch (error) {
-    setPhase('select');
-    flashError.value = mapHttpErrorToEnvelope(error);
-  }
-}
-```
+Shipped at `astros_vue/src/stores/firmware.ts:118-141`. Highlights:
+
+- Calls `apiClient.post(FIRMWARE_FLASH, body, { timeout: 30_000 })` directly (not `apiService.post`) so the per-request timeout option can attach. 30s timeout closes the "hung backend → forever flashing" hazard.
+- `flashError.value = null` and `phase.value = 'flashing'` set synchronously before the await, then on rejection the catch sets `phase.value = 'select'` and `flashError.value = mapHttpErrorToFlashEnvelope(error)`.
+- Double-click guard: returns early when `phase.value === 'flashing'` or `!canFlash.value`.
+- Catch block also `console.error`s the raw error for dev breadcrumb (the direct apiClient call bypasses apiService.post's auto-logging).
 
 `mapHttpErrorToFlashEnvelope` lives in `utils/firmwareFlashError.ts` (extracted to a pure module for unit-testability — same pattern as d.3's `strokeFor` and d.4's `selectModePillKind`). It:
 - Parses axios `error.response.status` + `error.response.data` into a `FlashErrorEnvelope`.
@@ -198,7 +184,7 @@ The mock is gated by `import.meta.env.DEV` — Vite strips the entire block in p
 ## Verification
 
 1. `npm run build` succeeds.
-2. `npx vitest run` — new tests for `firmwareStore` phase transitions, flash-error mapping, and `stageRowState` helper must pass; existing 89 tests keep passing.
+2. `npx vitest run` — new tests for `firmwareStore` phase transitions, flash-error mapping, and `stageRowState` helper must pass; existing tests keep passing.
 3. `npm run storybook` — visually confirm each new story:
    - `AstrosFirmwareStagesList`: `Idle`, `Flashing`, `Done`, `Failed`.
    - `AstrosFirmwareConfirmModal`: open, all three source variants render correctly; ESC + click-backdrop close; focus trap holds.
@@ -220,11 +206,11 @@ This PR touches **network I/O** (flash POST) and **modal lifecycle** (ConfirmMod
 
 | Hazard | Risk | Coverage |
 |---|---|---|
-| **Network**: POST /flash hangs forever | UI stuck in `flashing` with no recovery | axios timeout config (check existing apiService default); on timeout, set phase back to `select` with `network_error` envelope |
-| **Network**: POST returns unexpected payload shape | `mapHttpErrorToEnvelope` mis-classifies | helper falls back to `internal_server_error`; explicit unit test for malformed responses |
+| **Network**: POST /flash hangs forever | UI stuck in `flashing` with no recovery | 30s per-request `{ timeout }` on `apiClient.post`; mapper coerces `ECONNABORTED` (no response) → `network_error` envelope |
+| **Network**: POST returns unexpected payload shape | `mapHttpErrorToFlashEnvelope` mis-classifies | helper falls back to `internal_server_error` + `console.warn` with the unrecognized reason; explicit unit test |
 | **Concurrency**: User double-clicks Flash | Two POSTs in flight | `startFlash` returns early when `phase === 'flashing'`; button disabled while in flight; explicit test |
-| **Modal lifecycle**: ESC handler leaks after unmount | Memory leak / stray listener | listener attached/detached in `watchEffect` keyed on `open` prop; explicit unit test |
-| **Modal lifecycle**: Focus restore fails when trigger is unmounted | Focus stuck on body | `restoreFocus()` checks `triggerEl.isConnected` before refocusing |
+| **Modal lifecycle**: ESC handler leaks after unmount | Memory leak / stray listener | Native `<dialog>` element — no listener to leak; browser owns the handler lifecycle |
+| **Modal lifecycle**: Focus restore fails when trigger is unmounted | Focus stuck on body | Native `<dialog>.showModal()`/`.close()` handles focus restore; degrades gracefully on unmount |
 | **State**: User navigates away during `flashing` | View unmount discards phase state | acceptable — phase lives in Pinia store, survives route change; flash continues server-side |
 | **State**: Story Pinia setup leaks across renders | Stories show stale state | reuse the `setupStore()` pattern from d.4 stories (verified working) |
 
@@ -232,7 +218,7 @@ This PR touches **network I/O** (flash POST) and **modal lifecycle** (ConfirmMod
 
 ## Risks
 
-1. **Modal focus management** is hand-rolled. If `vue-focus-trap` (or similar) is already in deps, prefer it. Check `package.json` before writing manual implementation.
+1. **Modal a11y delegated to native `<dialog>.showModal()`.** Risk surface is browser-version-specific dialog quirks rather than implementation bugs.
 2. **`startFlash` HTTP error mapping** depends on the server returning a stable `error` field. The server controller is stable on develop (we just read it). Document any drift in the d.6 plan.
 3. **`phase` initial state.** Setting `phase = 'idle'` and transitioning to `'select'` in `FirmwareView.onMounted` couples the state machine to the view's lifecycle. If d.6 needs the store to enter `'flashing'` on cold-load with a job in flight (the late-join scenario from the master roadmap §"Late-join"), the store must be able to start in non-idle state. Mitigation: `fetchCurrentJob()` (d.6 work) is the natural place to set the initial phase from server state — d.5's idle→select transition is just the bootstrap path.
 4. **Dev fleet mock** could leak into prod if `import.meta.env.DEV` is mis-evaluated. Verify Vite strips the block in a production build (`npm run build`, then grep `dist/` for "Body / Core / Dome").

--- a/astros_vue/src/api/endpoints.ts
+++ b/astros_vue/src/api/endpoints.ts
@@ -29,3 +29,4 @@ export const REMOTE_CONFIG = 'api/remoteConfig';
 export const SYSTEM_STATUS = 'api/system/status';
 
 export const FIRMWARE_RELEASES = 'api/firmware/releases';
+export const FIRMWARE_FLASH = 'api/firmware/flash';

--- a/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.stories.ts
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import AstrosFirmwareConfirmModal from './AstrosFirmwareConfirmModal.vue';
+import type { FirmwareControllerView } from '@/types/firmware';
+
+const body: FirmwareControllerView = {
+  id: 'body',
+  label: 'Body',
+  glyph: 'B',
+  current: 'v1.3.0',
+  status: 'up',
+  isMaster: true,
+};
+const core: FirmwareControllerView = {
+  id: 'core',
+  label: 'Core',
+  glyph: 'C',
+  current: 'v1.4.0',
+  status: 'up',
+  isMaster: false,
+};
+
+const meta = {
+  title: 'Components/Firmware/AstrosFirmwareConfirmModal',
+  component: AstrosFirmwareConfirmModal,
+  parameters: { layout: 'centered' },
+  // Stories always render with `open: true` so the modal shows on the
+  // Storybook canvas. The `<dialog>.showModal()` API requires the element
+  // to be attached to the document, which Storybook handles via its render
+  // root — but the modal will visually occupy the canvas, not the host page.
+} satisfies Meta<typeof AstrosFirmwareConfirmModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SingleControllerGithub: Story = {
+  args: {
+    open: true,
+    target: 'v1.4.2',
+    sourceMode: 'github',
+    selectedControllers: [body],
+  },
+};
+
+export const AllControllersGithub: Story = {
+  args: {
+    open: true,
+    target: 'v1.4.2',
+    sourceMode: 'github',
+    selectedControllers: [body, core],
+  },
+};
+
+export const UploadSource: Story = {
+  args: {
+    open: true,
+    target: 'local-build',
+    sourceMode: 'upload',
+    uploadedFilename: 'astros-custom-build.bin',
+    selectedControllers: [body, core],
+  },
+};

--- a/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.vue
+++ b/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import AstrosFirmwareButton from '../firmwareButton/AstrosFirmwareButton.vue';
+import AstrosFirmwareVersionDelta from '../firmwareVersionDelta/AstrosFirmwareVersionDelta.vue';
+import type { FirmwareControllerView } from '@/types/firmware';
+
+const props = defineProps<{
+  open: boolean;
+  target: string | null;
+  selectedControllers: FirmwareControllerView[];
+  uploadedFilename?: string | null;
+  sourceMode: 'github' | 'upload';
+}>();
+
+const emit = defineEmits<{ cancel: []; confirm: [] }>();
+
+const { t } = useI18n();
+
+const dialogRef = ref<HTMLDialogElement | null>(null);
+
+// Native <dialog>.showModal() handles focus trap, ESC dismissal, and focus
+// restore for free. Sync .open prop to the imperative API.
+watch(
+  () => props.open,
+  (open) => {
+    const el = dialogRef.value;
+    if (!el) return;
+    if (open && !el.open) el.showModal();
+    else if (!open && el.open) el.close();
+  },
+);
+
+// Browser fires 'cancel' on ESC. Mirror it through our cancel emit so the
+// parent's open ref flips to false.
+function onDialogCancel(event: Event) {
+  event.preventDefault();
+  emit('cancel');
+}
+
+// Clicks on the dialog element directly (not its children) are clicks on the
+// ::backdrop. Use that as a cancel signal.
+function onDialogClick(event: MouseEvent) {
+  if (event.target === dialogRef.value) emit('cancel');
+}
+
+const sourceDisplay = (): string => {
+  if (props.sourceMode === 'github') return props.target ?? '—';
+  return props.uploadedFilename ?? '—';
+};
+</script>
+
+<template>
+  <dialog
+    ref="dialogRef"
+    class="astros-firmware-confirm-modal"
+    aria-labelledby="astros-firmware-confirm-modal-title"
+    @cancel="onDialogCancel"
+    @click="onDialogClick"
+  >
+    <div class="astros-firmware-confirm-modal__card">
+      <h2
+        id="astros-firmware-confirm-modal-title"
+        class="astros-firmware-confirm-modal__title"
+      >
+        {{ t('firmware_view.confirm_modal.title') }}
+      </h2>
+
+      <dl class="astros-firmware-confirm-modal__list">
+        <dt class="astros-firmware-confirm-modal__label">
+          {{ t('firmware_view.confirm_modal.source_label') }}
+        </dt>
+        <dd class="astros-firmware-confirm-modal__source-value">{{ sourceDisplay() }}</dd>
+
+        <dt class="astros-firmware-confirm-modal__label">
+          {{ t('firmware_view.confirm_modal.controllers_label') }}
+        </dt>
+        <dd>
+          <ul class="astros-firmware-confirm-modal__controllers">
+            <li
+              v-for="c in selectedControllers"
+              :key="c.id"
+              class="astros-firmware-confirm-modal__controller-row"
+            >
+              <span class="astros-firmware-confirm-modal__controller-name">{{ c.label }}</span>
+              <AstrosFirmwareVersionDelta
+                :current="c.current"
+                :target="target"
+              />
+            </li>
+          </ul>
+        </dd>
+      </dl>
+
+      <p
+        class="astros-firmware-confirm-modal__warning"
+        role="note"
+      >
+        {{ t('firmware_view.confirm_modal.power_warning') }}
+      </p>
+
+      <div class="astros-firmware-confirm-modal__actions">
+        <AstrosFirmwareButton
+          kind="secondary"
+          @click="emit('cancel')"
+        >
+          {{ t('firmware_view.confirm_modal.cancel') }}
+        </AstrosFirmwareButton>
+        <AstrosFirmwareButton
+          kind="primary"
+          @click="emit('confirm')"
+        >
+          {{ t('firmware_view.confirm_modal.confirm') }}
+        </AstrosFirmwareButton>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<style scoped>
+.astros-firmware-confirm-modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.astros-firmware-confirm-modal::backdrop {
+  background: rgba(14, 23, 38, 0.45);
+}
+
+.astros-firmware-confirm-modal__card {
+  background: #ffffff;
+  border: 1px solid #d6e0e6;
+  border-radius: 6px;
+  padding: 24px;
+  width: min(480px, calc(100vw - 32px));
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 12px 32px rgba(14, 23, 38, 0.18);
+}
+
+.astros-firmware-confirm-modal__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: #0e1726;
+}
+
+.astros-firmware-confirm-modal__list {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  row-gap: 8px;
+  column-gap: 12px;
+  margin: 0;
+}
+
+.astros-firmware-confirm-modal__label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4b5b73;
+  padding-top: 4px;
+}
+
+.astros-firmware-confirm-modal__source-value {
+  margin: 0;
+  font-family: ui-monospace, 'SF Mono', monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: #0e1726;
+  word-break: break-all;
+}
+
+.astros-firmware-confirm-modal__controllers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.astros-firmware-confirm-modal__controller-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.astros-firmware-confirm-modal__controller-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #0e1726;
+  min-width: 50px;
+}
+
+.astros-firmware-confirm-modal__warning {
+  margin: 0;
+  font-size: 12px;
+  color: #9a2828;
+  background: #fbe0e0;
+  border: 1px solid #cf424255;
+  padding: 10px 12px;
+  border-radius: 4px;
+}
+
+.astros-firmware-confirm-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+</style>

--- a/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.vue
+++ b/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.vue
@@ -3,14 +3,14 @@ import { ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import AstrosFirmwareButton from '../firmwareButton/AstrosFirmwareButton.vue';
 import AstrosFirmwareVersionDelta from '../firmwareVersionDelta/AstrosFirmwareVersionDelta.vue';
-import type { FirmwareControllerView } from '@/types/firmware';
+import type { FirmwareControllerView, FirmwareSourceMode } from '@/types/firmware';
 
 const props = defineProps<{
   open: boolean;
   target: string | null;
   selectedControllers: FirmwareControllerView[];
   uploadedFilename?: string | null;
-  sourceMode: 'github' | 'upload';
+  sourceMode: FirmwareSourceMode;
 }>();
 
 const emit = defineEmits<{ cancel: []; confirm: [] }>();

--- a/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.vue
+++ b/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.vue
@@ -21,6 +21,11 @@ const dialogRef = ref<HTMLDialogElement | null>(null);
 
 // Native <dialog>.showModal() handles focus trap, ESC dismissal, and focus
 // restore for free. Sync .open prop to the imperative API.
+//
+// `immediate: true` + `flush: 'post'` ensures a component mounted with
+// `open: true` (Storybook args, or a parent that renders it initially open)
+// actually calls `.showModal()` — post-flush defers the first run until after
+// the dialog element is in the DOM so `dialogRef.value` is populated.
 watch(
   () => props.open,
   (open) => {
@@ -29,6 +34,7 @@ watch(
     if (open && !el.open) el.showModal();
     else if (!open && el.open) el.close();
   },
+  { immediate: true, flush: 'post' },
 );
 
 // Browser fires 'cancel' on ESC. Mirror it through our cancel emit so the

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
@@ -14,6 +14,7 @@ function setupStore(opts: {
   target?: string | null;
   selected?: string[];
   controllers?: FirmwareControllerView[];
+  flashErrorReason?: string;
 }) {
   setActivePinia(createPinia());
   const store = useFirmwareStore();
@@ -21,6 +22,10 @@ function setupStore(opts: {
   store.sourceMode = 'github';
   store.selectedReleaseTag = opts.target ?? null;
   store.selectedControllerIds = new Set(opts.selected ?? []);
+  if (opts.flashErrorReason !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.flashError = { reason: opts.flashErrorReason as any };
+  }
 }
 
 const meta = {
@@ -80,6 +85,22 @@ export const SelectAllSelected: Story = {
     components: { AstrosFirmwareControllersPanel },
     setup() {
       setupStore({ target: 'v1.4.2', selected: ['body', 'core'] });
+      return { args };
+    },
+    template: '<AstrosFirmwareControllersPanel v-bind="args" />',
+  }),
+  args: { phase: 'select' },
+};
+
+export const SelectWithFlashError: Story = {
+  render: (args) => ({
+    components: { AstrosFirmwareControllersPanel },
+    setup() {
+      setupStore({
+        target: 'v1.4.2',
+        selected: ['body'],
+        flashErrorReason: 'job_already_running',
+      });
       return { args };
     },
     template: '<AstrosFirmwareControllersPanel v-bind="args" />',

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -20,11 +20,16 @@ const { controllers, selectedControllerIds, target, canFlash, anyDowngradeBlocke
   storeToRefs(firmware);
 
 const flashErrorMessage = computed(() => {
-  if (flashError.value === null) return null;
-  return t(`firmware_view.flash_errors.${flashError.value.reason}`, {
-    jobId: flashError.value.currentJobId ?? '',
-    detail: flashError.value.detail ?? '',
-  });
+  const err = flashError.value;
+  if (err === null) return null;
+  // The job_already_running key has a with-id variant that gracefully omits
+  // the parenthetical when the server doesn't include currentJobId.
+  if (err.reason === 'job_already_running' && err.currentJobId) {
+    return t('firmware_view.flash_errors.job_already_running_with_id', {
+      jobId: err.currentJobId,
+    });
+  }
+  return t(`firmware_view.flash_errors.${err.reason}`);
 });
 
 const rowMode = computed<'select' | 'progress'>(() =>

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -21,16 +21,18 @@ const { controllers, selectedControllerIds, target, canFlash, anyDowngradeBlocke
 
 const flashErrorMessage = computed(() => {
   if (flashError.value === null) return null;
-  return t(`firmware_view.flash_errors.${flashError.value.reason}`);
+  return t(`firmware_view.flash_errors.${flashError.value.reason}`, {
+    jobId: flashError.value.currentJobId ?? '',
+    detail: flashError.value.detail ?? '',
+  });
 });
 
 const rowMode = computed<'select' | 'progress'>(() =>
   props.phase === 'select' ? 'select' : 'progress',
 );
 
-// Dev-only invariant warnings. Vite tree-shakes the block in production —
-// these surface wiring bugs during local dev / Storybook when the panel is
-// integrated with the WS dispatcher in d.5/d.6.
+// Dev-only invariant warnings. Surface wiring bugs when the panel is driven
+// by the WS dispatcher; production strips the block via Vite tree-shake.
 if (import.meta.env.DEV) {
   watchEffect(() => {
     if (props.phase !== 'select' && target.value === null) {

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -16,8 +16,13 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const firmware = useFirmwareStore();
-const { controllers, selectedControllerIds, target, canFlash, anyDowngradeBlocked } =
+const { controllers, selectedControllerIds, target, canFlash, anyDowngradeBlocked, flashError } =
   storeToRefs(firmware);
+
+const flashErrorMessage = computed(() => {
+  if (flashError.value === null) return null;
+  return t(`firmware_view.flash_errors.${flashError.value.reason}`);
+});
 
 const rowMode = computed<'select' | 'progress'>(() =>
   props.phase === 'select' ? 'select' : 'progress',
@@ -109,6 +114,35 @@ const actionBarMessage = computed(() => {
         />
       </li>
     </ul>
+
+    <div
+      v-if="phase === 'select' && flashError !== null"
+      class="astros-firmware-controllers-panel__error-banner"
+      role="alert"
+      aria-live="polite"
+    >
+      <div class="astros-firmware-controllers-panel__error-text">
+        <span class="astros-firmware-controllers-panel__error-title">{{
+          t('firmware_view.controllers.flash_error_banner.title')
+        }}</span>
+        <span class="astros-firmware-controllers-panel__error-detail">{{ flashErrorMessage }}</span>
+      </div>
+      <div class="astros-firmware-controllers-panel__error-actions">
+        <AstrosFirmwareButton
+          kind="ghost"
+          @click="firmware.dismissError()"
+        >
+          {{ t('firmware_view.controllers.flash_error_banner.dismiss') }}
+        </AstrosFirmwareButton>
+        <AstrosFirmwareButton
+          kind="secondary"
+          :disabled="!canFlash"
+          @click="canFlash && emit('flash')"
+        >
+          {{ t('firmware_view.controllers.flash_error_banner.retry') }}
+        </AstrosFirmwareButton>
+      </div>
+    </div>
 
     <footer
       v-if="phase === 'select'"
@@ -317,5 +351,39 @@ const actionBarMessage = computed(() => {
 
 .astros-firmware-controllers-panel__result-text--failed {
   color: #9a2828;
+}
+
+.astros-firmware-controllers-panel__error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  background: #fbe0e0;
+  border-top: 1px solid #cf424255;
+}
+
+.astros-firmware-controllers-panel__error-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.astros-firmware-controllers-panel__error-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: #9a2828;
+}
+
+.astros-firmware-controllers-panel__error-detail {
+  font-size: 11px;
+  color: #9a2828;
+}
+
+.astros-firmware-controllers-panel__error-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
 }
 </style>

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -1,6 +1,6 @@
-import type { FirmwareStatusPillKind } from '@/types/firmware';
+import type { FirmwarePhase, FirmwareStatusPillKind } from '@/types/firmware';
 
-export type ControllersPanelPhase = 'select' | 'flashing' | 'done' | 'failed';
+export type ControllersPanelPhase = Exclude<FirmwarePhase, 'idle'>;
 
 export interface ControllerProgressEntry {
   status: FirmwareStatusPillKind;

--- a/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.stories.ts
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import AstrosFirmwareStagesList from './AstrosFirmwareStagesList.vue';
+
+const meta = {
+  title: 'Components/Firmware/AstrosFirmwareStagesList',
+  component: AstrosFirmwareStagesList,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (story) => ({
+      components: { story },
+      template:
+        '<div style="background: #f2f7fa; padding: 24px; max-width: 380px;"><story /></div>',
+    }),
+  ],
+} satisfies Meta<typeof AstrosFirmwareStagesList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  args: { phase: 'idle', currentStage: null },
+};
+
+export const Flashing: Story = {
+  args: { phase: 'flashing', currentStage: 'transfer' },
+};
+
+export const Done: Story = {
+  args: { phase: 'done', currentStage: null },
+};
+
+export const FailedAtTransfer: Story = {
+  args: { phase: 'failed', currentStage: null, failedStage: 'transfer' },
+};
+
+export const FailedAtDownload: Story = {
+  args: { phase: 'failed', currentStage: null, failedStage: 'download' },
+};

--- a/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.vue
+++ b/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.vue
@@ -12,6 +12,9 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
+// Dev-only invariant warnings. Surface wiring bugs when the WS dispatcher
+// transitions phase before setting the stage pointer; production strips the
+// block via Vite tree-shake.
 if (import.meta.env.DEV) {
   watchEffect(() => {
     if (props.phase === 'flashing' && props.currentStage === null) {

--- a/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.vue
+++ b/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { FIRMWARE_STAGES, stageRowState, type StageRowState } from './stageRowState';
 import type { FirmwarePhase, FirmwareStage } from '@/types/firmware';
@@ -11,6 +11,26 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (props.phase === 'flashing' && props.currentStage === null) {
+      console.warn(
+        '[AstrosFirmwareStagesList] phase="flashing" with currentStage=null — all rows ' +
+          'will render as idle. The dispatcher must set currentStage before transitioning.',
+      );
+    }
+    if (
+      props.phase === 'failed' &&
+      (props.failedStage === null || props.failedStage === undefined)
+    ) {
+      console.warn(
+        '[AstrosFirmwareStagesList] phase="failed" with failedStage=null — all rows ' +
+          'will render as idle. The dispatcher must set failedStage before transitioning.',
+      );
+    }
+  });
+}
 
 interface StageRow {
   stage: FirmwareStage;

--- a/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.vue
+++ b/astros_vue/src/components/firmware/firmwareStagesList/AstrosFirmwareStagesList.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { FIRMWARE_STAGES, stageRowState, type StageRowState } from './stageRowState';
+import type { FirmwarePhase, FirmwareStage } from '@/types/firmware';
+
+const props = defineProps<{
+  phase: FirmwarePhase;
+  currentStage: FirmwareStage | null;
+  failedStage?: FirmwareStage | null;
+}>();
+
+const { t } = useI18n();
+
+interface StageRow {
+  stage: FirmwareStage;
+  state: StageRowState;
+  index: number;
+  label: string;
+  hint: string;
+}
+
+const rows = computed<StageRow[]>(() =>
+  FIRMWARE_STAGES.map((stage, i) => ({
+    stage,
+    state: stageRowState({
+      stage,
+      phase: props.phase,
+      currentStage: props.currentStage,
+      failedStage: props.failedStage ?? null,
+    }),
+    index: i + 1,
+    label: t(`firmware_view.stages.${stage}.label`),
+    hint: t(`firmware_view.stages.${stage}.hint`),
+  })),
+);
+</script>
+
+<template>
+  <section
+    class="astros-firmware-stages-list"
+    role="list"
+    :aria-label="t('firmware_view.stages.eyebrow_title')"
+  >
+    <header class="astros-firmware-stages-list__header">
+      <span class="astros-firmware-stages-list__eyebrow">{{
+        t('firmware_view.stages.eyebrow_title')
+      }}</span>
+    </header>
+    <ul class="astros-firmware-stages-list__rows">
+      <li
+        v-for="row in rows"
+        :key="row.stage"
+        :class="[
+          'astros-firmware-stages-list__row',
+          `astros-firmware-stages-list__row--${row.state}`,
+        ]"
+        role="listitem"
+        :aria-current="row.state === 'current' ? 'step' : undefined"
+        :aria-invalid="row.state === 'failed' ? 'true' : undefined"
+      >
+        <span
+          :class="[
+            'astros-firmware-stages-list__bullet',
+            `astros-firmware-stages-list__bullet--${row.state}`,
+          ]"
+          aria-hidden="true"
+        >
+          <template v-if="row.state === 'done'">✓</template>
+          <template v-else-if="row.state === 'failed'">!</template>
+          <template v-else>{{ row.index }}</template>
+        </span>
+        <div class="astros-firmware-stages-list__text">
+          <span
+            :class="[
+              'astros-firmware-stages-list__label',
+              `astros-firmware-stages-list__label--${row.state}`,
+            ]"
+          >
+            {{ row.label }}
+          </span>
+          <span class="astros-firmware-stages-list__hint">{{ row.hint }}</span>
+        </div>
+        <span
+          v-if="row.state === 'current'"
+          class="astros-firmware-stages-list__in-progress"
+        >
+          {{ t('firmware_view.stages.in_progress') }}
+        </span>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.astros-firmware-stages-list {
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border: 1px solid #d6e0e6;
+  border-radius: 6px;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.astros-firmware-stages-list__header {
+  padding: 10px 14px;
+  background: #f6f9fb;
+  border-bottom: 1px solid #d6e0e6;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+}
+
+.astros-firmware-stages-list__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4b5b73;
+}
+
+.astros-firmware-stages-list__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.astros-firmware-stages-list__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-top: 1px solid #d6e0e6;
+}
+
+.astros-firmware-stages-list__row:first-child {
+  border-top: none;
+}
+
+.astros-firmware-stages-list__row--current {
+  background: #fff8e8;
+}
+
+.astros-firmware-stages-list__row--failed {
+  background: #fbe0e0;
+}
+
+.astros-firmware-stages-list__bullet {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.astros-firmware-stages-list__bullet--idle {
+  background: #e3edf2;
+  color: #4b5b73;
+}
+
+.astros-firmware-stages-list__bullet--done {
+  background: #3aa676;
+  color: #ffffff;
+}
+
+.astros-firmware-stages-list__bullet--current {
+  background: #e5a93a;
+  color: #ffffff;
+}
+
+.astros-firmware-stages-list__bullet--failed {
+  background: #cf4242;
+  color: #ffffff;
+}
+
+.astros-firmware-stages-list__text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+  min-width: 0;
+}
+
+.astros-firmware-stages-list__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #0e1726;
+}
+
+.astros-firmware-stages-list__label--failed {
+  color: #9a2828;
+}
+
+.astros-firmware-stages-list__hint {
+  font-size: 10px;
+  color: #4b5b73;
+}
+
+.astros-firmware-stages-list__in-progress {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #7d5a14;
+}
+</style>

--- a/astros_vue/src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { FIRMWARE_STAGES, stageRowState } from '../stageRowState';
+import type { FirmwarePhase, FirmwareStage } from '@/types/firmware';
+
+function rowsForPhase(opts: {
+  phase: FirmwarePhase;
+  currentStage?: FirmwareStage | null;
+  failedStage?: FirmwareStage | null;
+}) {
+  return FIRMWARE_STAGES.map((stage) =>
+    stageRowState({
+      stage,
+      phase: opts.phase,
+      currentStage: opts.currentStage ?? null,
+      failedStage: opts.failedStage ?? null,
+    }),
+  );
+}
+
+describe('stageRowState', () => {
+  it("marks every stage 'idle' when phase is 'idle' or 'select'", () => {
+    expect(rowsForPhase({ phase: 'idle' })).toEqual(['idle', 'idle', 'idle', 'idle', 'idle']);
+    expect(rowsForPhase({ phase: 'select' })).toEqual(['idle', 'idle', 'idle', 'idle', 'idle']);
+  });
+
+  it("marks every stage 'done' when phase is 'done'", () => {
+    expect(rowsForPhase({ phase: 'done' })).toEqual(['done', 'done', 'done', 'done', 'done']);
+  });
+
+  it("marks earlier stages 'done', the matching stage 'current', later stages 'idle' when flashing", () => {
+    expect(rowsForPhase({ phase: 'flashing', currentStage: 'flash' })).toEqual([
+      'done',
+      'done',
+      'current',
+      'idle',
+      'idle',
+    ]);
+  });
+
+  it("returns all 'idle' when flashing with no currentStage", () => {
+    expect(rowsForPhase({ phase: 'flashing', currentStage: null })).toEqual([
+      'idle',
+      'idle',
+      'idle',
+      'idle',
+      'idle',
+    ]);
+  });
+
+  it("marks the failing stage 'failed' with earlier stages 'done' and later stages 'idle'", () => {
+    expect(rowsForPhase({ phase: 'failed', failedStage: 'transfer' })).toEqual([
+      'done',
+      'failed',
+      'idle',
+      'idle',
+      'idle',
+    ]);
+  });
+
+  it("returns all 'idle' when failed with no failedStage", () => {
+    expect(rowsForPhase({ phase: 'failed', failedStage: null })).toEqual([
+      'idle',
+      'idle',
+      'idle',
+      'idle',
+      'idle',
+    ]);
+  });
+
+  it('handles the first-stage failure case (no earlier rows to mark done)', () => {
+    expect(rowsForPhase({ phase: 'failed', failedStage: 'download' })).toEqual([
+      'failed',
+      'idle',
+      'idle',
+      'idle',
+      'idle',
+    ]);
+  });
+
+  it('handles the last-stage current case (no later rows to mark idle)', () => {
+    expect(rowsForPhase({ phase: 'flashing', currentStage: 'reboot' })).toEqual([
+      'done',
+      'done',
+      'done',
+      'done',
+      'current',
+    ]);
+  });
+});

--- a/astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts
+++ b/astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts
@@ -1,0 +1,47 @@
+import type { FirmwarePhase, FirmwareStage } from '@/types/firmware';
+
+export const FIRMWARE_STAGES = ['download', 'transfer', 'flash', 'verify', 'reboot'] as const;
+
+export type StageRowState = 'idle' | 'done' | 'current' | 'failed';
+
+export interface StageRowStateInput {
+  stage: FirmwareStage;
+  phase: FirmwarePhase;
+  currentStage: FirmwareStage | null;
+  failedStage: FirmwareStage | null;
+}
+
+/**
+ * Derive the visual state for a single stage row given the overall phase and
+ * the current/failed stage pointers.
+ *
+ * Conventions:
+ * - `done` phase → every stage is `done`.
+ * - `failed` phase + `failedStage` matches → that row is `failed`; earlier
+ *   rows are `done`; later rows are `idle`.
+ * - `flashing` phase + `currentStage` matches → that row is `current`;
+ *   earlier rows are `done`; later rows are `idle`.
+ * - `idle` / `select` phases or unknown pointer values → all `idle`.
+ */
+export function stageRowState(input: StageRowStateInput): StageRowState {
+  const { stage, phase, currentStage, failedStage } = input;
+  const index = FIRMWARE_STAGES.indexOf(stage);
+  if (phase === 'done') return 'done';
+  if (phase === 'failed') {
+    if (failedStage === null) return 'idle';
+    const failedIndex = FIRMWARE_STAGES.indexOf(failedStage);
+    if (failedIndex === -1) return 'idle';
+    if (index < failedIndex) return 'done';
+    if (index === failedIndex) return 'failed';
+    return 'idle';
+  }
+  if (phase === 'flashing') {
+    if (currentStage === null) return 'idle';
+    const currentIndex = FIRMWARE_STAGES.indexOf(currentStage);
+    if (currentIndex === -1) return 'idle';
+    if (index < currentIndex) return 'done';
+    if (index === currentIndex) return 'current';
+    return 'idle';
+  }
+  return 'idle';
+}

--- a/astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts
+++ b/astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts
@@ -11,18 +11,6 @@ export interface StageRowStateInput {
   failedStage: FirmwareStage | null;
 }
 
-/**
- * Derive the visual state for a single stage row given the overall phase and
- * the current/failed stage pointers.
- *
- * Conventions:
- * - `done` phase → every stage is `done`.
- * - `failed` phase + `failedStage` matches → that row is `failed`; earlier
- *   rows are `done`; later rows are `idle`.
- * - `flashing` phase + `currentStage` matches → that row is `current`;
- *   earlier rows are `done`; later rows are `idle`.
- * - `idle` / `select` phases or unknown pointer values → all `idle`.
- */
 export function stageRowState(input: StageRowStateInput): StageRowState {
   const { stage, phase, currentStage, failedStage } = input;
   const index = FIRMWARE_STAGES.indexOf(stage);

--- a/astros_vue/src/components/firmware/firmwareTopology/types.ts
+++ b/astros_vue/src/components/firmware/firmwareTopology/types.ts
@@ -1,4 +1,6 @@
-export type TopologyPhase = 'idle' | 'select' | 'flashing' | 'done' | 'failed';
+import type { FirmwarePhase } from '@/types/firmware';
+
+export type TopologyPhase = FirmwarePhase;
 
 export interface TopologyController {
   id: string;

--- a/astros_vue/src/components/firmware/index.ts
+++ b/astros_vue/src/components/firmware/index.ts
@@ -5,6 +5,8 @@ export { default as AstrosFirmwareStatusPill } from './firmwareStatusPill/Astros
 export { default as AstrosFirmwareVersionDelta } from './firmwareVersionDelta/AstrosFirmwareVersionDelta.vue';
 export { default as AstrosFirmwareControllerRow } from './firmwareControllerRow/AstrosFirmwareControllerRow.vue';
 export { default as AstrosFirmwareControllersPanel } from './firmwareControllersPanel/AstrosFirmwareControllersPanel.vue';
+export { default as AstrosFirmwareStagesList } from './firmwareStagesList/AstrosFirmwareStagesList.vue';
+export { default as AstrosFirmwareConfirmModal } from './firmwareConfirmModal/AstrosFirmwareConfirmModal.vue';
 export type { AstrosFirmwareButtonKind } from './firmwareButton/types';
 export type { TopologyController, TopologyFleet, TopologyPhase } from './firmwareTopology/types';
 export type { ControllerRowMode, ControllerRowProps } from './firmwareControllerRow/types';
@@ -13,3 +15,10 @@ export type {
   ControllersPanelPhase,
   ControllersPanelProps,
 } from './firmwareControllersPanel/types';
+export type {
+  FirmwareControllerView,
+  FirmwarePhase,
+  FirmwareStage,
+  FlashErrorEnvelope,
+  FlashErrorReason,
+} from '@/types/firmware';

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -153,7 +153,8 @@
     },
     "flash_errors": {
       "invalid_body": "The request was malformed. This is a bug — please report it.",
-      "job_already_running": "Flash job {jobId} is already running. Wait for it to finish or cancel it before starting a new one.",
+      "job_already_running": "Another flash job is already running. Wait for it to finish or cancel it before starting a new one.",
+      "job_already_running_with_id": "Flash job {jobId} is already running. Wait for it to finish or cancel it before starting a new one.",
       "no_controllers": "No controllers were selected. Pick at least one before flashing.",
       "variant_mismatch": "The selected release doesn't include a firmware variant for one or more of the selected controllers.",
       "variant_unknown": "One of the selected controllers reports a variant the server doesn't recognize.",

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -153,7 +153,7 @@
     },
     "flash_errors": {
       "invalid_body": "The request was malformed. This is a bug — please report it.",
-      "job_already_running": "Another flash job is already running. Wait for it to finish or cancel it before starting a new one.",
+      "job_already_running": "Flash job {jobId} is already running. Wait for it to finish or cancel it before starting a new one.",
       "no_controllers": "No controllers were selected. Pick at least one before flashing.",
       "variant_mismatch": "The selected release doesn't include a firmware variant for one or more of the selected controllers.",
       "variant_unknown": "One of the selected controllers reports a variant the server doesn't recognize.",

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -111,7 +111,63 @@
         "failed_summary": "⚠ {label} failed during {stage}",
         "view_logs": "View logs",
         "done": "Done"
+      },
+      "flash_error_banner": {
+        "title": "Flash failed to start",
+        "retry": "Try again",
+        "dismiss": "Dismiss"
       }
+    },
+    "stages": {
+      "eyebrow_title": "STAGES",
+      "in_progress": "IN PROGRESS",
+      "download": {
+        "label": "Download",
+        "hint": "Master receives file"
+      },
+      "transfer": {
+        "label": "Transfer",
+        "hint": "Forward to padawans"
+      },
+      "flash": {
+        "label": "Flash",
+        "hint": "Write firmware"
+      },
+      "verify": {
+        "label": "Verify",
+        "hint": "Checksum"
+      },
+      "reboot": {
+        "label": "Reboot",
+        "hint": "Restart"
+      }
+    },
+    "confirm_modal": {
+      "title": "Confirm firmware update",
+      "source_label": "Source",
+      "controllers_label": "Targets",
+      "power_warning": "Do not cut power to any selected controller until the update completes — interrupting a flash can leave a controller in a bricked state.",
+      "cancel": "Cancel",
+      "confirm": "Push firmware",
+      "delta_separator": "→"
+    },
+    "flash_errors": {
+      "invalid_body": "The request was malformed. This is a bug — please report it.",
+      "job_already_running": "Another flash job is already running. Wait for it to finish or cancel it before starting a new one.",
+      "no_controllers": "No controllers were selected. Pick at least one before flashing.",
+      "variant_mismatch": "The selected release doesn't include a firmware variant for one or more of the selected controllers.",
+      "variant_unknown": "One of the selected controllers reports a variant the server doesn't recognize.",
+      "release_not_found": "The selected release could not be found on GitHub. Try refreshing the release list.",
+      "asset_not_found": "The selected release exists but is missing a firmware asset for the selected controllers.",
+      "no_upload": "Upload mode is selected but no firmware file has been uploaded yet.",
+      "release_lookup_failed": "Couldn't reach GitHub to fetch the release. Check the server's internet connection and try again.",
+      "source_resolution_failed": "Couldn't fetch the firmware binary from its source. Try again or pick a different release.",
+      "controllers_lookup_failed": "The server couldn't look up the selected controllers. Try again.",
+      "subscriber_attach_failed": "The server couldn't subscribe to deploy events. Try again or restart the server.",
+      "protocol_violation": "The serial protocol returned an unexpected message. Try again or restart the master controller.",
+      "streamer_unknown_error": "The firmware streamer failed with an unknown error. Try again.",
+      "internal_server_error": "The server hit an unexpected error. Check the server logs and try again.",
+      "network_error": "Couldn't reach the server. Check your network connection and try again."
     }
   },
   "placeholder": {

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -435,7 +435,7 @@ describe('firmware store', () => {
       expect(apiPost).toHaveBeenCalledWith(
         'api/firmware/flash',
         { source: { kind: 'github', version: 'v1.4.2' } },
-        expect.objectContaining({ timeout: expect.any(Number) }),
+        expect.objectContaining({ timeout: 30_000 }),
       );
       expect(store.phase).toBe('flashing');
       expect(store.flashError).toBeNull();
@@ -454,7 +454,7 @@ describe('firmware store', () => {
       expect(apiPost).toHaveBeenCalledWith(
         'api/firmware/flash',
         { source: { kind: 'upload' } },
-        expect.objectContaining({ timeout: expect.any(Number) }),
+        expect.objectContaining({ timeout: 30_000 }),
       );
       expect(store.phase).toBe('flashing');
       expect(store.flashError).toBeNull();
@@ -469,6 +469,20 @@ describe('firmware store', () => {
 
       expect(store.flashError).toBeNull();
       expect(store.phase).toBe('flashing');
+    });
+
+    it('replaces a prior flashError when a retry POST fails with a different reason', async () => {
+      // Pins both that the prior envelope is cleared on retry AND that the
+      // new envelope reflects the latest failure (not the earlier one).
+      apiPost.mockRejectedValueOnce({
+        response: { status: 400, data: { error: 'release_not_found' } },
+      });
+      const store = readyStore();
+      store.flashError = { reason: 'job_already_running', currentJobId: 'job-x' };
+
+      await store.startFlash();
+
+      expect(store.flashError).toEqual({ reason: 'release_not_found' });
     });
 
     it("rolls phase back to 'select' and surfaces the error envelope on failure", async () => {
@@ -534,7 +548,7 @@ describe('firmware store', () => {
       });
     });
 
-    it('swallows errors — cancel is best-effort and phase truth lives on WS in d.6', async () => {
+    it('swallows errors — cancel is best-effort and phase truth lives on WS', async () => {
       apiDelete.mockRejectedValueOnce(new Error('network'));
       const store = useFirmwareStore();
       store.setPhase('flashing');

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -4,9 +4,9 @@ import { createPinia, setActivePinia } from 'pinia';
 vi.mock('@/api/apiService', () => ({
   default: {
     get: vi.fn(),
-    post: vi.fn(),
   },
   apiClient: {
+    post: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -22,7 +22,7 @@ const sampleControllers: FirmwareControllerView[] = [
 ];
 
 const apiGet = apiService.get as ReturnType<typeof vi.fn>;
-const apiPost = apiService.post as ReturnType<typeof vi.fn>;
+const apiPost = apiClient.post as ReturnType<typeof vi.fn>;
 const apiDelete = apiClient.delete as ReturnType<typeof vi.fn>;
 
 const sampleReleases: ReleaseInfo[] = [
@@ -427,20 +427,22 @@ describe('firmware store', () => {
     }
 
     it("POSTs the github source shape and transitions to 'flashing' on 200", async () => {
-      apiPost.mockResolvedValueOnce({ jobId: 'job-1' });
+      apiPost.mockResolvedValueOnce({ data: { jobId: 'job-1' } });
       const store = readyStore();
 
       await store.startFlash();
 
-      expect(apiPost).toHaveBeenCalledWith('api/firmware/flash', {
-        source: { kind: 'github', version: 'v1.4.2' },
-      });
+      expect(apiPost).toHaveBeenCalledWith(
+        'api/firmware/flash',
+        { source: { kind: 'github', version: 'v1.4.2' } },
+        expect.objectContaining({ timeout: expect.any(Number) }),
+      );
       expect(store.phase).toBe('flashing');
       expect(store.flashError).toBeNull();
     });
 
     it("POSTs the upload source shape when sourceMode is 'upload'", async () => {
-      apiPost.mockResolvedValueOnce({ jobId: 'job-2' });
+      apiPost.mockResolvedValueOnce({ data: { jobId: 'job-2' } });
       const store = useFirmwareStore();
       store.controllers = sampleControllers;
       store.sourceMode = 'upload';
@@ -449,9 +451,23 @@ describe('firmware store', () => {
 
       await store.startFlash();
 
-      expect(apiPost).toHaveBeenCalledWith('api/firmware/flash', {
-        source: { kind: 'upload' },
-      });
+      expect(apiPost).toHaveBeenCalledWith(
+        'api/firmware/flash',
+        { source: { kind: 'upload' } },
+        expect.objectContaining({ timeout: expect.any(Number) }),
+      );
+      expect(store.phase).toBe('flashing');
+      expect(store.flashError).toBeNull();
+    });
+
+    it('clears a prior flashError when a retry POST succeeds', async () => {
+      apiPost.mockResolvedValueOnce({ data: { jobId: 'job-retry' } });
+      const store = readyStore();
+      store.flashError = { reason: 'job_already_running', currentJobId: 'job-x' };
+
+      await store.startFlash();
+
+      expect(store.flashError).toBeNull();
       expect(store.phase).toBe('flashing');
     });
 

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -4,10 +4,14 @@ import { createPinia, setActivePinia } from 'pinia';
 vi.mock('@/api/apiService', () => ({
   default: {
     get: vi.fn(),
+    post: vi.fn(),
+  },
+  apiClient: {
+    delete: vi.fn(),
   },
 }));
 
-import apiService from '@/api/apiService';
+import apiService, { apiClient } from '@/api/apiService';
 import { useFirmwareStore } from '../firmware';
 import type { FirmwareControllerView, ReleaseInfo, ReleaseListResult } from '@/types/firmware';
 
@@ -18,6 +22,8 @@ const sampleControllers: FirmwareControllerView[] = [
 ];
 
 const apiGet = apiService.get as ReturnType<typeof vi.fn>;
+const apiPost = apiService.post as ReturnType<typeof vi.fn>;
+const apiDelete = apiClient.delete as ReturnType<typeof vi.fn>;
 
 const sampleReleases: ReleaseInfo[] = [
   {
@@ -56,6 +62,8 @@ describe('firmware store', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     apiGet.mockReset();
+    apiPost.mockReset();
+    apiDelete.mockReset();
   });
 
   describe('initial state', () => {
@@ -365,6 +373,158 @@ describe('firmware store', () => {
       store.toggle('body'); // upgrade
       store.toggle('core'); // downgrade
       expect(store.canFlash).toBe(false);
+    });
+  });
+
+  describe('phase transitions', () => {
+    it("starts in 'idle'", () => {
+      const store = useFirmwareStore();
+      expect(store.phase).toBe('idle');
+    });
+
+    it('setPhase replaces the current phase', () => {
+      const store = useFirmwareStore();
+      store.setPhase('select');
+      expect(store.phase).toBe('select');
+      store.setPhase('flashing');
+      expect(store.phase).toBe('flashing');
+    });
+
+    it("resetToSelect clears currentStage, flashError, failedController and sets phase to 'select'", () => {
+      const store = useFirmwareStore();
+      store.setPhase('failed');
+      store.currentStage = 'transfer';
+      store.flashError = { reason: 'job_already_running' };
+      store.failedController = { id: 'core', label: 'Core', stage: 'transfer' };
+
+      store.resetToSelect();
+
+      expect(store.phase).toBe('select');
+      expect(store.currentStage).toBeNull();
+      expect(store.flashError).toBeNull();
+      expect(store.failedController).toBeNull();
+    });
+
+    it('dismissError clears flashError without changing phase', () => {
+      const store = useFirmwareStore();
+      store.setPhase('select');
+      store.flashError = { reason: 'release_not_found' };
+      store.dismissError();
+      expect(store.flashError).toBeNull();
+      expect(store.phase).toBe('select');
+    });
+  });
+
+  describe('startFlash', () => {
+    function readyStore() {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+      store.toggle('body');
+      store.setPhase('select');
+      return store;
+    }
+
+    it("POSTs the github source shape and transitions to 'flashing' on 200", async () => {
+      apiPost.mockResolvedValueOnce({ jobId: 'job-1' });
+      const store = readyStore();
+
+      await store.startFlash();
+
+      expect(apiPost).toHaveBeenCalledWith('api/firmware/flash', {
+        source: { kind: 'github', version: 'v1.4.2' },
+      });
+      expect(store.phase).toBe('flashing');
+      expect(store.flashError).toBeNull();
+    });
+
+    it("POSTs the upload source shape when sourceMode is 'upload'", async () => {
+      apiPost.mockResolvedValueOnce({ jobId: 'job-2' });
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'upload';
+      store.uploadedFilename = 'custom.bin';
+      store.toggle('body');
+
+      await store.startFlash();
+
+      expect(apiPost).toHaveBeenCalledWith('api/firmware/flash', {
+        source: { kind: 'upload' },
+      });
+      expect(store.phase).toBe('flashing');
+    });
+
+    it("rolls phase back to 'select' and surfaces the error envelope on failure", async () => {
+      apiPost.mockRejectedValueOnce({
+        response: { status: 409, data: { error: 'job_already_running', currentJobId: 'job-x' } },
+      });
+      const store = readyStore();
+
+      await store.startFlash();
+
+      expect(store.phase).toBe('select');
+      expect(store.flashError).toEqual({
+        reason: 'job_already_running',
+        currentJobId: 'job-x',
+      });
+    });
+
+    it('surfaces network_error when the request never reaches the server', async () => {
+      apiPost.mockRejectedValueOnce(new Error('Network Error'));
+      const store = readyStore();
+
+      await store.startFlash();
+
+      expect(store.phase).toBe('select');
+      expect(store.flashError).toEqual({ reason: 'network_error' });
+    });
+
+    it('is a no-op when canFlash is false (e.g. no controllers selected)', async () => {
+      const store = useFirmwareStore();
+      store.controllers = sampleControllers;
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+      // No selection.
+      await store.startFlash();
+      expect(apiPost).not.toHaveBeenCalled();
+      expect(store.phase).toBe('idle');
+    });
+
+    it("is a no-op when phase is already 'flashing' (double-click guard)", async () => {
+      const store = readyStore();
+      store.setPhase('flashing');
+      await store.startFlash();
+      expect(apiPost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelFlash', () => {
+    it('sends a DELETE with the provided reason in the request body', async () => {
+      apiDelete.mockResolvedValueOnce({ jobId: 'job-1', cancelled: true });
+      const store = useFirmwareStore();
+      await store.cancelFlash('operator-clicked-cancel');
+      expect(apiDelete).toHaveBeenCalledWith('api/firmware/flash', {
+        data: { reason: 'operator-clicked-cancel' },
+      });
+    });
+
+    it('defaults to reason="operator" when no reason is provided', async () => {
+      apiDelete.mockResolvedValueOnce({ jobId: 'job-1', cancelled: true });
+      const store = useFirmwareStore();
+      await store.cancelFlash();
+      expect(apiDelete).toHaveBeenCalledWith('api/firmware/flash', {
+        data: { reason: 'operator' },
+      });
+    });
+
+    it('swallows errors — cancel is best-effort and phase truth lives on WS in d.6', async () => {
+      apiDelete.mockRejectedValueOnce(new Error('network'));
+      const store = useFirmwareStore();
+      store.setPhase('flashing');
+      await store.cancelFlash();
+      // Did not throw; phase unchanged (WS dispatcher owns terminal state).
+      expect(store.phase).toBe('flashing');
     });
   });
 });

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -1,11 +1,15 @@
 import { computed, ref, watch } from 'vue';
 import { defineStore } from 'pinia';
-import apiService from '@/api/apiService';
-import { FIRMWARE_RELEASES } from '@/api/endpoints';
+import apiService, { apiClient } from '@/api/apiService';
+import { FIRMWARE_FLASH, FIRMWARE_RELEASES } from '@/api/endpoints';
 import { compareTags } from '@/utils/version';
+import { mapHttpErrorToFlashEnvelope } from '@/utils/firmwareFlashError';
 import type {
   FirmwareControllerView,
+  FirmwarePhase,
   FirmwareSourceMode,
+  FirmwareStage,
+  FlashErrorEnvelope,
   ReleaseInfo,
   ReleaseListResult,
   ReleasesLoadState,
@@ -22,6 +26,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
 
   const controllers = ref<FirmwareControllerView[]>([]);
   const selectedControllerIds = ref<ReadonlySet<string>>(new Set());
+
+  const phase = ref<FirmwarePhase>('idle');
+  const currentStage = ref<FirmwareStage | null>(null);
+  const flashError = ref<FlashErrorEnvelope | null>(null);
+  const failedController = ref<{ id: string; label: string; stage: FirmwareStage } | null>(null);
 
   // Reconcile selection against the fleet — when `controllers` is reassigned
   // (e.g. by a WS-driven refresh), prune any selected ids that no longer
@@ -86,6 +95,51 @@ export const useFirmwareStore = defineStore('firmware', () => {
     selectedControllerIds.value = new Set();
   }
 
+  function setPhase(next: FirmwarePhase): void {
+    phase.value = next;
+  }
+
+  function resetToSelect(): void {
+    phase.value = 'select';
+    currentStage.value = null;
+    flashError.value = null;
+    failedController.value = null;
+  }
+
+  function dismissError(): void {
+    flashError.value = null;
+  }
+
+  async function startFlash(): Promise<void> {
+    if (!canFlash.value || phase.value === 'flashing') return;
+    flashError.value = null;
+    const body =
+      sourceMode.value === 'github'
+        ? { source: { kind: 'github' as const, version: selectedReleaseTag.value } }
+        : { source: { kind: 'upload' as const } };
+    phase.value = 'flashing';
+    try {
+      await apiService.post(FIRMWARE_FLASH, body);
+      // HTTP 200 means orchestrator.start() resolved synchronously. Subsequent
+      // state (per-controller stages, completion, failure) is owned by the WS
+      // dispatcher in d.6. In d.5 we remain in 'flashing' until the operator
+      // dismisses the view; this is the documented d.5 behavior.
+    } catch (error) {
+      phase.value = 'select';
+      flashError.value = mapHttpErrorToFlashEnvelope(error);
+    }
+  }
+
+  async function cancelFlash(reason: string = 'operator'): Promise<void> {
+    try {
+      await apiClient.delete(FIRMWARE_FLASH, { data: { reason } });
+    } catch (error) {
+      // Cancel is best-effort. A failure here is logged but doesn't transition
+      // phase — the WS dispatcher in d.6 owns post-cancel state truth.
+      console.warn('firmware.cancelFlash failed', error);
+    }
+  }
+
   async function fetchReleases(): Promise<void> {
     releasesLoadState.value = 'loading';
     try {
@@ -110,12 +164,21 @@ export const useFirmwareStore = defineStore('firmware', () => {
     uploadedFilename,
     controllers,
     selectedControllerIds,
+    phase,
+    currentStage,
+    flashError,
+    failedController,
     target,
     anyDowngradeBlocked,
     canFlash,
     toggle,
     selectAll,
     clear,
+    setPhase,
+    resetToSelect,
+    dismissError,
+    startFlash,
+    cancelFlash,
     fetchReleases,
   };
 });

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -132,6 +132,9 @@ export const useFirmwareStore = defineStore('firmware', () => {
       // that dispatcher is wired in, phase stays 'flashing' until the operator
       // resets.
     } catch (error) {
+      // Direct apiClient.post bypasses apiService.post's console.error wrapper,
+      // so log here to preserve the dev breadcrumb for debugging real errors.
+      console.error('firmware.startFlash failed', error);
       phase.value = 'select';
       flashError.value = mapHttpErrorToFlashEnvelope(error);
     }

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -110,6 +110,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
     flashError.value = null;
   }
 
+  // 30s timeout on the flash POST. axios's default is no timeout — a hung
+  // backend would otherwise leave phase stuck at 'flashing' with no UI
+  // recovery short of a page refresh.
+  const FLASH_POST_TIMEOUT_MS = 30_000;
+
   async function startFlash(): Promise<void> {
     if (!canFlash.value || phase.value === 'flashing') return;
     flashError.value = null;
@@ -119,11 +124,13 @@ export const useFirmwareStore = defineStore('firmware', () => {
         : { source: { kind: 'upload' as const } };
     phase.value = 'flashing';
     try {
-      await apiService.post(FIRMWARE_FLASH, body);
-      // HTTP 200 means orchestrator.start() resolved synchronously. Subsequent
-      // state (per-controller stages, completion, failure) is owned by the WS
-      // dispatcher in d.6. In d.5 we remain in 'flashing' until the operator
-      // dismisses the view; this is the documented d.5 behavior.
+      // Direct apiClient call so we can attach a per-request timeout; the
+      // apiService.post wrapper doesn't expose the options bag.
+      await apiClient.post(FIRMWARE_FLASH, body, { timeout: FLASH_POST_TIMEOUT_MS });
+      // HTTP 200 only means orchestrator.start() resolved; per-controller stage
+      // progression, completion, and failure arrive on the WS surface. Until
+      // that dispatcher is wired in, phase stays 'flashing' until the operator
+      // resets.
     } catch (error) {
       phase.value = 'select';
       flashError.value = mapHttpErrorToFlashEnvelope(error);
@@ -132,10 +139,13 @@ export const useFirmwareStore = defineStore('firmware', () => {
 
   async function cancelFlash(reason: string = 'operator'): Promise<void> {
     try {
+      // Uses apiClient directly (not the apiService.delete wrapper) because
+      // the wrapper passes the second arg as `params`, not request body. The
+      // server reads `req.body?.reason`, so the body must transmit.
       await apiClient.delete(FIRMWARE_FLASH, { data: { reason } });
     } catch (error) {
-      // Cancel is best-effort. A failure here is logged but doesn't transition
-      // phase — the WS dispatcher in d.6 owns post-cancel state truth.
+      // Best-effort: failure here is logged but doesn't transition phase — the
+      // WS surface owns post-cancel state truth.
       console.warn('firmware.cancelFlash failed', error);
     }
   }

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -63,7 +63,7 @@ export type FirmwareStage = 'download' | 'transfer' | 'flash' | 'verify' | 'rebo
  * Subset of the server's FlashOrchestratorErrorReason that surfaces via the
  * HTTP error response. Post-streamer failures (hash_mismatch,
  * chunk_retry_exhausted, etc.) are deliberately omitted — those arrive on
- * the WS surface in d.6, not via this envelope.
+ * the WS surface, not via this envelope.
  */
 export type FlashErrorReason =
   | 'invalid_body'

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -54,3 +54,37 @@ export type FirmwareStatusPillKind =
   | 'upToDate'
   | 'offline'
   | 'downgrade';
+
+export type FirmwarePhase = 'idle' | 'select' | 'flashing' | 'done' | 'failed';
+
+export type FirmwareStage = 'download' | 'transfer' | 'flash' | 'verify' | 'reboot';
+
+/**
+ * Subset of the server's FlashOrchestratorErrorReason that surfaces via the
+ * HTTP error response. Post-streamer failures (hash_mismatch,
+ * chunk_retry_exhausted, etc.) are deliberately omitted — those arrive on
+ * the WS surface in d.6, not via this envelope.
+ */
+export type FlashErrorReason =
+  | 'invalid_body'
+  | 'job_already_running'
+  | 'no_controllers'
+  | 'variant_mismatch'
+  | 'variant_unknown'
+  | 'release_not_found'
+  | 'asset_not_found'
+  | 'no_upload'
+  | 'release_lookup_failed'
+  | 'source_resolution_failed'
+  | 'controllers_lookup_failed'
+  | 'subscriber_attach_failed'
+  | 'protocol_violation'
+  | 'streamer_unknown_error'
+  | 'internal_server_error'
+  | 'network_error';
+
+export interface FlashErrorEnvelope {
+  reason: FlashErrorReason;
+  detail?: string;
+  currentJobId?: string;
+}

--- a/astros_vue/src/utils/__tests__/firmwareFlashError.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareFlashError.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mapHttpErrorToFlashEnvelope } from '../firmwareFlashError';
+
+describe('mapHttpErrorToFlashEnvelope', () => {
+  it("returns network_error when the error has no response (axios 'no response received')", () => {
+    expect(mapHttpErrorToFlashEnvelope({ message: 'Network Error' })).toEqual({
+      reason: 'network_error',
+    });
+  });
+
+  it('returns network_error for arbitrary non-axios shapes', () => {
+    expect(mapHttpErrorToFlashEnvelope('boom')).toEqual({ reason: 'network_error' });
+    expect(mapHttpErrorToFlashEnvelope(null)).toEqual({ reason: 'network_error' });
+    expect(mapHttpErrorToFlashEnvelope(undefined)).toEqual({ reason: 'network_error' });
+  });
+
+  it('returns internal_server_error when response.data is not an object', () => {
+    expect(mapHttpErrorToFlashEnvelope({ response: { data: 'oops' } })).toEqual({
+      reason: 'internal_server_error',
+    });
+  });
+
+  it('maps recognized server `error` strings onto FlashErrorReason', () => {
+    expect(
+      mapHttpErrorToFlashEnvelope({ response: { data: { error: 'release_not_found' } } }),
+    ).toEqual({ reason: 'release_not_found' });
+  });
+
+  it('preserves detail and currentJobId when present', () => {
+    expect(
+      mapHttpErrorToFlashEnvelope({
+        response: { data: { error: 'job_already_running', currentJobId: 'job-42' } },
+      }),
+    ).toEqual({ reason: 'job_already_running', currentJobId: 'job-42' });
+
+    expect(
+      mapHttpErrorToFlashEnvelope({
+        response: { data: { error: 'no_controllers', detail: 'targets list was empty' } },
+      }),
+    ).toEqual({ reason: 'no_controllers', detail: 'targets list was empty' });
+  });
+
+  it('falls back to internal_server_error for unknown `error` strings', () => {
+    // Mutation guard: a future server adding a new reason would land here
+    // until the client type list is updated. The fallback prevents render
+    // crashes (missing i18n key) but is loud enough to debug.
+    expect(mapHttpErrorToFlashEnvelope({ response: { data: { error: 'meteor_strike' } } })).toEqual(
+      { reason: 'internal_server_error' },
+    );
+  });
+});

--- a/astros_vue/src/utils/firmwareFlashError.ts
+++ b/astros_vue/src/utils/firmwareFlashError.ts
@@ -43,10 +43,14 @@ export function mapHttpErrorToFlashEnvelope(error: unknown): FlashErrorEnvelope 
   const detailRaw = (body as { detail?: unknown }).detail;
   const currentJobIdRaw = (body as { currentJobId?: unknown }).currentJobId;
 
+  const isKnown = typeof reasonRaw === 'string' && KNOWN_REASONS.has(reasonRaw as FlashErrorReason);
+  if (!isKnown && typeof reasonRaw === 'string') {
+    console.warn(
+      `[firmwareFlashError] unrecognized server reason "${reasonRaw}"; mapping to internal_server_error`,
+    );
+  }
   const reason: FlashErrorReason = (
-    typeof reasonRaw === 'string' && KNOWN_REASONS.has(reasonRaw as FlashErrorReason)
-      ? reasonRaw
-      : 'internal_server_error'
+    isKnown ? reasonRaw : 'internal_server_error'
   ) as FlashErrorReason;
 
   const envelope: FlashErrorEnvelope = { reason };

--- a/astros_vue/src/utils/firmwareFlashError.ts
+++ b/astros_vue/src/utils/firmwareFlashError.ts
@@ -24,12 +24,11 @@ function isAxiosLikeError(value: unknown): value is { response?: { data?: unknow
 }
 
 /**
- * Map an axios-style error thrown by `apiService.post(FIRMWARE_FLASH, ...)`
- * onto a `FlashErrorEnvelope` the UI can render via i18n keys.
+ * Map an axios-style error thrown by the flash POST onto a FlashErrorEnvelope.
  *
  * No-response → `network_error`. Response with an unrecognized `error` field
  * → `internal_server_error`. Server's `currentJobId` is preserved for the
- * 409 case so the banner can mention which job is in flight.
+ * 409 case so the banner can name the in-flight job.
  */
 export function mapHttpErrorToFlashEnvelope(error: unknown): FlashErrorEnvelope {
   if (!isAxiosLikeError(error) || error.response === undefined) {

--- a/astros_vue/src/utils/firmwareFlashError.ts
+++ b/astros_vue/src/utils/firmwareFlashError.ts
@@ -1,0 +1,56 @@
+import type { FlashErrorEnvelope, FlashErrorReason } from '@/types/firmware';
+
+const KNOWN_REASONS: ReadonlySet<FlashErrorReason> = new Set<FlashErrorReason>([
+  'invalid_body',
+  'job_already_running',
+  'no_controllers',
+  'variant_mismatch',
+  'variant_unknown',
+  'release_not_found',
+  'asset_not_found',
+  'no_upload',
+  'release_lookup_failed',
+  'source_resolution_failed',
+  'controllers_lookup_failed',
+  'subscriber_attach_failed',
+  'protocol_violation',
+  'streamer_unknown_error',
+  'internal_server_error',
+  'network_error',
+]);
+
+function isAxiosLikeError(value: unknown): value is { response?: { data?: unknown } } {
+  return typeof value === 'object' && value !== null && 'response' in value;
+}
+
+/**
+ * Map an axios-style error thrown by `apiService.post(FIRMWARE_FLASH, ...)`
+ * onto a `FlashErrorEnvelope` the UI can render via i18n keys.
+ *
+ * No-response → `network_error`. Response with an unrecognized `error` field
+ * → `internal_server_error`. Server's `currentJobId` is preserved for the
+ * 409 case so the banner can mention which job is in flight.
+ */
+export function mapHttpErrorToFlashEnvelope(error: unknown): FlashErrorEnvelope {
+  if (!isAxiosLikeError(error) || error.response === undefined) {
+    return { reason: 'network_error' };
+  }
+  const body = error.response.data;
+  if (typeof body !== 'object' || body === null) {
+    return { reason: 'internal_server_error' };
+  }
+  const reasonRaw = (body as { error?: unknown }).error;
+  const detailRaw = (body as { detail?: unknown }).detail;
+  const currentJobIdRaw = (body as { currentJobId?: unknown }).currentJobId;
+
+  const reason: FlashErrorReason = (
+    typeof reasonRaw === 'string' && KNOWN_REASONS.has(reasonRaw as FlashErrorReason)
+      ? reasonRaw
+      : 'internal_server_error'
+  ) as FlashErrorReason;
+
+  const envelope: FlashErrorEnvelope = { reason };
+  if (typeof detailRaw === 'string') envelope.detail = detailRaw;
+  if (typeof currentJobIdRaw === 'string') envelope.currentJobId = currentJobIdRaw;
+  return envelope;
+}

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -55,6 +55,8 @@ const selectedControllerList = computed<FirmwareControllerView[]>(() =>
 
 const failedControllerId = computed(() => failedController.value?.id);
 
+// Dev-only invariant warning. Surfaces wiring bugs in the controllers-store
+// adapter; production strips the block via Vite tree-shake.
 if (import.meta.env.DEV) {
   watchEffect(() => {
     if (controllers.value.length > 0 && !controllers.value.some((c) => c.isMaster)) {

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -1,8 +1,17 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { AstrosLayout, AstrosFirmwareSourceStrip } from '@/components';
+import { storeToRefs } from 'pinia';
+import {
+  AstrosLayout,
+  AstrosFirmwareSourceStrip,
+  AstrosFirmwareTopology,
+  AstrosFirmwareStagesList,
+  AstrosFirmwareControllersPanel,
+  AstrosFirmwareConfirmModal,
+} from '@/components';
 import { useFirmwareStore } from '@/stores/firmware';
+import type { FirmwareControllerView, TopologyFleet } from '@/components';
 
 import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
@@ -11,15 +20,75 @@ import '@fontsource/inter/700.css';
 
 const { t } = useI18n();
 const firmware = useFirmwareStore();
+const {
+  phase,
+  controllers,
+  selectedControllerIds,
+  target,
+  currentStage,
+  failedController,
+  sourceMode,
+  uploadedFilename,
+} = storeToRefs(firmware);
 
-type Phase = 'select' | 'flashing' | 'done' | 'failed';
+const confirmOpen = ref(false);
 
-const phase = ref<Phase>('select');
+const subtitle = computed(() => {
+  if (phase.value === 'idle') return t('firmware_view.subtitle.select');
+  return t(`firmware_view.subtitle.${phase.value}`);
+});
 
-const subtitle = computed(() => t(`firmware_view.subtitle.${phase.value}`));
+const topologyFleet = computed<TopologyFleet | null>(() => {
+  const master = controllers.value.find((c) => c.isMaster);
+  if (!master) return null;
+  return {
+    master: { id: master.id, label: master.label },
+    padawans: controllers.value
+      .filter((c) => !c.isMaster)
+      .map((c) => ({ id: c.id, label: c.label })),
+  };
+});
 
-onMounted(() => {
-  firmware.fetchReleases();
+const selectedControllerList = computed<FirmwareControllerView[]>(() =>
+  controllers.value.filter((c) => selectedControllerIds.value.has(c.id)),
+);
+
+const failedControllerId = computed(() => failedController.value?.id);
+
+function openConfirm() {
+  confirmOpen.value = true;
+}
+
+function onConfirmCancel() {
+  confirmOpen.value = false;
+}
+
+async function onConfirmFlash() {
+  confirmOpen.value = false;
+  await firmware.startFlash();
+}
+
+function onResultBarDone() {
+  firmware.resetToSelect();
+}
+
+const DEV_SAMPLE_FLEET: FirmwareControllerView[] = [
+  { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
+  { id: 'core', label: 'Core', glyph: 'C', current: 'v1.4.0', status: 'up', isMaster: false },
+  { id: 'dome', label: 'Dome', glyph: 'D', current: 'v1.4.0', status: 'up', isMaster: false },
+];
+
+onMounted(async () => {
+  await firmware.fetchReleases();
+  // Dev-only fleet bootstrap. Vite strips the block in production. d.6 will
+  // populate `firmware.controllers` from the real controllers store on mount
+  // and via WS-driven snapshots.
+  if (import.meta.env.DEV && firmware.controllers.length === 0) {
+    firmware.controllers = DEV_SAMPLE_FLEET;
+  }
+  if (firmware.controllers.length > 0 && firmware.phase === 'idle') {
+    firmware.setPhase('select');
+  }
 });
 </script>
 
@@ -31,15 +100,57 @@ onMounted(() => {
         style="height: calc(100vh - 64px)"
       >
         <div class="flex items-center gap-4 p-4 bg-r2-complement shrink-0 mb-4">
-          <h1 class="text-2xl font-bold">{{ $t('firmware_view.title') }}</h1>
+          <h1 class="text-2xl font-bold">{{ t('firmware_view.title') }}</h1>
         </div>
         <div class="firmware-view firmware-view__content">
           <p class="firmware-view__subtitle">{{ subtitle }}</p>
+
           <AstrosFirmwareSourceStrip v-if="phase === 'select'" />
+
+          <div
+            v-if="phase !== 'idle'"
+            class="firmware-view__grid"
+          >
+            <div class="firmware-view__left-column">
+              <AstrosFirmwareTopology
+                v-if="topologyFleet"
+                :fleet="topologyFleet"
+                :selected-ids="[...selectedControllerIds]"
+                :target="target"
+                :phase="phase"
+                :failed-controller-id="failedControllerId"
+              />
+              <AstrosFirmwareStagesList
+                v-if="phase === 'flashing' || phase === 'done' || phase === 'failed'"
+                :phase="phase"
+                :current-stage="currentStage"
+                :failed-stage="failedController?.stage ?? null"
+              />
+            </div>
+
+            <AstrosFirmwareControllersPanel
+              class="firmware-view__panel"
+              :phase="phase"
+              :failed-controller-label="failedController?.label"
+              :failed-stage="failedController?.stage"
+              @flash="openConfirm"
+              @done="onResultBarDone"
+            />
+          </div>
         </div>
       </div>
     </template>
   </AstrosLayout>
+
+  <AstrosFirmwareConfirmModal
+    :open="confirmOpen"
+    :target="target"
+    :selected-controllers="selectedControllerList"
+    :source-mode="sourceMode"
+    :uploaded-filename="uploadedFilename"
+    @cancel="onConfirmCancel"
+    @confirm="onConfirmFlash"
+  />
 </template>
 
 <style scoped>
@@ -59,5 +170,29 @@ onMounted(() => {
   flex-direction: column;
   gap: 16px;
   box-sizing: border-box;
+  overflow-y: auto;
+}
+
+.firmware-view__grid {
+  display: grid;
+  grid-template-columns: 380px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+@media (max-width: 960px) {
+  .firmware-view__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.firmware-view__left-column {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.firmware-view__panel {
+  min-width: 0;
 }
 </style>

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 import {
@@ -55,6 +55,17 @@ const selectedControllerList = computed<FirmwareControllerView[]>(() =>
 
 const failedControllerId = computed(() => failedController.value?.id);
 
+if (import.meta.env.DEV) {
+  watchEffect(() => {
+    if (controllers.value.length > 0 && !controllers.value.some((c) => c.isMaster)) {
+      console.warn(
+        '[FirmwareView] no controller is flagged isMaster — topology will not render. ' +
+          'Every fleet snapshot must include exactly one master.',
+      );
+    }
+  });
+}
+
 function openConfirm() {
   confirmOpen.value = true;
 }
@@ -80,9 +91,8 @@ const DEV_SAMPLE_FLEET: FirmwareControllerView[] = [
 
 onMounted(async () => {
   await firmware.fetchReleases();
-  // Dev-only fleet bootstrap. Vite strips the block in production. d.6 will
-  // populate `firmware.controllers` from the real controllers store on mount
-  // and via WS-driven snapshots.
+  // Dev-only placeholder fleet. Replace with the real controllers-store
+  // adapter once it exists.
   if (import.meta.env.DEV && firmware.controllers.length === 0) {
     firmware.controllers = DEV_SAMPLE_FLEET;
   }


### PR DESCRIPTION
## Summary

- Wires d.1–d.4's presentational pieces into `FirmwareView`, adds the two remaining components (`StagesList`, `ConfirmModal`), moves the phase state machine into `firmwareStore`, and POSTs the flash request to the server. Page is now exercisable end-to-end in `npm run dev` against a dev-only sample fleet — only live in-flight progression (the WS dispatcher) waits for d.6.
- `firmwareStore` gains `phase`, `currentStage`, `flashError`, `failedController` state plus `setPhase`/`resetToSelect`/`dismissError`/`startFlash`/`cancelFlash` actions. `startFlash` posts with a 30s axios timeout so a hung backend can't leave the UI stuck in `flashing`; on rejection, server reasons map onto a typed `FlashErrorEnvelope` that drives an inline error banner.
- Three pure helpers extracted with their own unit tests (`stageRowState`, `mapHttpErrorToFlashEnvelope`) continue the d.3/d.4 pattern — pure logic out of `.vue` files into testable siblings. 118 tests total on the branch (+30 net for d.5).

## What ships

### Components

| Component | Folder | Role |
|---|---|---|
| `AstrosFirmwareStagesList` | `firmware/firmwareStagesList/` | 5 stages (download / transfer / flash / verify / reboot) with state-driven row styling. Pure `stageRowState` helper extracted with 8 unit tests covering all phase × stage combos. Dev-warn for null `currentStage` / `failedStage` in matching phases. |
| `AstrosFirmwareConfirmModal` | `firmware/firmwareConfirmModal/` | Native `<dialog>` element + `.showModal()` gives focus trap, ESC, and focus restore for free (no hand-rolled focus management). Click-backdrop detection via `event.target === dialog`. ESC `cancel` event preventDefaulted and re-emitted so the parent's `open` ref drives close (single-sourced). |
| `AstrosFirmwareControllersPanel` (modified) | `firmware/firmwareControllersPanel/` | Flash-error banner above the action bar reading `firmwareStore.flashError`. `role="alert"` + `aria-live="polite"`. `job_already_running` uses a separate `_with_id` i18n key to avoid the double-space rendering when the server omits `currentJobId`. |

### Store additions (`stores/firmware.ts`)

- `phase: ref<FirmwarePhase>` — `idle | select | flashing | done | failed`. Initial `'idle'`; bootstraps to `'select'` once `controllers` has rows.
- `currentStage`, `flashError`, `failedController` refs.
- `setPhase`, `resetToSelect`, `dismissError` actions for transitions.
- `startFlash` — POSTs `/api/firmware/flash` with the right body per `sourceMode`. 30s timeout via `apiClient.post(..., { timeout: 30_000 })`. Phase rolls back to `select` on error and the envelope drives the inline banner. Double-click guard returns early when `phase === 'flashing'`. Dev breadcrumb: `console.error` in catch since the direct `apiClient` call bypasses `apiService.post`'s auto-logging.
- `cancelFlash(reason)` — sends a DELETE with body via `apiClient.delete(url, { data: { reason } })`. Best-effort; swallows errors (the WS surface owns post-cancel state truth). Code-commented to make the wrapper-bypass intentional.

### Types (`types/firmware.ts`)

- `FirmwarePhase` (5-state union — single source of truth).
- `FirmwareStage` (5-stage union).
- `FlashErrorReason` (16-value closed union — deliberately excludes post-streamer reasons that arrive via WS in d.6).
- `FlashErrorEnvelope`.

Plus type consolidation: `TopologyPhase = FirmwarePhase` and `ControllersPanelPhase = Exclude<FirmwarePhase, 'idle'>` collapse three near-identical phase unions from prior phases into one source of truth.

### Page assembly (`FirmwareView.vue`)

- Subtitle reads from `firmwareStore.phase`.
- Two-column grid (`Topology + StagesList` left at 380px, `ControllersPanel` right at flex 1).
- Below 960px viewport, collapses to single column (per the design handoff).
- `ConfirmModal` mounted at view root; Flash button → opens modal → on confirm → `firmware.startFlash()`.
- Done button on result bar → `firmware.resetToSelect()`.
- Dev-only fleet bootstrap in `onMounted` (Body/Core/Dome with sample versions) so the assembled page is exercisable in `npm run dev`. `import.meta.env.DEV` guarded; Vite tree-shakes the block in production.
- Dev-warn `watchEffect` when `controllers` has rows but none flagged `isMaster` — surfaces wiring bugs in d.6's controllers-store adapter.

### i18n additions

- `firmware_view.stages.*` — 5 stages × (label + hint) + `eyebrow_title` + `in_progress`.
- `firmware_view.confirm_modal.*` — title, labels, power warning, cancel, confirm.
- `firmware_view.flash_errors.*` — 16 typed reason copy variants + a `job_already_running_with_id` variant for the 409 case.
- `firmware_view.controllers.flash_error_banner.*` — title, retry, dismiss.

### New endpoint constant

- `FIRMWARE_FLASH = 'api/firmware/flash'`.

## What's deferred to d.6

- **WS dispatcher + live in-flight rendering.** d.5 posts the flash and remains in `flashing` until the operator manually resets — d.6 wires real per-controller progression via the WebSocket surface.
- **Real `stores/controller` → `FirmwareControllerView` adapter.** d.5 uses a dev-only mock; d.6 swaps in the real adapter.
- **Lock-aware `AstrosWriteButton` + lock banner.** Cross-view concern; lives in d.6.
- **`timeout_error` reason distinct from `network_error`.** Currently both map to the same envelope; the new `console.error` breadcrumb carries the axios `ECONNABORTED` code for dev debugging.
- **Discriminated-union `FlashErrorEnvelope` keyed on `reason`.** The type-design-analyzer recommended deferring until d.6's WS errors create a second consumer.
- **`failedController` shape extension with `reason`/`detail` fields.** d.6 will populate this from WS; design the shape then.

## Test plan

- [ ] `npm run build` succeeds from `astros_vue/`.
- [ ] `npx vitest run` reports **118 tests passing**, including:
  - 39 firmware-store tests (was 6 from d.2; +33 across d.4 and d.5)
  - 5 `AstrosFirmwareVersionDelta` tests
  - 9 `selectModePillKind` tests
  - 8 `stageRowState` tests (new in d.5)
  - 6 `mapHttpErrorToFlashEnvelope` tests (new in d.5)
- [ ] `npm run storybook` and visually confirm the new stories:
  - `AstrosFirmwareStagesList`: 5 stories — `Idle`, `Flashing` (currentStage='transfer'), `Done`, `FailedAtTransfer`, `FailedAtDownload`.
  - `AstrosFirmwareConfirmModal`: 3 stories — `SingleControllerGithub`, `AllControllersGithub`, `UploadSource`. Verify ESC closes the modal, click outside the card closes it, focus is trapped while open, and focus returns to the trigger when closed.
  - `AstrosFirmwareControllersPanel.SelectWithFlashError`: red banner above the action bar with retry/dismiss controls.
- [ ] `npm run dev` end-to-end smoke test against the dev fleet:
  - Navigate to `/firmware` — verify SourceStrip + Topology + ControllersPanel all render with the mock Body/Core/Dome fleet.
  - Pick a release; tick at least one controller; verify Flash button enables.
  - Click Flash → ConfirmModal opens listing source + targets with version deltas + power warning.
  - Cancel → modal closes, focus returns to Flash button, phase stays `select`.
  - Confirm → POST fires; on success the page transitions to `flashing` and shows StagesList (currentStage=null in d.5 so all rows render idle).
  - With the server returning a 409 (e.g., trigger via curl while a job is running): phase rolls back to `select` and the error banner shows the `job_already_running_with_id` copy with the conflicting job id.
- [ ] DevTools console while interacting: expected dev-warns fire when intended (no-master fleet, null currentStage in flashing phase, unknown server reason). No unexpected warnings.
- [ ] Reduced-motion check unchanged from d.3 — topology dashed-line animation still halts under `prefers-reduced-motion: reduce`.
- [ ] **Regression:** topology + source-strip + controllers-panel stories from d.3/d.4 still render correctly. The phase-union consolidation is type-only; runtime behavior should be unchanged.
- [ ] Keyboard a11y on the modal: open via Enter on Flash button → focus inside modal → Tab cycles inside → ESC closes → focus returns to Flash button.

## Notes for reviewers

- **Two rounds of pre-push toolkit ran.** Round 1 surfaced 2 Critical (no axios timeout, fragile `apiClient.delete` bypass) and ~10 Important findings; all addressed in commit `a6b2ba3`. Round 2 surfaced a partial-fix-sweep pattern (sibling sites still referencing `d.6` by phase number) and a mutation-test gap (`expect.any(Number)` accepts 0); all addressed in commit `80d0c41`. Both round outputs are summarized in the commit messages.
- **The `apiClient.post` direct call in `startFlash`** is deliberate: it's the only path that needs the `{ timeout }` options bag, and `apiService.post` doesn't expose options. The `console.error` in the catch restores the dev breadcrumb that `apiService.post`'s wrapper would have provided.
- **The `cancelFlash` `apiClient.delete` bypass** is also deliberate: `apiService.delete` passes the second arg as `params` (URL query string), not request body, and the server reads `req.body?.reason`. A code comment documents this so a future "consistency refactor" doesn't silently regress the body transmission.
- **`stageRowState` extraction follows the d.3/d.4 pattern** of pulling pure decision logic out of Vue components into testable siblings. The 8 unit tests cover all 5 phase × 5 stage combos plus null-pointer edges.
- **Native `<dialog>` for the modal** is the right call over hand-rolled focus management or `vue-focus-trap`: it gives focus trap + ESC + focus restore + implicit `role="dialog"`/`aria-modal="true"` for free, and tests are simpler because the browser owns the lifecycle.
- **QA test plan is deferred to d.6 completion** per prior agreement — the comprehensive operator-flow QA will live at `.docs/qa/firmware-ota-flash-ui.md` once the feature is end-to-end testable. d.5's verification section above covers d.5's own scope.

