### PR TITLE
OTA Firmware - live wiring

### DIFF
--- a/.docs/plans/20260507-2153-firmware-ota-d-vue-firmware-view.md
+++ b/.docs/plans/20260507-2153-firmware-ota-d-vue-firmware-view.md
@@ -46,7 +46,7 @@ Source: `astros_api/src/firmware/flash_orchestrator.ts:323-344` (the `FlashOrche
 
 `lockStateChanged` (type=10) is already wired and is **flat** (`{type, locked, owner, since}`) — no change.
 
-Late-join: `astros_api/src/api_server.ts:652-660` sends one `flashJobStarted` snapshot on connect when a job is in flight; `firmwareStore.applyJobStarted` must be idempotent.
+Late-join: `astros_api/src/api_server.ts:654-669` sends one `flashJobStarted` snapshot on connect when a job is in flight; `firmwareStore.applyJobStarted` must be idempotent.
 
 ---
 
@@ -150,7 +150,7 @@ All concurrency hazards land in d.6. Apply `/pr-review-toolkit:review-pr` before
 
 - **Server-side WS contract (read-only):** `astros_api/src/firmware/flash_orchestrator.ts:323-344`, `astros_api/src/models/firmware/flash_job_state.ts`, `astros_api/src/models/enums.ts:82`.
 - **Server-side HTTP contract (read-only):** `astros_api/src/controllers/firmware_flash_controller.ts`.
-- **Late-join entry point (read-only):** `astros_api/src/api_server.ts:652-660`.
+- **Late-join entry point (read-only):** `astros_api/src/api_server.ts:654-669`.
 - **Vue patterns to mirror:** `astros_vue/src/stores/jobLock.ts`, `astros_vue/src/composables/useWebsocket.ts`, `astros_vue/src/views/ModulesView.vue` (chrome).
 - **Design source of truth:** `../design_handoff_firmware_update/README.md` + `firmwareDirectionC.jsx` + `firmwareShared.jsx`.
 - **Existing lock-aware button:** `astros_vue/src/components/common/AstrosWriteButton.vue` (extension point for d.6).

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -200,7 +200,7 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 **Scope shipped:** smoke spec covering page-chrome rendering, source-strip toggle visibility, controllers-panel header (Select all / Clear), and Flash-button initial disabled state. No WS-driven phase progression — that requires a WS-mock infrastructure the project doesn't have yet.
 
-**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, and lock-conflict logic are exhaustively covered by 21 new vitest tests in `firmware.spec.ts`. The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
+**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (202 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
 
 ---
 
@@ -251,7 +251,7 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 ## Verification
 
 1. `npm run build` succeeds.
-2. `npx vitest run` — new unit tests for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob`, and the 7 FMI hazards above. Plus updated `AstrosWriteButton` test suite (existing 9 + 3 new). Plus all 118 prior tests keep passing.
+2. `npx vitest run` — 202 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
 3. `npx playwright test firmware-flash.spec.ts` — the e2e spec passes locally against the mocked WS.
 4. `npm run storybook` — visual regression of d.3/d.4/d.5 stories unchanged. New stories for the lock-conflict banner (FirmwareView and AstrosLayout siblings).
 5. Manual `npm run dev` smoke test:

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -200,7 +200,7 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 **Scope shipped:** smoke spec covering page-chrome rendering, source-strip toggle visibility, controllers-panel header (Select all / Clear), and Flash-button initial disabled state. No WS-driven phase progression — that requires a WS-mock infrastructure the project doesn't have yet.
 
-**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (220 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
+**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (225 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
 
 ---
 
@@ -251,7 +251,7 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 ## Verification
 
 1. `npm run build` succeeds.
-2. `npx vitest run` — 220 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
+2. `npx vitest run` — 225 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
 3. `npx playwright test firmware-flash.spec.ts` — the e2e spec passes locally against the mocked WS.
 4. `npm run storybook` — visual regression of d.3/d.4/d.5 stories unchanged. New stories for the lock-conflict banner (FirmwareView and AstrosLayout siblings).
 5. Manual `npm run dev` smoke test:

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -215,20 +215,20 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 ## Tasks
 
-- [ ] Mirror server types (`ServerFwStage`, `ControllerFlashState`, `FlashJobState`, `FlashJobFailedData`) into `types/firmware.ts`. Cross-reference comment at top pointing at the server file.
-- [ ] Add `FLASH_JOB_ACTIVE = 11` through `FLASH_JOB_FAILED = 16` to `WebsocketMessageType` enum. Cross-reference comment.
-- [ ] Implement `utils/firmwareStageMapping.ts` (`mapServerStageToUiStage` + `controllerStatePillKind`) with full unit-test coverage.
-- [ ] Extend `firmwareStore`: add `currentJob`, `controllerStates`, `ownJobId` refs; turn `controllers` into a `computed` over `useControllerStore()` (replaces the d.5 ref and `DEV_SAMPLE_FLEET` bootstrap); add `applyJobStarted/applyControllerUpdate/applyControllerResult/applyJobDone/applyJobFailed` actions; add `fetchCurrentJob`; update `startFlash` to capture `ownJobId` from the POST response and to NOT manage phase directly (WS owns phase from `flashing` onward). Comprehensive unit tests for each handler + idempotency + replace-not-merge + the **5 FMI hazards** below.
-- [ ] Update `useWebsocket.ts` `handleMessage` switch with 5 new cases; new `handleFlashJobStarted` / `handleFlashControllerUpdate` / `handleFlashControllerResult` / `handleFlashJobDone` / `handleFlashJobFailed` functions following the existing try/catch pattern.
-- [ ] Extend `AstrosWriteButton.vue` to OR-in `useJobLockStore().locked`. Update tooltip key resolution. Update existing 9 tests if needed, add 3 new for jobLock-only / both-active / neither cases.
-- [ ] Add lock banner to `AstrosLayout.vue` — sibling component or inline. New i18n key. Verify it doesn't double up with the system-status banner when both readonly + locked.
-- [ ] Update `FirmwareView.vue`: drop `DEV_SAMPLE_FLEET`, drop the `onMounted` bootstrap (controllers now come from the computed), add `fetchCurrentJob` on mount, add lock-conflict alert section that renders when `lockStore.locked && !isOwnJob`.
-- [ ] Update `ControllersPanel` consumer of `progressByControllerId` — d.5 took this as a prop; d.6 reads it from `firmwareStore.controllerStates`. Either keep the prop (parent maps store→prop) or read from store directly. **Decision in plan**: keep the prop, with `FirmwareView` mapping the store's `controllerStates` Map → `Record<id, { status, stageLabel }>`. Less store coupling at the leaf.
-- [ ] Update i18n: `firmware_view.lock_active` (button tooltip), `firmware_view.lock_banner` (layout banner), `firmware_view.lock_conflict` (FirmwareView alert).
-- [ ] Implement Playwright spec `astros_vue/tests/e2e/firmware-flash.spec.ts` covering the full operator flow + late-join + lock-conflict variants. Add a `tests/e2e/_helpers/mockFirmwareWs.ts` helper for emitting the WS event sequence.
-- [ ] Replace dev-only fleet warning in `FirmwareView` (no-master warn) with a permanent assertion — if the controllers-store yields no master, something is genuinely broken.
-- [ ] Pre-commit gates: format, lint, type-check, vitest, per-commit `pr-review-toolkit:code-reviewer` agent.
-- [ ] Pre-push `/pr-review-toolkit:review-pr` 5-agent pass (mandatory per CLAUDE.md and required per roadmap for d.6).
+- [x] Mirror server types (`ServerFwStage`, `ControllerFlashState`, `FlashJobState`, `FlashJobFailedData`) into `types/firmware.ts`. Cross-reference comment at top pointing at the server file.
+- [x] Add `FLASH_JOB_ACTIVE = 11` through `FLASH_JOB_FAILED = 16` to `WebsocketMessageType` enum. Cross-reference comment.
+- [x] Implement `utils/firmwareStageMapping.ts` (`mapServerStageToUiStage` + `controllerStatePillKind`) with full unit-test coverage.
+- [x] Extend `firmwareStore`: add `currentJob`, `controllerStates`, `ownJobId` refs; turn `controllers` into a `computed` over `useControllerStore()` (replaces the d.5 ref and `DEV_SAMPLE_FLEET` bootstrap); add `applyJobStarted/applyControllerUpdate/applyControllerResult/applyJobDone/applyJobFailed` actions; add `fetchCurrentJob`; update `startFlash` to capture `ownJobId` from the POST response and to NOT manage phase directly (WS owns phase from `flashing` onward). Comprehensive unit tests for each handler + idempotency + replace-not-merge + the **5 FMI hazards** below.
+- [x] Update `useWebsocket.ts` `handleMessage` switch with 5 new cases; new `handleFlashJobStarted` / `handleFlashControllerUpdate` / `handleFlashControllerResult` / `handleFlashJobDone` / `handleFlashJobFailed` functions following the existing try/catch pattern.
+- [x] Extend `AstrosWriteButton.vue` to OR-in `useJobLockStore().locked`. Update tooltip key resolution. Update existing 9 tests if needed, add 3 new for jobLock-only / both-active / neither cases.
+- [x] Add lock banner to `AstrosLayout.vue` — sibling component or inline. New i18n key. Verify it doesn't double up with the system-status banner when both readonly + locked.
+- [x] Update `FirmwareView.vue`: drop `DEV_SAMPLE_FLEET`, drop the `onMounted` bootstrap (controllers now come from the computed), add `fetchCurrentJob` on mount, add lock-conflict alert section that renders when `lockStore.locked && !isOwnJob`.
+- [x] Update `ControllersPanel` consumer of `progressByControllerId` — d.5 took this as a prop; d.6 reads it from `firmwareStore.controllerStates`. Either keep the prop (parent maps store→prop) or read from store directly. **Decision in plan**: keep the prop, with `FirmwareView` mapping the store's `controllerStates` Map → `Record<id, { status, stageLabel }>`. Less store coupling at the leaf.
+- [x] Update i18n: `firmware_view.lock_active` (button tooltip), `firmware_view.lock_banner` (layout banner), `firmware_view.lock_conflict` (FirmwareView alert).
+- [x] Ship the e2e Playwright smoke spec for the firmware page (`e2e/C_01_firmware-page.spec.ts` — page renders, lock banner suppresses while own job runs, write actions disabled). **Scope deferred**: a full operator-flow / late-join / lock-conflict e2e variant requires a WS-mock harness that doesn't exist in the codebase yet; the gap is documented in the QA plan and `C_01_firmware-page.spec.ts:43-47` (the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` covers the full operator flow). Re-evaluate if a future PR introduces a WS-mock helper.
+- [x] Replace dev-only fleet warning in `FirmwareView` (no-master warn) with a permanent assertion — if the controllers-store yields no master, something is genuinely broken.
+- [x] Pre-commit gates: format, lint, type-check, vitest, per-commit `pr-review-toolkit:code-reviewer` agent.
+- [x] Pre-push `/pr-review-toolkit:review-pr` 5-agent pass (mandatory per CLAUDE.md and required per roadmap for d.6).
 
 ---
 

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -200,7 +200,7 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 **Scope shipped:** smoke spec covering page-chrome rendering, source-strip toggle visibility, controllers-panel header (Select all / Clear), and Flash-button initial disabled state. No WS-driven phase progression — that requires a WS-mock infrastructure the project doesn't have yet.
 
-**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (202 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
+**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (210 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
 
 ---
 
@@ -251,7 +251,7 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 ## Verification
 
 1. `npm run build` succeeds.
-2. `npx vitest run` — 202 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
+2. `npx vitest run` — 210 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
 3. `npx playwright test firmware-flash.spec.ts` — the e2e spec passes locally against the mocked WS.
 4. `npm run storybook` — visual regression of d.3/d.4/d.5 stories unchanged. New stories for the lock-conflict banner (FirmwareView and AstrosLayout siblings).
 5. Manual `npm run dev` smoke test:

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -196,21 +196,11 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 **`FirmwareView.vue`** — when `jobLock.locked && !isOwnJob`, render a `role="alert"` region above the SourceStrip with the lock owner and a "Try again later" hint. The Flash button is already disabled via the AstrosWriteButton extension; the alert just explains why.
 
-### E2E test (`tests/e2e/firmware-flash.spec.ts`)
+### E2E test (`e2e/C_01_firmware-page.spec.ts`)
 
-One Playwright spec:
-1. Launch dev server.
-2. Stub WS connection to emit a controlled sequence.
-3. Navigate to `/firmware`.
-4. Pick a release, select Body, click Flash → confirm modal opens.
-5. Confirm → expect POST to `/api/firmware/flash` (intercepted).
-6. Emit `flashJobStarted` → expect Topology/StagesList visible, phase `flashing`.
-7. Emit `flashControllerUpdate` with stage `UPLOADING_TO_MASTER` → expect StagesList shows `download` current.
-8. Emit `flashControllerResult` with stage `VERSION_CONFIRMED` → no row state change yet.
-9. Emit `flashJobDone` → expect result bar shows "All N controller(s) updated".
-10. Click Done → expect phase back to `select`, controllerStates cleared.
+**Scope shipped:** smoke spec covering page-chrome rendering, source-strip toggle visibility, controllers-panel header (Select all / Clear), and Flash-button initial disabled state. No WS-driven phase progression — that requires a WS-mock infrastructure the project doesn't have yet.
 
-Plus one variant: emit `flashJobStarted` BEFORE the user clicks Flash (simulating late-join while another operator's flash is in flight) → expect lock-conflict alert + Flash button disabled.
+**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, and lock-conflict logic are exhaustively covered by 21 new vitest tests in `firmware.spec.ts`. The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
 
 ---
 

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -1,0 +1,322 @@
+# d.6 — WebSocket dispatcher + live `firmwareStore` + lock-aware UI + e2e
+
+Phase d, PR 6 of 6 — the final phase. Wires the server's `FlashOrchestratorWsMessage` stream into the Vue UI: 5 new dispatcher cases route into `firmwareStore.apply*` handlers, the store transitions phases off WS events, the dev-mock fleet bootstrap is replaced by a real controllers-store adapter, the write-lock surfaces on `AstrosWriteButton` and a page-level banner, and `FirmwareView` renders a lock-conflict alert when another operator owns the lock.
+
+Roadmap reference: `20260507-2153-firmware-ota-d-vue-firmware-view.md` (§"WebSocket event contract", §"firmwareStore shape", §"Server-stage to UI-stage mapping", §"Lock-aware UI integration", §"FMI inventory").
+
+Per the roadmap, **this is the high-risk PR of phase d** — all concurrency hazards land here. `/pr-review-toolkit:review-pr` is mandatory before push.
+
+---
+
+## Scope decisions (confirmed with user)
+
+1. **Own-job identification: `firmwareStore.ownJobId`** captured from the `startFlash` POST 200 response. `currentJob.jobId === ownJobId` is the "this is ours" predicate. Lock owner string is informational only.
+2. **Controllers adapter: `firmwareStore.controllers` becomes a `computed`** that reads `useControllerStore()` per-location refs (`bodyStatus`/`coreStatus`/`domeStatus` + `bodyFirmware`/`coreFirmware`/`domeFirmware`) and projects them into `FirmwareControllerView[]`. d.5's `controllers = ref<FirmwareControllerView[]>([])` and the `DEV_SAMPLE_FLEET` bootstrap go away.
+3. **E2E: Playwright spec with WS stubbed via mock server.** One end-to-end spec that drives the full operator flow (`select → confirm → fake WS events → see Stages progress → done bar`) against a mock WS that the spec controls. Validates late-join + reconnect + lock-aware UI.
+4. **Stage mapper: sibling helper module** `utils/firmwareStageMapping.ts` with unit tests — same pattern as `strokeFor`, `selectModePillKind`, `stageRowState`, `firmwareFlashError`.
+
+---
+
+## WS event contract (truth source)
+
+Server side: `astros_api/src/firmware/flash_orchestrator.ts:335-344` defines `FlashOrchestratorWsMessage` as a discriminated union by `type` (`TransmissionType` enum values 12-16). The 5 variants we wire on the client:
+
+| `type` | Name | Envelope | Payload type |
+|---|---|---|---|
+| 12 | `flashJobStarted` | `{type, data}` | `FlashJobState` |
+| 13 | `flashControllerUpdate` | `{type, data}` | `ControllerFlashState` |
+| 14 | `flashControllerResult` | `{type, data}` | `{ jobId: string; controller: ControllerFlashState }` |
+| 15 | `flashJobDone` | `{type, data}` | `{ jobId: string; endedAt: string }` |
+| 16 | `flashJobFailed` | `{type, data}` | `FlashJobFailedData` |
+
+Existing wired types (0-10) untouched: SCRIPT, CONFIGURATION_SYNC, LOCATION_STATUS, CONTROLLERS_SYNC, RUN, PANIC, DIRECT_COMMAND, FORMAT_SD, SERVO_TEST, SYSTEM_STATUS, LOCK_STATE_CHANGED.
+
+Type 11 (`flashJobActive`) is a server-side rejection echo for write-class WS messages sent during a flash — the UI doesn't subscribe to it.
+
+`FwStage` enum (server-side string literals): `'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING' | 'VERSION_CONFIRMED' | 'FAILED'`. Client-side `FirmwareStage` is the narrower 5-value UI union.
+
+### Late-join contract
+
+`astros_api/src/api_server.ts:652-660` sends one `flashJobStarted` snapshot on connect when a job is in flight. The Vue client's `useWebsocket` reconnects every 3s on disconnect. **Net contract:** every WS connection that opens while a flash is in progress receives a fresh `flashJobStarted`. The store's `applyJobStarted` must be **idempotent and replace-not-merge**.
+
+---
+
+## Scope
+
+### Client-side type additions (`types/firmware.ts`)
+
+```ts
+// Mirror of the server's FwStage enum — pinned to string-literal values
+// to match the WS wire format. Verified against
+// `astros_api/src/models/firmware/firmware_messages.ts`.
+export type ServerFwStage =
+  | 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING'
+  | 'REBOOTING' | 'VERSION_CONFIRMED' | 'FAILED';
+
+// Mirror of the server's ControllerFlashState discriminated union, narrowed
+// to the fields the UI reads. `finalVersion` and `error` are stage-specific.
+export interface ControllerFlashState {
+  controllerId: string;
+  stage: ServerFwStage;
+  finalVersion?: string;
+  error?: string;
+}
+
+export interface FlashJobState {
+  jobId: string;
+  source: { kind: 'github'; version: string } | { kind: 'upload' };
+  controllers: ControllerFlashState[];
+  startedAt: string;
+  endedAt?: string;
+  abortReason?: string;
+}
+
+export interface FlashJobFailedData {
+  jobId: string;
+  endedAt: string;
+  reason?: FlashErrorReason;       // server passes its FlashOrchestratorErrorReason; we widen here
+  detail?: string;
+  abortReason?: string;
+}
+```
+
+### `firmwareStore` additions
+
+```ts
+// New state
+const currentJob = ref<FlashJobState | null>(null);
+const controllerStates = ref<Map<string, ControllerFlashState>>(new Map());
+const ownJobId = ref<string | null>(null);
+
+// New computeds (controllers becomes a computed)
+const controllers = computed<FirmwareControllerView[]>(() => /* read controllerStore */);
+const isOwnJob = computed(() => currentJob.value !== null && currentJob.value.jobId === ownJobId.value);
+
+// WS handlers — pure store-state writes, called from useWebsocket
+function applyJobStarted(data: FlashJobState): void;
+function applyControllerUpdate(data: ControllerFlashState): void;
+function applyControllerResult(data: { jobId: string; controller: ControllerFlashState }): void;
+function applyJobDone(data: { jobId: string; endedAt: string }): void;
+function applyJobFailed(data: FlashJobFailedData): void;
+
+// HTTP — cold-load resync (sets currentJob only if null)
+async function fetchCurrentJob(): Promise<void>;
+```
+
+**Replacement of d.5's `controllers: ref`:** becomes a `computed` over `useControllerStore()`. The `watch(controllers)` reconciler from d.4 still works (computed refs trigger watchers on value change). The dev-mock bootstrap in `FirmwareView.onMounted` goes away.
+
+**Phase transitions driven by WS:**
+
+| WS event | Phase transition | Other state |
+|---|---|---|
+| `flashJobStarted` (idempotent) | `select` → `flashing` (only if not already) | `currentJob = data`; `controllerStates` replaced from `data.controllers` |
+| `flashControllerUpdate` | (no phase change) | `controllerStates.set(controllerId, state)` |
+| `flashControllerResult` | (no phase change) | `controllerStates.set(controller.controllerId, controller)` |
+| `flashJobDone` | `flashing` → `done` | `currentJob.endedAt = data.endedAt` |
+| `flashJobFailed` | `flashing` → `failed` | `currentJob.endedAt` set; `flashError = { reason, detail }`; `failedController` derived from `controllerStates` (find the one whose stage === 'FAILED') |
+
+### WS dispatcher additions (`composables/useWebsocket.ts`)
+
+Add 5 case branches in `handleMessage`:
+```ts
+case WebsocketMessageType.FLASH_JOB_STARTED:
+  handleFlashJobStarted(parsedMessage); break;
+case WebsocketMessageType.FLASH_CONTROLLER_UPDATE:
+  handleFlashControllerUpdate(parsedMessage); break;
+case WebsocketMessageType.FLASH_CONTROLLER_RESULT:
+  handleFlashControllerResult(parsedMessage); break;
+case WebsocketMessageType.FLASH_JOB_DONE:
+  handleFlashJobDone(parsedMessage); break;
+case WebsocketMessageType.FLASH_JOB_FAILED:
+  handleFlashJobFailed(parsedMessage); break;
+```
+
+Each handler follows the existing `handleSyncMessage`/`handleStatusMessage` pattern: `try { useFirmwareStore().applyXxx(message.data); } catch (error) { console.error(...); }`. The catch is critical for **operability hazard #6** from the FMI — a malformed payload must not lock the UI in `flashing`.
+
+Add the new enum values to `enums/WebsocketMessageType.ts`:
+```ts
+FLASH_JOB_ACTIVE = 11,           // not subscribed by the UI; kept for completeness
+FLASH_JOB_STARTED = 12,
+FLASH_CONTROLLER_UPDATE = 13,
+FLASH_CONTROLLER_RESULT = 14,
+FLASH_JOB_DONE = 15,
+FLASH_JOB_FAILED = 16,
+```
+
+### Stage mapping helper (`utils/firmwareStageMapping.ts`)
+
+```ts
+export function mapServerStageToUiStage(stage: ServerFwStage): FirmwareStage | null {
+  switch (stage) {
+    case 'UPLOADING_TO_MASTER': return 'download';
+    case 'SENDING': return 'transfer';     // and implicitly 'flash' during send
+    case 'VERIFYING': return 'verify';
+    case 'REBOOTING': return 'reboot';
+    case 'QUEUED':
+    case 'VERSION_CONFIRMED':
+    case 'FAILED':
+      return null; // no specific UI stage; status-pill / terminal-row handles these
+  }
+}
+```
+
+Plus a `controllerStatePillKind(state: ControllerFlashState): FirmwareStatusPillKind` companion that maps the server stage onto the per-controller pill kind (`queued` / `updating` / `done` / `failed`). 7 stage values × 1 mapping each → ~12 unit-test cases.
+
+### Controllers adapter (computed in `firmwareStore`)
+
+```ts
+const controllers = computed<FirmwareControllerView[]>(() => {
+  const cs = useControllerStore();
+  const make = (id: 'body' | 'core' | 'dome', isMaster: boolean, label: string, glyph: string) => ({
+    id, label, glyph,
+    current: /* read cs.bodyFirmware etc. */ ?? '—',
+    status: /* map ControllerStatus → ControllerOnlineStatus */,
+    isMaster,
+  });
+  return [
+    make('body', true, 'Body', 'B'),
+    make('core', false, 'Core', 'C'),
+    make('dome', false, 'Dome', 'D'),
+  ];
+});
+```
+
+`ControllerStatus` (project enum) → `ControllerOnlineStatus` ('up' | 'down' | 'needsSynced') mapping needs care for `FIRMWARE_INCOMPATIBLE` — likely treat as `down` (the controller can't accept a flash) or add a 4th variant. Decision: treat `FIRMWARE_INCOMPATIBLE` as `needsSynced` so the pill says "needs sync" — the firmware update flow IS the sync. Document in code comment.
+
+### Lock-aware UI
+
+**`AstrosWriteButton.vue`** — extend the disabled computation to OR in `useJobLockStore().locked`:
+```ts
+const isJobLockDisabled = computed(() => jobLockStore.locked);
+const isDisabled = computed(() => props.disabled || isReadOnlyDisabled.value || isJobLockDisabled.value);
+```
+Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; existing `systemStatus.readOnly.disabled` when system-wide read-only. Existing 9 tests must keep passing; add 3 new tests for the jobLock cases.
+
+**`AstrosLayout.vue`** — add a passive page-level banner sibling to the existing `AstrosSystemStatusBanner`. Renders when `useJobLockStore().locked === true` AND `useFirmwareStore().isOwnJob !== true` (so our own flash doesn't trigger the banner on top of the FirmwareView UI).
+
+**`FirmwareView.vue`** — when `jobLock.locked && !isOwnJob`, render a `role="alert"` region above the SourceStrip with the lock owner and a "Try again later" hint. The Flash button is already disabled via the AstrosWriteButton extension; the alert just explains why.
+
+### E2E test (`tests/e2e/firmware-flash.spec.ts`)
+
+One Playwright spec:
+1. Launch dev server.
+2. Stub WS connection to emit a controlled sequence.
+3. Navigate to `/firmware`.
+4. Pick a release, select Body, click Flash → confirm modal opens.
+5. Confirm → expect POST to `/api/firmware/flash` (intercepted).
+6. Emit `flashJobStarted` → expect Topology/StagesList visible, phase `flashing`.
+7. Emit `flashControllerUpdate` with stage `UPLOADING_TO_MASTER` → expect StagesList shows `download` current.
+8. Emit `flashControllerResult` with stage `VERSION_CONFIRMED` → no row state change yet.
+9. Emit `flashJobDone` → expect result bar shows "All N controller(s) updated".
+10. Click Done → expect phase back to `select`, controllerStates cleared.
+
+Plus one variant: emit `flashJobStarted` BEFORE the user clicks Flash (simulating late-join while another operator's flash is in flight) → expect lock-conflict alert + Flash button disabled.
+
+---
+
+## Out of scope
+
+- **Cancel button in flashing UI** — design handoff doesn't include one; server's DELETE /flash exists but no UI surface for it in d.6. Operators wait or close the tab.
+- **Per-controller retry** — terminal failure surfaces in the result bar; retrying means starting a new flash from select phase.
+- **Topology animation per controller** — d.3's topology renders the flash flow at the fleet level; d.6 doesn't add per-controller animation gating.
+- **`flashJobActive` UI feedback** — server-side rejection echo; the UI shouldn't be sending write-class messages during a flash anyway (lock disables them).
+
+---
+
+## Tasks
+
+- [ ] Mirror server types (`ServerFwStage`, `ControllerFlashState`, `FlashJobState`, `FlashJobFailedData`) into `types/firmware.ts`. Cross-reference comment at top pointing at the server file.
+- [ ] Add `FLASH_JOB_ACTIVE = 11` through `FLASH_JOB_FAILED = 16` to `WebsocketMessageType` enum. Cross-reference comment.
+- [ ] Implement `utils/firmwareStageMapping.ts` (`mapServerStageToUiStage` + `controllerStatePillKind`) with full unit-test coverage.
+- [ ] Extend `firmwareStore`: add `currentJob`, `controllerStates`, `ownJobId` refs; turn `controllers` into a `computed` over `useControllerStore()` (replaces the d.5 ref and `DEV_SAMPLE_FLEET` bootstrap); add `applyJobStarted/applyControllerUpdate/applyControllerResult/applyJobDone/applyJobFailed` actions; add `fetchCurrentJob`; update `startFlash` to capture `ownJobId` from the POST response and to NOT manage phase directly (WS owns phase from `flashing` onward). Comprehensive unit tests for each handler + idempotency + replace-not-merge + the **5 FMI hazards** below.
+- [ ] Update `useWebsocket.ts` `handleMessage` switch with 5 new cases; new `handleFlashJobStarted` / `handleFlashControllerUpdate` / `handleFlashControllerResult` / `handleFlashJobDone` / `handleFlashJobFailed` functions following the existing try/catch pattern.
+- [ ] Extend `AstrosWriteButton.vue` to OR-in `useJobLockStore().locked`. Update tooltip key resolution. Update existing 9 tests if needed, add 3 new for jobLock-only / both-active / neither cases.
+- [ ] Add lock banner to `AstrosLayout.vue` — sibling component or inline. New i18n key. Verify it doesn't double up with the system-status banner when both readonly + locked.
+- [ ] Update `FirmwareView.vue`: drop `DEV_SAMPLE_FLEET`, drop the `onMounted` bootstrap (controllers now come from the computed), add `fetchCurrentJob` on mount, add lock-conflict alert section that renders when `lockStore.locked && !isOwnJob`.
+- [ ] Update `ControllersPanel` consumer of `progressByControllerId` — d.5 took this as a prop; d.6 reads it from `firmwareStore.controllerStates`. Either keep the prop (parent maps store→prop) or read from store directly. **Decision in plan**: keep the prop, with `FirmwareView` mapping the store's `controllerStates` Map → `Record<id, { status, stageLabel }>`. Less store coupling at the leaf.
+- [ ] Update i18n: `firmware_view.lock_active` (button tooltip), `firmware_view.lock_banner` (layout banner), `firmware_view.lock_conflict` (FirmwareView alert).
+- [ ] Implement Playwright spec `astros_vue/tests/e2e/firmware-flash.spec.ts` covering the full operator flow + late-join + lock-conflict variants. Add a `tests/e2e/_helpers/mockFirmwareWs.ts` helper for emitting the WS event sequence.
+- [ ] Replace dev-only fleet warning in `FirmwareView` (no-master warn) with a permanent assertion — if the controllers-store yields no master, something is genuinely broken.
+- [ ] Pre-commit gates: format, lint, type-check, vitest, per-commit `pr-review-toolkit:code-reviewer` agent.
+- [ ] Pre-push `/pr-review-toolkit:review-pr` 5-agent pass (mandatory per CLAUDE.md and required per roadmap for d.6).
+
+---
+
+## FMI inventory — REQUIRED (per CLAUDE.md and roadmap)
+
+This is the concurrency-surface PR of phase D. Each row has explicit unit-test coverage.
+
+| Hazard | Risk | Coverage |
+|---|---|---|
+| **Late-join + cold-load fetch race** | Both `fetchCurrentJob()` (HTTP GET on mount) and the WS replay `flashJobStarted` could fire on view enter | `applyJobStarted` is idempotent (compares `jobId` and is no-op on match); `fetchCurrentJob` sets state only if `currentJob === null`. Unit test: call both in either order, assert single coherent state. |
+| **WS reconnect during flash** | `useWebsocket` reconnects every 3s; server sends `flashJobStarted` snapshot on reconnect | `applyJobStarted` **replaces** (not merges) `controllerStates` from `data.controllers`. Unit test: pre-state with stale entries, applyJobStarted → only `data.controllers` remain. |
+| **Tab-close mid-flash** | Browser navigation/close is NOT a flash-cancel signal — server holds the lock until heartbeat / 15s timer | UI must NOT trigger cancel on `beforeunload`. Code review: no `beforeunload` listener added in FirmwareView or firmwareStore. On view re-enter, `fetchCurrentJob` + WS late-join populate state. Manual QA via e2e. |
+| **Stale `controllerStates` after job ends** | Next flash inherits stale per-controller stages | `resetToSelect()` clears `controllerStates`. Called when operator clicks "Done" in result bar. Unit test: failed phase → resetToSelect → controllerStates empty. |
+| **Enum drift between Vue and server** | `WebsocketMessageType` is a hand-maintained mirror; if server adds a value, the Vue switch silently misroutes | Comment cross-reference at top of `WebsocketMessageType.ts` AND `types/firmware.ts` pointing at server sources. Runtime `default:` warn-on-unknown in `handleMessage` (already present). |
+| **WS handler errors swallow real bugs** | Existing handlers `catch + log`; firmware handlers must also reset `phase` → `failed` (with envelope) on `flashJobFailed` even if the payload is malformed | `applyJobFailed` extracts what it can from a partial payload and surfaces `{ reason: 'internal_server_error' }` when fields are missing. Unit test: malformed `flashJobFailed` → phase = `failed`, `flashError` non-null. |
+| **`ownJobId` race with WS late-join** | If the WS `flashJobStarted` arrives before the HTTP POST returns (server emits before responding), `ownJobId` is briefly null and the UI shows lock-conflict for our own flash | `startFlash` sets `ownJobId` **before** the POST resolves (use a tentative-id pattern), OR delay phase-from-WS until POST resolves. **Decision in plan**: `applyJobStarted` is idempotent — accept that for ~50ms post-WS-pre-HTTP-response, the lock-conflict banner may flicker. Document as known limitation; if it visually flickers, add a 200ms debounce on the alert render. Unit test: simulate WS-first, then POST-resolves; assert final state is `isOwnJob === true`. |
+
+---
+
+## Verification
+
+1. `npm run build` succeeds.
+2. `npx vitest run` — new unit tests for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob`, and the 7 FMI hazards above. Plus updated `AstrosWriteButton` test suite (existing 9 + 3 new). Plus all 118 prior tests keep passing.
+3. `npx playwright test firmware-flash.spec.ts` — the e2e spec passes locally against the mocked WS.
+4. `npm run storybook` — visual regression of d.3/d.4/d.5 stories unchanged. New stories for the lock-conflict banner (FirmwareView and AstrosLayout siblings).
+5. Manual `npm run dev` smoke test:
+   - Page loads with real controllers from the controllers store (no dev mock).
+   - Flash button is disabled when `systemStatus.readOnly` OR `jobLock.locked` (verify both individually).
+   - Two-browser test: start a flash in tab A, open tab B to `/firmware` — tab B shows lock-conflict alert with lock owner identifier. Flash button disabled. After tab A flash completes, tab B's banner clears.
+6. Pre-push toolkit: 5-agent pass; address Critical/Important.
+
+---
+
+## Risks
+
+1. **Server stage enum drift.** `ServerFwStage` is a hand-maintained mirror of `astros_api/src/models/firmware/firmware_messages.ts`. Mitigation: comment cross-reference at top of the type def. If the server ever adds a stage, the runtime `default:` in `mapServerStageToUiStage` falls back to `null` (treated as "no specific UI stage"), so the worst case is missing a stage transition, not a crash.
+2. **`controllers` computed coupling to `useControllerStore()`.** If a future refactor splits the controllers store or renames the per-location refs, the firmwareStore computed breaks silently (TS will likely catch it). Mitigation: an integration test that asserts a sample controllerStore snapshot maps to the expected `FirmwareControllerView[]`.
+3. **Playwright spec brittleness.** Mocking WS via Playwright is doable but stage-dependent; if the WS lifecycle changes in `useWebsocket`, the spec needs updates. Mitigation: put all WS-mock fixtures in `tests/e2e/_helpers/mockFirmwareWs.ts` so they're maintained in one place.
+4. **`ownJobId` race.** See FMI table item 7. May result in a brief lock-conflict flicker for ~50ms. Acceptable per plan but worth re-verifying during manual QA.
+5. **Lock banner double-up.** When both `systemStatus.readOnly` AND `jobLock.locked` are true, both banners might stack. Decision: render only the more-recent / higher-priority one (system-readonly takes precedence — it's a broader condition). i18n key chosen accordingly.
+
+---
+
+## Critical files
+
+- `astros_api/src/firmware/flash_orchestrator.ts:335-344` — `FlashOrchestratorWsMessage` discriminated union (read-only, source of truth).
+- `astros_api/src/models/firmware/flash_job_state.ts:1-40` — `FlashJobState` and `ControllerFlashState` (read-only).
+- `astros_api/src/models/firmware/firmware_messages.ts` — `FwStage` enum (read-only).
+- `astros_api/src/models/enums.ts:82` — `TransmissionType` numeric values (read-only).
+- `astros_api/src/api_server.ts:652-660` — late-join `flashJobStarted` snapshot (read-only).
+- `astros_vue/src/composables/useWebsocket.ts:87-117` — dispatcher extension point.
+- `astros_vue/src/enums/WebsocketMessageType.ts` — add 5 new values.
+- `astros_vue/src/stores/firmware.ts` — phase from WS, new state, new actions, computed controllers.
+- `astros_vue/src/stores/controller.ts` — read-only; source for the controllers computed.
+- `astros_vue/src/components/common/AstrosWriteButton.vue` — extension point.
+- `astros_vue/src/views/FirmwareView.vue` — replace dev mock, add lock-conflict alert.
+- `astros_vue/src/components/AstrosLayout.vue` — sibling lock banner.
+
+---
+
+## QA test plan
+
+Per prior commitment: d.6 ships with the comprehensive operator-flow manual QA plan at `.docs/qa/firmware-ota-flash-ui.md`. Scope:
+- Cold-load `/firmware` with no job in flight.
+- Full happy-path flash (select → confirm → flashing → done).
+- Failure path (server returns 4xx; server emits `flashJobFailed` mid-flash).
+- Late-join: open a second tab while a flash is in progress.
+- Lock conflict: try writes elsewhere (Modules / Scripts / Playlists) during a flash; verify `AstrosWriteButton` is disabled with the right tooltip.
+- Network failure: simulate a server crash during a flash; verify the UI doesn't hang.
+- `prefers-reduced-motion`: topology dashed-line animation halts.
+
+---
+
+## Per-PR plan files (Phase D index — final)
+
+- d.1 → `20260507-2153-firmware-ota-d-1-page-chrome.md` ✅ merged
+- d.2 → `20260509-1716-firmware-ota-d-2-source-strip.md` ✅ merged
+- d.3 → `20260511-0651-firmware-ota-d-3-topology.md` ✅ merged
+- d.4 → `20260511-0811-firmware-ota-d-4-controllers-panel.md` ✅ merged
+- d.5 → `20260511-2217-firmware-ota-d-5-page-assembly.md` ✅ merged
+- d.6 → **this file** (final)

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -200,7 +200,7 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 **Scope shipped:** smoke spec covering page-chrome rendering, source-strip toggle visibility, controllers-panel header (Select all / Clear), and Flash-button initial disabled state. No WS-driven phase progression — that requires a WS-mock infrastructure the project doesn't have yet.
 
-**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (225 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
+**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (228 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
 
 ---
 
@@ -251,7 +251,7 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 ## Verification
 
 1. `npm run build` succeeds.
-2. `npx vitest run` — 225 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
+2. `npx vitest run` — 228 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
 3. `npx playwright test firmware-flash.spec.ts` — the e2e spec passes locally against the mocked WS.
 4. `npm run storybook` — visual regression of d.3/d.4/d.5 stories unchanged. New stories for the lock-conflict banner (FirmwareView and AstrosLayout siblings).
 5. Manual `npm run dev` smoke test:

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -200,7 +200,7 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 **Scope shipped:** smoke spec covering page-chrome rendering, source-strip toggle visibility, controllers-panel header (Select all / Clear), and Flash-button initial disabled state. No WS-driven phase progression — that requires a WS-mock infrastructure the project doesn't have yet.
 
-**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (210 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
+**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (220 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
 
 ---
 
@@ -251,7 +251,7 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 ## Verification
 
 1. `npm run build` succeeds.
-2. `npx vitest run` — 210 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
+2. `npx vitest run` — 220 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
 3. `npx playwright test firmware-flash.spec.ts` — the e2e spec passes locally against the mocked WS.
 4. `npm run storybook` — visual regression of d.3/d.4/d.5 stories unchanged. New stories for the lock-conflict banner (FirmwareView and AstrosLayout siblings).
 5. Manual `npm run dev` smoke test:

--- a/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
+++ b/.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md
@@ -37,7 +37,7 @@ Type 11 (`flashJobActive`) is a server-side rejection echo for write-class WS me
 
 ### Late-join contract
 
-`astros_api/src/api_server.ts:652-660` sends one `flashJobStarted` snapshot on connect when a job is in flight. The Vue client's `useWebsocket` reconnects every 3s on disconnect. **Net contract:** every WS connection that opens while a flash is in progress receives a fresh `flashJobStarted`. The store's `applyJobStarted` must be **idempotent and replace-not-merge**.
+`astros_api/src/api_server.ts:654-669` sends one `flashJobStarted` snapshot on connect when a job is in flight, EXCEPT when `currentJob.endedAt` is set (the 15s reboot-wait window — round-7 CR-1 mirrored this filter on the HTTP side too). The Vue client's `useWebsocket` reconnects every 3s on disconnect. **Net contract:** every WS connection that opens while a flash is in progress receives a fresh `flashJobStarted`. The store's `applyJobStarted` must be **idempotent and replace-not-merge**.
 
 ---
 
@@ -200,7 +200,7 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 
 **Scope shipped:** smoke spec covering page-chrome rendering, source-strip toggle visibility, controllers-panel header (Select all / Clear), and Flash-button initial disabled state. No WS-driven phase progression — that requires a WS-mock infrastructure the project doesn't have yet.
 
-**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (228 tests total at branch tip across rounds 1–4). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md` (12 scenarios).
+**Coverage substitute:** the 5 `apply*` handlers, late-join idempotency, replace-not-merge, lock-conflict logic, replay queue, multi-FAILED collection, and HTTP-staleness handling are exhaustively covered by the firmware/composables/views vitest suites (vue test count grows across rounds; see latest `npx vitest run` for current). The end-to-end operator flow (cold-load, happy-path, failure path, late-join, lock-conflict, WS reconnect, network failure, reduced-motion, dev-warns) lives in the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md`.
 
 ---
 
@@ -218,7 +218,7 @@ Tooltip key: prefer `firmware_view.lock_active` when only `jobLock.locked`; exis
 - [x] Mirror server types (`ServerFwStage`, `ControllerFlashState`, `FlashJobState`, `FlashJobFailedData`) into `types/firmware.ts`. Cross-reference comment at top pointing at the server file.
 - [x] Add `FLASH_JOB_ACTIVE = 11` through `FLASH_JOB_FAILED = 16` to `WebsocketMessageType` enum. Cross-reference comment.
 - [x] Implement `utils/firmwareStageMapping.ts` (`mapServerStageToUiStage` + `controllerStatePillKind`) with full unit-test coverage.
-- [x] Extend `firmwareStore`: add `currentJob`, `controllerStates`, `ownJobId` refs; turn `controllers` into a `computed` over `useControllerStore()` (replaces the d.5 ref and `DEV_SAMPLE_FLEET` bootstrap); add `applyJobStarted/applyControllerUpdate/applyControllerResult/applyJobDone/applyJobFailed` actions; add `fetchCurrentJob`; update `startFlash` to capture `ownJobId` from the POST response and to NOT manage phase directly (WS owns phase from `flashing` onward). Comprehensive unit tests for each handler + idempotency + replace-not-merge + the **5 FMI hazards** below.
+- [x] Extend `firmwareStore`: add `currentJob`, `controllerStates`, `ownJobId` refs; turn `controllers` into a `computed` over `useControllerStore()` (replaces the d.5 ref and `DEV_SAMPLE_FLEET` bootstrap); add `applyJobStarted/applyControllerUpdate/applyControllerResult/applyJobDone/applyJobFailed` actions; add `fetchCurrentJob`; update `startFlash` to capture `ownJobId` from the POST response and to NOT manage phase directly (WS owns phase from `flashing` onward). Comprehensive unit tests for each handler + idempotency + replace-not-merge + the **8 FMI hazards** below (the inventory grew during the round-3..round-7 review iterations; the 8th hazard for the reboot-wait wedge was added in round-7).
 - [x] Update `useWebsocket.ts` `handleMessage` switch with 5 new cases; new `handleFlashJobStarted` / `handleFlashControllerUpdate` / `handleFlashControllerResult` / `handleFlashJobDone` / `handleFlashJobFailed` functions following the existing try/catch pattern.
 - [x] Extend `AstrosWriteButton.vue` to OR-in `useJobLockStore().locked`. Update tooltip key resolution. Update existing 9 tests if needed, add 3 new for jobLock-only / both-active / neither cases.
 - [x] Add lock banner to `AstrosLayout.vue` — sibling component or inline. New i18n key. Verify it doesn't double up with the system-status banner when both readonly + locked.
@@ -243,7 +243,8 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 | **Tab-close mid-flash** | Browser navigation/close is NOT a flash-cancel signal — server holds the lock until heartbeat / 15s timer | UI must NOT trigger cancel on `beforeunload`. Code review: no `beforeunload` listener added in FirmwareView or firmwareStore. On view re-enter, `fetchCurrentJob` + WS late-join populate state. Manual QA via e2e. |
 | **Stale `controllerStates` after job ends** | Next flash inherits stale per-controller stages | `resetToSelect()` clears `controllerStates`. Called when operator clicks "Done" in result bar. Unit test: failed phase → resetToSelect → controllerStates empty. |
 | **Enum drift between Vue and server** | `WebsocketMessageType` is a hand-maintained mirror; if server adds a value, the Vue switch silently misroutes | Comment cross-reference at top of `WebsocketMessageType.ts` AND `types/firmware.ts` pointing at server sources. Runtime `default:` warn-on-unknown in `handleMessage` (already present). |
-| **WS handler errors swallow real bugs** | Existing handlers `catch + log`; firmware handlers must also reset `phase` → `failed` (with envelope) on `flashJobFailed` even if the payload is malformed | `applyJobFailed` extracts what it can from a partial payload and surfaces `{ reason: 'internal_server_error' }` when fields are missing. Unit test: malformed `flashJobFailed` → phase = `failed`, `flashError` non-null. |
+| **WS handler errors swallow real bugs** | Existing handlers `catch + log`; firmware handlers must also reset `phase` → `failed` (with envelope) on `flashJobFailed` even if the payload is malformed | `applyJobFailed` extracts what it can from a partial payload and surfaces `{ reason: 'internal_server_error' }` when fields are missing (unknown-server-reason fallback). Round-7 added a separate `'protocol_violation'` envelope for malformed WS-handler payloads (dispatcher catch blocks). Unit test: malformed `flashJobFailed` → phase = `failed`, `flashError` non-null. |
+| **Reboot-wait wedge after refresh** (round-7 CR-1) | A refresh during the 15s reboot-wait window (between `flashJobDone` and lock-release) would `applyJobStarted` an `endedAt`-set job, but the WS late-join filter skips emitting `flashJobStarted` for such jobs — UI wedged at phase='flashing' forever. | `fetchCurrentJob` mirrors `decideLateJoinSnapshot`'s `endedAt` filter. Defense-in-depth: `handleLockStateChanged` forces phase='done' when lock releases while phase still 'flashing'. Unit tests: fetchCurrentJob skips endedAt body; lockStateChanged recovers stuck phase. |
 | **`ownJobId` race with WS late-join** | If the WS `flashJobStarted` arrives before the HTTP POST returns (server emits before responding), `ownJobId` is briefly null and the UI shows lock-conflict for our own flash | `startFlash` sets `ownJobId` **before** the POST resolves (use a tentative-id pattern), OR delay phase-from-WS until POST resolves. **Decision in plan**: `applyJobStarted` is idempotent — accept that for ~50ms post-WS-pre-HTTP-response, the lock-conflict banner may flicker. Document as known limitation; if it visually flickers, add a 200ms debounce on the alert render. Unit test: simulate WS-first, then POST-resolves; assert final state is `isOwnJob === true`. |
 
 ---
@@ -251,7 +252,7 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 ## Verification
 
 1. `npm run build` succeeds.
-2. `npx vitest run` — 228 tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx), the 7 original FMI hazards, replay queue + multi-FAILED, staleness banner, lock-conflict gating, and dispatcher rollback paths. Updated `AstrosWriteButton` (existing 9 + 3 new).
+2. `npx vitest run` — all tests pass at branch tip across the firmware/composables/views test suites. Includes coverage for the 5 `applyXxx` handlers, `mapServerStageToUiStage`, `controllerStatePillKind`, `fetchCurrentJob` (incl. 404 vs 5xx and round-7 endedAt filter), the 7 FMI hazards plus the round-7 reboot-wait wedge, replay queue + multi-FAILED, staleness banner, lock-conflict gating, dispatcher rollback paths, jobId-mismatch guards, ServoTest modal lock-gating, and the wire-numeric pinning contract.
 3. `npx playwright test firmware-flash.spec.ts` — the e2e spec passes locally against the mocked WS.
 4. `npm run storybook` — visual regression of d.3/d.4/d.5 stories unchanged. New stories for the lock-conflict banner (FirmwareView and AstrosLayout siblings).
 5. Manual `npm run dev` smoke test:
@@ -275,10 +276,10 @@ This is the concurrency-surface PR of phase D. Each row has explicit unit-test c
 ## Critical files
 
 - `astros_api/src/firmware/flash_orchestrator.ts:335-344` — `FlashOrchestratorWsMessage` discriminated union (read-only, source of truth).
-- `astros_api/src/models/firmware/flash_job_state.ts:1-40` — `FlashJobState` and `ControllerFlashState` (read-only).
+- `astros_api/src/models/firmware/flash_job_state.ts:1-47` — `FlashJobState` and `ControllerFlashState` (read-only).
 - `astros_api/src/models/firmware/firmware_messages.ts` — `FwStage` enum (read-only).
 - `astros_api/src/models/enums.ts:82` — `TransmissionType` numeric values (read-only).
-- `astros_api/src/api_server.ts:652-660` — late-join `flashJobStarted` snapshot (read-only).
+- `astros_api/src/api_server.ts:654-669` — late-join `flashJobStarted` snapshot (read-only).
 - `astros_vue/src/composables/useWebsocket.ts:87-117` — dispatcher extension point.
 - `astros_vue/src/enums/WebsocketMessageType.ts` — add 5 new values.
 - `astros_vue/src/stores/firmware.ts` — phase from WS, new state, new actions, computed controllers.

--- a/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
+++ b/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
@@ -53,7 +53,7 @@ Single commit at end of phase. Message: `fix(firmware): round-7 Criticals — la
 
 Per CLAUDE.md, the plan file must be committed before any implementation code.
 
-- [ ] **A.0.1:** Stage and commit the plan file alone.
+- [x] **A.0.1:** Stage and commit the plan file alone.
 
 ```bash
 git add .docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
@@ -77,11 +77,11 @@ Server `TransmissionType` has implicit numeric values, so mid-insertion silently
 **Files:**
 - Modify: `astros_api/src/models/enums.ts:82-100` (the `TransmissionType` enum)
 
-- [ ] **A.1.1:** Read the current enum to confirm position ordering.
+- [x] **A.1.1:** Read the current enum to confirm position ordering.
 
 Run: `grep -n "TransmissionType" astros_api/src/models/enums.ts`
 
-- [ ] **A.1.2:** Edit the enum to add explicit values 0-16. Find the existing `export enum TransmissionType {` block and replace its body with:
+- [x] **A.1.2:** Edit the enum to add explicit values 0-16. Find the existing `export enum TransmissionType {` block and replace its body with:
 
 ```ts
 export enum TransmissionType {
@@ -107,7 +107,7 @@ export enum TransmissionType {
 
 Verify the comment block above the enum still accurately reflects the wire-mirror contract; update if needed.
 
-- [ ] **A.1.3:** Run server build + tests to confirm no value mismatch.
+- [x] **A.1.3:** Run server build + tests to confirm no value mismatch.
 
 Run: `cd astros_api && npm run build && npx vitest run`
 Expected: clean build, all tests pass.
@@ -119,7 +119,7 @@ Expected: clean build, all tests pass.
 **Files:**
 - Modify: `astros_vue/src/composables/__tests__/useWebsocket.spec.ts`
 
-- [ ] **A.2.1:** Add a top-level `describe` block at the end of the file:
+- [x] **A.2.1:** Add a top-level `describe` block at the end of the file:
 
 ```ts
 describe('WebsocketMessageType wire-numeric pinning (cross-process contract)', () => {
@@ -147,7 +147,7 @@ describe('WebsocketMessageType wire-numeric pinning (cross-process contract)', (
 
 Verify `WebsocketMessageType` is already imported at the top of the spec file (it is — round-3 work imported it). If not, add `import { WebsocketMessageType } from '@/enums/WebsocketMessageType';`.
 
-- [ ] **A.2.2:** Run the test:
+- [x] **A.2.2:** Run the test:
 
 Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts -t "wire-numeric pinning"`
 Expected: PASS (the client enum already has explicit values 0-16).
@@ -161,11 +161,11 @@ The dispatcher's `default` branch is a runtime `console.warn`. Convert to a `nev
 **Files:**
 - Modify: `astros_vue/src/composables/useWebsocket.ts` (the switch block around line 105-144)
 
-- [ ] **A.3.1:** Read the current switch block to confirm its shape.
+- [x] **A.3.1:** Read the current switch block to confirm its shape.
 
 Run: `grep -n "default:" astros_vue/src/composables/useWebsocket.ts`
 
-- [ ] **A.3.2:** In the dispatcher switch's `default` branch, add a `never` assignment to force TS exhaustiveness. The current default is:
+- [x] **A.3.2:** In the dispatcher switch's `default` branch, add a `never` assignment to force TS exhaustiveness. The current default is:
 
 ```ts
 default:
@@ -190,12 +190,12 @@ default: {
 
 Note the `as never` cast: today the switch's discriminator is a wide `WebsocketMessageType` enum and the case arms don't structurally narrow it (the parsed-message type is `BaseWsMessage`, not a true discriminated union). The `as never` is therefore an attestation, not a true compile-time check — but it documents intent and breaks loudly if someone refactors to a true discriminated union later. The full DU refactor is out of scope for this fix (it would require typing every handler's `data` payload, which is a bigger surface).
 
-- [ ] **A.3.3:** Confirm build still passes:
+- [x] **A.3.3:** Confirm build still passes:
 
 Run: `cd astros_vue && npm run build`
 Expected: success.
 
-- [ ] **A.3.4:** Run dispatcher tests:
+- [x] **A.3.4:** Run dispatcher tests:
 
 Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts`
 Expected: all pass.
@@ -208,7 +208,7 @@ Expected: all pass.
 - Modify: `astros_vue/src/stores/firmware.ts` (`applyControllerResult` function around line 353)
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts` (add test)
 
-- [ ] **A.4.1:** Write the failing test in `firmware.spec.ts`. Find the `describe('applyControllerResult', ...)` block (search for it; it should exist near the multi-failure tests). Add inside that block:
+- [x] **A.4.1:** Write the failing test in `firmware.spec.ts`. Find the `describe('applyControllerResult', ...)` block (search for it; it should exist near the multi-failure tests). Add inside that block:
 
 ```ts
 it('drops stale events whose jobId does not match currentJob (post-reconnect race protection)', () => {
@@ -233,12 +233,12 @@ it('drops stale events whose jobId does not match currentJob (post-reconnect rac
 
 (If `seedSampleFleet`, `sampleJobState`, and `BODY_MAC` are not the exact helper names, grep the spec file and use the actual names — round-5 added these helpers.)
 
-- [ ] **A.4.2:** Run the test to confirm it fails:
+- [x] **A.4.2:** Run the test to confirm it fails:
 
 Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts -t "drops stale events whose jobId"`
 Expected: FAIL — stage was mutated, no warn fired.
 
-- [ ] **A.4.3:** Edit `applyControllerResult` in `firmware.ts`. The current implementation looks roughly like:
+- [x] **A.4.3:** Edit `applyControllerResult` in `firmware.ts`. The current implementation looks roughly like:
 
 ```ts
 function applyControllerResult(payload: { jobId: string; controller: ControllerFlashState }): void {
@@ -261,7 +261,7 @@ function applyControllerResult(payload: { jobId: string; controller: ControllerF
 }
 ```
 
-- [ ] **A.4.4:** Run the test to confirm it passes:
+- [x] **A.4.4:** Run the test to confirm it passes:
 
 Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts -t "drops stale events whose jobId"`
 Expected: PASS.
@@ -274,7 +274,7 @@ Expected: PASS.
 - Modify: `astros_vue/src/stores/firmware.ts` (`applyJobDone` function around line 360-401)
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
 
-- [ ] **A.5.1:** Add failing test inside `describe('applyJobDone', ...)`:
+- [x] **A.5.1:** Add failing test inside `describe('applyJobDone', ...)`:
 
 ```ts
 it('drops stale flashJobDone whose jobId does not match currentJob', () => {
@@ -293,12 +293,12 @@ it('drops stale flashJobDone whose jobId does not match currentJob', () => {
 });
 ```
 
-- [ ] **A.5.2:** Run to confirm failure:
+- [x] **A.5.2:** Run to confirm failure:
 
 Run: `cd astros_vue && npx vitest run -t "drops stale flashJobDone"`
 Expected: FAIL — phase transitioned to 'done'.
 
-- [ ] **A.5.3:** Add the guard at entry of `applyJobDone`:
+- [x] **A.5.3:** Add the guard at entry of `applyJobDone`:
 
 ```ts
 function applyJobDone(data: { jobId: string; endedAt: string }): void {
@@ -313,7 +313,7 @@ function applyJobDone(data: { jobId: string; endedAt: string }): void {
 }
 ```
 
-- [ ] **A.5.4:** Run to confirm pass:
+- [x] **A.5.4:** Run to confirm pass:
 
 Run: `cd astros_vue && npx vitest run -t "drops stale flashJobDone"`
 Expected: PASS.
@@ -326,7 +326,7 @@ Expected: PASS.
 - Modify: `astros_vue/src/stores/firmware.ts` (`applyJobFailed` function around line 403-473)
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
 
-- [ ] **A.6.1:** Add failing test inside `describe('applyJobFailed', ...)`:
+- [x] **A.6.1:** Add failing test inside `describe('applyJobFailed', ...)`:
 
 ```ts
 it('drops stale flashJobFailed whose jobId does not match currentJob', () => {
@@ -349,12 +349,12 @@ it('drops stale flashJobFailed whose jobId does not match currentJob', () => {
 });
 ```
 
-- [ ] **A.6.2:** Run to confirm failure:
+- [x] **A.6.2:** Run to confirm failure:
 
 Run: `cd astros_vue && npx vitest run -t "drops stale flashJobFailed"`
 Expected: FAIL.
 
-- [ ] **A.6.3:** Add the guard at entry of `applyJobFailed`:
+- [x] **A.6.3:** Add the guard at entry of `applyJobFailed`:
 
 ```ts
 function applyJobFailed(data: FlashJobFailedData & { jobId: string }): void {
@@ -371,7 +371,7 @@ function applyJobFailed(data: FlashJobFailedData & { jobId: string }): void {
 
 If `data` doesn't currently include `jobId` in the type, check the call site in `useWebsocket.ts:handleFlashJobFailed` — the server payload has `jobId` per the orchestrator contract; the store handler should accept it. Update both type and signature consistently.
 
-- [ ] **A.6.4:** Run to confirm pass:
+- [x] **A.6.4:** Run to confirm pass:
 
 Run: `cd astros_vue && npx vitest run -t "drops stale flashJobFailed"`
 Expected: PASS.
@@ -386,7 +386,7 @@ When `currentJob.endedAt` is set (15s reboot-wait window), the server skips emit
 - Modify: `astros_vue/src/stores/firmware.ts` (`fetchCurrentJob` function around line 554-576)
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
 
-- [ ] **A.7.1:** Add failing test inside `describe('fetchCurrentJob', ...)` block:
+- [x] **A.7.1:** Add failing test inside `describe('fetchCurrentJob', ...)` block:
 
 ```ts
 it('skips applying a body with endedAt set (mirrors server late-join filter for reboot-wait window)', async () => {
@@ -405,12 +405,12 @@ it('skips applying a body with endedAt set (mirrors server late-join filter for 
 
 (Adjust `apiClient` mock helper to match what the spec file already uses — round-5 wired in a vitest mock; reuse it.)
 
-- [ ] **A.7.2:** Run to confirm failure:
+- [x] **A.7.2:** Run to confirm failure:
 
 Run: `cd astros_vue && npx vitest run -t "skips applying a body with endedAt"`
 Expected: FAIL — `currentJob` was populated and phase moved to 'flashing'.
 
-- [ ] **A.7.3:** Edit `fetchCurrentJob`. Current guard is:
+- [x] **A.7.3:** Edit `fetchCurrentJob`. Current guard is:
 
 ```ts
 if (body && body.jobId && currentJob.value === null) {
@@ -434,7 +434,7 @@ if (body && body.jobId && body.endedAt === undefined && currentJob.value === nul
 }
 ```
 
-- [ ] **A.7.4:** Run to confirm pass:
+- [x] **A.7.4:** Run to confirm pass:
 
 Run: `cd astros_vue && npx vitest run -t "skips applying a body with endedAt"`
 Expected: PASS.
@@ -449,7 +449,7 @@ If the client somehow lands at `phase='flashing'` while the lock has released (o
 - Modify: `astros_vue/src/composables/useWebsocket.ts` (`handleLockStateChanged` function around line 244-256)
 - Modify: `astros_vue/src/composables/__tests__/useWebsocket.spec.ts`
 
-- [ ] **A.8.1:** Add failing test inside the `handleLockStateChanged`/lockStateChanged describe block:
+- [x] **A.8.1:** Add failing test inside the `handleLockStateChanged`/lockStateChanged describe block:
 
 ```ts
 it('forces firmware phase to done when lock releases but firmware is still flashing (recovery defense)', () => {
@@ -470,12 +470,12 @@ it('forces firmware phase to done when lock releases but firmware is still flash
 });
 ```
 
-- [ ] **A.8.2:** Run to confirm failure:
+- [x] **A.8.2:** Run to confirm failure:
 
 Run: `cd astros_vue && npx vitest run -t "forces firmware phase to done when lock releases"`
 Expected: FAIL — phase stayed 'flashing'.
 
-- [ ] **A.8.3:** Edit `handleLockStateChanged`. After the existing `jobLockStore` update, add:
+- [x] **A.8.3:** Edit `handleLockStateChanged`. After the existing `jobLockStore` update, add:
 
 ```ts
 // Defense-in-depth: if the server has released the lock while we still think
@@ -497,7 +497,7 @@ if (!data.locked) {
 
 Confirm `useFirmwareStore` is imported in the file. Confirm `setPhase` is an exported action. If `setPhase` doesn't exist, add it to the firmware store as a public action (one-line wrapper around the ref).
 
-- [ ] **A.8.4:** Run to confirm pass:
+- [x] **A.8.4:** Run to confirm pass:
 
 Run: `cd astros_vue && npx vitest run -t "forces firmware phase to done when lock releases"`
 Expected: PASS.
@@ -512,7 +512,7 @@ Bus-wide ESP-NOW failure can leave FAILED-stage entries queued in pendingByMac b
 - Modify: `astros_vue/src/stores/firmware.ts` (`applyJobFailed` around line 449-472)
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
 
-- [ ] **A.9.1:** Add failing test inside `describe('applyJobFailed', ...)`:
+- [x] **A.9.1:** Add failing test inside `describe('applyJobFailed', ...)`:
 
 ```ts
 it('preserves FAILED entries from pendingByMac in failedControllers (bus-wide failure with unmapped MAC)', () => {
@@ -545,12 +545,12 @@ it('preserves FAILED entries from pendingByMac in failedControllers (bus-wide fa
 });
 ```
 
-- [ ] **A.9.2:** Run to confirm failure:
+- [x] **A.9.2:** Run to confirm failure:
 
 Run: `cd astros_vue && npx vitest run -t "preserves FAILED entries from pendingByMac"`
 Expected: FAIL — failedControllers doesn't contain the unmapped MAC.
 
-- [ ] **A.9.3:** Edit `applyJobFailed`. Before the `pendingByMac.value = new Map()` clear (around line 472), insert:
+- [x] **A.9.3:** Edit `applyJobFailed`. Before the `pendingByMac.value = new Map()` clear (around line 472), insert:
 
 ```ts
 // Scan pendingByMac for FAILED entries that never got their LocationStatus
@@ -577,7 +577,7 @@ for (const [mac, queue] of pendingByMac.value) {
 
 (The `id: mac as SlotId` cast is a known structural-vs-nominal compromise — see IM-11 in Phase B for the proper fix. For this commit, the cast is acceptable because `failedControllers` consumers iterate `id` only for keying/labeling.)
 
-- [ ] **A.9.4:** Run to confirm pass + run all firmware.spec.ts tests to confirm no regression:
+- [x] **A.9.4:** Run to confirm pass + run all firmware.spec.ts tests to confirm no regression:
 
 Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts`
 Expected: all pass.
@@ -592,7 +592,7 @@ Expected: all pass.
 - Modify: `astros_vue/src/composables/useWebsocket.ts` (catches around lines 303-306, 323-326)
 - Modify: `astros_vue/src/composables/__tests__/useWebsocket.spec.ts`
 
-- [ ] **A.10.1:** Add failing test:
+- [x] **A.10.1:** Add failing test:
 
 ```ts
 it('does NOT overwrite a terminal flashError with protocol_violation from mid-stream catch', () => {
@@ -614,12 +614,12 @@ it('does NOT overwrite a terminal flashError with protocol_violation from mid-st
 });
 ```
 
-- [ ] **A.10.2:** Run to confirm failure:
+- [x] **A.10.2:** Run to confirm failure:
 
 Run: `cd astros_vue && npx vitest run -t "does NOT overwrite a terminal flashError"`
 Expected: FAIL — flashError was clobbered to protocol_violation.
 
-- [ ] **A.10.3:** Edit the catch blocks. For each of `handleFlashControllerUpdate` (line ~303) and `handleFlashControllerResult` (line ~323), change the catch from:
+- [x] **A.10.3:** Edit the catch blocks. For each of `handleFlashControllerUpdate` (line ~303) and `handleFlashControllerResult` (line ~323), change the catch from:
 
 ```ts
 } catch (error) {
@@ -651,7 +651,7 @@ to:
 
 Mirror the same pattern in `handleFlashControllerResult`'s catch (with `flashControllerResult` in the detail string).
 
-- [ ] **A.10.4:** Run to confirm pass + all dispatcher tests:
+- [x] **A.10.4:** Run to confirm pass + all dispatcher tests:
 
 Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts`
 Expected: all pass.
@@ -666,7 +666,7 @@ ServoTest writes during flash get silently rejected by the server (`FLASH_JOB_AC
 - Modify: `astros_vue/src/components/modals/modules/AstrosServoTestModal.vue`
 - Create: `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`
 
-- [ ] **A.11.1:** Create the new spec file at `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`:
+- [x] **A.11.1:** Create the new spec file at `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`:
 
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -731,12 +731,12 @@ describe('AstrosServoTestModal', () => {
 });
 ```
 
-- [ ] **A.11.2:** Run the new spec to confirm it fails on missing `data-test` selectors / lock gate:
+- [x] **A.11.2:** Run the new spec to confirm it fails on missing `data-test` selectors / lock gate:
 
 Run: `cd astros_vue && npx vitest run src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`
 Expected: FAIL (selectors not present, locked-case not gated).
 
-- [ ] **A.11.3:** Edit `AstrosServoTestModal.vue`. Update the `<script setup>` to import and consume the lock store:
+- [x] **A.11.3:** Edit `AstrosServoTestModal.vue`. Update the `<script setup>` to import and consume the lock store:
 
 ```vue
 <script setup lang="ts">
@@ -798,12 +798,12 @@ Then in the `<template>`, find the Enable Test button and the slider. Add `data-
 
 (Use the modal's existing button/slider markup and ADD the `data-test` and `:disabled` bindings — don't rewrite the whole template.)
 
-- [ ] **A.11.4:** Verify `common.write_locked` i18n key exists (it does — round-5 added it for `AstrosWriteButton`). If not, add to `enUS.json`.
+- [x] **A.11.4:** Verify `common.write_locked` i18n key exists (it does — round-5 added it for `AstrosWriteButton`). If not, add to `enUS.json`.
 
 Run: `grep -n "write_locked" astros_vue/src/locales/enUS.json`
 Expected: one or more matches.
 
-- [ ] **A.11.5:** Run the new spec to confirm it passes:
+- [x] **A.11.5:** Run the new spec to confirm it passes:
 
 Run: `cd astros_vue && npx vitest run src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`
 Expected: PASS.
@@ -812,23 +812,23 @@ Expected: PASS.
 
 ## Task A.12: Phase A wrap — verify, review, commit
 
-- [ ] **A.12.1:** Run full Vue test suite + build:
+- [x] **A.12.1:** Run full Vue test suite + build:
 
 Run: `cd astros_vue && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run`
 Expected: all green.
 
-- [ ] **A.12.2:** Run full API test suite + build:
+- [x] **A.12.2:** Run full API test suite + build:
 
 Run: `cd astros_api && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run`
 Expected: all green.
 
-- [ ] **A.12.3:** Invoke code-review subagent on the Phase A diff. Use `superpowers:requesting-code-review` with a prompt that includes:
+- [x] **A.12.3:** Invoke code-review subagent on the Phase A diff. Use `superpowers:requesting-code-review` with a prompt that includes:
 
 > Review the changes since the commit `<plan-commit-sha>` for Phase A of the round-7 review fixes. The diff implements 6 Critical findings: dispatcher numeric pinning + never-exhaustiveness, jobId guards on applyControllerResult/applyJobDone/applyJobFailed, fetchCurrentJob endedAt filter, handleLockStateChanged defense-in-depth, applyJobFailed pendingByMac sweep for FAILED entries, mid-stream catch isolation (no flashError clobber), and AstrosServoTestModal lock-gating. Look for: any missed sibling claims (CLAUDE.md partial-fix sweep), test names that drift from what's tested, dead/unused additions, doc-vs-code drift in any header docstrings I touched.
 
 Address any **Critical** or **Important** findings from the reviewer before commit. Re-run tests after each fix.
 
-- [ ] **A.12.4:** Stage and commit Phase A:
+- [x] **A.12.4:** Stage and commit Phase A:
 
 ```bash
 git add astros_api/src/models/enums.ts \
@@ -873,7 +873,7 @@ EOF
 )"
 ```
 
-- [ ] **A.12.5:** Update this plan to check off Phase A. Commit the plan update:
+- [x] **A.12.5:** Update this plan to check off Phase A. Commit the plan update:
 
 ```bash
 git add .docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md

--- a/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
+++ b/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
@@ -1,0 +1,1775 @@
+# d.6 — Round-7 review fixes (Criticals + Importants from `/pr-review-toolkit:review-pr`)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the 18 actionable findings from the round-7 multi-agent PR review on `feature/firmware-ota-d-6-live-wiring`, organized into 3 sequential commits.
+
+**Architecture:**
+- **Commit A (6 Criticals):** State-machine guards (reboot-wait wedge, jobId validation), multi-FAILED preservation, mid-stream catch isolation, modal lock-gating, dispatcher compile-time exhaustiveness.
+- **Commit B (7 Importants — code+tests):** Discriminated-union tightening (ControllerFlashState, ControllersPanelProps), SlotId wire/slot split, validation hardening, WebSocket lifecycle hygiene, 8 test-coverage gaps.
+- **Commit C (5 Importants — prose+cleanup):** Wire/remove dead `abortReason`, rename 3 drifted test names, fix dispatcher sole-writer comment, fix `FlashJobState.source` doc, sweep 5 plan/QA prose drifts.
+
+**Tech Stack:** TypeScript (Vue 3, Pinia, Vitest), Express/Node API, hand-mirrored WS protocol between server (`TransmissionType`) and client (`WebsocketMessageType`).
+
+**Review report:** Convergent findings across 5 agents (code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer). Two findings appear in multiple agents' reports (CR-4 jobId validation, CR-6 dispatcher drift) — these carry the highest signal.
+
+**Sequencing rationale:** Inside each phase, structural/lowest-risk changes go first (CR-6 enum pinning before behavioral state-machine work; IM-3 validation before IM-2 discriminated union). Within commits, every fix is TDD: failing test → run → fix → run → next item.
+
+**Branch:** `feature/firmware-ota-d-6-live-wiring` (already exists). No new branch.
+
+**Pre-commit ritual (each commit):** prettier:write → lint:fix → build → `npx vitest run` → `superpowers:requesting-code-review` on diff vs prior commit → address Critical/Important reviewer findings → commit.
+
+---
+
+## File touch summary
+
+| Phase | File | Why |
+|---|---|---|
+| A | `astros_api/src/models/enums.ts` | Add explicit `= N` to `TransmissionType` |
+| A | `astros_vue/src/composables/useWebsocket.ts` | `never`-exhaustiveness; mid-stream catch guards; `handleLockStateChanged` defense; closure capture (B) |
+| A | `astros_vue/src/composables/__tests__/useWebsocket.spec.ts` | Numeric-pinning test; new behavioral tests |
+| A | `astros_vue/src/stores/firmware.ts` | `fetchCurrentJob` endedAt guard; `applyJobFailed` pendingByMac sweep; jobId guards on `applyControllerResult/applyJobDone/applyJobFailed` |
+| A | `astros_vue/src/stores/__tests__/firmware.spec.ts` | New tests + strengthen replace-not-merge (B) |
+| A | `astros_vue/src/components/modals/modules/AstrosServoTestModal.vue` | Gate slider on `useJobLockStore().locked` |
+| A | `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts` | NEW — lock-gating test |
+| B | `astros_vue/src/types/firmware.ts` | Discriminated-union ControllerFlashState; SlotId wire-vs-slot split; doc fix (C) |
+| B | `astros_vue/src/components/firmware/firmwareControllersPanel/types.ts` | Discriminated-union ControllersPanelProps; narrow `failedStage` |
+| B | `astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue` | Consume narrower types |
+| B | `astros_vue/src/utils/firmwareStageMapping.spec.ts` | Add i18n key contract test |
+| B | `astros_vue/src/views/__tests__/FirmwareView.spec.ts` | Add `lockSinceFormatted` NaN fallback test |
+| C | `astros_vue/src/views/FirmwareView.vue` | Render `abortReason` OR remove writes |
+| C | `astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts` | Rename test |
+| C | `astros_vue/src/stores/__tests__/firmware.spec.ts` | Rename 2 tests |
+| C | `.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md` | Fix 5 prose drift sites |
+| C | `.docs/qa/firmware-ota-flash-ui.md` | Fix test-count drift |
+
+---
+
+# Phase A — Criticals (Commit A)
+
+Single commit at end of phase. Message: `fix(firmware): round-7 Criticals — late-join wedge + multi-FAILED + protocol_violation guards + jobId validation + modal lock-gate + dispatcher exhaustiveness`.
+
+## Task A.0: Commit the plan file FIRST (before any code)
+
+Per CLAUDE.md, the plan file must be committed before any implementation code.
+
+- [ ] **A.0.1:** Stage and commit the plan file alone.
+
+```bash
+git add .docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
+git commit -m "$(cat <<'EOF'
+docs(plans): round-7 review fixes plan for d.6 live wiring
+
+Captures 18 actionable findings from the multi-agent review across
+3 sequential commits (6 Criticals, 7 code-Importants, 5 prose-Importants).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task A.1: CR-6a — Pin `TransmissionType` numeric values on the server
+
+Server `TransmissionType` has implicit numeric values, so mid-insertion silently renumbers downstream. Pin explicit `= N` so a future PR that adds a value MUST pick an explicit slot.
+
+**Files:**
+- Modify: `astros_api/src/models/enums.ts:82-100` (the `TransmissionType` enum)
+
+- [ ] **A.1.1:** Read the current enum to confirm position ordering.
+
+Run: `grep -n "TransmissionType" astros_api/src/models/enums.ts`
+
+- [ ] **A.1.2:** Edit the enum to add explicit values 0-16. Find the existing `export enum TransmissionType {` block and replace its body with:
+
+```ts
+export enum TransmissionType {
+  script = 0,
+  sync = 1,
+  status = 2,
+  controllers = 3,
+  run = 4,
+  panic = 5,
+  directCommand = 6,
+  formatSD = 7,
+  servoTest = 8,
+  systemStatus = 9,
+  lockStateChanged = 10,
+  flashJobActive = 11,
+  flashJobStarted = 12,
+  flashControllerUpdate = 13,
+  flashControllerResult = 14,
+  flashJobDone = 15,
+  flashJobFailed = 16,
+}
+```
+
+Verify the comment block above the enum still accurately reflects the wire-mirror contract; update if needed.
+
+- [ ] **A.1.3:** Run server build + tests to confirm no value mismatch.
+
+Run: `cd astros_api && npm run build && npx vitest run`
+Expected: clean build, all tests pass.
+
+---
+
+## Task A.2: CR-6b — Numeric-pinning contract test on the client
+
+**Files:**
+- Modify: `astros_vue/src/composables/__tests__/useWebsocket.spec.ts`
+
+- [ ] **A.2.1:** Add a top-level `describe` block at the end of the file:
+
+```ts
+describe('WebsocketMessageType wire-numeric pinning (cross-process contract)', () => {
+  it('pins the wire numeric values that the server emits — drift here breaks every WS message', () => {
+    expect(WebsocketMessageType.SCRIPT).toBe(0);
+    expect(WebsocketMessageType.CONFIGURATION_SYNC).toBe(1);
+    expect(WebsocketMessageType.LOCATION_STATUS).toBe(2);
+    expect(WebsocketMessageType.CONTROLLERS_SYNC).toBe(3);
+    expect(WebsocketMessageType.RUN).toBe(4);
+    expect(WebsocketMessageType.PANIC).toBe(5);
+    expect(WebsocketMessageType.DIRECT_COMMAND).toBe(6);
+    expect(WebsocketMessageType.FORMAT_SD).toBe(7);
+    expect(WebsocketMessageType.SERVO_TEST).toBe(8);
+    expect(WebsocketMessageType.SYSTEM_STATUS).toBe(9);
+    expect(WebsocketMessageType.LOCK_STATE_CHANGED).toBe(10);
+    expect(WebsocketMessageType.FLASH_JOB_ACTIVE).toBe(11);
+    expect(WebsocketMessageType.FLASH_JOB_STARTED).toBe(12);
+    expect(WebsocketMessageType.FLASH_CONTROLLER_UPDATE).toBe(13);
+    expect(WebsocketMessageType.FLASH_CONTROLLER_RESULT).toBe(14);
+    expect(WebsocketMessageType.FLASH_JOB_DONE).toBe(15);
+    expect(WebsocketMessageType.FLASH_JOB_FAILED).toBe(16);
+  });
+});
+```
+
+Verify `WebsocketMessageType` is already imported at the top of the spec file (it is — round-3 work imported it). If not, add `import { WebsocketMessageType } from '@/enums/WebsocketMessageType';`.
+
+- [ ] **A.2.2:** Run the test:
+
+Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts -t "wire-numeric pinning"`
+Expected: PASS (the client enum already has explicit values 0-16).
+
+---
+
+## Task A.3: CR-6c — Compile-time exhaustiveness on the dispatcher switch
+
+The dispatcher's `default` branch is a runtime `console.warn`. Convert to a `never`-cast so a new server-side TransmissionType the client hasn't handled fails to compile.
+
+**Files:**
+- Modify: `astros_vue/src/composables/useWebsocket.ts` (the switch block around line 105-144)
+
+- [ ] **A.3.1:** Read the current switch block to confirm its shape.
+
+Run: `grep -n "default:" astros_vue/src/composables/useWebsocket.ts`
+
+- [ ] **A.3.2:** In the dispatcher switch's `default` branch, add a `never` assignment to force TS exhaustiveness. The current default is:
+
+```ts
+default:
+  console.warn('Unknown WebSocket message type:', parsedMessage.type);
+  break;
+```
+
+Replace with:
+
+```ts
+default: {
+  // Compile-time exhaustiveness — adding a new WebsocketMessageType variant
+  // without a case here is a build error, not a silent runtime warn. The
+  // runtime warn stays for forward-compat with future server-side values
+  // we haven't yet typed.
+  const _exhaustive: never = parsedMessage.type as never;
+  void _exhaustive;
+  console.warn('Unknown WebSocket message type:', parsedMessage.type);
+  break;
+}
+```
+
+Note the `as never` cast: today the switch's discriminator is a wide `WebsocketMessageType` enum and the case arms don't structurally narrow it (the parsed-message type is `BaseWsMessage`, not a true discriminated union). The `as never` is therefore an attestation, not a true compile-time check — but it documents intent and breaks loudly if someone refactors to a true discriminated union later. The full DU refactor is out of scope for this fix (it would require typing every handler's `data` payload, which is a bigger surface).
+
+- [ ] **A.3.3:** Confirm build still passes:
+
+Run: `cd astros_vue && npm run build`
+Expected: success.
+
+- [ ] **A.3.4:** Run dispatcher tests:
+
+Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts`
+Expected: all pass.
+
+---
+
+## Task A.4: CR-4a — Add jobId guard to `applyControllerResult`
+
+**Files:**
+- Modify: `astros_vue/src/stores/firmware.ts` (`applyControllerResult` function around line 353)
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts` (add test)
+
+- [ ] **A.4.1:** Write the failing test in `firmware.spec.ts`. Find the `describe('applyControllerResult', ...)` block (search for it; it should exist near the multi-failure tests). Add inside that block:
+
+```ts
+it('drops stale events whose jobId does not match currentJob (post-reconnect race protection)', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const store = useFirmwareStore();
+    seedSampleFleet();
+    store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
+    const beforeStage = store.controllerStates.get('body')?.stage;
+    // Stale event from Job A: jobId mismatch
+    store.applyControllerResult({
+      jobId: 'job-A',
+      controller: { controllerId: BODY_MAC, stage: 'VERSION_CONFIRMED', finalVersion: 'v9.9.9' },
+    });
+    expect(store.controllerStates.get('body')?.stage).toBe(beforeStage);
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('jobId mismatch');
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+```
+
+(If `seedSampleFleet`, `sampleJobState`, and `BODY_MAC` are not the exact helper names, grep the spec file and use the actual names — round-5 added these helpers.)
+
+- [ ] **A.4.2:** Run the test to confirm it fails:
+
+Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts -t "drops stale events whose jobId"`
+Expected: FAIL — stage was mutated, no warn fired.
+
+- [ ] **A.4.3:** Edit `applyControllerResult` in `firmware.ts`. The current implementation looks roughly like:
+
+```ts
+function applyControllerResult(payload: { jobId: string; controller: ControllerFlashState }): void {
+  applyControllerUpdate(payload.controller);
+}
+```
+
+Add a guard at entry:
+
+```ts
+function applyControllerResult(payload: { jobId: string; controller: ControllerFlashState }): void {
+  if (currentJob.value !== null && payload.jobId !== currentJob.value.jobId) {
+    console.warn(
+      `[firmwareStore] applyControllerResult: jobId mismatch ` +
+        `(payload="${payload.jobId}" current="${currentJob.value.jobId}"). Dropping stale event.`,
+    );
+    return;
+  }
+  applyControllerUpdate(payload.controller);
+}
+```
+
+- [ ] **A.4.4:** Run the test to confirm it passes:
+
+Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts -t "drops stale events whose jobId"`
+Expected: PASS.
+
+---
+
+## Task A.5: CR-4b — Add jobId guard to `applyJobDone`
+
+**Files:**
+- Modify: `astros_vue/src/stores/firmware.ts` (`applyJobDone` function around line 360-401)
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
+
+- [ ] **A.5.1:** Add failing test inside `describe('applyJobDone', ...)`:
+
+```ts
+it('drops stale flashJobDone whose jobId does not match currentJob', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const store = useFirmwareStore();
+    seedSampleFleet();
+    store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
+    expect(store.phase).toBe('flashing');
+    store.applyJobDone({ jobId: 'job-A', endedAt: '2026-05-14T08:00:00Z' });
+    expect(store.phase).toBe('flashing');
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('jobId mismatch');
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+```
+
+- [ ] **A.5.2:** Run to confirm failure:
+
+Run: `cd astros_vue && npx vitest run -t "drops stale flashJobDone"`
+Expected: FAIL — phase transitioned to 'done'.
+
+- [ ] **A.5.3:** Add the guard at entry of `applyJobDone`:
+
+```ts
+function applyJobDone(data: { jobId: string; endedAt: string }): void {
+  if (currentJob.value !== null && data.jobId !== currentJob.value.jobId) {
+    console.warn(
+      `[firmwareStore] applyJobDone: jobId mismatch ` +
+        `(event="${data.jobId}" current="${currentJob.value.jobId}"). Dropping stale event.`,
+    );
+    return;
+  }
+  // ... existing body unchanged
+}
+```
+
+- [ ] **A.5.4:** Run to confirm pass:
+
+Run: `cd astros_vue && npx vitest run -t "drops stale flashJobDone"`
+Expected: PASS.
+
+---
+
+## Task A.6: CR-4c — Add jobId guard to `applyJobFailed`
+
+**Files:**
+- Modify: `astros_vue/src/stores/firmware.ts` (`applyJobFailed` function around line 403-473)
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
+
+- [ ] **A.6.1:** Add failing test inside `describe('applyJobFailed', ...)`:
+
+```ts
+it('drops stale flashJobFailed whose jobId does not match currentJob', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const store = useFirmwareStore();
+    seedSampleFleet();
+    store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
+    store.applyJobFailed({
+      jobId: 'job-A',
+      endedAt: '2026-05-14T08:00:00Z',
+      reason: 'internal_server_error',
+    });
+    expect(store.phase).toBe('flashing');
+    expect(store.flashError).toBeNull();
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('jobId mismatch');
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+```
+
+- [ ] **A.6.2:** Run to confirm failure:
+
+Run: `cd astros_vue && npx vitest run -t "drops stale flashJobFailed"`
+Expected: FAIL.
+
+- [ ] **A.6.3:** Add the guard at entry of `applyJobFailed`:
+
+```ts
+function applyJobFailed(data: FlashJobFailedData & { jobId: string }): void {
+  if (currentJob.value !== null && data.jobId !== currentJob.value.jobId) {
+    console.warn(
+      `[firmwareStore] applyJobFailed: jobId mismatch ` +
+        `(event="${data.jobId}" current="${currentJob.value.jobId}"). Dropping stale event.`,
+    );
+    return;
+  }
+  // ... existing body unchanged
+}
+```
+
+If `data` doesn't currently include `jobId` in the type, check the call site in `useWebsocket.ts:handleFlashJobFailed` — the server payload has `jobId` per the orchestrator contract; the store handler should accept it. Update both type and signature consistently.
+
+- [ ] **A.6.4:** Run to confirm pass:
+
+Run: `cd astros_vue && npx vitest run -t "drops stale flashJobFailed"`
+Expected: PASS.
+
+---
+
+## Task A.7: CR-1a — `fetchCurrentJob` mirrors server's `endedAt` filter
+
+When `currentJob.endedAt` is set (15s reboot-wait window), the server skips emitting `flashJobStarted` on reconnect. HTTP cold-load must mirror that filter or the UI wedges at `phase='flashing'`.
+
+**Files:**
+- Modify: `astros_vue/src/stores/firmware.ts` (`fetchCurrentJob` function around line 554-576)
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
+
+- [ ] **A.7.1:** Add failing test inside `describe('fetchCurrentJob', ...)` block:
+
+```ts
+it('skips applying a body with endedAt set (mirrors server late-join filter for reboot-wait window)', async () => {
+  const store = useFirmwareStore();
+  const endedJob = sampleJobState({
+    jobId: 'job-completed',
+    endedAt: '2026-05-14T08:00:15Z',
+  });
+  vi.mocked(apiClient.get).mockResolvedValueOnce({ data: endedJob } as never);
+  await store.fetchCurrentJob();
+  expect(store.currentJob).toBeNull();
+  expect(store.phase).toBe('idle');
+  expect(store.currentJobLoadFailed).toBe(false);
+});
+```
+
+(Adjust `apiClient` mock helper to match what the spec file already uses — round-5 wired in a vitest mock; reuse it.)
+
+- [ ] **A.7.2:** Run to confirm failure:
+
+Run: `cd astros_vue && npx vitest run -t "skips applying a body with endedAt"`
+Expected: FAIL — `currentJob` was populated and phase moved to 'flashing'.
+
+- [ ] **A.7.3:** Edit `fetchCurrentJob`. Current guard is:
+
+```ts
+if (body && body.jobId && currentJob.value === null) {
+  applyJobStarted(body);
+}
+```
+
+Replace with:
+
+```ts
+// Mirror server-side decideLateJoinSnapshot: a job with endedAt is in the
+// reboot-wait window. No subsequent flashJobStarted will arrive on the
+// WS, so populating the store would wedge phase at 'flashing' indefinitely.
+if (body && body.jobId && body.endedAt === undefined && currentJob.value === null) {
+  applyJobStarted(body);
+} else if (body && body.jobId && body.endedAt !== undefined) {
+  console.info(
+    `[firmwareStore] fetchCurrentJob: server returned job in reboot-wait window ` +
+      `(jobId="${body.jobId}", endedAt="${body.endedAt}"). Skipping apply to avoid wedge.`,
+  );
+}
+```
+
+- [ ] **A.7.4:** Run to confirm pass:
+
+Run: `cd astros_vue && npx vitest run -t "skips applying a body with endedAt"`
+Expected: PASS.
+
+---
+
+## Task A.8: CR-1b — Defense-in-depth: `handleLockStateChanged` recovers stuck phase
+
+If the client somehow lands at `phase='flashing'` while the lock has released (out-of-order events, partial WS delivery, the CR-1a race surviving despite the fix), force terminal so the UI doesn't wedge.
+
+**Files:**
+- Modify: `astros_vue/src/composables/useWebsocket.ts` (`handleLockStateChanged` function around line 244-256)
+- Modify: `astros_vue/src/composables/__tests__/useWebsocket.spec.ts`
+
+- [ ] **A.8.1:** Add failing test inside the `handleLockStateChanged`/lockStateChanged describe block:
+
+```ts
+it('forces firmware phase to done when lock releases but firmware is still flashing (recovery defense)', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('flashing');
+    handleMessage(JSON.stringify({
+      type: WebsocketMessageType.LOCK_STATE_CHANGED,
+      data: { locked: false, owner: null, since: null },
+    }));
+    expect(firmware.phase).toBe('done');
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('phase=flashing with lock released');
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+```
+
+- [ ] **A.8.2:** Run to confirm failure:
+
+Run: `cd astros_vue && npx vitest run -t "forces firmware phase to done when lock releases"`
+Expected: FAIL — phase stayed 'flashing'.
+
+- [ ] **A.8.3:** Edit `handleLockStateChanged`. After the existing `jobLockStore` update, add:
+
+```ts
+// Defense-in-depth: if the server has released the lock while we still think
+// we're flashing, a terminal-event (flashJobDone/flashJobFailed) was lost or
+// arrived out of order. Force phase to 'done' so the UI doesn't wedge.
+// Combined with the fetchCurrentJob endedAt filter, this closes the
+// reboot-wait wedge that the CR-1 review identified.
+if (!data.locked) {
+  const firmware = useFirmwareStore();
+  if (firmware.phase === 'flashing') {
+    console.warn(
+      '[useWebsocket] handleLockStateChanged: phase=flashing with lock released. ' +
+        'Forcing phase=done as recovery; a terminal-event may have been lost.',
+    );
+    firmware.setPhase('done');
+  }
+}
+```
+
+Confirm `useFirmwareStore` is imported in the file. Confirm `setPhase` is an exported action. If `setPhase` doesn't exist, add it to the firmware store as a public action (one-line wrapper around the ref).
+
+- [ ] **A.8.4:** Run to confirm pass:
+
+Run: `cd astros_vue && npx vitest run -t "forces firmware phase to done when lock releases"`
+Expected: PASS.
+
+---
+
+## Task A.9: CR-2 — `applyJobFailed` collects FAILED entries from `pendingByMac`
+
+Bus-wide ESP-NOW failure can leave FAILED-stage entries queued in pendingByMac because the LocationStatus hasn't arrived for that MAC. The current `applyJobFailed` wipes pendingByMac without scanning it.
+
+**Files:**
+- Modify: `astros_vue/src/stores/firmware.ts` (`applyJobFailed` around line 449-472)
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
+
+- [ ] **A.9.1:** Add failing test inside `describe('applyJobFailed', ...)`:
+
+```ts
+it('preserves FAILED entries from pendingByMac in failedControllers (bus-wide failure with unmapped MAC)', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const store = useFirmwareStore();
+    seedSampleFleet();
+    store.applyJobStarted(sampleJobState({ jobId: 'job-1' }));
+    // Body has a known MAC (mapped via seedSampleFleet); core does too.
+    // Now queue a FAILED entry for an unmapped MAC.
+    store.applyControllerUpdate({
+      controllerId: 'aa:bb:cc:dd:ee:99',
+      stage: 'FAILED',
+      error: 'esp_now timeout',
+    });
+    expect(store.pendingByMac.get('aa:bb:cc:dd:ee:99')?.length).toBe(1);
+    store.applyJobFailed({
+      jobId: 'job-1',
+      endedAt: '2026-05-14T08:01:00Z',
+      reason: 'internal_server_error',
+    });
+    const failedIds = store.failedControllers.map((c) => c.id);
+    expect(failedIds).toContain('aa:bb:cc:dd:ee:99');
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain(
+      'FAILED entry for unmapped MAC',
+    );
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+```
+
+- [ ] **A.9.2:** Run to confirm failure:
+
+Run: `cd astros_vue && npx vitest run -t "preserves FAILED entries from pendingByMac"`
+Expected: FAIL — failedControllers doesn't contain the unmapped MAC.
+
+- [ ] **A.9.3:** Edit `applyJobFailed`. Before the `pendingByMac.value = new Map()` clear (around line 472), insert:
+
+```ts
+// Scan pendingByMac for FAILED entries that never got their LocationStatus
+// learning. These are real bricked controllers whose MAC -> slot mapping
+// never arrived; the operator must see them in failedControllers so the
+// bus-wide failure mode isn't silently truncated.
+for (const [mac, queue] of pendingByMac.value) {
+  for (const entry of queue) {
+    if (entry.stage === 'FAILED') {
+      console.warn(
+        `[firmwareStore] applyJobFailed: FAILED entry for unmapped MAC="${mac}" ` +
+          `surfaced from pendingByMac. LocationStatus never arrived; ` +
+          `using MAC as label.`,
+      );
+      failed.push({
+        id: mac as SlotId,
+        label: mac,
+        stage: currentStage.value,
+      });
+    }
+  }
+}
+```
+
+(The `id: mac as SlotId` cast is a known structural-vs-nominal compromise — see IM-11 in Phase B for the proper fix. For this commit, the cast is acceptable because `failedControllers` consumers iterate `id` only for keying/labeling.)
+
+- [ ] **A.9.4:** Run to confirm pass + run all firmware.spec.ts tests to confirm no regression:
+
+Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts`
+Expected: all pass.
+
+---
+
+## Task A.10: CR-3 — Mid-stream catches don't clobber a legitimate `flashError`
+
+`handleFlashControllerUpdate` and `handleFlashControllerResult` catches unconditionally call `setFlashError({reason:'protocol_violation'})`. If a terminal failure already set a specific reason, a stray malformed mid-stream frame can silently overwrite it.
+
+**Files:**
+- Modify: `astros_vue/src/composables/useWebsocket.ts` (catches around lines 303-306, 323-326)
+- Modify: `astros_vue/src/composables/__tests__/useWebsocket.spec.ts`
+
+- [ ] **A.10.1:** Add failing test:
+
+```ts
+it('does NOT overwrite a terminal flashError with protocol_violation from mid-stream catch', () => {
+  const { handleMessage } = useWebsocket();
+  const firmware = useFirmwareStore();
+  // Simulate a terminal failure that set a specific reason.
+  firmware.setFlashError({
+    reason: 'internal_server_error',
+    detail: 'asset checksum mismatch on Core',
+  });
+  firmware.setPhase('failed');
+  // Now a malformed mid-stream frame arrives.
+  handleMessage(JSON.stringify({
+    type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+    data: null,  // malformed — triggers the catch
+  }));
+  expect(firmware.flashError?.reason).toBe('internal_server_error');
+  expect(firmware.flashError?.detail).toBe('asset checksum mismatch on Core');
+});
+```
+
+- [ ] **A.10.2:** Run to confirm failure:
+
+Run: `cd astros_vue && npx vitest run -t "does NOT overwrite a terminal flashError"`
+Expected: FAIL — flashError was clobbered to protocol_violation.
+
+- [ ] **A.10.3:** Edit the catch blocks. For each of `handleFlashControllerUpdate` (line ~303) and `handleFlashControllerResult` (line ~323), change the catch from:
+
+```ts
+} catch (error) {
+  console.error('Error handling flashControllerUpdate:', error);
+  store.setFlashError({
+    reason: 'protocol_violation',
+    detail: 'Malformed flashControllerUpdate from server',
+  });
+}
+```
+
+to:
+
+```ts
+} catch (error) {
+  console.error('Error handling flashControllerUpdate:', error);
+  // Don't clobber a terminal flashError that already carries the actual
+  // root cause from a job-lifecycle event (applyJobFailed sets specific
+  // reasons; a malformed mid-stream frame's protocol_violation is less
+  // informative). Only set if we don't have a terminal error already.
+  if (store.flashError === null || store.phase === 'flashing') {
+    store.setFlashError({
+      reason: 'protocol_violation',
+      detail: 'Malformed flashControllerUpdate from server',
+    });
+  }
+}
+```
+
+Mirror the same pattern in `handleFlashControllerResult`'s catch (with `flashControllerResult` in the detail string).
+
+- [ ] **A.10.4:** Run to confirm pass + all dispatcher tests:
+
+Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts`
+Expected: all pass.
+
+---
+
+## Task A.11: CR-5 — Gate `AstrosServoTestModal` slider on `useJobLockStore().locked`
+
+ServoTest writes during flash get silently rejected by the server (`FLASH_JOB_ACTIVE`). The slider currently allows operator to drag with no visible signal.
+
+**Files:**
+- Modify: `astros_vue/src/components/modals/modules/AstrosServoTestModal.vue`
+- Create: `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`
+
+- [ ] **A.11.1:** Create the new spec file at `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { useJobLockStore } from '@/stores/jobLock';
+import AstrosServoTestModal from '../AstrosServoTestModal.vue';
+
+const stubSendMessage = vi.fn();
+vi.mock('@/composables/useWebsocket', () => ({
+  useWebsocket: () => ({ wsSendMessage: stubSendMessage }),
+}));
+
+const defaultProps = {
+  controllerAddress: 'aa:bb:cc:dd:ee:01',
+  controllerName: 'Core',
+  moduleSubType: 1,
+  moduleIdx: 0,
+  channelNumber: 0,
+  homePosition: 500,
+};
+
+function makeWrapper(opts: { locked: boolean }) {
+  const wrapper = mount(AstrosServoTestModal, {
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn })],
+      mocks: { $t: (k: string) => k },
+    },
+    props: defaultProps,
+  });
+  const lockStore = useJobLockStore();
+  lockStore.locked = opts.locked;
+  lockStore.owner = opts.locked ? 'flash:job-A' : null;
+  return wrapper;
+}
+
+describe('AstrosServoTestModal', () => {
+  beforeEach(() => stubSendMessage.mockClear());
+
+  it('disables the Enable Test button when jobLock.locked is true', () => {
+    const wrapper = makeWrapper({ locked: true });
+    const btn = wrapper.find('[data-test="enable-test-button"]');
+    expect(btn.attributes('disabled')).toBeDefined();
+  });
+
+  it('does NOT send servoTest when locked even if onSliderChange fires', async () => {
+    const wrapper = makeWrapper({ locked: true });
+    // Force-enable test internally to prove the lock blocks downstream.
+    // This is a defense-in-depth check; the button should be disabled
+    // independently but the slider handler should also no-op.
+    const slider = wrapper.find('[data-test="position-slider"]');
+    await slider.trigger('change');
+    expect(stubSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('allows enabling and sending servoTest when not locked', async () => {
+    const wrapper = makeWrapper({ locked: false });
+    const btn = wrapper.find('[data-test="enable-test-button"]');
+    await btn.trigger('click');
+    expect(stubSendMessage).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **A.11.2:** Run the new spec to confirm it fails on missing `data-test` selectors / lock gate:
+
+Run: `cd astros_vue && npx vitest run src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`
+Expected: FAIL (selectors not present, locked-case not gated).
+
+- [ ] **A.11.3:** Edit `AstrosServoTestModal.vue`. Update the `<script setup>` to import and consume the lock store:
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useWebsocket } from '@/composables/useWebsocket';
+import { useJobLockStore } from '@/stores/jobLock';
+import type { ServoTestEvent } from '@/models/events';
+
+const { wsSendMessage } = useWebsocket();
+const jobLock = useJobLockStore();
+
+const props = defineProps<ServoTestEvent>();
+const emit = defineEmits<{ close: [] }>();
+
+const disabled = ref(true);
+const label = ref('modals.servo_test.enable_test');
+const value = ref(props.homePosition);
+
+const writesBlocked = computed(() => jobLock.locked);
+
+const onSliderChange = () => {
+  if (disabled.value || writesBlocked.value) return;
+  wsSendMessage(JSON.stringify(servoTestMessage()));
+};
+
+const enableTest = () => {
+  if (writesBlocked.value) return;
+  disabled.value = !disabled.value;
+  if (!disabled.value) {
+    label.value = 'modals.servo_test.disable_test';
+    wsSendMessage(JSON.stringify(servoTestMessage()));
+  } else {
+    label.value = 'modals.servo_test.enable_test';
+  }
+};
+// ... rest unchanged
+</script>
+```
+
+Then in the `<template>`, find the Enable Test button and the slider. Add `data-test` attributes and bind disabled state:
+
+```vue
+<button
+  data-test="enable-test-button"
+  :disabled="writesBlocked"
+  :title="writesBlocked ? $t('common.write_locked') : ''"
+  class="btn btn-primary"
+  @click="enableTest"
+>{{ $t(label) }}</button>
+
+<input
+  data-test="position-slider"
+  type="range"
+  :disabled="disabled || writesBlocked"
+  v-model.number="value"
+  @change="onSliderChange"
+/>
+```
+
+(Use the modal's existing button/slider markup and ADD the `data-test` and `:disabled` bindings — don't rewrite the whole template.)
+
+- [ ] **A.11.4:** Verify `common.write_locked` i18n key exists (it does — round-5 added it for `AstrosWriteButton`). If not, add to `enUS.json`.
+
+Run: `grep -n "write_locked" astros_vue/src/locales/enUS.json`
+Expected: one or more matches.
+
+- [ ] **A.11.5:** Run the new spec to confirm it passes:
+
+Run: `cd astros_vue && npx vitest run src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts`
+Expected: PASS.
+
+---
+
+## Task A.12: Phase A wrap — verify, review, commit
+
+- [ ] **A.12.1:** Run full Vue test suite + build:
+
+Run: `cd astros_vue && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run`
+Expected: all green.
+
+- [ ] **A.12.2:** Run full API test suite + build:
+
+Run: `cd astros_api && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run`
+Expected: all green.
+
+- [ ] **A.12.3:** Invoke code-review subagent on the Phase A diff. Use `superpowers:requesting-code-review` with a prompt that includes:
+
+> Review the changes since the commit `<plan-commit-sha>` for Phase A of the round-7 review fixes. The diff implements 6 Critical findings: dispatcher numeric pinning + never-exhaustiveness, jobId guards on applyControllerResult/applyJobDone/applyJobFailed, fetchCurrentJob endedAt filter, handleLockStateChanged defense-in-depth, applyJobFailed pendingByMac sweep for FAILED entries, mid-stream catch isolation (no flashError clobber), and AstrosServoTestModal lock-gating. Look for: any missed sibling claims (CLAUDE.md partial-fix sweep), test names that drift from what's tested, dead/unused additions, doc-vs-code drift in any header docstrings I touched.
+
+Address any **Critical** or **Important** findings from the reviewer before commit. Re-run tests after each fix.
+
+- [ ] **A.12.4:** Stage and commit Phase A:
+
+```bash
+git add astros_api/src/models/enums.ts \
+  astros_vue/src/composables/useWebsocket.ts \
+  astros_vue/src/composables/__tests__/useWebsocket.spec.ts \
+  astros_vue/src/stores/firmware.ts \
+  astros_vue/src/stores/__tests__/firmware.spec.ts \
+  astros_vue/src/components/modals/modules/AstrosServoTestModal.vue \
+  astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
+git commit -m "$(cat <<'EOF'
+fix(firmware): round-7 Criticals — late-join wedge + multi-FAILED + protocol_violation guards + jobId validation + modal lock-gate + dispatcher exhaustiveness
+
+CR-1: fetchCurrentJob mirrors server's decideLateJoinSnapshot endedAt
+  filter — prevents UI wedge at phase='flashing' during reboot-wait
+  window after a refresh.
+
+CR-1b: handleLockStateChanged forces phase='done' when the server
+  releases the lock while we're still 'flashing'. Defense-in-depth
+  against any terminal-event arrival gap.
+
+CR-2: applyJobFailed scans pendingByMac for FAILED entries before
+  wiping the queue. Bus-wide ESP-NOW failures with unmapped MACs
+  now surface in failedControllers instead of being silently dropped.
+
+CR-3: handleFlashControllerUpdate/Result catches no longer clobber
+  a terminal flashError. A stray malformed mid-stream frame can't
+  overwrite the specific reason from applyJobFailed.
+
+CR-4: applyControllerResult/applyJobDone/applyJobFailed now compare
+  payload.jobId to currentJob.jobId at entry. Stale events from a
+  prior job (post-reconnect race) are dropped with a warn.
+
+CR-5: AstrosServoTestModal gates Enable/slider on useJobLockStore().
+  Writes during flash no longer fire silently-rejected WS messages.
+
+CR-6: TransmissionType enum on the server now pins explicit numeric
+  values. Client adds a numeric-pinning contract test. Dispatcher
+  default branch documents intent via `never`-cast.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **A.12.5:** Update this plan to check off Phase A. Commit the plan update:
+
+```bash
+git add .docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
+git commit -m "docs(plans): check off Phase A of round-7 review fixes"
+```
+
+---
+
+# Phase B — Importants (code + tests) (Commit B)
+
+Single commit at end of phase. Message: `fix(firmware): round-7 Importants (code+tests) — discriminated unions + SlotId split + WS lifecycle + 8 coverage gaps`.
+
+## Task B.1: IM-3 — Tighten `buildControllerStatesMap` and per-element validation
+
+**Files:**
+- Modify: `astros_vue/src/stores/firmware.ts` (`buildControllerStatesMap` around line 248-274; also `handleFlashJobStarted` guard upstream)
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
+
+- [ ] **B.1.1:** Add failing test:
+
+```ts
+describe('buildControllerStatesMap defensive validation (IM-3)', () => {
+  it('returns empty map when states is not an array (string, object, number)', () => {
+    const store = useFirmwareStore();
+    // Pass through applyJobStarted with garbage controllers — should not throw or pollute
+    store.applyJobStarted({
+      jobId: 'job-1',
+      source: { kind: 'github', version: 'v1' },
+      controllers: 'not-an-array' as unknown as ControllerFlashState[],
+      startedAt: '2026-05-14T08:00:00Z',
+    });
+    expect(store.controllerStates.size).toBe(0);
+    expect(store.pendingByMac.size).toBe(0);
+  });
+
+  it('skips elements with non-string controllerId and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const store = useFirmwareStore();
+      store.applyJobStarted({
+        jobId: 'job-1',
+        source: { kind: 'github', version: 'v1' },
+        controllers: [
+          { stage: 'QUEUED' } as ControllerFlashState,  // missing controllerId
+          { controllerId: 123 as unknown as string, stage: 'QUEUED' },  // non-string
+        ],
+        startedAt: '2026-05-14T08:00:00Z',
+      });
+      expect(store.controllerStates.size).toBe(0);
+      expect(store.pendingByMac.size).toBe(0);
+      expect(warnSpy.mock.calls.flat().join(' ')).toContain('invalid controllerId');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});
+```
+
+- [ ] **B.1.2:** Run to confirm failure.
+
+Run: `cd astros_vue && npx vitest run -t "buildControllerStatesMap defensive validation"`
+Expected: FAIL.
+
+- [ ] **B.1.3:** Edit `buildControllerStatesMap`. Replace the guard `if (!states) return m;` with:
+
+```ts
+function buildControllerStatesMap(
+  states: ControllerFlashState[] | undefined,
+): Map<SlotId, ControllerFlashState> {
+  const m = new Map<SlotId, ControllerFlashState>();
+  if (!Array.isArray(states)) return m;
+  for (const s of states) {
+    if (!s || typeof s.controllerId !== 'string' || s.controllerId.length === 0) {
+      console.warn(
+        `[firmwareStore] buildControllerStatesMap: skipping element with invalid controllerId`,
+        s,
+      );
+      continue;
+    }
+    // ... existing per-element handling (resolveSlot / enqueuePending)
+  }
+  return m;
+}
+```
+
+Preserve the existing per-element body (resolveSlot → enqueuePending fallback) — only the guards above change.
+
+- [ ] **B.1.4:** Run to confirm pass + full firmware suite:
+
+Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts`
+Expected: all pass.
+
+---
+
+## Task B.2: IM-2 — Convert client `ControllerFlashState` to discriminated union on `stage`
+
+Server's `ControllerFlashState` is a discriminated union: `VersionConfirmed/finalVersion:string` and `Failed/error:string` are required-on-variant. Client mirror flattens them to optional. This task tightens the mirror.
+
+**Files:**
+- Modify: `astros_vue/src/types/firmware.ts:157-164`
+- Modify: `astros_vue/src/stores/firmware.ts` (any sites that assume optional fields)
+- Modify: `astros_vue/src/utils/firmwareStageMapping.ts` (consumers of `state.stage`)
+- Modify: `astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue` (consumers of finalVersion / error)
+
+- [ ] **B.2.1:** Read the server-side discriminated union to mirror exactly.
+
+Run: `grep -n "type ControllerFlashState\|interface ControllerFlashState\|FwStage\.Failed\|FwStage\.VersionConfirmed" astros_api/src/models/firmware/flash_job_state.ts`
+
+- [ ] **B.2.2:** Replace the client `ControllerFlashState` interface in `types/firmware.ts:157-164`:
+
+```ts
+/**
+ * Mirror of the server's discriminated `ControllerFlashState`, narrowed
+ * to fields the UI reads. The server wire carries bytesSent/totalBytes/
+ * detail on every variant; we omit those since the UI doesn't render them.
+ *
+ * Source of truth: `astros_api/src/models/firmware/flash_job_state.ts`.
+ *
+ * IMPORTANT: `controllerId` may be EITHER a MAC string (wire form, pre-
+ * resolution) OR a `SlotId` (post-resolution, in-store form). TS can't
+ * distinguish nominally; the data-flow position determines meaning. See
+ * `buildControllerStatesMap` for the translation site.
+ */
+export type ControllerFlashState =
+  | { controllerId: string; stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING' }
+  | { controllerId: string; stage: 'VERSION_CONFIRMED'; finalVersion: string }
+  | { controllerId: string; stage: 'FAILED'; error: string };
+```
+
+- [ ] **B.2.3:** Run TS build to find every site that breaks:
+
+Run: `cd astros_vue && npm run build`
+Expected: failures at consumer sites that read `state.error` or `state.finalVersion` without first narrowing on `stage`. Fix each by checking `state.stage === 'FAILED'` or `state.stage === 'VERSION_CONFIRMED'` first.
+
+- [ ] **B.2.4:** For each compile error, narrow at the read site. Examples:
+  - `controllerStatePillKind(state)` in `selectModePillKind.ts` or `firmwareStageMapping.ts` — narrow inside the switch on `state.stage`
+  - `state.finalVersion` reads in `AstrosFirmwareControllerRow.vue` — gate on `state.stage === 'VERSION_CONFIRMED'`
+  - `state.error` reads — gate on `state.stage === 'FAILED'`
+
+For each narrowing, prefer a small `if`-gate over an `as` cast.
+
+- [ ] **B.2.5:** Run build + tests:
+
+Run: `cd astros_vue && npm run build && npx vitest run`
+Expected: all green.
+
+---
+
+## Task B.3: IM-11 — Split `ControllerFlashState` into wire vs by-slot views
+
+The current `controllerId: string` field carries either MAC or SlotId depending on position. Three `as SlotId` casts in `firmware.ts:239, 456, 610` paper over this. Split the type.
+
+**Files:**
+- Modify: `astros_vue/src/types/firmware.ts`
+- Modify: `astros_vue/src/stores/firmware.ts`
+
+- [ ] **B.3.1:** Add a new `ControllerFlashStateBySlot` type next to the existing `ControllerFlashState` (which becomes wire-side only):
+
+```ts
+/**
+ * Wire-side `ControllerFlashState` (above) carries `controllerId: string`
+ * which is a MAC. After `buildControllerStatesMap` translates MAC -> SlotId,
+ * the in-store value uses a `SlotId` keyed view:
+ */
+export type ControllerFlashStateBySlot =
+  | { controllerId: SlotId; stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING' }
+  | { controllerId: SlotId; stage: 'VERSION_CONFIRMED'; finalVersion: string }
+  | { controllerId: SlotId; stage: 'FAILED'; error: string };
+```
+
+- [ ] **B.3.2:** Update `firmware.ts`:
+  - The store's `controllerStates` map becomes `ReadonlyMap<SlotId, ControllerFlashStateBySlot>`.
+  - `buildControllerStatesMap` returns `Map<SlotId, ControllerFlashStateBySlot>` and is the translation site.
+  - `applyControllerUpdate` translates incoming `ControllerFlashState` to `ControllerFlashStateBySlot` by replacing `controllerId` with the resolved slot.
+
+- [ ] **B.3.3:** Run build:
+
+Run: `cd astros_vue && npm run build`
+Expected: cast count at line 239/456/610 drops to one (the translation in `buildControllerStatesMap`). Fix any new compile errors at consumer sites.
+
+- [ ] **B.3.4:** Run tests:
+
+Run: `cd astros_vue && npx vitest run`
+Expected: all pass.
+
+---
+
+## Task B.4: IM-12 — `ControllersPanelProps` discriminated union + narrow `failedStage`
+
+**Files:**
+- Modify: `astros_vue/src/components/firmware/firmwareControllersPanel/types.ts:21-33`
+- Modify: `astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue`
+- Modify: `astros_vue/src/views/FirmwareView.vue` (the call site)
+
+- [ ] **B.4.1:** Replace `ControllersPanelProps` with a discriminated union:
+
+```ts
+import type { FirmwareStage, ControllerProgressEntry, SlotId } from '@/types/firmware';
+
+type ProgressMap = Partial<Record<SlotId, ControllerProgressEntry>>;
+
+export type ControllersPanelProps =
+  | { phase: 'select' }
+  | { phase: 'flashing'; progressByControllerId: ProgressMap }
+  | { phase: 'done'; progressByControllerId: ProgressMap; doneCount?: number }
+  | {
+      phase: 'failed';
+      progressByControllerId: ProgressMap;
+      failedControllerLabel: string;
+      failedStage?: FirmwareStage;
+      failedCount: number;
+    };
+```
+
+- [ ] **B.4.2:** Update `AstrosFirmwareControllersPanel.vue`. Replace the existing `defineProps<ControllersPanelProps>()` and the dev-only `watchEffect` warnings (since TS now enforces the constraints). Use TS narrowing throughout the template:
+
+```ts
+const props = defineProps<ControllersPanelProps>();
+// Remove the watchEffect blocks at lines 43-66 — TS structural narrowing
+// enforces phase-vs-fields correlation now.
+```
+
+In the template, narrow by phase before reading phase-specific props.
+
+- [ ] **B.4.3:** Update the call site in `FirmwareView.vue`. The current `<AstrosFirmwareControllersPanel ... />` call passes all optional props; update to pass only the phase-appropriate set, conditionally:
+
+```vue
+<AstrosFirmwareControllersPanel
+  v-if="firmwareStore.phase === 'select'"
+  phase="select"
+/>
+<AstrosFirmwareControllersPanel
+  v-else-if="firmwareStore.phase === 'flashing'"
+  phase="flashing"
+  :progress-by-controller-id="progressByControllerId"
+/>
+<AstrosFirmwareControllersPanel
+  v-else-if="firmwareStore.phase === 'done'"
+  phase="done"
+  :progress-by-controller-id="progressByControllerId"
+  :done-count="doneCount"
+/>
+<AstrosFirmwareControllersPanel
+  v-else-if="firmwareStore.phase === 'failed'"
+  phase="failed"
+  :progress-by-controller-id="progressByControllerId"
+  :failed-controller-label="failedControllerLabel"
+  :failed-stage="failedStage ?? undefined"
+  :failed-count="failedCount"
+/>
+```
+
+- [ ] **B.4.4:** Run build + the panel's existing spec:
+
+Run: `cd astros_vue && npm run build && npx vitest run src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts`
+Expected: all pass. If the existing tests passed flat-shape props, update them to pass discriminated shape.
+
+---
+
+## Task B.5: IM-9 — `useWebsocket.wsConnect` closure capture
+
+Handler closures reference `ws.value` (mutable). Re-connect during HMR or programmatic retry can cause cross-socket close.
+
+**Files:**
+- Modify: `astros_vue/src/composables/useWebsocket.ts:35-65`
+
+- [ ] **B.5.1:** Read the current `wsConnect` to confirm shape:
+
+Run: `grep -n "function wsConnect\|onopen\|onerror\|onmessage\|onclose" astros_vue/src/composables/useWebsocket.ts`
+
+- [ ] **B.5.2:** Refactor `wsConnect` to capture the socket locally:
+
+```ts
+function wsConnect() {
+  intentionallyClosed = false;
+  // Capture the new socket in a local so handlers don't close over
+  // ws.value (which is mutated by subsequent reconnects).
+  const socket = new WebSocket(getWsUrl());
+  ws.value = socket;
+  socket.onopen = () => {
+    wsHasEverConnected.value = true;
+    // ... existing onopen body using `socket`, not `ws.value`
+  };
+  socket.onerror = (error) => {
+    console.error('WebSocket error:', error);
+    socket.close();
+  };
+  socket.onmessage = (event) => {
+    handleMessage(event.data);
+  };
+  socket.onclose = () => {
+    if (!intentionallyClosed) {
+      setTimeout(wsConnect, 3000);
+    }
+  };
+}
+```
+
+Preserve the existing handler body content; only swap `ws.value?.` references to `socket.` and confirm setTimeout/intentionallyClosed flow is preserved.
+
+- [ ] **B.5.3:** Run tests:
+
+Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts`
+Expected: all pass.
+
+---
+
+## Task B.6: IM-10 — `cancelFlash` surfaces errors via flashError
+
+Decision: surface (not delete). The action is exported and intended for future Cancel UI; silently logging on failure would leave the operator stranded.
+
+**Files:**
+- Modify: `astros_vue/src/stores/firmware.ts` (`cancelFlash` around line 522-533)
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
+
+- [ ] **B.6.1:** Add failing test:
+
+```ts
+it('surfaces flashError when the cancel HTTP fails (operator visibility)', async () => {
+  const store = useFirmwareStore();
+  vi.mocked(apiClient.delete).mockRejectedValueOnce(new Error('network down'));
+  await store.cancelFlash();
+  expect(store.flashError?.reason).toBe('network_error');
+  expect(store.flashError?.detail).toContain('Cancel request failed');
+});
+```
+
+- [ ] **B.6.2:** Run to confirm failure.
+
+- [ ] **B.6.3:** Update `cancelFlash` catch:
+
+```ts
+async function cancelFlash(): Promise<void> {
+  try {
+    await apiClient.delete(FIRMWARE_FLASH);
+  } catch (error) {
+    console.warn('firmware.cancelFlash failed', error);
+    setFlashError({
+      reason: 'network_error',
+      detail:
+        'Cancel request failed; the flash may still be running. Refresh to recheck status.',
+    });
+  }
+}
+```
+
+- [ ] **B.6.4:** Run tests:
+
+Run: `cd astros_vue && npx vitest run -t "surfaces flashError when the cancel HTTP fails"`
+Expected: PASS.
+
+---
+
+## Task B.7: IM-8 — Test coverage additions (8 tests)
+
+Bundle these into one task since each is small. Each follows: write the test → run/fail → no implementation needed (the production code already does the right thing OR a tiny implementation fix follows) → run/pass.
+
+**Files:**
+- Modify: `astros_vue/src/composables/__tests__/useWebsocket.spec.ts`
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
+- Modify: `astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts`
+- Modify: `astros_vue/src/views/__tests__/FirmwareView.spec.ts`
+
+- [ ] **B.7.1:** Add `FLASH_CONTROLLER_RESULT` happy-path dispatcher test (pr-test-analyzer C2):
+
+```ts
+// In useWebsocket.spec.ts inside the existing dispatcher describe:
+it('routes FLASH_CONTROLLER_RESULT through applyControllerResult with the full payload (happy path)', () => {
+  const { handleMessage } = useWebsocket();
+  const firmware = useFirmwareStore();
+  const controllers = useControllerStore();
+  controllers.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+  firmware.applyJobStarted({
+    jobId: 'job-1',
+    source: { kind: 'github', version: 'v1.4.2' },
+    controllers: [{ controllerId: 'aa:bb:cc:dd:ee:01', stage: 'VERIFYING' }],
+    startedAt: '2026-05-14T08:00:00Z',
+  });
+  handleMessage(JSON.stringify({
+    type: WebsocketMessageType.FLASH_CONTROLLER_RESULT,
+    data: {
+      jobId: 'job-1',
+      controller: { controllerId: 'aa:bb:cc:dd:ee:01', stage: 'VERSION_CONFIRMED', finalVersion: 'v1.4.2' },
+    },
+  }));
+  const core = firmware.controllerStates.get('core');
+  expect(core?.stage).toBe('VERSION_CONFIRMED');
+  expect(core?.stage === 'VERSION_CONFIRMED' && core.finalVersion).toBe('v1.4.2');
+});
+```
+
+- [ ] **B.7.2:** Add `FLASH_JOB_ACTIVE` no-op contract test (pr-test-analyzer C3):
+
+```ts
+it('FLASH_JOB_ACTIVE is a no-op: phase, flashError, controllerStates all unchanged', () => {
+  const { handleMessage } = useWebsocket();
+  const firmware = useFirmwareStore();
+  firmware.setPhase('flashing');
+  const phaseBefore = firmware.phase;
+  const errorBefore = firmware.flashError;
+  const statesSizeBefore = firmware.controllerStates.size;
+  handleMessage(JSON.stringify({
+    type: WebsocketMessageType.FLASH_JOB_ACTIVE,
+    data: { reason: 'write_during_flash' },
+  }));
+  expect(firmware.phase).toBe(phaseBefore);
+  expect(firmware.flashError).toBe(errorBefore);
+  expect(firmware.controllerStates.size).toBe(statesSizeBefore);
+});
+```
+
+- [ ] **B.7.3:** Add `flushPendingForMac` re-queue forensic warn test (pr-test-analyzer C4):
+
+```ts
+// In firmware.spec.ts inside an appropriate describe:
+it('logs a distinct re-queue warning when flushPendingForMac re-enqueues during flush (forensic breadcrumb)', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const store = useFirmwareStore();
+    // Force pendingByMac to have an entry by applying an update with no slot mapping
+    store.applyControllerUpdate({ controllerId: 'aa:bb:cc:dd:ee:99', stage: 'SENDING' });
+    expect(store.pendingByMac.size).toBe(1);
+    // Flush without first calling setControllerMac — resolver still returns null
+    store.flushPendingForMac('aa:bb:cc:dd:ee:99');
+    const warnText = warnSpy.mock.calls.flat().join(' ');
+    expect(warnText).toContain('re-queued during flush');
+    expect(warnText).toContain('aa:bb:cc:dd:ee:99');
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+```
+
+(`flushPendingForMac` must be exposed on the store for this test. If it isn't, expose it as a public action — round-5 may have already done so.)
+
+- [ ] **B.7.4:** Strengthen `applyJobStarted` replace-not-merge mutation test (pr-test-analyzer C6). Find the existing test at `firmware.spec.ts:653` and replace its body:
+
+```ts
+it('REPLACES (not merges) controllerStates on duplicate flashJobStarted', () => {
+  const store = useFirmwareStore();
+  seedSampleFleet();
+  store.applyJobStarted(sampleJobState());
+  store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
+  store.applyControllerUpdate({ controllerId: CORE_MAC, stage: 'SENDING' });
+  // Both are now SENDING. New snapshot contains only body at VERIFYING.
+  store.applyJobStarted(sampleJobState({
+    controllers: [{ controllerId: BODY_MAC, stage: 'VERIFYING' }],
+  }));
+  // Replace semantics: core must be absent. Merge would keep it at SENDING.
+  expect(store.controllerStates.get('body')?.stage).toBe('VERIFYING');
+  expect(store.controllerStates.get('core')).toBeUndefined();
+  expect(store.controllerStates.size).toBe(1);
+});
+```
+
+- [ ] **B.7.5:** Add `FLASH_JOB_STARTED` dispatcher happy-path test (pr-test-analyzer I3):
+
+```ts
+it('routes well-formed FLASH_JOB_STARTED through applyJobStarted', () => {
+  const { handleMessage } = useWebsocket();
+  const firmware = useFirmwareStore();
+  handleMessage(JSON.stringify({
+    type: WebsocketMessageType.FLASH_JOB_STARTED,
+    data: {
+      jobId: 'job-X',
+      source: { kind: 'github', version: 'v1.0' },
+      controllers: [],
+      startedAt: '2026-05-14T08:00:00Z',
+    },
+  }));
+  expect(firmware.currentJob?.jobId).toBe('job-X');
+  expect(firmware.phase).toBe('flashing');
+});
+```
+
+- [ ] **B.7.6:** Add i18n key contract test (pr-test-analyzer I4):
+
+```ts
+// In firmwareStageMapping.spec.ts or a new firmwareFlashError.spec.ts:
+import { FLASH_ERROR_REASONS } from '@/types/firmware';
+import enUS from '@/locales/enUS.json';
+
+it('every FlashErrorReason has a corresponding firmware_view.flash_errors.* i18n key', () => {
+  for (const reason of FLASH_ERROR_REASONS) {
+    expect(enUS.firmware_view.flash_errors).toHaveProperty(reason);
+  }
+});
+```
+
+- [ ] **B.7.7:** Add `flashError` persists-across-success test (pr-test-analyzer I7):
+
+```ts
+// In useWebsocket.spec.ts:
+it('flashError persists across a subsequent successful applyControllerUpdate (operator must dismiss)', () => {
+  const { handleMessage } = useWebsocket();
+  const firmware = useFirmwareStore();
+  const controllers = useControllerStore();
+  controllers.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+  firmware.setFlashError({ reason: 'protocol_violation', detail: 'earlier error' });
+  handleMessage(JSON.stringify({
+    type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+    data: { controllerId: 'aa:bb:cc:dd:ee:01', stage: 'VERIFYING' },
+  }));
+  expect(firmware.flashError?.reason).toBe('protocol_violation');
+});
+```
+
+- [ ] **B.7.8:** Add `lockSinceFormatted` defensive NaN-fallback test (pr-test-analyzer I8):
+
+```ts
+// In FirmwareView.spec.ts:
+it('lockSinceFormatted renders a fallback (not "Invalid Date") for malformed ISO', async () => {
+  // Mount with a jobLockStore.since set to a malformed string
+  // and assert the banner copy doesn't contain "Invalid Date" or "NaN".
+  // Use the existing mount helper from this file and stub useJobLockStore.
+});
+```
+
+(Fill in the test body using the existing FirmwareView mount helper pattern. The assertion goes against the rendered banner text.)
+
+- [ ] **B.7.9:** Run all tests:
+
+Run: `cd astros_vue && npx vitest run`
+Expected: all pass.
+
+---
+
+## Task B.8: Phase B wrap — verify, review, commit
+
+- [ ] **B.8.1:** Run prettier + lint + build + tests on both projects.
+
+Run:
+```bash
+cd astros_vue && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run
+cd ../astros_api && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run
+```
+Expected: all green.
+
+- [ ] **B.8.2:** Invoke `superpowers:requesting-code-review` on the Phase B diff. Prompt:
+
+> Review the changes since Commit A for Phase B of the round-7 review fixes. The diff implements 7 Important findings: array/element validation in buildControllerStatesMap (IM-3), discriminated-union ControllerFlashState (IM-2), SlotId wire-vs-by-slot split (IM-11), ControllersPanelProps discriminated union (IM-12), useWebsocket closure capture (IM-9), cancelFlash error surfacing (IM-10), plus 8 test coverage additions (IM-8). Look for: type-narrowing sites that should use a discriminated check instead of an `as` cast, missed sibling claims after the type changes (CLAUDE.md partial-fix sweep — header docstrings, plan refs), any test added that's vacuous (would pass if production code was reverted).
+
+Address any Critical or Important findings.
+
+- [ ] **B.8.3:** Stage and commit Phase B:
+
+```bash
+git add astros_vue/src/types/firmware.ts \
+  astros_vue/src/stores/firmware.ts \
+  astros_vue/src/stores/__tests__/firmware.spec.ts \
+  astros_vue/src/composables/useWebsocket.ts \
+  astros_vue/src/composables/__tests__/useWebsocket.spec.ts \
+  astros_vue/src/components/firmware/firmwareControllersPanel/types.ts \
+  astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue \
+  astros_vue/src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts \
+  astros_vue/src/views/FirmwareView.vue \
+  astros_vue/src/views/__tests__/FirmwareView.spec.ts \
+  astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts \
+  astros_vue/src/utils/firmwareStageMapping.ts \
+  astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue
+git commit -m "$(cat <<'EOF'
+fix(firmware): round-7 Importants (code+tests) — discriminated unions + SlotId split + WS lifecycle + 8 coverage gaps
+
+IM-3: buildControllerStatesMap rejects non-array states and warns on
+  invalid per-element shape. Prevents pendingByMac pollution from
+  malformed server payloads.
+
+IM-2: ControllerFlashState (client mirror) is now a discriminated
+  union on stage. VERSION_CONFIRMED requires finalVersion, FAILED
+  requires error — matches the server's contract.
+
+IM-11: ControllerFlashState split into wire (`controllerId: string`
+  MAC) and by-slot (`controllerId: SlotId`) views. The cast tax in
+  applyControllerUpdate/applyJobFailed drops from 3 sites to 1
+  (buildControllerStatesMap, the translation boundary).
+
+IM-12: ControllersPanelProps is a discriminated union on phase.
+  Phase-vs-fields correlations enforced at compile time; dev-only
+  watchEffect warnings retired.
+
+IM-9: useWebsocket.wsConnect captures the socket locally so handlers
+  reference the correct WebSocket across reconnects. Closes a
+  potential cross-socket-close HMR race.
+
+IM-10: cancelFlash surfaces a network_error flashError on HTTP
+  failure instead of logging silently.
+
+IM-8: 8 coverage gaps closed — happy-path dispatch for
+  flashControllerResult and flashJobStarted, FLASH_JOB_ACTIVE no-op
+  contract pin, flushPendingForMac re-queue forensic warn, mutation-
+  resistant replace-not-merge, i18n key contract for FlashErrorReason,
+  flashError-persists-across-success, lockSinceFormatted NaN fallback.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **B.8.4:** Check off Phase B in this plan, commit the update.
+
+---
+
+# Phase C — Importants (prose + cleanup) (Commit C)
+
+Single commit at end of phase. Message: `fix(firmware): round-7 Importants (prose+cleanup) — abortReason wired + 3 test renames + 5 plan/QA drifts + dispatcher comment + source-type doc`.
+
+## Task C.1: IM-1 — Wire `currentJob.abortReason` into FirmwareView (or remove writes)
+
+Decision: **wire into the failed-result bar.** The data is captured at `applyJobFailed:411-413` but unused. Operators benefit from seeing the abort reason inline with the failure attribution.
+
+**Files:**
+- Modify: `astros_vue/src/views/FirmwareView.vue` (failed-phase render block)
+- Modify: `astros_vue/src/locales/enUS.json` (add an i18n key for the abort label if needed)
+
+- [ ] **C.1.1:** Find the failed-result bar in `FirmwareView.vue` (search for `phase === 'failed'` template region or the `failedControllerLabels` rendering).
+
+- [ ] **C.1.2:** Add a render for `currentJob?.abortReason` near the failure detail. Example:
+
+```vue
+<div v-if="firmwareStore.phase === 'failed' && firmwareStore.currentJob?.abortReason"
+     class="text-sm opacity-80 mt-1">
+  {{ $t('firmware_view.failed.abort_reason', { reason: firmwareStore.currentJob.abortReason }) }}
+</div>
+```
+
+- [ ] **C.1.3:** Add the i18n key to `enUS.json`:
+
+```json
+"firmware_view": {
+  "failed": {
+    "abort_reason": "Abort reason: {reason}"
+  }
+}
+```
+
+(Place inside the existing `firmware_view.failed.*` block.)
+
+- [ ] **C.1.4:** Add a view test:
+
+```ts
+// In FirmwareView.spec.ts:
+it('renders abortReason in the failed-result bar when present', () => {
+  const wrapper = mountWithStore({
+    phase: 'failed',
+    currentJob: makeJob({ abortReason: 'user_cancel' }),
+    failedControllers: [{ id: 'core', label: 'Core', stage: 'transfer' }],
+  });
+  expect(wrapper.text()).toContain('user_cancel');
+});
+```
+
+Adjust `mountWithStore`/`makeJob` to match the file's existing helpers.
+
+- [ ] **C.1.5:** Run tests:
+
+Run: `cd astros_vue && npx vitest run src/views/__tests__/FirmwareView.spec.ts`
+Expected: all pass.
+
+---
+
+## Task C.2: IM-4 — Rename 3 drifted test-name format strings
+
+**Files:**
+- Modify: `astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts:65`
+- Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts:1023, 1100`
+
+- [ ] **C.2.1:** In `AstrosWriteButton.spec.ts:65`, rename the test from `'applies the tooltip class to the wrapper only when readOnly is true'` to `'applies the tooltip class to the wrapper when either readOnly OR jobLock.locked is true'`. Add a positive locked-tooltip assertion alongside the existing readOnly one (or split into two tests with accurate names).
+
+- [ ] **C.2.2:** In `firmware.spec.ts:1023`, rename `'collects ALL FAILED entries (multi-failure realistic on bus-wide ESP-NOW errors)'` to `'collects ALL FAILED entries AND attributes stage from the shared currentStage ref (not per-controller history)'`. Or split into two tests.
+
+- [ ] **C.2.3:** In `firmware.spec.ts:1100`, rename `'preserves server-reported FAILED entries during the failed normalize (preserves their error string)'` to `'preserves server-reported FAILED error strings AND leaves demoted entries without an error string (C1 normalize attribution)'`. Or split.
+
+- [ ] **C.2.4:** Run all affected tests:
+
+Run: `cd astros_vue && npx vitest run src/components/common/__tests__/AstrosWriteButton.spec.ts src/stores/__tests__/firmware.spec.ts`
+Expected: all pass.
+
+---
+
+## Task C.3: IM-7 — Update dispatcher sole-writer comment
+
+**Files:**
+- Modify: `astros_vue/src/composables/useWebsocket.ts:258-265`
+
+- [ ] **C.3.1:** Find the comment block at lines 258-265 (search for "directly" near the firmware-flash handler family doc). Replace `the catch path may also write store.flashError directly` with:
+
+```ts
+// The catch path may also call store.setFlashError(...) to surface a
+// generic envelope (when the store can't see the malformed input to
+// recover by itself). All flashError writes route through setFlashError
+// (the round-6 sole-writer pattern — see firmware.ts:209 setFlashError).
+```
+
+- [ ] **C.3.2:** Search for any other comments in `useWebsocket.ts` that reference `flashError =` or `store.flashError =`. Replace with `setFlashError` references.
+
+Run: `grep -n "flashError\s*=" astros_vue/src/composables/useWebsocket.ts`
+Expected: no comment-level direct-write references remain (test files and stories are not in scope).
+
+---
+
+## Task C.4: IM-6 — Fix `FlashJobState.source` doc
+
+**Files:**
+- Modify: `astros_vue/src/types/firmware.ts:166-168`
+
+- [ ] **C.4.1:** Replace the docstring above `FlashJobState`:
+
+```ts
+/**
+ * Mirror of the server's `FlashJobState`, narrowed to UI-readable fields.
+ * The server transmits the full `FlashSource` shape (sha256, sizeBytes,
+ * displayName); we keep only what the UI needs. Source of truth:
+ * `astros_api/src/models/firmware/flash_job_state.ts`.
+ *
+ * Note: `endedAt` is set on both success and failure terminal states.
+ * `abortReason` is set only on cancel/streamer-rejection paths.
+ */
+```
+
+---
+
+## Task C.5: IM-5a — Fix plan-file line refs and stale claims (5 sites)
+
+**Files:**
+- Modify: `.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md`
+
+- [ ] **C.5.1:** Update L40 and L281: change `api_server.ts:652-660` → `api_server.ts:654-669`.
+
+- [ ] **C.5.2:** Update L203: change `"228 tests total at branch tip across rounds 1–4"` → `"228 tests total at branch tip across all six (now seven) fix rounds"`.
+
+- [ ] **C.5.3:** Update L221: change `"5 FMI hazards"` → `"7 FMI hazards"` (or however many rows the table actually has — count and match).
+
+- [ ] **C.5.4:** Update L246 (FMI item 6): change `'internal_server_error'` → `'protocol_violation'` for the WS-handler malformed-payload envelope. (Note: `internal_server_error` remains the correct envelope for the `applyJobFailed` unknown-server-reason fallback — clarify both.)
+
+- [ ] **C.5.5:** Update L278: change `flash_job_state.ts:1-40` → `flash_job_state.ts:1-47` (or drop the line range entirely).
+
+- [ ] **C.5.6:** Add a new FMI inventory row capturing the CR-1 reboot-wait wedge race (per the round-7 review finding):
+
+```
+| 8 | HTTP cold-load during reboot-wait window | fetchCurrentJob applied an endedAt-set body, wedging phase at flashing | Mirrored server's decideLateJoinSnapshot filter; defense-in-depth in handleLockStateChanged forces phase=done on lock release |
+```
+
+(Adjust column/format to match the existing FMI table layout.)
+
+---
+
+## Task C.6: IM-5b — Fix QA plan test-count drift
+
+**Files:**
+- Modify: `.docs/qa/firmware-ota-flash-ui.md`
+
+- [ ] **C.6.1:** Find line 166 (`"The 210 vitest tests still pass"`) and update to `"All vitest tests still pass"` (drop the number to avoid future drift), or update to the post-round-7 count once Phase C is complete.
+
+Run: `cd astros_vue && npx vitest run 2>&1 | tail -5` to get the post-round-7 count.
+
+- [ ] **C.6.2:** Update line 3 if needed to match.
+
+- [ ] **C.6.3:** Add a QA test case §6.5 covering the reboot-wait wedge fix from CR-1:
+
+```markdown
+### 6.5 Refresh during the 15s reboot-wait window after a successful flash
+
+**Preconditions:** A flash has just completed; the result bar shows "✓ all updated"; the server is in the reboot-wait window (lock still held).
+
+**Steps:**
+1. Refresh the browser tab.
+
+**Expected:**
+- Page shows phase='idle' / Select panel (CR-1a fix).
+- Lock-conflict banner may briefly appear if the lock hasn't released yet; it disappears within ~15s.
+- No UI wedge at phase='flashing'.
+
+**Regression signal (pre-fix):** Page rendered phase='flashing' indefinitely until a second refresh.
+```
+
+---
+
+## Task C.7: Sweep — partial-fix check on all renamed/edited claims
+
+CLAUDE.md emphasizes the "partial-fix sweep" pattern: fix the cited site AND every sibling. After Phase C's edits, grep for any remaining stale references.
+
+- [ ] **C.7.1:** Sweep for `"210"` in `.docs/`:
+
+Run: `grep -rn "210" .docs/ | grep -v node_modules`
+Inspect each match — any reference to "210 tests" or "210 passing" is stale; update.
+
+- [ ] **C.7.2:** Sweep for old API-server line refs:
+
+Run: `grep -rn "api_server.ts:65" .docs/`
+Inspect each — confirm they point at the post-round-7 line numbers.
+
+- [ ] **C.7.3:** Sweep for `"rounds 1–4"` / `"rounds 1-4"` in `.docs/`:
+
+Run: `grep -rn "rounds 1.4\|round 4\|round-4" .docs/`
+Inspect — any "at branch tip" claim should reflect round 7.
+
+- [ ] **C.7.4:** Sweep `useWebsocket.ts` for any other stale direct-write claims:
+
+Run: `grep -n "flashError\s*=" astros_vue/src/composables/useWebsocket.ts`
+Expected: no comment-level direct-write references; only `setFlashError(...)` calls.
+
+- [ ] **C.7.5:** Sweep the round-7 plan file itself for any line refs that may have shifted:
+
+Run: `grep -n "firmware.ts:\|useWebsocket.ts:\|api_server.ts:" .docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md`
+Inspect — confirm line numbers point at the post-Phase-B state (these are best-effort because the plan was written before the code shifted; flag any that are clearly off).
+
+---
+
+## Task C.8: Phase C wrap — verify, review, commit
+
+- [ ] **C.8.1:** Run prettier + lint + build + tests on Vue (no API changes in Phase C):
+
+Run: `cd astros_vue && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run`
+Expected: all green.
+
+- [ ] **C.8.2:** Invoke `superpowers:requesting-code-review` on the Phase C diff. Prompt:
+
+> Review the changes since Commit B for Phase C of the round-7 review fixes. The diff implements 5 Important prose/cleanup findings: abortReason wired into the failed-result bar (IM-1), 3 test renames to fix format-string drifts (IM-4), dispatcher sole-writer comment update (IM-7), FlashJobState.source docstring correction (IM-6), 5 plan/QA prose drift fixes including a new FMI row and QA test case for the CR-1 wedge fix (IM-5). Look specifically for: any test rename that now lies in a different way, any sibling claim I missed in the prose sweep (CLAUDE.md partial-fix sweep), any rendered abortReason path that crashes on undefined.
+
+Address any Critical or Important findings.
+
+- [ ] **C.8.3:** Stage and commit Phase C:
+
+```bash
+git add astros_vue/src/views/FirmwareView.vue \
+  astros_vue/src/views/__tests__/FirmwareView.spec.ts \
+  astros_vue/src/locales/enUS.json \
+  astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts \
+  astros_vue/src/stores/__tests__/firmware.spec.ts \
+  astros_vue/src/composables/useWebsocket.ts \
+  astros_vue/src/types/firmware.ts \
+  .docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md \
+  .docs/qa/firmware-ota-flash-ui.md
+git commit -m "$(cat <<'EOF'
+fix(firmware): round-7 Importants (prose+cleanup) — abortReason wired + 3 test renames + 5 plan/QA drifts + dispatcher comment + source-type doc
+
+IM-1: currentJob.abortReason now renders in the failed-result bar.
+  The field was being captured at applyJobFailed but never displayed
+  — operators saw the FlashError detail but not the abort reason.
+
+IM-4: 3 test names renamed to match what they actually verify
+  (AstrosWriteButton tooltip-on-locked, firmware.spec.ts shared-
+  stage attribution, firmware.spec.ts normalize-without-error).
+  Closes the CLAUDE.md flagged broken-test-name format-string category.
+
+IM-7: Dispatcher sole-writer comment now correctly references
+  setFlashError instead of "flashError directly", matching the
+  round-6 contract.
+
+IM-6: FlashJobState.source docstring points at FlashSource (server's
+  actual transmit type) instead of FlashRequest (the POST body
+  shape). Adds note on endedAt/abortReason semantics.
+
+IM-5: Plan file line refs corrected (api_server.ts:654-669, not
+  :652-660; flash_job_state.ts:1-47, not :1-40). Stale test count
+  (210) replaced. FMI hazard count corrected (7, not 5). Round-6
+  protocol_violation envelope added to FMI item 6. New FMI row 8
+  added for the CR-1 reboot-wait wedge race. QA plan adds test
+  case 6.5 for the reboot-wait refresh scenario.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **C.8.4:** Check off Phase C in this plan, commit the update.
+
+---
+
+# Post-phase verification
+
+After all 3 commits land:
+
+- [ ] **Z.1:** Re-run the full pre-push toolkit on the branch vs `origin/develop`:
+
+Run: `/pr-review-toolkit:review-pr`
+
+Expected: All 6 Criticals from round-7 resolved; the 12 Importants addressed or downgraded. Any new findings from the toolkit pass become round-8 work (or fold into existing commits if the user requests).
+
+- [ ] **Z.2:** Confirm test count, build pass, lint clean:
+
+Run:
+```bash
+cd astros_vue && npm run build && npx vitest run 2>&1 | tail -3
+cd ../astros_api && npm run build && npx vitest run 2>&1 | tail -3
+```
+
+- [ ] **Z.3:** Hand off to user for VS Code push (per memory: never push from terminal).
+
+---
+
+# Notes on this plan
+
+- **No new branches.** All commits land on `feature/firmware-ota-d-6-live-wiring`.
+- **No `git push`.** The user pushes via VS Code per their workflow.
+- **Plan commits are part of the deliverable.** The plan commit (A.0) and the post-phase plan-update commits (A.12.5, B.8.4, C.8.4) keep this file as the single source of truth for progress.
+- **Each phase is independently shippable.** If interrupted, the branch can be pushed with just Phase A landed and the remaining work picked up next session.
+- **TDD where applicable.** Store/composable/util/type changes have failing-test-first. UI template tweaks (e.g., the abortReason render in C.1) get a test after, per CLAUDE.md's TDD-exception for UI work.
+- **The code-review subagent runs before EACH commit.** This is mandatory per CLAUDE.md's pre-commit section (carve-outs don't apply because every commit touches `.ts`/`.vue` logic).

--- a/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
+++ b/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
@@ -892,7 +892,7 @@ Single commit at end of phase. Message: `fix(firmware): round-7 Importants (code
 - Modify: `astros_vue/src/stores/firmware.ts` (`buildControllerStatesMap` around line 248-274; also `handleFlashJobStarted` guard upstream)
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
 
-- [ ] **B.1.1:** Add failing test:
+- [x] **B.1.1:** Add failing test:
 
 ```ts
 describe('buildControllerStatesMap defensive validation (IM-3)', () => {
@@ -932,12 +932,12 @@ describe('buildControllerStatesMap defensive validation (IM-3)', () => {
 });
 ```
 
-- [ ] **B.1.2:** Run to confirm failure.
+- [x] **B.1.2:** Run to confirm failure.
 
 Run: `cd astros_vue && npx vitest run -t "buildControllerStatesMap defensive validation"`
 Expected: FAIL.
 
-- [ ] **B.1.3:** Edit `buildControllerStatesMap`. Replace the guard `if (!states) return m;` with:
+- [x] **B.1.3:** Edit `buildControllerStatesMap`. Replace the guard `if (!states) return m;` with:
 
 ```ts
 function buildControllerStatesMap(
@@ -961,7 +961,7 @@ function buildControllerStatesMap(
 
 Preserve the existing per-element body (resolveSlot → enqueuePending fallback) — only the guards above change.
 
-- [ ] **B.1.4:** Run to confirm pass + full firmware suite:
+- [x] **B.1.4:** Run to confirm pass + full firmware suite:
 
 Run: `cd astros_vue && npx vitest run src/stores/__tests__/firmware.spec.ts`
 Expected: all pass.
@@ -978,11 +978,11 @@ Server's `ControllerFlashState` is a discriminated union: `VersionConfirmed/fina
 - Modify: `astros_vue/src/utils/firmwareStageMapping.ts` (consumers of `state.stage`)
 - Modify: `astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue` (consumers of finalVersion / error)
 
-- [ ] **B.2.1:** Read the server-side discriminated union to mirror exactly.
+- [x] **B.2.1:** Read the server-side discriminated union to mirror exactly.
 
 Run: `grep -n "type ControllerFlashState\|interface ControllerFlashState\|FwStage\.Failed\|FwStage\.VersionConfirmed" astros_api/src/models/firmware/flash_job_state.ts`
 
-- [ ] **B.2.2:** Replace the client `ControllerFlashState` interface in `types/firmware.ts:157-164`:
+- [x] **B.2.2:** Replace the client `ControllerFlashState` interface in `types/firmware.ts:157-164`:
 
 ```ts
 /**
@@ -1003,19 +1003,19 @@ export type ControllerFlashState =
   | { controllerId: string; stage: 'FAILED'; error: string };
 ```
 
-- [ ] **B.2.3:** Run TS build to find every site that breaks:
+- [x] **B.2.3:** Run TS build to find every site that breaks:
 
 Run: `cd astros_vue && npm run build`
 Expected: failures at consumer sites that read `state.error` or `state.finalVersion` without first narrowing on `stage`. Fix each by checking `state.stage === 'FAILED'` or `state.stage === 'VERSION_CONFIRMED'` first.
 
-- [ ] **B.2.4:** For each compile error, narrow at the read site. Examples:
+- [x] **B.2.4:** For each compile error, narrow at the read site. Examples:
   - `controllerStatePillKind(state)` in `selectModePillKind.ts` or `firmwareStageMapping.ts` — narrow inside the switch on `state.stage`
   - `state.finalVersion` reads in `AstrosFirmwareControllerRow.vue` — gate on `state.stage === 'VERSION_CONFIRMED'`
   - `state.error` reads — gate on `state.stage === 'FAILED'`
 
 For each narrowing, prefer a small `if`-gate over an `as` cast.
 
-- [ ] **B.2.5:** Run build + tests:
+- [x] **B.2.5:** Run build + tests:
 
 Run: `cd astros_vue && npm run build && npx vitest run`
 Expected: all green.
@@ -1030,7 +1030,7 @@ The current `controllerId: string` field carries either MAC or SlotId depending 
 - Modify: `astros_vue/src/types/firmware.ts`
 - Modify: `astros_vue/src/stores/firmware.ts`
 
-- [ ] **B.3.1:** Add a new `ControllerFlashStateBySlot` type next to the existing `ControllerFlashState` (which becomes wire-side only):
+- [x] **B.3.1:** Add a new `ControllerFlashStateBySlot` type next to the existing `ControllerFlashState` (which becomes wire-side only):
 
 ```ts
 /**
@@ -1044,17 +1044,17 @@ export type ControllerFlashStateBySlot =
   | { controllerId: SlotId; stage: 'FAILED'; error: string };
 ```
 
-- [ ] **B.3.2:** Update `firmware.ts`:
+- [x] **B.3.2:** Update `firmware.ts`:
   - The store's `controllerStates` map becomes `ReadonlyMap<SlotId, ControllerFlashStateBySlot>`.
   - `buildControllerStatesMap` returns `Map<SlotId, ControllerFlashStateBySlot>` and is the translation site.
   - `applyControllerUpdate` translates incoming `ControllerFlashState` to `ControllerFlashStateBySlot` by replacing `controllerId` with the resolved slot.
 
-- [ ] **B.3.3:** Run build:
+- [x] **B.3.3:** Run build:
 
 Run: `cd astros_vue && npm run build`
 Expected: cast count at line 239/456/610 drops to one (the translation in `buildControllerStatesMap`). Fix any new compile errors at consumer sites.
 
-- [ ] **B.3.4:** Run tests:
+- [x] **B.3.4:** Run tests:
 
 Run: `cd astros_vue && npx vitest run`
 Expected: all pass.
@@ -1068,7 +1068,7 @@ Expected: all pass.
 - Modify: `astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue`
 - Modify: `astros_vue/src/views/FirmwareView.vue` (the call site)
 
-- [ ] **B.4.1:** Replace `ControllersPanelProps` with a discriminated union:
+- [x] **B.4.1:** Replace `ControllersPanelProps` with a discriminated union:
 
 ```ts
 import type { FirmwareStage, ControllerProgressEntry, SlotId } from '@/types/firmware';
@@ -1088,7 +1088,7 @@ export type ControllersPanelProps =
     };
 ```
 
-- [ ] **B.4.2:** Update `AstrosFirmwareControllersPanel.vue`. Replace the existing `defineProps<ControllersPanelProps>()` and the dev-only `watchEffect` warnings (since TS now enforces the constraints). Use TS narrowing throughout the template:
+- [x] **B.4.2:** Update `AstrosFirmwareControllersPanel.vue`. Replace the existing `defineProps<ControllersPanelProps>()` and the dev-only `watchEffect` warnings (since TS now enforces the constraints). Use TS narrowing throughout the template:
 
 ```ts
 const props = defineProps<ControllersPanelProps>();
@@ -1098,7 +1098,7 @@ const props = defineProps<ControllersPanelProps>();
 
 In the template, narrow by phase before reading phase-specific props.
 
-- [ ] **B.4.3:** Update the call site in `FirmwareView.vue`. The current `<AstrosFirmwareControllersPanel ... />` call passes all optional props; update to pass only the phase-appropriate set, conditionally:
+- [x] **B.4.3:** Update the call site in `FirmwareView.vue`. The current `<AstrosFirmwareControllersPanel ... />` call passes all optional props; update to pass only the phase-appropriate set, conditionally:
 
 ```vue
 <AstrosFirmwareControllersPanel
@@ -1126,7 +1126,7 @@ In the template, narrow by phase before reading phase-specific props.
 />
 ```
 
-- [ ] **B.4.4:** Run build + the panel's existing spec:
+- [x] **B.4.4:** Run build + the panel's existing spec:
 
 Run: `cd astros_vue && npm run build && npx vitest run src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts`
 Expected: all pass. If the existing tests passed flat-shape props, update them to pass discriminated shape.
@@ -1140,11 +1140,11 @@ Handler closures reference `ws.value` (mutable). Re-connect during HMR or progra
 **Files:**
 - Modify: `astros_vue/src/composables/useWebsocket.ts:35-65`
 
-- [ ] **B.5.1:** Read the current `wsConnect` to confirm shape:
+- [x] **B.5.1:** Read the current `wsConnect` to confirm shape:
 
 Run: `grep -n "function wsConnect\|onopen\|onerror\|onmessage\|onclose" astros_vue/src/composables/useWebsocket.ts`
 
-- [ ] **B.5.2:** Refactor `wsConnect` to capture the socket locally:
+- [x] **B.5.2:** Refactor `wsConnect` to capture the socket locally:
 
 ```ts
 function wsConnect() {
@@ -1174,7 +1174,7 @@ function wsConnect() {
 
 Preserve the existing handler body content; only swap `ws.value?.` references to `socket.` and confirm setTimeout/intentionallyClosed flow is preserved.
 
-- [ ] **B.5.3:** Run tests:
+- [x] **B.5.3:** Run tests:
 
 Run: `cd astros_vue && npx vitest run src/composables/__tests__/useWebsocket.spec.ts`
 Expected: all pass.
@@ -1189,7 +1189,7 @@ Decision: surface (not delete). The action is exported and intended for future C
 - Modify: `astros_vue/src/stores/firmware.ts` (`cancelFlash` around line 522-533)
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts`
 
-- [ ] **B.6.1:** Add failing test:
+- [x] **B.6.1:** Add failing test:
 
 ```ts
 it('surfaces flashError when the cancel HTTP fails (operator visibility)', async () => {
@@ -1201,9 +1201,9 @@ it('surfaces flashError when the cancel HTTP fails (operator visibility)', async
 });
 ```
 
-- [ ] **B.6.2:** Run to confirm failure.
+- [x] **B.6.2:** Run to confirm failure.
 
-- [ ] **B.6.3:** Update `cancelFlash` catch:
+- [x] **B.6.3:** Update `cancelFlash` catch:
 
 ```ts
 async function cancelFlash(): Promise<void> {
@@ -1220,7 +1220,7 @@ async function cancelFlash(): Promise<void> {
 }
 ```
 
-- [ ] **B.6.4:** Run tests:
+- [x] **B.6.4:** Run tests:
 
 Run: `cd astros_vue && npx vitest run -t "surfaces flashError when the cancel HTTP fails"`
 Expected: PASS.
@@ -1237,7 +1237,7 @@ Bundle these into one task since each is small. Each follows: write the test →
 - Modify: `astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts`
 - Modify: `astros_vue/src/views/__tests__/FirmwareView.spec.ts`
 
-- [ ] **B.7.1:** Add `FLASH_CONTROLLER_RESULT` happy-path dispatcher test (pr-test-analyzer C2):
+- [x] **B.7.1:** Add `FLASH_CONTROLLER_RESULT` happy-path dispatcher test (pr-test-analyzer C2):
 
 ```ts
 // In useWebsocket.spec.ts inside the existing dispatcher describe:
@@ -1265,7 +1265,7 @@ it('routes FLASH_CONTROLLER_RESULT through applyControllerResult with the full p
 });
 ```
 
-- [ ] **B.7.2:** Add `FLASH_JOB_ACTIVE` no-op contract test (pr-test-analyzer C3):
+- [x] **B.7.2:** Add `FLASH_JOB_ACTIVE` no-op contract test (pr-test-analyzer C3):
 
 ```ts
 it('FLASH_JOB_ACTIVE is a no-op: phase, flashError, controllerStates all unchanged', () => {
@@ -1285,7 +1285,7 @@ it('FLASH_JOB_ACTIVE is a no-op: phase, flashError, controllerStates all unchang
 });
 ```
 
-- [ ] **B.7.3:** Add `flushPendingForMac` re-queue forensic warn test (pr-test-analyzer C4):
+- [x] **B.7.3:** Add `flushPendingForMac` re-queue forensic warn test (pr-test-analyzer C4):
 
 ```ts
 // In firmware.spec.ts inside an appropriate describe:
@@ -1309,7 +1309,7 @@ it('logs a distinct re-queue warning when flushPendingForMac re-enqueues during 
 
 (`flushPendingForMac` must be exposed on the store for this test. If it isn't, expose it as a public action — round-5 may have already done so.)
 
-- [ ] **B.7.4:** Strengthen `applyJobStarted` replace-not-merge mutation test (pr-test-analyzer C6). Find the existing test at `firmware.spec.ts:653` and replace its body:
+- [x] **B.7.4:** Strengthen `applyJobStarted` replace-not-merge mutation test (pr-test-analyzer C6). Find the existing test at `firmware.spec.ts:653` and replace its body:
 
 ```ts
 it('REPLACES (not merges) controllerStates on duplicate flashJobStarted', () => {
@@ -1329,7 +1329,7 @@ it('REPLACES (not merges) controllerStates on duplicate flashJobStarted', () => 
 });
 ```
 
-- [ ] **B.7.5:** Add `FLASH_JOB_STARTED` dispatcher happy-path test (pr-test-analyzer I3):
+- [x] **B.7.5:** Add `FLASH_JOB_STARTED` dispatcher happy-path test (pr-test-analyzer I3):
 
 ```ts
 it('routes well-formed FLASH_JOB_STARTED through applyJobStarted', () => {
@@ -1349,7 +1349,7 @@ it('routes well-formed FLASH_JOB_STARTED through applyJobStarted', () => {
 });
 ```
 
-- [ ] **B.7.6:** Add i18n key contract test (pr-test-analyzer I4):
+- [x] **B.7.6:** Add i18n key contract test (pr-test-analyzer I4):
 
 ```ts
 // In firmwareStageMapping.spec.ts or a new firmwareFlashError.spec.ts:
@@ -1363,7 +1363,7 @@ it('every FlashErrorReason has a corresponding firmware_view.flash_errors.* i18n
 });
 ```
 
-- [ ] **B.7.7:** Add `flashError` persists-across-success test (pr-test-analyzer I7):
+- [x] **B.7.7:** Add `flashError` persists-across-success test (pr-test-analyzer I7):
 
 ```ts
 // In useWebsocket.spec.ts:
@@ -1381,7 +1381,7 @@ it('flashError persists across a subsequent successful applyControllerUpdate (op
 });
 ```
 
-- [ ] **B.7.8:** Add `lockSinceFormatted` defensive NaN-fallback test (pr-test-analyzer I8):
+- [x] **B.7.8:** Add `lockSinceFormatted` defensive NaN-fallback test (pr-test-analyzer I8):
 
 ```ts
 // In FirmwareView.spec.ts:
@@ -1394,7 +1394,7 @@ it('lockSinceFormatted renders a fallback (not "Invalid Date") for malformed ISO
 
 (Fill in the test body using the existing FirmwareView mount helper pattern. The assertion goes against the rendered banner text.)
 
-- [ ] **B.7.9:** Run all tests:
+- [x] **B.7.9:** Run all tests:
 
 Run: `cd astros_vue && npx vitest run`
 Expected: all pass.
@@ -1403,7 +1403,7 @@ Expected: all pass.
 
 ## Task B.8: Phase B wrap — verify, review, commit
 
-- [ ] **B.8.1:** Run prettier + lint + build + tests on both projects.
+- [x] **B.8.1:** Run prettier + lint + build + tests on both projects.
 
 Run:
 ```bash
@@ -1412,13 +1412,13 @@ cd ../astros_api && npm run prettier:write && npm run lint:fix && npm run build 
 ```
 Expected: all green.
 
-- [ ] **B.8.2:** Invoke `superpowers:requesting-code-review` on the Phase B diff. Prompt:
+- [x] **B.8.2:** Invoke `superpowers:requesting-code-review` on the Phase B diff. Prompt:
 
 > Review the changes since Commit A for Phase B of the round-7 review fixes. The diff implements 7 Important findings: array/element validation in buildControllerStatesMap (IM-3), discriminated-union ControllerFlashState (IM-2), SlotId wire-vs-by-slot split (IM-11), ControllersPanelProps discriminated union (IM-12), useWebsocket closure capture (IM-9), cancelFlash error surfacing (IM-10), plus 8 test coverage additions (IM-8). Look for: type-narrowing sites that should use a discriminated check instead of an `as` cast, missed sibling claims after the type changes (CLAUDE.md partial-fix sweep — header docstrings, plan refs), any test added that's vacuous (would pass if production code was reverted).
 
 Address any Critical or Important findings.
 
-- [ ] **B.8.3:** Stage and commit Phase B:
+- [x] **B.8.3:** Stage and commit Phase B:
 
 ```bash
 git add astros_vue/src/types/firmware.ts \
@@ -1472,7 +1472,7 @@ EOF
 )"
 ```
 
-- [ ] **B.8.4:** Check off Phase B in this plan, commit the update.
+- [x] **B.8.4:** Check off Phase B in this plan, commit the update.
 
 ---
 

--- a/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
+++ b/.docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md
@@ -1488,9 +1488,9 @@ Decision: **wire into the failed-result bar.** The data is captured at `applyJob
 - Modify: `astros_vue/src/views/FirmwareView.vue` (failed-phase render block)
 - Modify: `astros_vue/src/locales/enUS.json` (add an i18n key for the abort label if needed)
 
-- [ ] **C.1.1:** Find the failed-result bar in `FirmwareView.vue` (search for `phase === 'failed'` template region or the `failedControllerLabels` rendering).
+- [x] **C.1.1:** Find the failed-result bar in `FirmwareView.vue` (search for `phase === 'failed'` template region or the `failedControllerLabels` rendering).
 
-- [ ] **C.1.2:** Add a render for `currentJob?.abortReason` near the failure detail. Example:
+- [x] **C.1.2:** Add a render for `currentJob?.abortReason` near the failure detail. Example:
 
 ```vue
 <div v-if="firmwareStore.phase === 'failed' && firmwareStore.currentJob?.abortReason"
@@ -1499,7 +1499,7 @@ Decision: **wire into the failed-result bar.** The data is captured at `applyJob
 </div>
 ```
 
-- [ ] **C.1.3:** Add the i18n key to `enUS.json`:
+- [x] **C.1.3:** Add the i18n key to `enUS.json`:
 
 ```json
 "firmware_view": {
@@ -1511,7 +1511,7 @@ Decision: **wire into the failed-result bar.** The data is captured at `applyJob
 
 (Place inside the existing `firmware_view.failed.*` block.)
 
-- [ ] **C.1.4:** Add a view test:
+- [x] **C.1.4:** Add a view test:
 
 ```ts
 // In FirmwareView.spec.ts:
@@ -1527,7 +1527,7 @@ it('renders abortReason in the failed-result bar when present', () => {
 
 Adjust `mountWithStore`/`makeJob` to match the file's existing helpers.
 
-- [ ] **C.1.5:** Run tests:
+- [x] **C.1.5:** Run tests:
 
 Run: `cd astros_vue && npx vitest run src/views/__tests__/FirmwareView.spec.ts`
 Expected: all pass.
@@ -1540,13 +1540,13 @@ Expected: all pass.
 - Modify: `astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts:65`
 - Modify: `astros_vue/src/stores/__tests__/firmware.spec.ts:1023, 1100`
 
-- [ ] **C.2.1:** In `AstrosWriteButton.spec.ts:65`, rename the test from `'applies the tooltip class to the wrapper only when readOnly is true'` to `'applies the tooltip class to the wrapper when either readOnly OR jobLock.locked is true'`. Add a positive locked-tooltip assertion alongside the existing readOnly one (or split into two tests with accurate names).
+- [x] **C.2.1:** In `AstrosWriteButton.spec.ts:65`, rename the test from `'applies the tooltip class to the wrapper only when readOnly is true'` to `'applies the tooltip class to the wrapper when either readOnly OR jobLock.locked is true'`. Add a positive locked-tooltip assertion alongside the existing readOnly one (or split into two tests with accurate names).
 
-- [ ] **C.2.2:** In `firmware.spec.ts:1023`, rename `'collects ALL FAILED entries (multi-failure realistic on bus-wide ESP-NOW errors)'` to `'collects ALL FAILED entries AND attributes stage from the shared currentStage ref (not per-controller history)'`. Or split into two tests.
+- [x] **C.2.2:** In `firmware.spec.ts:1023`, rename `'collects ALL FAILED entries (multi-failure realistic on bus-wide ESP-NOW errors)'` to `'collects ALL FAILED entries AND attributes stage from the shared currentStage ref (not per-controller history)'`. Or split into two tests.
 
-- [ ] **C.2.3:** In `firmware.spec.ts:1100`, rename `'preserves server-reported FAILED entries during the failed normalize (preserves their error string)'` to `'preserves server-reported FAILED error strings AND leaves demoted entries without an error string (C1 normalize attribution)'`. Or split.
+- [x] **C.2.3:** In `firmware.spec.ts:1100`, rename `'preserves server-reported FAILED entries during the failed normalize (preserves their error string)'` to `'preserves server-reported FAILED error strings AND leaves demoted entries without an error string (C1 normalize attribution)'`. Or split.
 
-- [ ] **C.2.4:** Run all affected tests:
+- [x] **C.2.4:** Run all affected tests:
 
 Run: `cd astros_vue && npx vitest run src/components/common/__tests__/AstrosWriteButton.spec.ts src/stores/__tests__/firmware.spec.ts`
 Expected: all pass.
@@ -1558,7 +1558,7 @@ Expected: all pass.
 **Files:**
 - Modify: `astros_vue/src/composables/useWebsocket.ts:258-265`
 
-- [ ] **C.3.1:** Find the comment block at lines 258-265 (search for "directly" near the firmware-flash handler family doc). Replace `the catch path may also write store.flashError directly` with:
+- [x] **C.3.1:** Find the comment block at lines 258-265 (search for "directly" near the firmware-flash handler family doc). Replace `the catch path may also write store.flashError directly` with:
 
 ```ts
 // The catch path may also call store.setFlashError(...) to surface a
@@ -1567,7 +1567,7 @@ Expected: all pass.
 // (the round-6 sole-writer pattern — see firmware.ts:209 setFlashError).
 ```
 
-- [ ] **C.3.2:** Search for any other comments in `useWebsocket.ts` that reference `flashError =` or `store.flashError =`. Replace with `setFlashError` references.
+- [x] **C.3.2:** Search for any other comments in `useWebsocket.ts` that reference `flashError =` or `store.flashError =`. Replace with `setFlashError` references.
 
 Run: `grep -n "flashError\s*=" astros_vue/src/composables/useWebsocket.ts`
 Expected: no comment-level direct-write references remain (test files and stories are not in scope).
@@ -1579,7 +1579,7 @@ Expected: no comment-level direct-write references remain (test files and storie
 **Files:**
 - Modify: `astros_vue/src/types/firmware.ts:166-168`
 
-- [ ] **C.4.1:** Replace the docstring above `FlashJobState`:
+- [x] **C.4.1:** Replace the docstring above `FlashJobState`:
 
 ```ts
 /**
@@ -1600,17 +1600,17 @@ Expected: no comment-level direct-write references remain (test files and storie
 **Files:**
 - Modify: `.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md`
 
-- [ ] **C.5.1:** Update L40 and L281: change `api_server.ts:652-660` → `api_server.ts:654-669`.
+- [x] **C.5.1:** Update L40 and L281: change `api_server.ts:652-660` → `api_server.ts:654-669`.
 
-- [ ] **C.5.2:** Update L203: change `"228 tests total at branch tip across rounds 1–4"` → `"228 tests total at branch tip across all six (now seven) fix rounds"`.
+- [x] **C.5.2:** Update L203: change `"228 tests total at branch tip across rounds 1–4"` → `"228 tests total at branch tip across all six (now seven) fix rounds"`.
 
-- [ ] **C.5.3:** Update L221: change `"5 FMI hazards"` → `"7 FMI hazards"` (or however many rows the table actually has — count and match).
+- [x] **C.5.3:** Update L221: change `"5 FMI hazards"` → `"7 FMI hazards"` (or however many rows the table actually has — count and match).
 
-- [ ] **C.5.4:** Update L246 (FMI item 6): change `'internal_server_error'` → `'protocol_violation'` for the WS-handler malformed-payload envelope. (Note: `internal_server_error` remains the correct envelope for the `applyJobFailed` unknown-server-reason fallback — clarify both.)
+- [x] **C.5.4:** Update L246 (FMI item 6): change `'internal_server_error'` → `'protocol_violation'` for the WS-handler malformed-payload envelope. (Note: `internal_server_error` remains the correct envelope for the `applyJobFailed` unknown-server-reason fallback — clarify both.)
 
-- [ ] **C.5.5:** Update L278: change `flash_job_state.ts:1-40` → `flash_job_state.ts:1-47` (or drop the line range entirely).
+- [x] **C.5.5:** Update L278: change `flash_job_state.ts:1-40` → `flash_job_state.ts:1-47` (or drop the line range entirely).
 
-- [ ] **C.5.6:** Add a new FMI inventory row capturing the CR-1 reboot-wait wedge race (per the round-7 review finding):
+- [x] **C.5.6:** Add a new FMI inventory row capturing the CR-1 reboot-wait wedge race (per the round-7 review finding):
 
 ```
 | 8 | HTTP cold-load during reboot-wait window | fetchCurrentJob applied an endedAt-set body, wedging phase at flashing | Mirrored server's decideLateJoinSnapshot filter; defense-in-depth in handleLockStateChanged forces phase=done on lock release |
@@ -1625,13 +1625,13 @@ Expected: no comment-level direct-write references remain (test files and storie
 **Files:**
 - Modify: `.docs/qa/firmware-ota-flash-ui.md`
 
-- [ ] **C.6.1:** Find line 166 (`"The 210 vitest tests still pass"`) and update to `"All vitest tests still pass"` (drop the number to avoid future drift), or update to the post-round-7 count once Phase C is complete.
+- [x] **C.6.1:** Find line 166 (`"The 210 vitest tests still pass"`) and update to `"All vitest tests still pass"` (drop the number to avoid future drift), or update to the post-round-7 count once Phase C is complete.
 
 Run: `cd astros_vue && npx vitest run 2>&1 | tail -5` to get the post-round-7 count.
 
-- [ ] **C.6.2:** Update line 3 if needed to match.
+- [x] **C.6.2:** Update line 3 if needed to match.
 
-- [ ] **C.6.3:** Add a QA test case §6.5 covering the reboot-wait wedge fix from CR-1:
+- [x] **C.6.3:** Add a QA test case §6.5 covering the reboot-wait wedge fix from CR-1:
 
 ```markdown
 ### 6.5 Refresh during the 15s reboot-wait window after a successful flash
@@ -1655,27 +1655,27 @@ Run: `cd astros_vue && npx vitest run 2>&1 | tail -5` to get the post-round-7 co
 
 CLAUDE.md emphasizes the "partial-fix sweep" pattern: fix the cited site AND every sibling. After Phase C's edits, grep for any remaining stale references.
 
-- [ ] **C.7.1:** Sweep for `"210"` in `.docs/`:
+- [x] **C.7.1:** Sweep for `"210"` in `.docs/`:
 
 Run: `grep -rn "210" .docs/ | grep -v node_modules`
 Inspect each match — any reference to "210 tests" or "210 passing" is stale; update.
 
-- [ ] **C.7.2:** Sweep for old API-server line refs:
+- [x] **C.7.2:** Sweep for old API-server line refs:
 
 Run: `grep -rn "api_server.ts:65" .docs/`
 Inspect each — confirm they point at the post-round-7 line numbers.
 
-- [ ] **C.7.3:** Sweep for `"rounds 1–4"` / `"rounds 1-4"` in `.docs/`:
+- [x] **C.7.3:** Sweep for `"rounds 1–4"` / `"rounds 1-4"` in `.docs/`:
 
 Run: `grep -rn "rounds 1.4\|round 4\|round-4" .docs/`
 Inspect — any "at branch tip" claim should reflect round 7.
 
-- [ ] **C.7.4:** Sweep `useWebsocket.ts` for any other stale direct-write claims:
+- [x] **C.7.4:** Sweep `useWebsocket.ts` for any other stale direct-write claims:
 
 Run: `grep -n "flashError\s*=" astros_vue/src/composables/useWebsocket.ts`
 Expected: no comment-level direct-write references; only `setFlashError(...)` calls.
 
-- [ ] **C.7.5:** Sweep the round-7 plan file itself for any line refs that may have shifted:
+- [x] **C.7.5:** Sweep the round-7 plan file itself for any line refs that may have shifted:
 
 Run: `grep -n "firmware.ts:\|useWebsocket.ts:\|api_server.ts:" .docs/plans/20260514-0734-firmware-ota-d-6-round-7-review-fixes.md`
 Inspect — confirm line numbers point at the post-Phase-B state (these are best-effort because the plan was written before the code shifted; flag any that are clearly off).
@@ -1684,18 +1684,18 @@ Inspect — confirm line numbers point at the post-Phase-B state (these are best
 
 ## Task C.8: Phase C wrap — verify, review, commit
 
-- [ ] **C.8.1:** Run prettier + lint + build + tests on Vue (no API changes in Phase C):
+- [x] **C.8.1:** Run prettier + lint + build + tests on Vue (no API changes in Phase C):
 
 Run: `cd astros_vue && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run`
 Expected: all green.
 
-- [ ] **C.8.2:** Invoke `superpowers:requesting-code-review` on the Phase C diff. Prompt:
+- [x] **C.8.2:** Invoke `superpowers:requesting-code-review` on the Phase C diff. Prompt:
 
 > Review the changes since Commit B for Phase C of the round-7 review fixes. The diff implements 5 Important prose/cleanup findings: abortReason wired into the failed-result bar (IM-1), 3 test renames to fix format-string drifts (IM-4), dispatcher sole-writer comment update (IM-7), FlashJobState.source docstring correction (IM-6), 5 plan/QA prose drift fixes including a new FMI row and QA test case for the CR-1 wedge fix (IM-5). Look specifically for: any test rename that now lies in a different way, any sibling claim I missed in the prose sweep (CLAUDE.md partial-fix sweep), any rendered abortReason path that crashes on undefined.
 
 Address any Critical or Important findings.
 
-- [ ] **C.8.3:** Stage and commit Phase C:
+- [x] **C.8.3:** Stage and commit Phase C:
 
 ```bash
 git add astros_vue/src/views/FirmwareView.vue \
@@ -1739,7 +1739,7 @@ EOF
 )"
 ```
 
-- [ ] **C.8.4:** Check off Phase C in this plan, commit the update.
+- [x] **C.8.4:** Check off Phase C in this plan, commit the update.
 
 ---
 

--- a/.docs/plans/20260514-0946-firmware-ota-d-6-round-8-fixes.md
+++ b/.docs/plans/20260514-0946-firmware-ota-d-6-round-8-fixes.md
@@ -8,37 +8,37 @@
 
 ## Tasks
 
-- [ ] **1. NEW-C1 — CR-3 guard logical operator fix (`||` → `&&`)**
+- [x] **1. NEW-C1 — CR-3 guard logical operator fix (`||` → `&&`)**
   - File: `astros_vue/src/composables/useWebsocket.ts:347, 370` (both mid-stream catches)
   - Add test in `useWebsocket.spec.ts` for `phase='done' + flashError=null + malformed frame → flashError stays null` before fixing.
 
-- [ ] **2. NEW-C2 — CR-1b recovery delegates to applyJobDone instead of setPhase**
+- [x] **2. NEW-C2 — CR-1b recovery delegates to applyJobDone instead of setPhase**
   - File: `astros_vue/src/composables/useWebsocket.ts:283` (the recovery branch)
   - Replace `firmware.setPhase('done')` with `firmware.applyJobDone({jobId: firmware.currentJob?.jobId ?? '<recovery>', endedAt: new Date().toISOString()})`. Also set a `protocol_violation` flashError so operators see "recovered from lost terminal event."
   - Update existing CR-1b test in `useWebsocket.spec.ts` to assert (a) phase='done', (b) flashError surfaces recovery breadcrumb, (c) any mid-flow controllerStates were normalized.
 
-- [ ] **3. NEW-IM1 — `applyControllerUpdate` element validation**
+- [x] **3. NEW-IM1 — `applyControllerUpdate` element validation**
   - File: `astros_vue/src/stores/firmware.ts:320` (function entry)
   - Mirror IM-3's guard from `buildControllerStatesMap`: reject `!data || typeof data.controllerId !== 'string' || data.controllerId.length === 0` with a warn and early return.
   - Test in `firmware.spec.ts`.
 
-- [ ] **4. NEW-IM2 — Empty-string jobId in fetchCurrentJob**
+- [x] **4. NEW-IM2 — Empty-string jobId in fetchCurrentJob**
   - File: `astros_vue/src/stores/firmware.ts:656` (fetchCurrentJob guard)
   - Change truthy check on `body.jobId` to explicit `typeof body.jobId === 'string' && body.jobId.length > 0`. Add warn for empty-string case.
   - Test in `firmware.spec.ts`.
 
-- [ ] **5. NEW-IM3 — Phase guard in `applyControllerUpdate`/`applyControllerResult`**
+- [x] **5. NEW-IM3 — Phase guard in `applyControllerUpdate`/`applyControllerResult`**
   - File: `astros_vue/src/stores/firmware.ts:320, 375` (both handlers)
   - Early-return with warn when `phase.value === 'done' || phase.value === 'failed'`. Prevents trailing updates from mutating terminal state.
   - Tests in `firmware.spec.ts`.
 
-- [ ] **6. NEW-IM4 — Surface flashError in phase='done'**
+- [x] **6. NEW-IM4 — Surface flashError in phase='done'**
   - File: `astros_vue/src/views/FirmwareView.vue` (around `showFlashErrorRegion` computed)
   - Widen to render the region in phase='done' when flashError is non-null. Use a "warning" rather than "error" visual variant (distinct from the failed-phase title).
   - Add i18n key `firmware_view.mid_flash_error.title_done_with_warning` for the title in done phase.
   - Test in `FirmwareView.spec.ts`.
 
-- [ ] **7. Verify + review + commit**
+- [x] **7. Verify + review + commit**
   - prettier/lint/build/tests on Vue + API
   - Run `superpowers:requesting-code-review` on the diff vs prior commit
   - Address Critical/Important reviewer findings

--- a/.docs/plans/20260514-0946-firmware-ota-d-6-round-8-fixes.md
+++ b/.docs/plans/20260514-0946-firmware-ota-d-6-round-8-fixes.md
@@ -1,0 +1,45 @@
+# d.6 — Round-8 review fixes (Criticals + 4 convergent Importants)
+
+**Goal:** Apply 6 findings from the round-8 multi-agent review (2 Criticals + 4 Importants flagged by 2+ agents each). Single commit at end of work.
+
+**Tier:** Light plan. All fixes are <30 lines each and well-scoped. TDD where the production code allows (no UI-only changes).
+
+**Branch:** `feature/firmware-ota-d-6-live-wiring` (already exists).
+
+## Tasks
+
+- [ ] **1. NEW-C1 — CR-3 guard logical operator fix (`||` → `&&`)**
+  - File: `astros_vue/src/composables/useWebsocket.ts:347, 370` (both mid-stream catches)
+  - Add test in `useWebsocket.spec.ts` for `phase='done' + flashError=null + malformed frame → flashError stays null` before fixing.
+
+- [ ] **2. NEW-C2 — CR-1b recovery delegates to applyJobDone instead of setPhase**
+  - File: `astros_vue/src/composables/useWebsocket.ts:283` (the recovery branch)
+  - Replace `firmware.setPhase('done')` with `firmware.applyJobDone({jobId: firmware.currentJob?.jobId ?? '<recovery>', endedAt: new Date().toISOString()})`. Also set a `protocol_violation` flashError so operators see "recovered from lost terminal event."
+  - Update existing CR-1b test in `useWebsocket.spec.ts` to assert (a) phase='done', (b) flashError surfaces recovery breadcrumb, (c) any mid-flow controllerStates were normalized.
+
+- [ ] **3. NEW-IM1 — `applyControllerUpdate` element validation**
+  - File: `astros_vue/src/stores/firmware.ts:320` (function entry)
+  - Mirror IM-3's guard from `buildControllerStatesMap`: reject `!data || typeof data.controllerId !== 'string' || data.controllerId.length === 0` with a warn and early return.
+  - Test in `firmware.spec.ts`.
+
+- [ ] **4. NEW-IM2 — Empty-string jobId in fetchCurrentJob**
+  - File: `astros_vue/src/stores/firmware.ts:656` (fetchCurrentJob guard)
+  - Change truthy check on `body.jobId` to explicit `typeof body.jobId === 'string' && body.jobId.length > 0`. Add warn for empty-string case.
+  - Test in `firmware.spec.ts`.
+
+- [ ] **5. NEW-IM3 — Phase guard in `applyControllerUpdate`/`applyControllerResult`**
+  - File: `astros_vue/src/stores/firmware.ts:320, 375` (both handlers)
+  - Early-return with warn when `phase.value === 'done' || phase.value === 'failed'`. Prevents trailing updates from mutating terminal state.
+  - Tests in `firmware.spec.ts`.
+
+- [ ] **6. NEW-IM4 — Surface flashError in phase='done'**
+  - File: `astros_vue/src/views/FirmwareView.vue` (around `showFlashErrorRegion` computed)
+  - Widen to render the region in phase='done' when flashError is non-null. Use a "warning" rather than "error" visual variant (distinct from the failed-phase title).
+  - Add i18n key `firmware_view.mid_flash_error.title_done_with_warning` for the title in done phase.
+  - Test in `FirmwareView.spec.ts`.
+
+- [ ] **7. Verify + review + commit**
+  - prettier/lint/build/tests on Vue + API
+  - Run `superpowers:requesting-code-review` on the diff vs prior commit
+  - Address Critical/Important reviewer findings
+  - Commit with message: `fix(firmware): round-8 follow-ups — CR-3 guard AND + CR-1b normalize + apply* validation/phase-guards + done-phase flashError`

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,6 +1,6 @@
 # Firmware OTA — Vue UI QA
 
-Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (171 tests at d.6 close).
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (202 tests at d.6 close).
 
 ## Preconditions
 

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,6 +1,6 @@
 # Firmware OTA — Vue UI QA
 
-Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (225 tests at d.6 close).
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (228 tests at d.6 close).
 
 ## Preconditions
 

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,6 +1,6 @@
 # Firmware OTA — Vue UI QA
 
-Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (220 tests at d.6 close).
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (225 tests at d.6 close).
 
 ## Preconditions
 

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,6 +1,6 @@
 # Firmware OTA — Vue UI QA
 
-Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (228 tests at d.6 close).
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (see latest `cd astros_vue && npx vitest run` for current count).
 
 ## Preconditions
 
@@ -163,8 +163,22 @@ Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1
 ## Regression check
 
 - All d.3 / d.4 / d.5 storybook stories still render correctly.
-- The 210 vitest tests still pass: `cd astros_vue && npx vitest run`.
+- All vitest tests still pass: `cd astros_vue && npx vitest run`.
 - The smoke e2e spec passes locally: `npx playwright test e2e/C_01_firmware-page.spec.ts` (requires a running server).
+
+## 6.5 Refresh during the 15s reboot-wait window (round-7 CR-1 regression check)
+
+**Preconditions:** A flash has just completed; the result bar shows "✓ all updated"; the server is in the reboot-wait window (lock still held — typically the ~15s after a successful flash).
+
+**Steps:**
+1. Refresh the browser tab during this window.
+
+**Expected (post-round-7):**
+- Page shows phase='idle' / Select panel.
+- Lock-conflict banner may briefly appear if the lock hasn't released yet; it disappears within ~15s as the server releases the lock.
+- No UI wedge at phase='flashing'.
+
+**Regression signal (pre-fix):** Page rendered phase='flashing' indefinitely until a second refresh after the lock released. Round-7 CR-1a (fetchCurrentJob endedAt filter) + CR-1b (handleLockStateChanged defense) close this.
 
 ## Known limitations (documented, not blockers)
 

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,0 +1,173 @@
+# Firmware OTA — Vue UI QA
+
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (151 tests at d.6 close).
+
+## Preconditions
+
+- AstrOs.Server running with a working `~/.config/astrosserver/database.sqlite3` and at least one connected ESP fleet (Body master, Core padawan, Dome padawan). The bench rig (see `project_bench_servo_geometry`) is sufficient for visual flow tests; real flash tests need an actual fleet.
+- Vue app running: `cd astros_vue && npm run dev`. Browser at `http://localhost:5173`.
+- Devtools open with the Network and Console tabs visible.
+- Login credentials handy.
+- For tests that simulate a second operator: a second browser (or incognito window) ready.
+
+## Test cases
+
+### 1. Cold-load with no flash in flight
+
+**Steps:**
+1. Stop and restart the server (clean state).
+2. Log in and navigate to `/firmware`.
+
+**Expected:**
+- Page chrome renders: "Firmware" header, "Push firmware..." subtitle.
+- SourceStrip visible with GitHub/Upload toggle.
+- Topology card and Controllers panel render below.
+- Controllers panel lists Body / Core / Dome with their current firmware versions and online status dots.
+- Flash button is disabled (no source picked + no controllers selected).
+- DevTools console shows no warnings.
+
+### 2. Happy-path flash (select → confirm → flashing → done)
+
+**Steps:**
+1. From `/firmware`, pick a GitHub release that's a valid upgrade from current.
+2. Tick Body and Core.
+3. Click "Flash firmware".
+4. Confirm modal opens; click "Push firmware".
+
+**Expected:**
+- Modal lists source tag + target controllers with version deltas + power warning.
+- After confirm: phase transitions to `flashing`. Topology shows animated dashed lines on connected segments; StagesList appears below with `download` (or whichever stage the server first emits) as current.
+- ControllerRow on the right switches from checkbox mode to status pill ("Updating" for active, "Queued" otherwise).
+- WebSocket events `flashControllerUpdate` flow in as stages progress: `UPLOADING_TO_MASTER → SENDING → VERIFYING → REBOOTING → VERSION_CONFIRMED`.
+- On completion: phase → `done`. Result bar shows "✓ All N controller(s) updated" on green background. View logs + Done buttons.
+- Click Done → returns to `select` phase, panel resets, controllerStates cleared.
+
+### 3. Failure path — server returns 4xx synchronously
+
+**Steps:**
+1. Make the GitHub fetch fail (e.g., disconnect network temporarily, or pick a release tag that doesn't exist on disk).
+2. Pick a release, tick controllers, click Flash, confirm.
+
+**Expected:**
+- POST `/api/firmware/flash` returns 4xx (e.g., 400 `release_not_found` or 502 `release_lookup_failed`).
+- Phase rolls back to `select`.
+- Inline error banner appears above the action bar with the localized error copy.
+- Banner has "Try again" and "Dismiss" buttons. Try again is disabled until the underlying issue is fixed (e.g., source still missing); Dismiss clears the banner.
+
+### 4. Failure path — mid-flash WS `flashJobFailed`
+
+**Steps:**
+1. Pick a release with a real download.
+2. Start the flash.
+3. During the SENDING stage, kill one of the padawan ESPs (power cycle Core, for instance).
+
+**Expected:**
+- WS emits `flashControllerUpdate` with stage `FAILED` for the affected controller.
+- Eventually `flashJobFailed` arrives.
+- Phase → `failed`. Result bar shows "⚠ Core failed during transfer" (or matching stage) on red background.
+- The failed controller's row shows the red `!` glyph on the topology, red status pill on the panel.
+- Click Done → resetToSelect clears terminal state.
+
+### 5. Late-join — open page during another operator's flash
+
+**Steps:**
+1. Operator A: start a flash from one browser. Wait for it to be mid-flight (stage SENDING or VERIFYING).
+2. Operator B: open a second browser, log in, navigate to `/firmware`.
+
+**Expected:**
+- Operator B sees a lock-conflict alert above the SourceStrip ("Firmware update in progress / Another operator started a firmware update at {since}").
+- SourceStrip + Topology + Controllers panel are NOT rendered for Operator B (lock conflict suppresses the working UI).
+- The global `AstrosLockStateBanner` also appears at the top of Operator B's page.
+- When Operator A's flash completes, Operator B's lock-conflict alert clears automatically (WS `flashJobDone` triggers store update, lock releases).
+
+### 6. Cold-load while own flash is in flight
+
+**Steps:**
+1. Start a flash.
+2. While flashing, refresh the page (F5).
+
+**Expected:**
+- `firmwareStore.fetchCurrentJob()` runs on mount; HTTP GET `/api/firmware/flash` returns the active job.
+- WS late-join also delivers `flashJobStarted`; both paths converge on the same state via the store's idempotency.
+- The page shows the in-flight UI (flashing phase). `isOwnJob` is `true` since `ownJobId` was captured from the earlier POST response — **but** this state is lost across a page refresh, so the user effectively sees the in-flight state without "ownership." **Known limitation:** post-refresh, the lock-conflict alert WILL appear because `ownJobId` is no longer set. The flash continues server-side regardless. The QA expectation: page shows flashing UI either way; the conflict alert vs. flashing UI distinction is acceptable in either direction post-refresh.
+
+### 7. Lock-aware write button — global enforcement
+
+**Steps:**
+1. Start a flash from `/firmware`.
+2. While flashing, navigate to other write surfaces: `/modules`, `/scripts`, `/playlists`, `/utility`.
+
+**Expected:**
+- Every `AstrosWriteButton` instance (Save module, Save script, etc.) is disabled.
+- Hovering the disabled button shows the lock-active tooltip ("A firmware update is in progress — write actions are disabled until it completes.").
+- When the flash completes, write buttons re-enable automatically.
+
+### 8. Tab-close mid-flash
+
+**Steps:**
+1. Start a flash.
+2. While flashing, close the tab without clicking Cancel or Done.
+
+**Expected:**
+- The flash continues server-side (verify via server logs or by reopening `/firmware` and confirming the lock-conflict alert).
+- No `beforeunload` cancel signal is sent.
+- After re-opening `/firmware`: the in-flight UI (or lock-conflict alert per #6) renders.
+
+### 9. Network failure during flash POST
+
+**Steps:**
+1. Pick a release, tick controllers.
+2. Disconnect network or stop the server.
+3. Click Flash → Confirm.
+
+**Expected:**
+- POST hangs up to the 30s timeout.
+- Phase rolls back to `select`.
+- Error banner shows `network_error` copy ("Couldn't reach the server...").
+- DevTools console shows the underlying axios error (the `console.error` breadcrumb in `startFlash`'s catch).
+
+### 10. WS reconnect during flash
+
+**Steps:**
+1. Start a flash.
+2. During flashing, kill the WS connection (e.g., briefly disconnect network).
+3. Wait 3s+ for `useWebsocket`'s reconnect.
+
+**Expected:**
+- Vue reconnects; server emits a fresh `flashJobStarted` snapshot.
+- The store's `applyJobStarted` replaces (not merges) controllerStates from the snapshot.
+- UI remains coherent — no stale per-controller stages from before the disconnect.
+
+### 11. `prefers-reduced-motion`
+
+**Steps:**
+1. DevTools → Rendering → Emulate CSS media → `prefers-reduced-motion: reduce`.
+2. Start a flash (or view the d.3 Storybook `Flashing` story).
+
+**Expected:**
+- Topology dashed-line animation halts (lines still dashed but not flowing).
+- All other UI behavior unchanged.
+
+### 12. Dev-mode invariant warnings
+
+**Steps:**
+1. With `npm run dev`, navigate to `/firmware`.
+2. Open the DevTools console.
+3. Force fleet states to trigger each dev warning:
+   - Set all three controllers to non-master via a manual controllerStore mutation in the console (or a temporary code edit): expect `[FirmwareView] no controller is flagged isMaster — topology will not render.` warn.
+   - With `phase=flashing` but no controllerStates yet (visible briefly between POST and WS): expect `[AstrosFirmwareControllersPanel] progressByControllerId is undefined during phase="flashing"` warn (if the panel renders before the WS event lands).
+
+**Expected:**
+- Warns fire only in dev. Production build (`npm run build`) strips them via `import.meta.env.DEV`.
+
+## Regression check
+
+- All d.3 / d.4 / d.5 storybook stories still render correctly.
+- The 151 vitest tests still pass: `cd astros_vue && npx vitest run`.
+- The smoke e2e spec passes locally: `npx playwright test e2e/C_01_firmware-page.spec.ts` (requires a running server).
+
+## Known limitations (documented, not blockers)
+
+- **`ownJobId` not persisted across refresh.** Post-refresh, a flash that was "ours" appears as another operator's job until it completes. The flash itself is unaffected. d.7 (if ever) could persist `ownJobId` in `sessionStorage`.
+- **No in-UI cancel during flash.** The design handoff doesn't include a Cancel button mid-flash. Operators must let the flash complete (or kill the server) to abort.
+- **`network_error` and `timeout_error` collapse to one envelope.** A 30s+ hung POST and a never-reached server both surface the same banner copy. The `console.error` breadcrumb in `startFlash`'s catch carries the underlying axios `code` (`ECONNABORTED` vs network failure) for debugging.

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,6 +1,6 @@
 # Firmware OTA — Vue UI QA
 
-Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (202 tests at d.6 close).
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (210 tests at d.6 close).
 
 ## Preconditions
 
@@ -163,7 +163,7 @@ Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1
 ## Regression check
 
 - All d.3 / d.4 / d.5 storybook stories still render correctly.
-- The 171 vitest tests still pass: `cd astros_vue && npx vitest run`.
+- The 210 vitest tests still pass: `cd astros_vue && npx vitest run`.
 - The smoke e2e spec passes locally: `npx playwright test e2e/C_01_firmware-page.spec.ts` (requires a running server).
 
 ## Known limitations (documented, not blockers)

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,6 +1,6 @@
 # Firmware OTA — Vue UI QA
 
-Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (151 tests at d.6 close).
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (171 tests at d.6 close).
 
 ## Preconditions
 
@@ -163,7 +163,7 @@ Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1
 ## Regression check
 
 - All d.3 / d.4 / d.5 storybook stories still render correctly.
-- The 151 vitest tests still pass: `cd astros_vue && npx vitest run`.
+- The 171 vitest tests still pass: `cd astros_vue && npx vitest run`.
 - The smoke e2e spec passes locally: `npx playwright test e2e/C_01_firmware-page.spec.ts` (requires a running server).
 
 ## Known limitations (documented, not blockers)

--- a/.docs/qa/firmware-ota-flash-ui.md
+++ b/.docs/qa/firmware-ota-flash-ui.md
@@ -1,6 +1,6 @@
 # Firmware OTA — Vue UI QA
 
-Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (210 tests at d.6 close).
+Manual operator-flow QA for the `/firmware` view shipped across phase D (PRs d.1–d.6). Run end-to-end after d.6 merges. Unit-level coverage of the WS dispatcher, store handlers, type mapping, and lock-aware components lives in vitest (220 tests at d.6 close).
 
 ## Preconditions
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -919,6 +919,7 @@ export class ApiServer {
         success: true,
         message: '',
         controllerId: controller.id,
+        controllerAddress: val.controller.address,
         controllerLocation: location.locationName,
         up: true,
         synced: val.controller.fingerprint === location.configFingerprint,

--- a/astros_api/src/models/enums.ts
+++ b/astros_api/src/models/enums.ts
@@ -82,8 +82,9 @@ export enum ControllerStatus {
 // Wire-format numeric IDs. Hand-mirrored by the Vue client's
 // `WebsocketMessageType` enum — adding or reordering values here without
 // updating the client mirror silently breaks every WS message. Explicit
-// `= N` annotations pin the numeric values so a mid-insertion is a
-// compile-time conflict rather than a silent renumber.
+// `= N` annotations make mid-block insertions visible in diffs rather
+// than silently renumbering downstream values; the runtime contract is
+// pinned by the wire-numeric test in useWebsocket.spec.ts.
 export enum TransmissionType {
   script = 0,
   sync = 1,

--- a/astros_api/src/models/enums.ts
+++ b/astros_api/src/models/enums.ts
@@ -79,24 +79,29 @@ export enum ControllerStatus {
   down,
 }
 
+// Wire-format numeric IDs. Hand-mirrored by the Vue client's
+// `WebsocketMessageType` enum — adding or reordering values here without
+// updating the client mirror silently breaks every WS message. Explicit
+// `= N` annotations pin the numeric values so a mid-insertion is a
+// compile-time conflict rather than a silent renumber.
 export enum TransmissionType {
-  script,
-  sync,
-  status,
-  controllers,
-  run,
-  panic,
-  directCommand,
-  formatSD,
-  servoTest,
-  systemStatus,
-  lockStateChanged,
-  flashJobActive,
-  flashJobStarted,
-  flashControllerUpdate,
-  flashControllerResult,
-  flashJobDone,
-  flashJobFailed,
+  script = 0,
+  sync = 1,
+  status = 2,
+  controllers = 3,
+  run = 4,
+  panic = 5,
+  directCommand = 6,
+  formatSD = 7,
+  servoTest = 8,
+  systemStatus = 9,
+  lockStateChanged = 10,
+  flashJobActive = 11,
+  flashJobStarted = 12,
+  flashControllerUpdate = 13,
+  flashControllerResult = 14,
+  flashJobDone = 15,
+  flashJobFailed = 16,
 }
 
 export enum TransmissionStatus {

--- a/astros_api/src/models/networking/status_response.ts
+++ b/astros_api/src/models/networking/status_response.ts
@@ -2,6 +2,13 @@ import { BaseResponse } from './base_response.js';
 
 export interface StatusResponse extends BaseResponse {
   controllerId: string;
+  /**
+   * Hardware MAC address of the controller. Distinct from `controllerId`
+   * (which is the database UUID) — the firmware flash flow uses this as
+   * the per-controller key on the WS event stream
+   * (`FlashJobState.controllers[].controllerId`).
+   */
+  controllerAddress: string;
   controllerLocation: string;
   up: boolean;
   synced: boolean;

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -43,6 +43,6 @@ test.describe('Firmware Page', () => {
   // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
   // result bar) requires a WS-mock infrastructure that doesn't exist yet
   // in this codebase. Phase progression + apply* handlers are covered by
-  // 151 vitest tests; the full operator flow is covered by the manual QA
+  // 171 vitest tests; the full operator flow is covered by the manual QA
   // plan at `.docs/qa/firmware-ota-flash-ui.md`.
 });

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -43,6 +43,6 @@ test.describe('Firmware Page', () => {
   // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
   // result bar) requires a WS-mock infrastructure that doesn't exist yet
   // in this codebase. Phase progression + apply* handlers are covered by
-  // 228 vitest tests; the full operator flow is covered by the manual QA
-  // plan at `.docs/qa/firmware-ota-flash-ui.md`.
+  // the firmware/composables/views vitest suites; the full operator flow
+  // is covered by the manual QA plan at `.docs/qa/firmware-ota-flash-ui.md`.
 });

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -43,6 +43,6 @@ test.describe('Firmware Page', () => {
   // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
   // result bar) requires a WS-mock infrastructure that doesn't exist yet
   // in this codebase. Phase progression + apply* handlers are covered by
-  // 225 vitest tests; the full operator flow is covered by the manual QA
+  // 228 vitest tests; the full operator flow is covered by the manual QA
   // plan at `.docs/qa/firmware-ota-flash-ui.md`.
 });

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -43,6 +43,6 @@ test.describe('Firmware Page', () => {
   // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
   // result bar) requires a WS-mock infrastructure that doesn't exist yet
   // in this codebase. Phase progression + apply* handlers are covered by
-  // 202 vitest tests; the full operator flow is covered by the manual QA
+  // 210 vitest tests; the full operator flow is covered by the manual QA
   // plan at `.docs/qa/firmware-ota-flash-ui.md`.
 });

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -43,6 +43,6 @@ test.describe('Firmware Page', () => {
   // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
   // result bar) requires a WS-mock infrastructure that doesn't exist yet
   // in this codebase. Phase progression + apply* handlers are covered by
-  // 210 vitest tests; the full operator flow is covered by the manual QA
+  // 220 vitest tests; the full operator flow is covered by the manual QA
   // plan at `.docs/qa/firmware-ota-flash-ui.md`.
 });

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -43,6 +43,6 @@ test.describe('Firmware Page', () => {
   // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
   // result bar) requires a WS-mock infrastructure that doesn't exist yet
   // in this codebase. Phase progression + apply* handlers are covered by
-  // 220 vitest tests; the full operator flow is covered by the manual QA
+  // 225 vitest tests; the full operator flow is covered by the manual QA
   // plan at `.docs/qa/firmware-ota-flash-ui.md`.
 });

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -43,6 +43,6 @@ test.describe('Firmware Page', () => {
   // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
   // result bar) requires a WS-mock infrastructure that doesn't exist yet
   // in this codebase. Phase progression + apply* handlers are covered by
-  // 171 vitest tests; the full operator flow is covered by the manual QA
+  // 202 vitest tests; the full operator flow is covered by the manual QA
   // plan at `.docs/qa/firmware-ota-flash-ui.md`.
 });

--- a/astros_vue/e2e/C_01_firmware-page.spec.ts
+++ b/astros_vue/e2e/C_01_firmware-page.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect, Page } from '@playwright/test';
+import { authenticateUser } from './utility/auth_helper';
+
+async function openFirmwarePage(page: Page): Promise<void> {
+  await authenticateUser(page);
+  await page.click('label[for="nav-menu-drawer"]');
+  await page.getByRole('link', { name: /firmware/i }).click();
+  await expect(page).toHaveURL(/\/firmware/);
+  await expect(page.getByRole('heading', { name: /firmware/i })).toBeVisible();
+}
+
+test.describe('Firmware Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await openFirmwarePage(page);
+  });
+
+  test('renders the page chrome with title and subtitle', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /firmware/i })).toBeVisible();
+    // The subtitle is one of the four phase copy strings; in initial select
+    // phase it mentions ESP-NOW.
+    await expect(page.getByText(/ESP-NOW/i).first()).toBeVisible();
+  });
+
+  test('shows the source strip with GitHub/Upload toggle in select phase', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /^github$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^upload$/i })).toBeVisible();
+  });
+
+  test('shows the controllers panel header with select-all/clear buttons', async ({ page }) => {
+    // CONTROLLERS eyebrow.
+    await expect(page.getByText(/^CONTROLLERS$/)).toBeVisible();
+    // Action buttons only appear in select phase.
+    await expect(page.getByRole('button', { name: /select all/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^clear$/i })).toBeVisible();
+  });
+
+  test('Flash button is disabled when no source or selection is chosen', async ({ page }) => {
+    const flashBtn = page.getByRole('button', { name: /flash firmware/i });
+    await expect(flashBtn).toBeVisible();
+    await expect(flashBtn).toBeDisabled();
+  });
+
+  // NOTE: Driving a full flash flow (POST → WS-driven phase progression →
+  // result bar) requires a WS-mock infrastructure that doesn't exist yet
+  // in this codebase. Phase progression + apply* handlers are covered by
+  // 151 vitest tests; the full operator flow is covered by the manual QA
+  // plan at `.docs/qa/firmware-ota-flash-ui.md`.
+});

--- a/astros_vue/src/components/common/AstrosWriteButton.vue
+++ b/astros_vue/src/components/common/AstrosWriteButton.vue
@@ -2,11 +2,13 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useSystemStatusStore } from '@/stores/systemStatus';
+import { useJobLockStore } from '@/stores/jobLock';
 
 interface Props {
   // Optional caller-supplied disabled state (loading, validation, etc.).
-  // ORed with the system read-only state so callers don't lose capability
-  // vs. the hand-rolled inline pattern this component replaces.
+  // ORed with the system read-only state and the firmware-job lock so
+  // callers don't lose capability vs. the hand-rolled inline pattern this
+  // component replaces.
   disabled?: boolean;
 }
 
@@ -14,9 +16,21 @@ const props = withDefaults(defineProps<Props>(), { disabled: false });
 
 const { t } = useI18n();
 const systemStatusStore = useSystemStatusStore();
+const jobLockStore = useJobLockStore();
 
 const isReadOnlyDisabled = computed(() => systemStatusStore.readOnly);
-const isDisabled = computed(() => props.disabled || isReadOnlyDisabled.value);
+const isJobLockDisabled = computed(() => jobLockStore.locked);
+const isDisabled = computed(
+  () => props.disabled || isReadOnlyDisabled.value || isJobLockDisabled.value,
+);
+
+// Tooltip priority: system read-only is broader than a flash lock, so it
+// takes precedence when both are active.
+const tooltipKey = computed(() => {
+  if (isReadOnlyDisabled.value) return 'systemStatus.readOnly.disabled';
+  if (isJobLockDisabled.value) return 'firmware_view.lock_active';
+  return null;
+});
 
 // Route every other attribute (class, data-testid, type, aria-*) onto the
 // inner button rather than the wrapper div. Without this, Vue would default
@@ -27,8 +41,8 @@ defineOptions({ inheritAttrs: false });
 
 <template>
   <div
-    :class="isReadOnlyDisabled ? 'tooltip' : ''"
-    :data-tip="t('systemStatus.readOnly.disabled')"
+    :class="tooltipKey !== null ? 'tooltip' : ''"
+    :data-tip="tooltipKey !== null ? t(tooltipKey) : undefined"
   >
     <button
       v-bind="$attrs"

--- a/astros_vue/src/components/common/__tests__/AstrosLockStateBanner.spec.ts
+++ b/astros_vue/src/components/common/__tests__/AstrosLockStateBanner.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createI18n } from 'vue-i18n';
+import enUS from '@/locales/enUS.json';
+import AstrosLockStateBanner from '@/components/common/lockStateBanner/AstrosLockStateBanner.vue';
+import { useJobLockStore } from '@/stores/jobLock';
+import { useFirmwareStore } from '@/stores/firmware';
+
+function createTestI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'enUS',
+    fallbackLocale: 'enUS',
+    messages: { enUS },
+  });
+}
+
+function mountBanner() {
+  return mount(AstrosLockStateBanner, {
+    global: {
+      plugins: [createTestI18n()],
+    },
+  });
+}
+
+describe('AstrosLockStateBanner', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders nothing when the job lock is idle (no flash in flight)', () => {
+    const wrapper = mountBanner();
+    expect(wrapper.find('[role="status"]').exists()).toBe(false);
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('renders the ambient banner with role="status" when the lock is held by another view', async () => {
+    // Pin role="status" (not role="alert") — this banner is ambient cross-page
+    // context, not an interrupt. The FirmwareView's in-page lock-conflict
+    // region uses role="alert"; doubling up would be screen-reader noise.
+    const lockStore = useJobLockStore();
+    lockStore.locked = true;
+
+    const wrapper = mountBanner();
+    await wrapper.vm.$nextTick();
+
+    const banner = wrapper.find('[role="status"]');
+    expect(banner.exists()).toBe(true);
+    expect(banner.attributes('aria-live')).toBe('polite');
+    expect(banner.text()).toContain('Firmware update in progress');
+  });
+
+  it('hides the banner when the lock is held by the firmware view itself (isOwnJob)', async () => {
+    // The FirmwareView surfaces its own in-context job UI; the ambient banner
+    // would be redundant there. Verify the suppression actually fires when
+    // currentJob.jobId matches ownJobId.
+    const lockStore = useJobLockStore();
+    lockStore.locked = true;
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.applyJobStarted({
+      jobId: 'own-job',
+      source: { kind: 'github', version: 'v1.4.2' },
+      controllers: [],
+      startedAt: '2026-05-12T00:00:00.000Z',
+    });
+    firmwareStore.ownJobId = 'own-job';
+
+    const wrapper = mountBanner();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[role="status"]').exists()).toBe(false);
+  });
+});

--- a/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
+++ b/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
@@ -62,14 +62,27 @@ describe('AstrosWriteButton', () => {
     expect(wrapper.find('button').attributes('disabled')).toBeDefined();
   });
 
-  it('applies the tooltip class to the wrapper only when readOnly is true', async () => {
-    // Not read-only: no tooltip class.
+  it('applies the tooltip class to the wrapper when either readOnly OR jobLock.locked is true', async () => {
+    // Baseline: no readOnly + no lock → no tooltip class.
     let wrapper = mountButton();
     expect(wrapper.find('div').classes()).not.toContain('tooltip');
 
     // Read-only: tooltip class present.
     setActivePinia(createPinia());
     useSystemStatusStore().setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    wrapper = mountButton();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('div').classes()).toContain('tooltip');
+
+    // Lock-active (no readOnly): tooltip class also present. After
+    // round-5 added lock-aware UI, the tooltip wrapper fires for
+    // either trigger, not exclusively readOnly.
+    setActivePinia(createPinia());
+    useJobLockStore().setState({
+      locked: true,
+      owner: 'flash:job-A',
+      since: '2026-05-14T08:00:00Z',
+    });
     wrapper = mountButton();
     await wrapper.vm.$nextTick();
     expect(wrapper.find('div').classes()).toContain('tooltip');

--- a/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
+++ b/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
@@ -5,6 +5,7 @@ import { createI18n } from 'vue-i18n';
 import enUS from '@/locales/enUS.json';
 import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import { useSystemStatusStore } from '@/stores/systemStatus';
+import { useJobLockStore } from '@/stores/jobLock';
 
 function createTestI18n() {
   return createI18n({
@@ -104,5 +105,47 @@ describe('AstrosWriteButton', () => {
     await wrapper.find('button').trigger('click');
     // Browsers suppress click on disabled buttons; jsdom respects this too.
     expect(wrapper.emitted('click')).toBeUndefined();
+  });
+
+  it('is disabled when jobLock.locked is true even if readOnly is false', async () => {
+    useJobLockStore().setState({
+      locked: true,
+      owner: 'flash-job-xyz',
+      since: '2026-05-12T08:00:00Z',
+    });
+    const wrapper = mountButton();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+  });
+
+  it('shows the lock-active tooltip when only jobLock.locked is true', async () => {
+    useJobLockStore().setState({
+      locked: true,
+      owner: 'flash-job-xyz',
+      since: '2026-05-12T08:00:00Z',
+    });
+    const wrapper = mountButton();
+    await wrapper.vm.$nextTick();
+    const wrapperDiv = wrapper.find('div');
+    expect(wrapperDiv.classes()).toContain('tooltip');
+    // The data-tip resolves to the firmware_view.lock_active i18n key.
+    expect(wrapperDiv.attributes('data-tip')).toBeTruthy();
+  });
+
+  it('prefers the read-only tooltip when both readOnly and jobLock.locked are true', async () => {
+    useSystemStatusStore().setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    useJobLockStore().setState({
+      locked: true,
+      owner: 'flash-job-xyz',
+      since: '2026-05-12T08:00:00Z',
+    });
+    const wrapper = mountButton();
+    await wrapper.vm.$nextTick();
+    const wrapperDiv = wrapper.find('div');
+    expect(wrapperDiv.classes()).toContain('tooltip');
+    // Read-only is broader; takes precedence per the tooltipKey computed.
+    const readOnlyMsg = (enUS as { systemStatus?: { readOnly?: { disabled?: string } } })
+      ?.systemStatus?.readOnly?.disabled;
+    expect(wrapperDiv.attributes('data-tip')).toBe(readOnlyMsg);
   });
 });

--- a/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
+++ b/astros_vue/src/components/common/__tests__/AstrosWriteButton.spec.ts
@@ -74,9 +74,8 @@ describe('AstrosWriteButton', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.find('div').classes()).toContain('tooltip');
 
-    // Lock-active (no readOnly): tooltip class also present. After
-    // round-5 added lock-aware UI, the tooltip wrapper fires for
-    // either trigger, not exclusively readOnly.
+    // Lock-active (no readOnly): tooltip class also present. The
+    // tooltip wrapper fires for either trigger, not exclusively readOnly.
     setActivePinia(createPinia());
     useJobLockStore().setState({
       locked: true,

--- a/astros_vue/src/components/common/layout/AstrosLayout.vue
+++ b/astros_vue/src/components/common/layout/AstrosLayout.vue
@@ -3,6 +3,7 @@ import router from '@/router';
 import apiService from '@/api/apiService';
 import { ref, watch } from 'vue';
 import AstrosSystemStatusBanner from '@/components/common/systemStatusBanner/AstrosSystemStatusBanner.vue';
+import AstrosLockStateBanner from '@/components/common/lockStateBanner/AstrosLockStateBanner.vue';
 
 const props = defineProps({
   isSidebarOpen: {
@@ -46,6 +47,7 @@ function logout() {
     />
     <div class="drawer-content">
       <AstrosSystemStatusBanner />
+      <AstrosLockStateBanner />
       <div class="navbar bg-base-100 shadow-sm">
         <div class="flex-none pl-2 flex items-center">
           <label

--- a/astros_vue/src/components/common/lockStateBanner/AstrosLockStateBanner.vue
+++ b/astros_vue/src/components/common/lockStateBanner/AstrosLockStateBanner.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useJobLockStore } from '@/stores/jobLock';
+import { useFirmwareStore } from '@/stores/firmware';
+
+const jobLockStore = useJobLockStore();
+const firmwareStore = useFirmwareStore();
+
+// Show the banner globally when a flash is in flight UNLESS this view owns
+// the flash. The FirmwareView surfaces its own in-context UI for the active
+// job, so doubling up the banner there is just noise.
+const visible = computed(() => jobLockStore.locked && !firmwareStore.isOwnJob);
+</script>
+
+<template>
+  <!--
+    role="status" (not "alert") is intentional: this is an ambient
+    cross-page indicator that writes are disabled, not an interrupt-class
+    notification. The FirmwareView's in-page lock-conflict region uses
+    role="alert" because it actively blocks the operator from interacting
+    with the flash UI; this banner is informational background context.
+  -->
+  <div
+    v-if="visible"
+    class="alert alert-info rounded-none"
+    role="status"
+    aria-live="polite"
+  >
+    <span>{{ $t('firmware_view.lock_banner') }}</span>
+  </div>
+</template>

--- a/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareConfirmModal/AstrosFirmwareConfirmModal.stories.ts
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import AstrosFirmwareConfirmModal from './AstrosFirmwareConfirmModal.vue';
+import { Location } from '@/enums';
 import type { FirmwareControllerView } from '@/types/firmware';
 
 const body: FirmwareControllerView = {
-  id: 'body',
+  id: Location.BODY,
   label: 'Body',
   glyph: 'B',
   current: 'v1.3.0',
@@ -11,7 +12,7 @@ const body: FirmwareControllerView = {
   isMaster: true,
 };
 const core: FirmwareControllerView = {
-  id: 'core',
+  id: Location.CORE,
   label: 'Core',
   glyph: 'C',
   current: 'v1.4.0',

--- a/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.stories.ts
@@ -84,7 +84,7 @@ export const ProgressModeUpdating: Story = {
     mode: 'progress',
     selected: true,
     progressStatus: 'updating',
-    stageLabel: 'Transfer',
+    stageLabelKey: 'firmware_view.stages.transfer.label',
   },
 };
 

--- a/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.stories.ts
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import AstrosFirmwareControllerRow from './AstrosFirmwareControllerRow.vue';
+import { Location } from '@/enums';
 import type { FirmwareControllerView } from '@/types/firmware';
 
 const body: FirmwareControllerView = {
-  id: 'body',
+  id: Location.BODY,
   label: 'Body',
   glyph: 'B',
   current: 'v1.3.0',
@@ -11,7 +12,7 @@ const body: FirmwareControllerView = {
   isMaster: true,
 };
 const core: FirmwareControllerView = {
-  id: 'core',
+  id: Location.CORE,
   label: 'Core',
   glyph: 'C',
   current: 'v1.4.0',
@@ -19,7 +20,7 @@ const core: FirmwareControllerView = {
   isMaster: false,
 };
 const domeOffline: FirmwareControllerView = {
-  id: 'dome',
+  id: Location.DOME,
   label: 'Dome',
   glyph: 'D',
   current: 'v1.4.0',

--- a/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/AstrosFirmwareControllerRow.vue
@@ -94,9 +94,9 @@ function onCheckboxChange() {
       <template v-else-if="progressStatus">
         <AstrosFirmwareStatusPill :kind="progressStatus" />
         <span
-          v-if="progressStatus === 'updating' && stageLabel"
+          v-if="progressStatus === 'updating' && stageLabelKey"
           class="astros-firmware-controller-row__stage"
-          >{{ stageLabel }}</span
+          >{{ t(stageLabelKey) }}</span
         >
       </template>
     </div>

--- a/astros_vue/src/components/firmware/firmwareControllerRow/__tests__/selectModePillKind.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/__tests__/selectModePillKind.spec.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { selectModePillKind } from '../selectModePillKind';
+import { Location } from '@/enums';
 import type { FirmwareControllerView } from '@/types/firmware';
 
 function ctrl(overrides: Partial<FirmwareControllerView> = {}): FirmwareControllerView {
   return {
-    id: 'core',
+    id: Location.CORE,
     label: 'Core',
     glyph: 'C',
     current: 'v1.4.0',

--- a/astros_vue/src/components/firmware/firmwareControllerRow/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/types.ts
@@ -1,4 +1,8 @@
-import type { FirmwareControllerView, FirmwareStatusPillKind } from '@/types/firmware';
+import type {
+  FirmwareControllerView,
+  FirmwareStageLabelKey,
+  FirmwareStatusPillKind,
+} from '@/types/firmware';
 
 export type ControllerRowMode = 'select' | 'progress';
 
@@ -11,5 +15,5 @@ export interface ControllerRowProps {
   /** Status pill shown in `progress` mode. */
   progressStatus?: FirmwareStatusPillKind;
   /** i18n key path for the stage label rendered under the status pill in `progress` mode when updating. */
-  stageLabelKey?: string;
+  stageLabelKey?: FirmwareStageLabelKey;
 }

--- a/astros_vue/src/components/firmware/firmwareControllerRow/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllerRow/types.ts
@@ -10,6 +10,6 @@ export interface ControllerRowProps {
   selected: boolean;
   /** Status pill shown in `progress` mode. */
   progressStatus?: FirmwareStatusPillKind;
-  /** Stage label rendered under the status pill in `progress` mode when updating. */
-  stageLabel?: string;
+  /** i18n key path for the stage label rendered under the status pill in `progress` mode when updating. */
+  stageLabelKey?: string;
 }

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
@@ -2,23 +2,27 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { createPinia, setActivePinia } from 'pinia';
 import AstrosFirmwareControllersPanel from './AstrosFirmwareControllersPanel.vue';
 import { useFirmwareStore } from '@/stores/firmware';
-import type { FirmwareControllerView } from '@/types/firmware';
-
-const SAMPLE_CONTROLLERS: FirmwareControllerView[] = [
-  { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
-  { id: 'core', label: 'Core', glyph: 'C', current: 'v1.4.0', status: 'up', isMaster: false },
-  { id: 'dome', label: 'Dome', glyph: 'D', current: 'v1.4.0', status: 'down', isMaster: false },
-];
+import { useControllerStore } from '@/stores/controller';
+import { ControllerStatus } from '@/enums';
 
 function setupStore(opts: {
   target?: string | null;
   selected?: string[];
-  controllers?: FirmwareControllerView[];
   flashErrorReason?: string;
+  domeStatus?: ControllerStatus;
 }) {
   setActivePinia(createPinia());
+  // Seed the underlying controllerStore — the firmwareStore's `controllers`
+  // computed projects from there.
+  const cs = useControllerStore();
+  cs.bodyStatus = ControllerStatus.UP;
+  cs.bodyFirmware = 'v1.3.0';
+  cs.coreStatus = ControllerStatus.UP;
+  cs.coreFirmware = 'v1.4.0';
+  cs.domeStatus = opts.domeStatus ?? ControllerStatus.DOWN;
+  cs.domeFirmware = 'v1.4.0';
+
   const store = useFirmwareStore();
-  store.controllers = opts.controllers ?? SAMPLE_CONTROLLERS;
   store.sourceMode = 'github';
   store.selectedReleaseTag = opts.target ?? null;
   store.selectedControllerIds = new Set(opts.selected ?? []);

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.stories.ts
@@ -136,7 +136,7 @@ export const Flashing: Story = {
   args: {
     phase: 'flashing',
     progressByControllerId: {
-      body: { status: 'updating', stageLabel: 'Transfer' },
+      body: { status: 'updating', stageLabelKey: 'firmware_view.stages.transfer.label' },
       core: { status: 'queued' },
       dome: { status: 'idle' },
     },

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -212,7 +212,7 @@ const actionBarMessage = computed(() => {
         {{
           t('firmware_view.controllers.result_bar.failed_summary', {
             label: failedControllerLabel ?? '—',
-            stage: failedStage ?? '—',
+            stage: failedStage ? t(`firmware_view.stages.${failedStage}.label`) : '—',
           })
         }}
       </span>

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -6,6 +6,7 @@ import { useFirmwareStore } from '@/stores/firmware';
 import AstrosFirmwareControllerRow from '../firmwareControllerRow/AstrosFirmwareControllerRow.vue';
 import AstrosFirmwareButton from '../firmwareButton/AstrosFirmwareButton.vue';
 import type { ControllersPanelProps } from './types';
+import type { SlotId } from '@/types/firmware';
 
 const props = defineProps<ControllersPanelProps>();
 const emit = defineEmits<{
@@ -54,7 +55,7 @@ if (import.meta.env.DEV) {
     }
     if (props.phase !== 'select' && props.progressByControllerId !== undefined) {
       const missing = controllers.value
-        .filter((c) => props.progressByControllerId?.[c.id] === undefined)
+        .filter((c) => props.progressByControllerId?.[c.id as SlotId] === undefined)
         .map((c) => c.id);
       if (missing.length > 0) {
         console.warn(
@@ -115,8 +116,8 @@ const actionBarMessage = computed(() => {
           :target="target"
           :mode="rowMode"
           :selected="selectedControllerIds.has(c.id)"
-          :progress-status="progressByControllerId?.[c.id]?.status"
-          :stage-label-key="progressByControllerId?.[c.id]?.stageLabelKey"
+          :progress-status="progressByControllerId?.[c.id as SlotId]?.status"
+          :stage-label-key="progressByControllerId?.[c.id as SlotId]?.stageLabelKey"
           @toggle="firmware.toggle"
         />
       </li>
@@ -210,10 +211,17 @@ const actionBarMessage = computed(() => {
         class="astros-firmware-controllers-panel__result-text astros-firmware-controllers-panel__result-text--failed"
       >
         {{
-          t('firmware_view.controllers.result_bar.failed_summary', {
-            label: failedControllerLabel ?? '—',
-            stage: failedStage ? t(`firmware_view.stages.${failedStage}.label`) : '—',
-          })
+          // Use the multi-failure copy for >=2 AND for 0 (pre-streamer
+          // abort: job failed before any controller transitioned to FAILED;
+          // the singular key's `{stage}` placeholder would render '—').
+          (failedCount ?? 1) !== 1
+            ? t('firmware_view.controllers.result_bar.failed_summary_multi', {
+                labels: failedControllerLabel ?? '—',
+              })
+            : t('firmware_view.controllers.result_bar.failed_summary', {
+                label: failedControllerLabel ?? '—',
+                stage: failedStage ? t(`firmware_view.stages.${failedStage}.label`) : '—',
+              })
         }}
       </span>
       <div class="astros-firmware-controllers-panel__action-bar-buttons">

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -6,7 +6,6 @@ import { useFirmwareStore } from '@/stores/firmware';
 import AstrosFirmwareControllerRow from '../firmwareControllerRow/AstrosFirmwareControllerRow.vue';
 import AstrosFirmwareButton from '../firmwareButton/AstrosFirmwareButton.vue';
 import type { ControllersPanelProps } from './types';
-import type { SlotId } from '@/types/firmware';
 
 const props = defineProps<ControllersPanelProps>();
 const emit = defineEmits<{
@@ -55,7 +54,7 @@ if (import.meta.env.DEV) {
     }
     if (props.phase !== 'select' && props.progressByControllerId !== undefined) {
       const missing = controllers.value
-        .filter((c) => props.progressByControllerId?.[c.id as SlotId] === undefined)
+        .filter((c) => props.progressByControllerId?.[c.id] === undefined)
         .map((c) => c.id);
       if (missing.length > 0) {
         console.warn(
@@ -116,8 +115,8 @@ const actionBarMessage = computed(() => {
           :target="target"
           :mode="rowMode"
           :selected="selectedControllerIds.has(c.id)"
-          :progress-status="progressByControllerId?.[c.id as SlotId]?.status"
-          :stage-label-key="progressByControllerId?.[c.id as SlotId]?.stageLabelKey"
+          :progress-status="progressByControllerId?.[c.id]?.status"
+          :stage-label-key="progressByControllerId?.[c.id]?.stageLabelKey"
           @toggle="firmware.toggle"
         />
       </li>

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/AstrosFirmwareControllersPanel.vue
@@ -116,7 +116,7 @@ const actionBarMessage = computed(() => {
           :mode="rowMode"
           :selected="selectedControllerIds.has(c.id)"
           :progress-status="progressByControllerId?.[c.id]?.status"
-          :stage-label="progressByControllerId?.[c.id]?.stageLabel"
+          :stage-label-key="progressByControllerId?.[c.id]?.stageLabelKey"
           @toggle="firmware.toggle"
         />
       </li>

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts
@@ -80,6 +80,24 @@ describe('AstrosFirmwareControllersPanel failed-result-bar predicate (I-test-2)'
     expect(text).not.toMatch(/failed during Transfer/);
   });
 
+  it('defaults to singular copy when failedCount is omitted (?? 1 fallback)', async () => {
+    // I12: pin the `(failedCount ?? 1) !== 1` predicate's default path.
+    // A regression that changed `?? 1` to `?? 0` would render the multi
+    // copy when the parent forgets to pass failedCount.
+    const wrapper = mountPanel({
+      phase: 'failed',
+      progressByControllerId: {},
+      failedControllerLabel: 'Core',
+      failedStage: 'transfer',
+      // No failedCount prop — should fall through to singular via `?? 1`.
+    });
+    await wrapper.vm.$nextTick();
+    const text = wrapper.text();
+    expect(text).toContain('Core');
+    expect(text).toContain('Transfer');
+    expect(text).not.toMatch(/failed during the flash/);
+  });
+
   it('routes failedCount === 0 (pre-streamer abort) to the multi copy, not singular with — fallback', async () => {
     // I2 + I-test-2: a pre-streamer abort has no per-controller failure
     // record. The singular key would render "⚠ — failed during —". The

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createI18n } from 'vue-i18n';
+import enUS from '@/locales/enUS.json';
+import AstrosFirmwareControllersPanel from '../AstrosFirmwareControllersPanel.vue';
+import { useControllerStore } from '@/stores/controller';
+import { ControllerStatus } from '@/enums';
+
+function createTestI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'enUS',
+    fallbackLocale: 'enUS',
+    messages: { enUS },
+  });
+}
+
+function seedFleet() {
+  const store = useControllerStore();
+  store.bodyStatus = ControllerStatus.UP;
+  store.coreStatus = ControllerStatus.UP;
+  store.domeStatus = ControllerStatus.UP;
+  store.bodyFirmware = 'v1.4.0';
+  store.coreFirmware = 'v1.4.0';
+  store.domeFirmware = 'v1.4.0';
+}
+
+function mountPanel(props: Record<string, unknown>) {
+  return mount(AstrosFirmwareControllersPanel, {
+    props: props as never,
+    global: {
+      plugins: [createTestI18n()],
+      stubs: {
+        // Stub the row + button so we can focus on the result-bar template.
+        AstrosFirmwareControllerRow: { template: '<div />' },
+        AstrosFirmwareButton: { template: '<button><slot /></button>' },
+      },
+    },
+  });
+}
+
+describe('AstrosFirmwareControllersPanel failed-result-bar predicate (I-test-2)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    seedFleet();
+  });
+
+  it('renders singular copy when failedCount === 1 with both label and stage', async () => {
+    const wrapper = mountPanel({
+      phase: 'failed',
+      progressByControllerId: {},
+      failedControllerLabel: 'Core',
+      failedStage: 'transfer',
+      failedCount: 1,
+    });
+    await wrapper.vm.$nextTick();
+
+    const text = wrapper.text();
+    // Singular: "⚠ {label} failed during {stage}"
+    expect(text).toContain('Core');
+    expect(text).toContain('Transfer'); // localized from `firmware_view.stages.transfer.label`
+  });
+
+  it('renders multi copy when failedCount === 2, dropping stage attribution (controllers may have failed at different stages)', async () => {
+    const wrapper = mountPanel({
+      phase: 'failed',
+      progressByControllerId: {},
+      failedControllerLabel: 'Body, Core',
+      failedStage: 'transfer',
+      failedCount: 2,
+    });
+    await wrapper.vm.$nextTick();
+
+    const text = wrapper.text();
+    expect(text).toContain('Body, Core');
+    expect(text).toContain('failed during the flash'); // multi key copy
+    // The singular "failed during {stage}" copy must NOT render — its
+    // {stage} placeholder would lie about all entries sharing transfer.
+    expect(text).not.toMatch(/failed during Transfer/);
+  });
+
+  it('routes failedCount === 0 (pre-streamer abort) to the multi copy, not singular with — fallback', async () => {
+    // I2 + I-test-2: a pre-streamer abort has no per-controller failure
+    // record. The singular key would render "⚠ — failed during —". The
+    // multi key with empty labels renders "⚠ — failed during the flash"
+    // which is less misleading.
+    const wrapper = mountPanel({
+      phase: 'failed',
+      progressByControllerId: {},
+      failedCount: 0,
+    });
+    await wrapper.vm.$nextTick();
+
+    const text = wrapper.text();
+    expect(text).toContain('failed during the flash');
+    expect(text).not.toMatch(/failed during —/);
+  });
+});

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/__tests__/AstrosFirmwareControllersPanel.spec.ts
@@ -40,7 +40,7 @@ function mountPanel(props: Record<string, unknown>) {
   });
 }
 
-describe('AstrosFirmwareControllersPanel failed-result-bar predicate (I-test-2)', () => {
+describe('AstrosFirmwareControllersPanel failed-result-bar predicate', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     seedFleet();
@@ -99,10 +99,10 @@ describe('AstrosFirmwareControllersPanel failed-result-bar predicate (I-test-2)'
   });
 
   it('routes failedCount === 0 (pre-streamer abort) to the multi copy, not singular with — fallback', async () => {
-    // I2 + I-test-2: a pre-streamer abort has no per-controller failure
-    // record. The singular key would render "⚠ — failed during —". The
-    // multi key with empty labels renders "⚠ — failed during the flash"
-    // which is less misleading.
+    // A pre-streamer abort has no per-controller failure record. The
+    // singular key would render "⚠ — failed during —". The multi key
+    // with empty labels renders "⚠ — failed during the flash" — less
+    // misleading.
     const wrapper = mountPanel({
       phase: 'failed',
       progressByControllerId: {},

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -1,4 +1,8 @@
-import type { FirmwarePhase, FirmwareStatusPillKind } from '@/types/firmware';
+import type {
+  FirmwarePhase,
+  FirmwareStageLabelKey,
+  FirmwareStatusPillKind,
+} from '@/types/firmware';
 
 export type ControllersPanelPhase = Exclude<FirmwarePhase, 'idle'>;
 
@@ -10,7 +14,7 @@ export interface ControllerProgressEntry {
    * The row component resolves this via t() — keeps localization at the
    * consumer rather than the producer.
    */
-  stageLabelKey?: string;
+  stageLabelKey?: FirmwareStageLabelKey;
 }
 
 export interface ControllersPanelProps {

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -22,17 +22,16 @@ export interface ControllerProgressEntry {
 /**
  * Props for AstrosFirmwareControllersPanel.
  *
- * Phase-vs-fields correlation (documented; only `progressByControllerId`
- * is enforced at runtime by the dev-only watchEffect in the panel
- * component — the result-bar fields below are documentation-only and
- * the consumer is responsible for setting them in the right phase):
- *  - `progressByControllerId`: required in non-select phases (flashing/done/failed) — runtime-checked in dev
+ * Phase-vs-fields correlation (documentation-only except where noted):
+ *  - `progressByControllerId`: required in non-select phases; runtime-checked
+ *    in dev by a watchEffect inside the panel
  *  - `doneCount`: only meaningful in `phase === 'done'`
- *  - `failedControllerLabel`, `failedStage`, `failedCount`: only meaningful in `phase === 'failed'`
+ *  - `failedControllerLabel`, `failedStage`, `failedCount`: only meaningful
+ *    in `phase === 'failed'`
  *
- * IM-12: `failedStage` is narrowed to `FirmwareStage` so the panel
+ * `failedStage` is narrowed to `FirmwareStage` (not `string`) so the panel
  * template's `t('firmware_view.stages.${failedStage}.label')` always
- * resolves to a known i18n key path.
+ * resolves to a valid i18n key.
  */
 export interface ControllersPanelProps {
   phase: ControllersPanelPhase;

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -4,8 +4,13 @@ export type ControllersPanelPhase = Exclude<FirmwarePhase, 'idle'>;
 
 export interface ControllerProgressEntry {
   status: FirmwareStatusPillKind;
-  /** Stage label shown under the status pill when status === 'updating'. */
-  stageLabel?: string;
+  /**
+   * i18n key path (e.g. `firmware_view.stages.transfer.label`) for the
+   * stage label shown under the status pill when status === 'updating'.
+   * The row component resolves this via t() — keeps localization at the
+   * consumer rather than the producer.
+   */
+  stageLabelKey?: string;
 }
 
 export interface ControllersPanelProps {

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -1,5 +1,6 @@
 import type {
   FirmwarePhase,
+  FirmwareStage,
   FirmwareStageLabelKey,
   FirmwareStatusPillKind,
   SlotId,
@@ -18,6 +19,21 @@ export interface ControllerProgressEntry {
   stageLabelKey?: FirmwareStageLabelKey;
 }
 
+/**
+ * Props for AstrosFirmwareControllersPanel.
+ *
+ * Phase-vs-fields correlation (documented; only `progressByControllerId`
+ * is enforced at runtime by the dev-only watchEffect in the panel
+ * component — the result-bar fields below are documentation-only and
+ * the consumer is responsible for setting them in the right phase):
+ *  - `progressByControllerId`: required in non-select phases (flashing/done/failed) — runtime-checked in dev
+ *  - `doneCount`: only meaningful in `phase === 'done'`
+ *  - `failedControllerLabel`, `failedStage`, `failedCount`: only meaningful in `phase === 'failed'`
+ *
+ * IM-12: `failedStage` is narrowed to `FirmwareStage` so the panel
+ * template's `t('firmware_view.stages.${failedStage}.label')` always
+ * resolves to a known i18n key path.
+ */
 export interface ControllersPanelProps {
   phase: ControllersPanelPhase;
   /** Per-controller progress state keyed by SlotId; read in non-select phases. */
@@ -27,7 +43,7 @@ export interface ControllersPanelProps {
   /** Result bar label in `failed` phase. With multi-failure, the consumer joins labels comma-separated. */
   failedControllerLabel?: string;
   /** Result bar stage name in `failed` phase. Omitted when `failedCount > 1` because failures may span stages. */
-  failedStage?: string;
+  failedStage?: FirmwareStage;
   /** Number of failed controllers; controls singular vs multi result-bar copy. Defaults to 1. */
   failedCount?: number;
 }

--- a/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
+++ b/astros_vue/src/components/firmware/firmwareControllersPanel/types.ts
@@ -2,6 +2,7 @@ import type {
   FirmwarePhase,
   FirmwareStageLabelKey,
   FirmwareStatusPillKind,
+  SlotId,
 } from '@/types/firmware';
 
 export type ControllersPanelPhase = Exclude<FirmwarePhase, 'idle'>;
@@ -19,12 +20,14 @@ export interface ControllerProgressEntry {
 
 export interface ControllersPanelProps {
   phase: ControllersPanelPhase;
-  /** Per-controller progress state keyed by controller id; read in non-select phases. */
-  progressByControllerId?: Record<string, ControllerProgressEntry>;
+  /** Per-controller progress state keyed by SlotId; read in non-select phases. */
+  progressByControllerId?: Partial<Record<SlotId, ControllerProgressEntry>>;
   /** Result bar count in `done` phase; falls back to `selectedControllerIds.size`. */
   doneCount?: number;
-  /** Result bar label in `failed` phase. */
+  /** Result bar label in `failed` phase. With multi-failure, the consumer joins labels comma-separated. */
   failedControllerLabel?: string;
-  /** Result bar stage name in `failed` phase. */
+  /** Result bar stage name in `failed` phase. Omitted when `failedCount > 1` because failures may span stages. */
   failedStage?: string;
+  /** Number of failed controllers; controls singular vs multi result-bar copy. Defaults to 1. */
+  failedCount?: number;
 }

--- a/astros_vue/src/components/firmware/firmwareSourceStrip/AstrosFirmwareSourceStrip.vue
+++ b/astros_vue/src/components/firmware/firmwareSourceStrip/AstrosFirmwareSourceStrip.vue
@@ -142,9 +142,6 @@ const primaryAssetSize = computed<number | null>(() => {
         >
           {{ $t('firmware_view.source.releases_stale_warning', { since: formatDate(staleSince) }) }}
         </p>
-        <!-- TODO(d.5): the i18n string says "Try again." but there's no retry control here.
-             Add a retry button that calls firmware.fetchReleases() once d.5 lands the
-             page-level action bar; until then the user has to refresh the route. -->
         <p
           v-else-if="releasesLoadState === 'error'"
           class="astros-firmware-source-strip__warning astros-firmware-source-strip__warning--error"

--- a/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
+++ b/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
@@ -19,9 +19,9 @@ const disabled = ref(true);
 const label = ref('modals.servo_test.enable_test');
 const value = ref(props.homePosition);
 
-// CR-5: ServoTest writes during a flash get silently rejected by the
-// server (FLASH_JOB_ACTIVE). Gate the slider + button so the operator
-// gets clear visual feedback rather than dragging into the void.
+// ServoTest writes during a flash get silently rejected server-side.
+// Gate the slider + button so operators see disabled controls rather
+// than dragging into the void.
 const writesBlocked = computed(() => jobLockLocked.value);
 
 // If a flash starts while the modal is already open with the test active,

--- a/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
+++ b/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useWebsocket } from '@/composables/useWebsocket';
+import { useJobLockStore } from '@/stores/jobLock';
+import { storeToRefs } from 'pinia';
 import type { ServoTestEvent } from '@/models/events';
 
 const { wsSendMessage } = useWebsocket();
+const jobLock = useJobLockStore();
+const { locked: jobLockLocked } = storeToRefs(jobLock);
 
 const props = defineProps<ServoTestEvent>();
 
@@ -15,8 +19,22 @@ const disabled = ref(true);
 const label = ref('modals.servo_test.enable_test');
 const value = ref(props.homePosition);
 
+// CR-5: ServoTest writes during a flash get silently rejected by the
+// server (FLASH_JOB_ACTIVE). Gate the slider + button so the operator
+// gets clear visual feedback rather than dragging into the void.
+const writesBlocked = computed(() => jobLockLocked.value);
+
+// If a flash starts while the modal is already open with the test active,
+// auto-disable so further slider input is ignored locally as well.
+watch(writesBlocked, (nowBlocked) => {
+  if (nowBlocked && !disabled.value) {
+    disabled.value = true;
+    label.value = 'modals.servo_test.enable_test';
+  }
+});
+
 const onSliderChange = () => {
-  if (disabled.value) {
+  if (disabled.value || writesBlocked.value) {
     return;
   }
   wsSendMessage(JSON.stringify(servoTestMessage()));
@@ -37,6 +55,7 @@ function servoTestMessage() {
 }
 
 const enableTest = () => {
+  if (writesBlocked.value) return;
   disabled.value = !disabled.value;
   if (!disabled.value) {
     label.value = 'modals.servo_test.disable_test';
@@ -75,16 +94,27 @@ const closeModal = () => {
           min="500"
           max="2500"
           v-model.number="value"
-          :disabled="disabled"
+          :disabled="disabled || writesBlocked"
           @input="onSliderChange"
           class="range range-primary mt-4"
           step="1"
         />
+        <div
+          v-if="writesBlocked"
+          role="status"
+          aria-live="polite"
+          class="text-sm text-warning text-center mt-2"
+          data-testid="lock-active-notice"
+        >
+          {{ $t('firmware_view.lock_active') }}
+        </div>
       </div>
       <div class="mt-5 flex flex-row">
         <div class="grow"></div>
         <button
           data-testid="enable-test-button"
+          :disabled="writesBlocked"
+          :title="writesBlocked ? $t('firmware_view.lock_active') : ''"
           class="btn btn-primary w-25 text-lg py-1.25 mx-1.25"
           @click="enableTest"
         >

--- a/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
+++ b/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createI18n } from 'vue-i18n';
+import { nextTick } from 'vue';
+import enUS from '@/locales/enUS.json';
+import AstrosServoTestModal from '@/components/modals/modules/AstrosServoTestModal.vue';
+import { useJobLockStore } from '@/stores/jobLock';
+
+const stubSendMessage = vi.fn();
+vi.mock('@/composables/useWebsocket', () => ({
+  useWebsocket: () => ({ wsSendMessage: stubSendMessage }),
+}));
+
+function createTestI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'enUS',
+    fallbackLocale: 'enUS',
+    messages: { enUS },
+  });
+}
+
+const defaultProps = {
+  controllerAddress: 'aa:bb:cc:dd:ee:01',
+  controllerName: 'Core',
+  moduleSubType: 1,
+  moduleIdx: 0,
+  channelNumber: 0,
+  homePosition: 1500,
+};
+
+function mountModal(): VueWrapper {
+  return mount(AstrosServoTestModal, {
+    props: defaultProps,
+    global: { plugins: [createTestI18n()] },
+  });
+}
+
+describe('AstrosServoTestModal — CR-5 lock-aware gating', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    stubSendMessage.mockClear();
+  });
+
+  it('renders normally and allows enabling when not locked', async () => {
+    const wrapper = mountModal();
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    expect(btn.attributes('disabled')).toBeUndefined();
+    await btn.trigger('click');
+    expect(stubSendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the Enable Test button when jobLock.locked is true', async () => {
+    const lockStore = useJobLockStore();
+    lockStore.setState({
+      locked: true,
+      owner: 'flash:job-A',
+      since: '2026-05-14T08:00:00Z',
+    });
+    const wrapper = mountModal();
+    await nextTick();
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    expect(btn.attributes('disabled')).toBeDefined();
+  });
+
+  it('does NOT send servoTest when enableTest is invoked while locked', async () => {
+    const lockStore = useJobLockStore();
+    lockStore.setState({
+      locked: true,
+      owner: 'flash:job-A',
+      since: '2026-05-14T08:00:00Z',
+    });
+    const wrapper = mountModal();
+    await nextTick();
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    await btn.trigger('click');
+    expect(stubSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('renders the lock-active notice region with role=status when locked', async () => {
+    const lockStore = useJobLockStore();
+    lockStore.setState({
+      locked: true,
+      owner: 'flash:job-A',
+      since: '2026-05-14T08:00:00Z',
+    });
+    const wrapper = mountModal();
+    await nextTick();
+    const notice = wrapper.find('[data-testid="lock-active-notice"]');
+    expect(notice.exists()).toBe(true);
+    expect(notice.attributes('role')).toBe('status');
+    expect(notice.attributes('aria-live')).toBe('polite');
+  });
+
+  it('disables the slider when locked', async () => {
+    const lockStore = useJobLockStore();
+    lockStore.setState({
+      locked: true,
+      owner: 'flash:job-A',
+      since: '2026-05-14T08:00:00Z',
+    });
+    const wrapper = mountModal();
+    await nextTick();
+    const slider = wrapper.find('input[type="range"]');
+    expect(slider.attributes('disabled')).toBeDefined();
+  });
+
+  it('auto-disables an active test if a lock acquires mid-session', async () => {
+    const wrapper = mountModal();
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    // Enable test while unlocked
+    await btn.trigger('click');
+    expect(stubSendMessage).toHaveBeenCalledTimes(1);
+    stubSendMessage.mockClear();
+    // Lock acquires
+    const lockStore = useJobLockStore();
+    lockStore.setState({
+      locked: true,
+      owner: 'flash:job-A',
+      since: '2026-05-14T08:00:00Z',
+    });
+    await nextTick();
+    // Slider change should be a no-op now
+    const slider = wrapper.find('input[type="range"]');
+    await slider.trigger('input');
+    expect(stubSendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
+++ b/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
@@ -37,7 +37,7 @@ function mountModal(): VueWrapper {
   });
 }
 
-describe('AstrosServoTestModal — CR-5 lock-aware gating', () => {
+describe('AstrosServoTestModal — lock-aware gating', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     stubSendMessage.mockClear();

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -369,6 +369,38 @@ describe('CR-3 mid-stream catch does not clobber terminal flashError', () => {
     );
     expect(firmware.flashError?.reason).toBe('protocol_violation');
   });
+
+  it('does NOT set protocol_violation when phase=done and flashError is null (round-8 NEW-C1)', () => {
+    // After a clean flash completion, phase='done' with no flashError. A
+    // stray malformed mid-stream frame (e.g., server retransmit during
+    // reboot-wait) must NOT clobber the happy "✓ all updated" UI with a
+    // red protocol_violation banner. The CR-3 guard was originally `||`
+    // (set if EITHER is OK) which allowed this; tightening to `&&` (set
+    // only when BOTH conditions hold — mid-flow AND no existing error)
+    // closes the visual contradiction.
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('done');
+    expect(firmware.flashError).toBeNull();
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+      }),
+    );
+    expect(firmware.flashError).toBeNull();
+  });
+
+  it('does NOT set protocol_violation when phase=done via FLASH_CONTROLLER_RESULT malformed frame', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('done');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_CONTROLLER_RESULT,
+      }),
+    );
+    expect(firmware.flashError).toBeNull();
+  });
 });
 
 describe('handleLockStateChanged — CR-1b recovery defense', () => {
@@ -420,6 +452,60 @@ describe('handleLockStateChanged — CR-1b recovery defense', () => {
       }),
     );
     expect(firmware.phase).toBe('flashing');
+  });
+
+  it('NEW-C2: recovery normalizes controllerStates (delegates to applyJobDone, not bare setPhase)', () => {
+    // Round-8 NEW-C2: without normalization, the panel renders "✓ done"
+    // while rows still show "Updating" pills + stage labels. Forcing the
+    // recovery through applyJobDone runs the demote-non-terminal-stages
+    // loop so the per-row UI matches the terminal phase.
+    const controllers = useControllerStore();
+    controllers.setControllerMac(Location.BODY, '00:00:00:00:00:00');
+    controllers.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.applyJobStarted({
+      jobId: 'job-1',
+      source: { kind: 'github', version: 'v1.0' },
+      controllers: [
+        { controllerId: '00:00:00:00:00:00', stage: 'SENDING' },
+        { controllerId: 'aa:bb:cc:dd:ee:01', stage: 'QUEUED' },
+      ],
+      startedAt: '2026-05-14T08:00:00Z',
+    });
+    // Mid-flow states present.
+    expect(firmware.controllerStates.get('body')?.stage).toBe('SENDING');
+    expect(firmware.controllerStates.get('core')?.stage).toBe('QUEUED');
+
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.LOCK_STATE_CHANGED,
+        locked: false,
+        owner: null,
+        since: null,
+      }),
+    );
+
+    expect(firmware.phase).toBe('done');
+    // Both per-controller states normalized to VERSION_CONFIRMED.
+    expect(firmware.controllerStates.get('body')?.stage).toBe('VERSION_CONFIRMED');
+    expect(firmware.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
+  });
+
+  it('NEW-C2: recovery surfaces a protocol_violation flashError breadcrumb so operators see the recovery', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('flashing');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.LOCK_STATE_CHANGED,
+        locked: false,
+        owner: null,
+        since: null,
+      }),
+    );
+    expect(firmware.flashError?.reason).toBe('protocol_violation');
+    expect(firmware.flashError?.detail).toContain('terminal event');
   });
 });
 

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -316,3 +316,131 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
     });
   });
 });
+
+describe('CR-3 mid-stream catch does not clobber terminal flashError', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('handleFlashControllerUpdate catch preserves a terminal flashError', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setFlashError({
+      reason: 'internal_server_error',
+      detail: 'asset checksum mismatch on Core',
+    });
+    firmware.setPhase('failed');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+        // missing/null data => triggers the catch
+      }),
+    );
+    expect(firmware.flashError?.reason).toBe('internal_server_error');
+    expect(firmware.flashError?.detail).toBe('asset checksum mismatch on Core');
+  });
+
+  it('handleFlashControllerResult catch preserves a terminal flashError', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setFlashError({
+      reason: 'internal_server_error',
+      detail: 'verify failed on Body',
+    });
+    firmware.setPhase('failed');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_CONTROLLER_RESULT,
+        // missing/null data => triggers the catch
+      }),
+    );
+    expect(firmware.flashError?.reason).toBe('internal_server_error');
+    expect(firmware.flashError?.detail).toBe('verify failed on Body');
+  });
+
+  it('handleFlashControllerUpdate catch DOES set protocol_violation when no existing flashError', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('flashing');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+      }),
+    );
+    expect(firmware.flashError?.reason).toBe('protocol_violation');
+  });
+});
+
+describe('handleLockStateChanged — CR-1b recovery defense', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('forces firmware phase=done when lock releases but firmware is still flashing', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('flashing');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.LOCK_STATE_CHANGED,
+        locked: false,
+        owner: null,
+        since: null,
+      }),
+    );
+    expect(firmware.phase).toBe('done');
+    expect(warnSpy.mock.calls.flat().join(' ')).toContain('phase=flashing with lock released');
+  });
+
+  it('does NOT force phase=done when firmware is not flashing (no spurious transitions)', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('select');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.LOCK_STATE_CHANGED,
+        locked: false,
+        owner: null,
+        since: null,
+      }),
+    );
+    expect(firmware.phase).toBe('select');
+  });
+
+  it('does NOT force phase transition when locked=true (no inverse trigger)', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('flashing');
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.LOCK_STATE_CHANGED,
+        locked: true,
+        owner: 'other-op',
+        since: '2026-05-14T08:00:00Z',
+      }),
+    );
+    expect(firmware.phase).toBe('flashing');
+  });
+});
+
+describe('WebsocketMessageType wire-numeric pinning (cross-process contract)', () => {
+  it('pins the wire numeric values that the server emits — drift here breaks every WS message', () => {
+    expect(WebsocketMessageType.SCRIPT).toBe(0);
+    expect(WebsocketMessageType.CONFIGURATION_SYNC).toBe(1);
+    expect(WebsocketMessageType.LOCATION_STATUS).toBe(2);
+    expect(WebsocketMessageType.CONTROLLERS_SYNC).toBe(3);
+    expect(WebsocketMessageType.RUN).toBe(4);
+    expect(WebsocketMessageType.PANIC).toBe(5);
+    expect(WebsocketMessageType.DIRECT_COMMAND).toBe(6);
+    expect(WebsocketMessageType.FORMAT_SD).toBe(7);
+    expect(WebsocketMessageType.SERVO_TEST).toBe(8);
+    expect(WebsocketMessageType.SYSTEM_STATUS).toBe(9);
+    expect(WebsocketMessageType.LOCK_STATE_CHANGED).toBe(10);
+    expect(WebsocketMessageType.FLASH_JOB_ACTIVE).toBe(11);
+    expect(WebsocketMessageType.FLASH_JOB_STARTED).toBe(12);
+    expect(WebsocketMessageType.FLASH_CONTROLLER_UPDATE).toBe(13);
+    expect(WebsocketMessageType.FLASH_CONTROLLER_RESULT).toBe(14);
+    expect(WebsocketMessageType.FLASH_JOB_DONE).toBe(15);
+    expect(WebsocketMessageType.FLASH_JOB_FAILED).toBe(16);
+  });
+});

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -255,6 +255,10 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
       // recover the row. But the operator-visible error must surface.
       expect(firmware.flashError?.reason).toBe('internal_server_error');
       expect(firmware.flashError?.detail).toBe('Malformed flashControllerUpdate from server');
+      // Pin the non-rollback contract: a regression that added
+      // setPhase('select' | 'failed') to this catch would pass the
+      // flashError assertion but break the recover-row design intent.
+      expect(firmware.phase).toBe('flashing');
     });
 
     it('surfaces flashError when applyControllerResult throws', () => {
@@ -273,6 +277,42 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
       );
 
       expect(firmware.flashError?.detail).toBe('Malformed flashControllerResult from server');
+      // Pin the non-rollback contract per applyControllerUpdate above.
+      expect(firmware.phase).toBe('flashing');
+    });
+
+    it('does NOT roll phase on unrecognized garbage controllerLocation in handleStatusMessage (I-test-4)', () => {
+      // The C1 test pins Location.UNKNOWN. Server contract drift could
+      // send any arbitrary string (e.g. `"head"` after a rename). The
+      // default branch covers this case structurally — pin it explicitly
+      // so a regression that hard-coded `if (location === UNKNOWN)` would
+      // fail.
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      const controllerStore = useControllerStore();
+      firmware.currentJobLoadFailed = true; // banner should survive
+      firmware.applyControllerUpdate({ controllerId: 'aa:bb:cc:00:00:01', stage: 'SENDING' });
+      expect(firmware.pendingByMac.size).toBe(1);
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.LOCATION_STATUS,
+          controllerLocation: 'unrecognized-location-string',
+          controllerId: 'db-uuid',
+          controllerAddress: 'aa:bb:cc:00:00:01',
+          up: true,
+          synced: true,
+          firmwareCompatible: true,
+        }),
+      );
+
+      // No mapping written, no flush triggered, banner preserved, queue
+      // entry unchanged.
+      expect(controllerStore.coreMac).toBeNull();
+      expect(controllerStore.domeMac).toBeNull();
+      expect(controllerStore.bodyMac).toBe('00:00:00:00:00:00');
+      expect(firmware.currentJobLoadFailed).toBe(true);
+      expect(firmware.pendingByMac.get('aa:bb:cc:00:00:01')).toHaveLength(1);
     });
   });
 });

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useWebsocket } from '../useWebsocket';
+import { useFirmwareStore } from '@/stores/firmware';
+import { useControllerStore } from '@/stores/controller';
+import { WebsocketMessageType, Location } from '@/enums';
+
+// Capture warn calls so individual tests can assert against them, while
+// suppressing the expected stderr noise from error/log paths. The spies
+// are reset between tests so call lists don't bleed across cases.
+let warnSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('handleFlashJobStarted malformed-payload rollback', () => {
+    it("rolls phase to 'select' and surfaces flashError when payload is missing data.jobId", () => {
+      // The dispatcher catch is load-bearing: without it a malformed
+      // flashJobStarted would leave the UI stuck at 'flashing' with no
+      // operator-visible reason. Pin: setPhase('select') + flashError.
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      firmware.setPhase('flashing'); // simulate just-clicked-Flash
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.FLASH_JOB_STARTED,
+          // No `data` field → malformed.
+        }),
+      );
+
+      expect(firmware.phase).toBe('select');
+      expect(firmware.flashError).toEqual({
+        reason: 'internal_server_error',
+        detail: 'Malformed flashJobStarted from server',
+      });
+    });
+  });
+
+  describe('handleFlashJobFailed malformed-payload rollback', () => {
+    it("rolls phase to 'failed' when payload is missing data.endedAt", () => {
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      firmware.setPhase('flashing');
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.FLASH_JOB_FAILED,
+          data: { jobId: 'job-1' }, // missing endedAt
+        }),
+      );
+
+      expect(firmware.phase).toBe('failed');
+      expect(firmware.flashError?.reason).toBe('internal_server_error');
+      expect(firmware.flashError?.detail).toBe('Malformed flashJobFailed from server');
+    });
+  });
+
+  describe('handleFlashJobDone fallback (I1 fix)', () => {
+    it("forces phase to 'done' if the store's applyJobDone throws", () => {
+      // Previously this handler only console.error'd and continued — a throw
+      // would leave phase at 'flashing' indefinitely with the server having
+      // marked the job done. Pin: catch transitions to 'done' so the UI
+      // exits the flashing state regardless.
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      firmware.setPhase('flashing');
+      // Force applyJobDone to throw to simulate a future invariant violation.
+      firmware.applyJobDone = (() => {
+        throw new Error('synthetic invariant violation');
+      }) as typeof firmware.applyJobDone;
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.FLASH_JOB_DONE,
+          data: { jobId: 'job-1', endedAt: '2026-05-13T08:05:00Z' },
+        }),
+      );
+
+      expect(firmware.phase).toBe('done');
+      expect(firmware.flashError?.reason).toBe('internal_server_error');
+      expect(firmware.flashError?.detail).toBe('Malformed flashJobDone from server');
+    });
+  });
+
+  describe('handleStatusMessage controllerAddress branches (I4 fix)', () => {
+    it('learns the MAC mapping when controllerAddress is a non-empty string', () => {
+      const { handleMessage } = useWebsocket();
+      const controllerStore = useControllerStore();
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.LOCATION_STATUS,
+          controllerLocation: Location.CORE,
+          controllerId: 'db-uuid-core',
+          controllerAddress: 'aa:bb:cc:dd:ee:01',
+          up: true,
+          synced: true,
+          firmwareCompatible: true,
+        }),
+      );
+
+      expect(controllerStore.coreMac).toBe('aa:bb:cc:dd:ee:01');
+      expect(controllerStore.controllerIdToLocation('aa:bb:cc:dd:ee:01')).toBe(Location.CORE);
+    });
+
+    it('skips MAC learning silently when controllerAddress is undefined (rolling-deploy tolerance)', () => {
+      const { handleMessage } = useWebsocket();
+      const controllerStore = useControllerStore();
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.LOCATION_STATUS,
+          controllerLocation: Location.CORE,
+          controllerId: 'db-uuid-core',
+          // No controllerAddress field (older server).
+          up: true,
+          synced: true,
+          firmwareCompatible: true,
+        }),
+      );
+
+      expect(controllerStore.coreMac).toBeNull();
+    });
+
+    it('warns but skips MAC learning when controllerAddress is empty string (server contract bug)', () => {
+      // Empty string is a server bug, not deploy-skew — surfacing it lets
+      // a stuck row be traced back to its origin during ops debugging.
+      // warnSpy is the outer-beforeEach spy; calls accumulate from the start
+      // of the test so the assertion is not subject to spy-stacking races.
+      const { handleMessage } = useWebsocket();
+      const controllerStore = useControllerStore();
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.LOCATION_STATUS,
+          controllerLocation: Location.CORE,
+          controllerId: 'db-uuid-core',
+          controllerAddress: '',
+          up: true,
+          synced: true,
+          firmwareCompatible: true,
+        }),
+      );
+
+      expect(controllerStore.coreMac).toBeNull();
+      const warnCalls = warnSpy.mock.calls.flat().join(' ');
+      expect(warnCalls).toContain('empty controllerAddress');
+    });
+  });
+
+  describe('handleStatusMessage drains the firmware-store pending queue after setControllerMac (C1 integration)', () => {
+    it('replays queued ControllerFlashState entries once the matching LocationStatus arrives', () => {
+      // The late-MAC race fix: a flashControllerUpdate for an unmapped MAC
+      // is queued; the next LocationStatus for that MAC drains the queue.
+      // Pin the integration via the dispatcher — store-only tests can't
+      // catch a regression where useWebsocket forgets to call flushPendingForMac.
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      const MAC = 'aa:bb:cc:dd:ee:01';
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+          data: { controllerId: MAC, stage: 'SENDING' },
+        }),
+      );
+      expect(firmware.controllerStates.size).toBe(0);
+      expect(firmware.pendingByMac.get(MAC)).toHaveLength(1);
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.LOCATION_STATUS,
+          controllerLocation: Location.CORE,
+          controllerId: 'db-uuid-core',
+          controllerAddress: MAC,
+          up: true,
+          synced: true,
+          firmwareCompatible: true,
+        }),
+      );
+
+      expect(firmware.controllerStates.get('core')?.stage).toBe('SENDING');
+      expect(firmware.pendingByMac.has(MAC)).toBe(false);
+    });
+  });
+});

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -63,12 +63,11 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
     });
   });
 
-  describe('handleFlashJobDone fallback (I1 fix)', () => {
+  describe('handleFlashJobDone fallback', () => {
     it("forces phase to 'done' if the store's applyJobDone throws", () => {
-      // Previously this handler only console.error'd and continued — a throw
-      // would leave phase at 'flashing' indefinitely with the server having
-      // marked the job done. Pin: catch transitions to 'done' so the UI
-      // exits the flashing state regardless.
+      // Without the catch fallback, a thrown applyJobDone would leave phase
+      // at 'flashing' indefinitely even though the server marked the job
+      // done. The catch transitions to 'done' so the UI exits regardless.
       const { handleMessage } = useWebsocket();
       const firmware = useFirmwareStore();
       firmware.setPhase('flashing');
@@ -90,7 +89,7 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
     });
   });
 
-  describe('handleStatusMessage controllerAddress branches (I4 fix)', () => {
+  describe('handleStatusMessage controllerAddress branches', () => {
     it('learns the MAC mapping when controllerAddress is a non-empty string', () => {
       const { handleMessage } = useWebsocket();
       const controllerStore = useControllerStore();
@@ -156,12 +155,13 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
     });
   });
 
-  describe('handleStatusMessage drains the firmware-store pending queue after setControllerMac (C1 integration)', () => {
+  describe('handleStatusMessage drains the firmware-store pending queue after setControllerMac', () => {
     it('replays queued ControllerFlashState entries once the matching LocationStatus arrives', () => {
-      // The late-MAC race fix: a flashControllerUpdate for an unmapped MAC
-      // is queued; the next LocationStatus for that MAC drains the queue.
-      // Pin the integration via the dispatcher — store-only tests can't
-      // catch a regression where useWebsocket forgets to call flushPendingForMac.
+      // Late-MAC race: a flashControllerUpdate for an unmapped MAC is
+      // queued; the next LocationStatus for that MAC drains the queue.
+      // This test pins the integration via the dispatcher — store-only
+      // tests can't catch a regression where useWebsocket forgets to
+      // call flushPendingForMac.
       const { handleMessage } = useWebsocket();
       const firmware = useFirmwareStore();
       const MAC = 'aa:bb:cc:dd:ee:01';
@@ -191,13 +191,12 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
       expect(firmware.pendingByMac.has(MAC)).toBe(false);
     });
 
-    it('skips setControllerMac AND flushPendingForMac when location is UNKNOWN (C1 fix)', () => {
-      // Previously, the dispatcher fell through to the controllerAddress
-      // block on UNKNOWN, calling setControllerMac (no-op for UNKNOWN) and
-      // flushPendingForMac (which would re-queue endlessly because
-      // resolveSlot still returned null). Plus the firmwareStore's
-      // currentJobLoadFailed clear ran every time, silently dismissing
-      // the only operator-visible "something wrong" banner.
+    it('skips setControllerMac AND flushPendingForMac when location is UNKNOWN', () => {
+      // For UNKNOWN locations, setControllerMac is a no-op and
+      // flushPendingForMac would re-queue endlessly because resolveSlot
+      // still returns null. Skipping both also prevents the firmware
+      // store's staleness banner from being silently dismissed on every
+      // UNKNOWN update.
       const { handleMessage } = useWebsocket();
       const firmware = useFirmwareStore();
       const controllerStore = useControllerStore();
@@ -232,11 +231,11 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
     });
   });
 
-  describe('handleFlashControllerUpdate / handleFlashControllerResult error surfaces (C2 fix)', () => {
+  describe('handleFlashControllerUpdate / handleFlashControllerResult error surfaces', () => {
     it('surfaces flashError when applyControllerUpdate throws so the operator sees a signal', () => {
-      // Previously this handler only console.error'd and continued; a thrown
-      // applyControllerUpdate would leave phase='flashing' with no signal
-      // and no error envelope. Pin the new flashError fallback.
+      // Without the flashError fallback, a thrown applyControllerUpdate
+      // would leave phase='flashing' with no envelope and no operator-
+      // visible signal that anything went wrong.
       const { handleMessage } = useWebsocket();
       const firmware = useFirmwareStore();
       firmware.setPhase('flashing');
@@ -281,12 +280,11 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
       expect(firmware.phase).toBe('flashing');
     });
 
-    it('does NOT roll phase on unrecognized garbage controllerLocation in handleStatusMessage (I-test-4)', () => {
-      // The C1 test pins Location.UNKNOWN. Server contract drift could
-      // send any arbitrary string (e.g. `"head"` after a rename). The
-      // default branch covers this case structurally — pin it explicitly
-      // so a regression that hard-coded `if (location === UNKNOWN)` would
-      // fail.
+    it('does NOT roll phase on unrecognized garbage controllerLocation in handleStatusMessage', () => {
+      // The UNKNOWN-location test covers the enum case. Server contract
+      // drift could also send any arbitrary string (e.g. "head" after a
+      // rename). Pin the default-branch coverage so a regression that
+      // hard-coded `if (location === UNKNOWN)` would fail.
       const { handleMessage } = useWebsocket();
       const firmware = useFirmwareStore();
       const controllerStore = useControllerStore();
@@ -317,7 +315,7 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
   });
 });
 
-describe('CR-3 mid-stream catch does not clobber terminal flashError', () => {
+describe('mid-stream catch does not clobber terminal flashError', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
   });
@@ -370,14 +368,11 @@ describe('CR-3 mid-stream catch does not clobber terminal flashError', () => {
     expect(firmware.flashError?.reason).toBe('protocol_violation');
   });
 
-  it('does NOT set protocol_violation when phase=done and flashError is null (round-8 NEW-C1)', () => {
-    // After a clean flash completion, phase='done' with no flashError. A
-    // stray malformed mid-stream frame (e.g., server retransmit during
-    // reboot-wait) must NOT clobber the happy "✓ all updated" UI with a
-    // red protocol_violation banner. The CR-3 guard was originally `||`
-    // (set if EITHER is OK) which allowed this; tightening to `&&` (set
-    // only when BOTH conditions hold — mid-flow AND no existing error)
-    // closes the visual contradiction.
+  it('does NOT set protocol_violation when phase=done and flashError is null', () => {
+    // After a clean completion, a stray malformed mid-stream frame (e.g.,
+    // server retransmit during reboot-wait) must not clobber the "all
+    // updated" UI with a protocol_violation banner. The guard requires
+    // BOTH mid-flow phase AND no existing flashError before writing.
     const { handleMessage } = useWebsocket();
     const firmware = useFirmwareStore();
     firmware.setPhase('done');
@@ -403,7 +398,7 @@ describe('CR-3 mid-stream catch does not clobber terminal flashError', () => {
   });
 });
 
-describe('handleLockStateChanged — CR-1b recovery defense', () => {
+describe('handleLockStateChanged — lock-release recovery defense', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
   });
@@ -454,11 +449,10 @@ describe('handleLockStateChanged — CR-1b recovery defense', () => {
     expect(firmware.phase).toBe('flashing');
   });
 
-  it('NEW-C2: recovery normalizes controllerStates (delegates to applyJobDone, not bare setPhase)', () => {
-    // Round-8 NEW-C2: without normalization, the panel renders "✓ done"
-    // while rows still show "Updating" pills + stage labels. Forcing the
-    // recovery through applyJobDone runs the demote-non-terminal-stages
-    // loop so the per-row UI matches the terminal phase.
+  it('recovery normalizes controllerStates (delegates to applyJobDone, not bare setPhase)', () => {
+    // Without normalization, the panel renders "all updated" while rows
+    // still show "Updating" pills. Delegating to applyJobDone runs the
+    // demote-non-terminal-stages loop so per-row UI matches phase.
     const controllers = useControllerStore();
     controllers.setControllerMac(Location.BODY, '00:00:00:00:00:00');
     controllers.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
@@ -492,7 +486,7 @@ describe('handleLockStateChanged — CR-1b recovery defense', () => {
     expect(firmware.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
   });
 
-  it('NEW-C2: recovery surfaces a protocol_violation flashError breadcrumb so operators see the recovery', () => {
+  it('recovery surfaces a protocol_violation flashError breadcrumb so operators see the recovery', () => {
     const { handleMessage } = useWebsocket();
     const firmware = useFirmwareStore();
     firmware.setPhase('flashing');
@@ -509,12 +503,12 @@ describe('handleLockStateChanged — CR-1b recovery defense', () => {
   });
 });
 
-describe('IM-8 coverage gaps — dispatcher happy paths + contract pins', () => {
+describe('dispatcher happy paths + contract pins', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
   });
 
-  it('routes well-formed FLASH_JOB_STARTED through applyJobStarted (IM-8: dispatcher happy path)', () => {
+  it('routes well-formed FLASH_JOB_STARTED through applyJobStarted', () => {
     const { handleMessage } = useWebsocket();
     const firmware = useFirmwareStore();
     handleMessage(
@@ -532,7 +526,7 @@ describe('IM-8 coverage gaps — dispatcher happy paths + contract pins', () => 
     expect(firmware.phase).toBe('flashing');
   });
 
-  it('routes FLASH_CONTROLLER_RESULT through applyControllerResult with the full payload (IM-8: dispatcher happy path)', () => {
+  it('routes FLASH_CONTROLLER_RESULT through applyControllerResult with the full payload', () => {
     const { handleMessage } = useWebsocket();
     const firmware = useFirmwareStore();
     const controllers = useControllerStore();
@@ -563,7 +557,7 @@ describe('IM-8 coverage gaps — dispatcher happy paths + contract pins', () => 
     }
   });
 
-  it('FLASH_JOB_ACTIVE is a no-op: phase, flashError, controllerStates all unchanged (IM-8: contract pin)', () => {
+  it('FLASH_JOB_ACTIVE is a no-op: phase, flashError, controllerStates all unchanged', () => {
     const { handleMessage } = useWebsocket();
     const firmware = useFirmwareStore();
     firmware.setPhase('flashing');

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -423,6 +423,94 @@ describe('handleLockStateChanged — CR-1b recovery defense', () => {
   });
 });
 
+describe('IM-8 coverage gaps — dispatcher happy paths + contract pins', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('routes well-formed FLASH_JOB_STARTED through applyJobStarted (IM-8: dispatcher happy path)', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_JOB_STARTED,
+        data: {
+          jobId: 'job-X',
+          source: { kind: 'github', version: 'v1.0' },
+          controllers: [],
+          startedAt: '2026-05-14T08:00:00Z',
+        },
+      }),
+    );
+    expect(firmware.currentJob?.jobId).toBe('job-X');
+    expect(firmware.phase).toBe('flashing');
+  });
+
+  it('routes FLASH_CONTROLLER_RESULT through applyControllerResult with the full payload (IM-8: dispatcher happy path)', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    const controllers = useControllerStore();
+    controllers.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+    firmware.applyJobStarted({
+      jobId: 'job-1',
+      source: { kind: 'github', version: 'v1.4.2' },
+      controllers: [{ controllerId: 'aa:bb:cc:dd:ee:01', stage: 'VERIFYING' }],
+      startedAt: '2026-05-14T08:00:00Z',
+    });
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_CONTROLLER_RESULT,
+        data: {
+          jobId: 'job-1',
+          controller: {
+            controllerId: 'aa:bb:cc:dd:ee:01',
+            stage: 'VERSION_CONFIRMED',
+            finalVersion: 'v1.4.2',
+          },
+        },
+      }),
+    );
+    const core = firmware.controllerStates.get('core');
+    expect(core?.stage).toBe('VERSION_CONFIRMED');
+    if (core?.stage === 'VERSION_CONFIRMED') {
+      expect(core.finalVersion).toBe('v1.4.2');
+    }
+  });
+
+  it('FLASH_JOB_ACTIVE is a no-op: phase, flashError, controllerStates all unchanged (IM-8: contract pin)', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    firmware.setPhase('flashing');
+    const phaseBefore = firmware.phase;
+    const errorBefore = firmware.flashError;
+    const statesSizeBefore = firmware.controllerStates.size;
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_JOB_ACTIVE,
+        data: { reason: 'write_during_flash' },
+      }),
+    );
+    expect(firmware.phase).toBe(phaseBefore);
+    expect(firmware.flashError).toBe(errorBefore);
+    expect(firmware.controllerStates.size).toBe(statesSizeBefore);
+  });
+
+  it('flashError persists across a subsequent successful applyControllerUpdate (operator must dismiss)', () => {
+    const { handleMessage } = useWebsocket();
+    const firmware = useFirmwareStore();
+    const controllers = useControllerStore();
+    controllers.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+    firmware.setFlashError({ reason: 'protocol_violation', detail: 'earlier error' });
+    handleMessage(
+      JSON.stringify({
+        type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+        data: { controllerId: 'aa:bb:cc:dd:ee:01', stage: 'VERIFYING' },
+      }),
+    );
+    expect(firmware.flashError?.reason).toBe('protocol_violation');
+  });
+});
+
 describe('WebsocketMessageType wire-numeric pinning (cross-process contract)', () => {
   it('pins the wire numeric values that the server emits — drift here breaks every WS message', () => {
     expect(WebsocketMessageType.SCRIPT).toBe(0);

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -38,7 +38,7 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
 
       expect(firmware.phase).toBe('select');
       expect(firmware.flashError).toEqual({
-        reason: 'internal_server_error',
+        reason: 'protocol_violation',
         detail: 'Malformed flashJobStarted from server',
       });
     });
@@ -58,7 +58,7 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
       );
 
       expect(firmware.phase).toBe('failed');
-      expect(firmware.flashError?.reason).toBe('internal_server_error');
+      expect(firmware.flashError?.reason).toBe('protocol_violation');
       expect(firmware.flashError?.detail).toBe('Malformed flashJobFailed from server');
     });
   });
@@ -85,7 +85,7 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
       );
 
       expect(firmware.phase).toBe('done');
-      expect(firmware.flashError?.reason).toBe('internal_server_error');
+      expect(firmware.flashError?.reason).toBe('protocol_violation');
       expect(firmware.flashError?.detail).toBe('Malformed flashJobDone from server');
     });
   });
@@ -253,7 +253,7 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
 
       // Phase intentionally NOT rolled — the next valid update should
       // recover the row. But the operator-visible error must surface.
-      expect(firmware.flashError?.reason).toBe('internal_server_error');
+      expect(firmware.flashError?.reason).toBe('protocol_violation');
       expect(firmware.flashError?.detail).toBe('Malformed flashControllerUpdate from server');
       // Pin the non-rollback contract: a regression that added
       // setPhase('select' | 'failed') to this catch would pass the

--- a/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
+++ b/astros_vue/src/composables/__tests__/useWebsocket.spec.ts
@@ -190,5 +190,89 @@ describe('useWebsocket handleMessage — firmware-flash dispatcher', () => {
       expect(firmware.controllerStates.get('core')?.stage).toBe('SENDING');
       expect(firmware.pendingByMac.has(MAC)).toBe(false);
     });
+
+    it('skips setControllerMac AND flushPendingForMac when location is UNKNOWN (C1 fix)', () => {
+      // Previously, the dispatcher fell through to the controllerAddress
+      // block on UNKNOWN, calling setControllerMac (no-op for UNKNOWN) and
+      // flushPendingForMac (which would re-queue endlessly because
+      // resolveSlot still returned null). Plus the firmwareStore's
+      // currentJobLoadFailed clear ran every time, silently dismissing
+      // the only operator-visible "something wrong" banner.
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      const controllerStore = useControllerStore();
+      const MAC = 'aa:bb:cc:dd:ee:99';
+
+      // Seed staleness flag (HTTP fetch had earlier failed).
+      firmware.currentJobLoadFailed = true;
+      // Queue an entry under MAC so we can prove flushPendingForMac
+      // is NOT called below (which would re-queue, but the size would
+      // still match).
+      firmware.applyControllerUpdate({ controllerId: MAC, stage: 'SENDING' });
+      expect(firmware.pendingByMac.get(MAC)).toHaveLength(1);
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.LOCATION_STATUS,
+          controllerLocation: Location.UNKNOWN,
+          controllerId: 'db-uuid-unknown',
+          controllerAddress: MAC,
+          up: true,
+          synced: true,
+          firmwareCompatible: true,
+        }),
+      );
+
+      expect(controllerStore.coreMac).toBeNull(); // no mapping written
+      expect(controllerStore.domeMac).toBeNull();
+      expect(controllerStore.bodyMac).toBe('00:00:00:00:00:00'); // sentinel unchanged
+      expect(firmware.currentJobLoadFailed).toBe(true); // banner preserved
+      // Pending queue unchanged — neither drained nor re-queued.
+      expect(firmware.pendingByMac.get(MAC)).toHaveLength(1);
+    });
+  });
+
+  describe('handleFlashControllerUpdate / handleFlashControllerResult error surfaces (C2 fix)', () => {
+    it('surfaces flashError when applyControllerUpdate throws so the operator sees a signal', () => {
+      // Previously this handler only console.error'd and continued; a thrown
+      // applyControllerUpdate would leave phase='flashing' with no signal
+      // and no error envelope. Pin the new flashError fallback.
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      firmware.setPhase('flashing');
+      firmware.applyControllerUpdate = (() => {
+        throw new Error('synthetic invariant violation');
+      }) as typeof firmware.applyControllerUpdate;
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.FLASH_CONTROLLER_UPDATE,
+          data: { controllerId: 'whatever', stage: 'SENDING' },
+        }),
+      );
+
+      // Phase intentionally NOT rolled — the next valid update should
+      // recover the row. But the operator-visible error must surface.
+      expect(firmware.flashError?.reason).toBe('internal_server_error');
+      expect(firmware.flashError?.detail).toBe('Malformed flashControllerUpdate from server');
+    });
+
+    it('surfaces flashError when applyControllerResult throws', () => {
+      const { handleMessage } = useWebsocket();
+      const firmware = useFirmwareStore();
+      firmware.setPhase('flashing');
+      firmware.applyControllerResult = (() => {
+        throw new Error('synthetic invariant violation');
+      }) as typeof firmware.applyControllerResult;
+
+      handleMessage(
+        JSON.stringify({
+          type: WebsocketMessageType.FLASH_CONTROLLER_RESULT,
+          data: { jobId: 'job-1', controller: { controllerId: 'whatever', stage: 'FAILED' } },
+        }),
+      );
+
+      expect(firmware.flashError?.detail).toBe('Malformed flashControllerResult from server');
+    });
   });
 });

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -181,9 +181,11 @@ export function useWebsocket() {
           break;
       }
       // Learn the MAC↔location mapping so the firmware view can translate
-      // WS `controllerId` (MAC) back to a slot for the progress projection.
-      if (data.controllerId) {
-        controllerStore.setControllerMac(data.controllerLocation, data.controllerId);
+      // FlashJobState's `controllerId` (MAC) back to a slot for the progress
+      // projection. The LocationStatus `controllerId` is a DB UUID — the
+      // MAC lives on `controllerAddress`.
+      if (data.controllerAddress) {
+        controllerStore.setControllerMac(data.controllerLocation, data.controllerAddress);
       }
     } catch (error) {
       console.error('Error handling status message:', error);

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -271,17 +271,28 @@ export function useWebsocket() {
       // CR-1b defense-in-depth: if the server has released the lock while
       // the firmware store still thinks we're 'flashing', a terminal-event
       // (flashJobDone / flashJobFailed) was lost or arrived out of order.
-      // Force phase='done' so the UI doesn't wedge. Combined with the
-      // fetchCurrentJob endedAt filter (CR-1a), this closes the reboot-
-      // wait wedge identified in the round-7 review.
+      // Recover via applyJobDone so per-controller states are normalized
+      // (round-8 NEW-C2 — bare setPhase left the per-row UI showing
+      // "Updating" pills while the footer claimed "✓ All updated"). Also
+      // surface a protocol_violation flashError so operators see a visible
+      // breadcrumb that recovery fired — they should verify controllers
+      // actually flashed before treating the result as authoritative.
       if (!data.locked) {
         const firmware = useFirmwareStore();
         if (firmware.phase === 'flashing') {
           console.warn(
             '[useWebsocket] handleLockStateChanged: phase=flashing with lock released. ' +
-              'Forcing phase=done as recovery; a terminal-event may have been lost.',
+              'Recovering via applyJobDone; a terminal-event may have been lost.',
           );
-          firmware.setPhase('done');
+          firmware.applyJobDone({
+            jobId: firmware.currentJob?.jobId ?? '<recovery>',
+            endedAt: new Date().toISOString(),
+          });
+          firmware.setFlashError({
+            reason: 'protocol_violation',
+            detail:
+              'Recovered from lost terminal event — verify each controller actually flashed before treating the result as authoritative.',
+          });
         }
       }
     } catch (error) {
@@ -294,13 +305,17 @@ export function useWebsocket() {
   // to surface a generic envelope (when the store can't see the malformed
   // input to recover by itself). All flashError writes route through
   // setFlashError — the round-6 sole-writer pattern, see firmware.ts
-  // setPhase/setFlashError. Pin: a swallowed error must still produce an
-  // operator-visible signal. The job-lifecycle handlers (Started/Done/Failed)
-  // transition phase in their catch (Started → 'select' rollback; Done →
-  // 'done'; Failed → 'failed'); the mid-stream handlers (controllerUpdate/
-  // Result) surface flashError without rolling phase, AND skip the write
-  // when a terminal flashError is already in place (CR-3 guard — preserves
-  // the specific job-lifecycle reason vs. clobbering with protocol_violation).
+  // setFlashError/clearFlashError. Pin: a swallowed error must still produce
+  // an operator-visible signal. The job-lifecycle handlers (Started/Done/
+  // Failed) transition phase in their catch (Started → 'select' rollback;
+  // Done → 'done'; Failed → 'failed'); the mid-stream handlers
+  // (controllerUpdate/Result) surface flashError without rolling phase, BUT
+  // skip the write when EITHER (a) we're no longer mid-flow (phase !=
+  // 'flashing') so a stray malformed frame after completion can't clobber
+  // a clean "✓ all updated" UI, OR (b) an existing flashError already
+  // carries the specific job-lifecycle reason (preserves it vs. clobbering
+  // with protocol_violation). CR-3 guard tightened from `||` to `&&` in
+  // round-8 NEW-C1 — both conditions must hold for the catch to write.
   // The next valid update can still recover the per-row state.
   function handleFlashJobStarted(message: BaseWsMessage) {
     const store = useFirmwareStore();
@@ -330,6 +345,15 @@ export function useWebsocket() {
     const store = useFirmwareStore();
     try {
       const data = (message as unknown as { data: ControllerFlashState }).data;
+      // Dispatcher-level wire-shape validation: a malformed envelope (no
+      // data, missing controllerId) must reach the catch so the operator
+      // sees a protocol_violation breadcrumb. The store's NEW-IM1 guard
+      // is silent — that's correct for the "internal caller passes bad
+      // data" path but wrong for the "WS payload is malformed" path that
+      // this dispatcher catch was designed to surface.
+      if (!data || typeof data.controllerId !== 'string' || data.controllerId.length === 0) {
+        throw new Error('malformed flashControllerUpdate: missing/invalid controllerId');
+      }
       store.applyControllerUpdate(data);
     } catch (error) {
       console.error('Error handling flashControllerUpdate:', error);
@@ -340,11 +364,13 @@ export function useWebsocket() {
       // applyJobDone, applyJobFailed) clears flashError. The operator-
       // visible "something went wrong" signal is the load-bearing piece.
       //
-      // CR-3 guard: don't clobber a terminal flashError that already carries
-      // the actual root cause (applyJobFailed sets specific reasons; a
-      // malformed mid-stream frame's protocol_violation is less informative).
-      // Only write when there's no existing error OR we're still mid-flow.
-      if (store.flashError === null || store.phase === 'flashing') {
+      // CR-3 guard (tightened in round-8 NEW-C1): only set the
+      // protocol_violation envelope when BOTH (a) we're still mid-flow AND
+      // (b) no existing flashError is already in place. Round-7's `||` was
+      // too permissive — after a clean completion (phase='done',
+      // flashError=null), a stray malformed frame would set a red
+      // protocol_violation banner over the happy "✓ all updated" UI.
+      if (store.flashError === null && store.phase === 'flashing') {
         store.setFlashError({
           reason: 'protocol_violation',
           detail: 'Malformed flashControllerUpdate from server',
@@ -361,13 +387,24 @@ export function useWebsocket() {
           data: { jobId: string; controller: ControllerFlashState };
         }
       ).data;
+      // Dispatcher-level wire-shape validation — see
+      // handleFlashControllerUpdate for the rationale.
+      if (
+        !data ||
+        !data.controller ||
+        typeof data.controller.controllerId !== 'string' ||
+        data.controller.controllerId.length === 0
+      ) {
+        throw new Error('malformed flashControllerResult: missing/invalid controller payload');
+      }
       store.applyControllerResult(data);
     } catch (error) {
       console.error('Error handling flashControllerResult:', error);
       // Mirrors handleFlashControllerUpdate: surface but don't transition.
       // The banner persists until operator-dismiss or a job-lifecycle clear.
-      // CR-3 guard — see handleFlashControllerUpdate.
-      if (store.flashError === null || store.phase === 'flashing') {
+      // CR-3 guard (round-8 NEW-C1 tightened to `&&`) — see
+      // handleFlashControllerUpdate for the full rationale.
+      if (store.flashError === null && store.phase === 'flashing') {
         store.setFlashError({
           reason: 'protocol_violation',
           detail: 'Malformed flashControllerResult from server',

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -180,6 +180,11 @@ export function useWebsocket() {
           controllerStore.bodyFirmware = data.firmwareVersion;
           break;
       }
+      // Learn the MAC↔location mapping so the firmware view can translate
+      // WS `controllerId` (MAC) back to a slot for the progress projection.
+      if (data.controllerId) {
+        controllerStore.setControllerMac(data.controllerLocation, data.controllerId);
+      }
     } catch (error) {
       console.error('Error handling status message:', error);
     }
@@ -215,13 +220,26 @@ export function useWebsocket() {
   // Firmware-flash WS handlers. Each delegates to the firmwareStore's apply*
   // action so the store remains the sole writer of server-pushed flash state.
   // The try/catch is load-bearing: a malformed payload must not lock the UI
-  // in 'flashing' — store actions handle defensive cases internally.
+  // in 'flashing' — store actions handle defensive cases internally and the
+  // catch surfaces a flashError envelope on the failure path so the operator
+  // sees something rather than a wedged UI.
   function handleFlashJobStarted(message: BaseWsMessage) {
+    const store = useFirmwareStore();
     try {
-      const data = (message as unknown as { data: FlashJobState }).data;
-      useFirmwareStore().applyJobStarted(data);
+      const data = (message as unknown as { data: FlashJobState | undefined }).data;
+      if (!data || typeof data.jobId !== 'string') {
+        throw new Error('malformed flashJobStarted payload (missing data or jobId)');
+      }
+      store.applyJobStarted(data);
     } catch (error) {
       console.error('Error handling flashJobStarted:', error);
+      // Roll the UI back to select with a surfaced error so the operator
+      // isn't wedged in 'flashing' awaiting a snapshot we can't parse.
+      store.setPhase('select');
+      store.flashError = {
+        reason: 'internal_server_error',
+        detail: 'Malformed flashJobStarted from server',
+      };
     }
   }
 
@@ -257,11 +275,22 @@ export function useWebsocket() {
   }
 
   function handleFlashJobFailed(message: BaseWsMessage) {
+    const store = useFirmwareStore();
     try {
-      const data = (message as unknown as { data: FlashJobFailedData }).data;
-      useFirmwareStore().applyJobFailed(data);
+      const data = (message as unknown as { data: FlashJobFailedData | undefined }).data;
+      if (!data || typeof data.endedAt !== 'string') {
+        throw new Error('malformed flashJobFailed payload (missing data or endedAt)');
+      }
+      store.applyJobFailed(data);
     } catch (error) {
       console.error('Error handling flashJobFailed:', error);
+      // Force the UI out of 'flashing' so the operator isn't wedged when the
+      // payload can't be parsed. Envelope is generic; server logs are truth.
+      store.setPhase('failed');
+      store.flashError = {
+        reason: 'internal_server_error',
+        detail: 'Malformed flashJobFailed from server',
+      };
     }
   }
 

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -273,11 +273,15 @@ export function useWebsocket() {
       store.applyJobStarted(data);
     } catch (error) {
       console.error('Error handling flashJobStarted:', error);
-      // Roll the UI back to select with a surfaced error so the operator
-      // isn't wedged in 'flashing' awaiting a snapshot we can't parse.
-      store.setPhase('select');
+      // Full reset: a malformed flashJobStarted means we can't trust
+      // anything that follows for this job. setPhase('select') alone
+      // leaves any prior `controllerStates` / `pendingByMac` / `currentJob`
+      // visible in 'select' phase (the panel's progress gate hides them,
+      // but the store invariant "select has no active job" would be
+      // violated). resetToSelect drops it all atomically.
+      store.resetToSelect();
       store.setFlashError({
-        reason: 'internal_server_error',
+        reason: 'protocol_violation',
         detail: 'Malformed flashJobStarted from server',
       });
     }
@@ -297,7 +301,7 @@ export function useWebsocket() {
       // applyJobDone, applyJobFailed) clears flashError. The operator-
       // visible "something went wrong" signal is the load-bearing piece.
       store.setFlashError({
-        reason: 'internal_server_error',
+        reason: 'protocol_violation',
         detail: 'Malformed flashControllerUpdate from server',
       });
     }
@@ -317,7 +321,7 @@ export function useWebsocket() {
       // Mirrors handleFlashControllerUpdate: surface but don't transition.
       // The banner persists until operator-dismiss or a job-lifecycle clear.
       store.setFlashError({
-        reason: 'internal_server_error',
+        reason: 'protocol_violation',
         detail: 'Malformed flashControllerResult from server',
       });
     }
@@ -337,7 +341,7 @@ export function useWebsocket() {
       // indefinitely. Generic envelope; server logs are truth.
       store.setPhase('done');
       store.setFlashError({
-        reason: 'internal_server_error',
+        reason: 'protocol_violation',
         detail: 'Malformed flashJobDone from server',
       });
     }
@@ -357,7 +361,7 @@ export function useWebsocket() {
       // payload can't be parsed. Envelope is generic; server logs are truth.
       store.setPhase('failed');
       store.setFlashError({
-        reason: 'internal_server_error',
+        reason: 'protocol_violation',
         detail: 'Malformed flashJobFailed from server',
       });
     }

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -34,10 +34,10 @@ function getWsUrl(): string {
 export function useWebsocket() {
   function wsConnect() {
     intentionallyClosed = false;
-    // IM-9: capture the new socket in a local so handlers don't close
-    // over ws.value (which is mutated by subsequent reconnects). Without
-    // this, a stale onerror from socket A could close socket B during
-    // HMR or an in-flight reconnect.
+    // Capture the new socket in a local so handlers don't close over
+    // ws.value, which is mutated by subsequent reconnects. Without this,
+    // a stale onerror from one socket could close a newer one during HMR
+    // or an in-flight reconnect.
     const socket = new WebSocket(getWsUrl());
     ws.value = socket;
 
@@ -61,8 +61,6 @@ export function useWebsocket() {
 
     socket.onerror = (error) => {
       console.error('WebSocket error:', error);
-      // Close the captured socket (not ws.value, which may have been
-      // reassigned to a new socket by a parallel wsConnect call).
       socket.close();
     };
 
@@ -142,18 +140,15 @@ export function useWebsocket() {
         break;
       case WebsocketMessageType.FLASH_JOB_ACTIVE:
         // Server-side rejection echo for write-class messages sent during a
-        // flash; the UI doesn't act on this directly. Lock-aware UI
-        // elements (AstrosWriteButton, AstrosServoTestModal) gate writes
-        // during a flash so this rejection should never fire in normal use.
+        // flash. Lock-aware UI elements gate writes so this should never
+        // fire in normal operation.
         break;
       default: {
-        // Compile-time exhaustiveness attestation: adding a new
-        // WebsocketMessageType variant the dispatcher doesn't handle should
-        // be visible at refactor time. The `as never` is an attestation
-        // (the switch discriminator is the wide enum, not a true
-        // discriminated union), but it breaks loudly if someone later
-        // refactors to a structural DU. The runtime warn stays for
-        // forward-compat with future server-side values not yet typed.
+        // `as never` attestation: the switch discriminator is the wide
+        // enum, not a structural discriminated union, so this isn't a real
+        // compile-time exhaustiveness check — but it documents intent and
+        // breaks if someone later refactors to a true DU. The runtime warn
+        // is the actual forward-compat path.
         const _exhaustive: never = parsedMessage.type as never;
         void _exhaustive;
         console.warn('Unhandled message type:', message);
@@ -268,15 +263,13 @@ export function useWebsocket() {
         owner: data.owner,
         since: data.since,
       });
-      // CR-1b defense-in-depth: if the server has released the lock while
-      // the firmware store still thinks we're 'flashing', a terminal-event
-      // (flashJobDone / flashJobFailed) was lost or arrived out of order.
-      // Recover via applyJobDone so per-controller states are normalized
-      // (round-8 NEW-C2 — bare setPhase left the per-row UI showing
-      // "Updating" pills while the footer claimed "✓ All updated"). Also
-      // surface a protocol_violation flashError so operators see a visible
-      // breadcrumb that recovery fired — they should verify controllers
-      // actually flashed before treating the result as authoritative.
+      // Defense-in-depth: a lock release while we still think we're
+      // flashing means a terminal event was lost or arrived out of order.
+      // Delegate to applyJobDone so per-controller states normalize (a
+      // bare setPhase would leave rows showing "Updating" beneath an
+      // "All updated" footer). The protocol_violation breadcrumb is the
+      // operator-visible signal that recovery fired — they should verify
+      // controllers actually flashed before trusting the result.
       if (!data.locked) {
         const firmware = useFirmwareStore();
         if (firmware.phase === 'flashing') {
@@ -300,23 +293,19 @@ export function useWebsocket() {
     }
   }
 
-  // Firmware-flash WS handlers. The happy path delegates to the firmwareStore's
-  // apply* actions; the catch path may also call `store.setFlashError(...)`
-  // to surface a generic envelope (when the store can't see the malformed
-  // input to recover by itself). All flashError writes route through
-  // setFlashError — the round-6 sole-writer pattern, see firmware.ts
-  // setFlashError/clearFlashError. Pin: a swallowed error must still produce
-  // an operator-visible signal. The job-lifecycle handlers (Started/Done/
-  // Failed) transition phase in their catch (Started → 'select' rollback;
-  // Done → 'done'; Failed → 'failed'); the mid-stream handlers
-  // (controllerUpdate/Result) surface flashError without rolling phase, BUT
-  // skip the write when EITHER (a) we're no longer mid-flow (phase !=
-  // 'flashing') so a stray malformed frame after completion can't clobber
-  // a clean "✓ all updated" UI, OR (b) an existing flashError already
-  // carries the specific job-lifecycle reason (preserves it vs. clobbering
-  // with protocol_violation). CR-3 guard tightened from `||` to `&&` in
-  // round-8 NEW-C1 — both conditions must hold for the catch to write.
-  // The next valid update can still recover the per-row state.
+  // Firmware-flash WS handlers. Happy path delegates to the firmwareStore's
+  // apply* actions; catch paths call `store.setFlashError(...)` to surface
+  // a generic envelope when the store can't recover from malformed input.
+  // All flashError writes route through setFlashError (sole-writer pattern;
+  // see firmware.ts setFlashError/clearFlashError).
+  //
+  // Job-lifecycle handlers (Started/Done/Failed) transition phase in their
+  // catch (Started → 'select' rollback; Done → 'done'; Failed → 'failed').
+  // Mid-stream handlers (controllerUpdate/Result) surface flashError without
+  // rolling phase, but only write when BOTH phase === 'flashing' AND no
+  // existing flashError is set — protects clean "all updated" UIs from
+  // stray malformed frames AND preserves any specific job-lifecycle reason
+  // already in place.
   function handleFlashJobStarted(message: BaseWsMessage) {
     const store = useFirmwareStore();
     try {
@@ -345,31 +334,21 @@ export function useWebsocket() {
     const store = useFirmwareStore();
     try {
       const data = (message as unknown as { data: ControllerFlashState }).data;
-      // Dispatcher-level wire-shape validation: a malformed envelope (no
-      // data, missing controllerId) must reach the catch so the operator
-      // sees a protocol_violation breadcrumb. The store's NEW-IM1 guard
-      // is silent — that's correct for the "internal caller passes bad
-      // data" path but wrong for the "WS payload is malformed" path that
-      // this dispatcher catch was designed to surface.
+      // Wire-shape validation throws so the catch surfaces a
+      // protocol_violation breadcrumb. The store's own guard returns
+      // silently for the rare internal-caller-with-bad-data path; the
+      // throw here covers the WS-payload-malformed path that needs an
+      // operator-visible signal.
       if (!data || typeof data.controllerId !== 'string' || data.controllerId.length === 0) {
         throw new Error('malformed flashControllerUpdate: missing/invalid controllerId');
       }
       store.applyControllerUpdate(data);
     } catch (error) {
       console.error('Error handling flashControllerUpdate:', error);
-      // No phase rollback — the next valid update can recover the per-row
-      // state. Note: the flashError banner is NOT auto-cleared by a
-      // subsequent successful applyControllerUpdate; it persists until the
-      // operator dismisses it or a job-lifecycle event (applyJobStarted,
-      // applyJobDone, applyJobFailed) clears flashError. The operator-
-      // visible "something went wrong" signal is the load-bearing piece.
-      //
-      // CR-3 guard (tightened in round-8 NEW-C1): only set the
-      // protocol_violation envelope when BOTH (a) we're still mid-flow AND
-      // (b) no existing flashError is already in place. Round-7's `||` was
-      // too permissive — after a clean completion (phase='done',
-      // flashError=null), a stray malformed frame would set a red
-      // protocol_violation banner over the happy "✓ all updated" UI.
+      // No phase rollback — the next valid update can recover per-row
+      // state. flashError persists until operator-dismiss or a
+      // job-lifecycle event overwrites it (applyJobStarted clears;
+      // applyJobFailed sets a specific reason).
       if (store.flashError === null && store.phase === 'flashing') {
         store.setFlashError({
           reason: 'protocol_violation',
@@ -387,8 +366,6 @@ export function useWebsocket() {
           data: { jobId: string; controller: ControllerFlashState };
         }
       ).data;
-      // Dispatcher-level wire-shape validation — see
-      // handleFlashControllerUpdate for the rationale.
       if (
         !data ||
         !data.controller ||
@@ -400,10 +377,6 @@ export function useWebsocket() {
       store.applyControllerResult(data);
     } catch (error) {
       console.error('Error handling flashControllerResult:', error);
-      // Mirrors handleFlashControllerUpdate: surface but don't transition.
-      // The banner persists until operator-dismiss or a job-lifecycle clear.
-      // CR-3 guard (round-8 NEW-C1 tightened to `&&`) — see
-      // handleFlashControllerUpdate for the full rationale.
       if (store.flashError === null && store.phase === 'flashing') {
         store.setFlashError({
           reason: 'protocol_violation',

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -284,9 +284,12 @@ export function useWebsocket() {
       store.applyControllerUpdate(data);
     } catch (error) {
       console.error('Error handling flashControllerUpdate:', error);
-      // No phase rollback — the next valid update can recover the row —
-      // but surface a flashError so the operator isn't stuck staring at
-      // frozen progress with no signal that something went wrong.
+      // No phase rollback — the next valid update can recover the per-row
+      // state. Note: the flashError banner is NOT auto-cleared by a
+      // subsequent successful applyControllerUpdate; it persists until the
+      // operator dismisses it or a job-lifecycle event (applyJobStarted,
+      // applyJobDone, applyJobFailed) clears flashError. The operator-
+      // visible "something went wrong" signal is the load-bearing piece.
       store.flashError = {
         reason: 'internal_server_error',
         detail: 'Malformed flashControllerUpdate from server',
@@ -306,6 +309,7 @@ export function useWebsocket() {
     } catch (error) {
       console.error('Error handling flashControllerResult:', error);
       // Mirrors handleFlashControllerUpdate: surface but don't transition.
+      // The banner persists until operator-dismiss or a job-lifecycle clear.
       store.flashError = {
         reason: 'internal_server_error',
         detail: 'Malformed flashControllerResult from server',

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -18,6 +18,11 @@ import type { ControllerFlashState, FlashJobFailedData, FlashJobState } from '@/
 
 const ws = ref<WebSocket | null>(null);
 const wsIsConnected = ref(false);
+// Latched true on the first successful WS connect; never resets. Used by
+// the FirmwareView's flash-stream-suspended banner to distinguish "WS
+// hasn't connected YET" (early-mount, no operator alarm needed) from
+// "WS connected and then dropped" (genuine staleness signal).
+const wsHasEverConnected = ref(false);
 const retryInterval = 3000;
 let retryTimeout: number | null = null;
 let intentionallyClosed = false;
@@ -33,6 +38,7 @@ export function useWebsocket() {
 
     ws.value.onopen = () => {
       wsIsConnected.value = true;
+      wsHasEverConnected.value = true;
       console.log('WebSocket connected');
       if (retryTimeout) {
         clearTimeout(retryTimeout);
@@ -270,10 +276,10 @@ export function useWebsocket() {
       // Roll the UI back to select with a surfaced error so the operator
       // isn't wedged in 'flashing' awaiting a snapshot we can't parse.
       store.setPhase('select');
-      store.flashError = {
+      store.setFlashError({
         reason: 'internal_server_error',
         detail: 'Malformed flashJobStarted from server',
-      };
+      });
     }
   }
 
@@ -290,10 +296,10 @@ export function useWebsocket() {
       // operator dismisses it or a job-lifecycle event (applyJobStarted,
       // applyJobDone, applyJobFailed) clears flashError. The operator-
       // visible "something went wrong" signal is the load-bearing piece.
-      store.flashError = {
+      store.setFlashError({
         reason: 'internal_server_error',
         detail: 'Malformed flashControllerUpdate from server',
-      };
+      });
     }
   }
 
@@ -310,10 +316,10 @@ export function useWebsocket() {
       console.error('Error handling flashControllerResult:', error);
       // Mirrors handleFlashControllerUpdate: surface but don't transition.
       // The banner persists until operator-dismiss or a job-lifecycle clear.
-      store.flashError = {
+      store.setFlashError({
         reason: 'internal_server_error',
         detail: 'Malformed flashControllerResult from server',
-      };
+      });
     }
   }
 
@@ -330,10 +336,10 @@ export function useWebsocket() {
       // catch, an applyJobDone throw would leave phase at 'flashing'
       // indefinitely. Generic envelope; server logs are truth.
       store.setPhase('done');
-      store.flashError = {
+      store.setFlashError({
         reason: 'internal_server_error',
         detail: 'Malformed flashJobDone from server',
-      };
+      });
     }
   }
 
@@ -350,10 +356,10 @@ export function useWebsocket() {
       // Force the UI out of 'flashing' so the operator isn't wedged when the
       // payload can't be parsed. Envelope is generic; server logs are truth.
       store.setPhase('failed');
-      store.flashError = {
+      store.setFlashError({
         reason: 'internal_server_error',
         detail: 'Malformed flashJobFailed from server',
-      };
+      });
     }
   }
 
@@ -377,6 +383,7 @@ export function useWebsocket() {
     wsConnect,
     wsDisconnect,
     wsIsConnected,
+    wsHasEverConnected,
     wsSendMessage,
     // Exposed for unit testing the dispatcher's malformed-payload guards
     // and the firmware-flash handlers' rollback behavior. Production code

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -179,6 +179,14 @@ export function useWebsocket() {
           controllerStore.bodyStatus = status;
           controllerStore.bodyFirmware = data.firmwareVersion;
           break;
+        default:
+          // An unrecognized location (server contract drift, misrouted
+          // POLL_ACK, or Location.UNKNOWN) is invisible to the UI without
+          // this log. Combined with the MAC-mapping skip below, a stuck
+          // controller row would otherwise have no breadcrumb.
+          console.warn(
+            `[useWebsocket] handleStatusMessage: unrecognized controllerLocation="${data.controllerLocation}". Skipping status update.`,
+          );
       }
       // Learn the MAC↔location mapping so the firmware view can translate
       // FlashJobState's `controllerId` (MAC) back to a slot for the progress
@@ -186,7 +194,17 @@ export function useWebsocket() {
       // MAC lives on `controllerAddress`. After updating the resolver, drain
       // any flash events that were queued because this MAC wasn't mapped
       // yet (cold-load / late-join race).
-      if (data.controllerAddress) {
+      // Distinguish undefined (rolling-deploy: old server hasn't been
+      // updated to populate the field) from empty string (server bug:
+      // populated as ''). Both must skip the resolver write, but empty
+      // string warrants a warn since it's not deploy-skew.
+      if (data.controllerAddress === undefined) {
+        // Silent: expected during a rolling deploy of the server.
+      } else if (data.controllerAddress === '') {
+        console.warn(
+          `[useWebsocket] handleStatusMessage: empty controllerAddress for location="${data.controllerLocation}". Server contract bug.`,
+        );
+      } else {
         controllerStore.setControllerMac(data.controllerLocation, data.controllerAddress);
         useFirmwareStore().flushPendingForMac(data.controllerAddress);
       }
@@ -222,12 +240,12 @@ export function useWebsocket() {
     }
   }
 
-  // Firmware-flash WS handlers. Each delegates to the firmwareStore's apply*
-  // action so the store remains the sole writer of server-pushed flash state.
-  // The try/catch is load-bearing: a malformed payload must not lock the UI
-  // in 'flashing' — store actions handle defensive cases internally and the
-  // catch surfaces a flashError envelope on the failure path so the operator
-  // sees something rather than a wedged UI.
+  // Firmware-flash WS handlers. The happy path delegates to the firmwareStore's
+  // apply* actions (sole writer of server-pushed flash state). On a malformed
+  // payload the dispatcher falls back to a direct phase/flashError write so the
+  // UI exits 'flashing' rather than wedging — the store doesn't see invalid
+  // data so it can't recover by itself. Pin: a swallowed error must still
+  // produce a terminal phase transition for the three handlers that own one.
   function handleFlashJobStarted(message: BaseWsMessage) {
     const store = useFirmwareStore();
     try {
@@ -271,11 +289,20 @@ export function useWebsocket() {
   }
 
   function handleFlashJobDone(message: BaseWsMessage) {
+    const store = useFirmwareStore();
     try {
       const data = (message as unknown as { data: { jobId: string; endedAt: string } }).data;
-      useFirmwareStore().applyJobDone(data);
+      store.applyJobDone(data);
     } catch (error) {
       console.error('Error handling flashJobDone:', error);
+      // Force terminal: the server has marked the job done and the lock is
+      // released. Without this, an applyJobDone throw would leave phase at
+      // 'flashing' indefinitely. Generic envelope; server logs are truth.
+      store.setPhase('done');
+      store.flashError = {
+        reason: 'internal_server_error',
+        detail: 'Malformed flashJobDone from server',
+      };
     }
   }
 
@@ -320,5 +347,9 @@ export function useWebsocket() {
     wsDisconnect,
     wsIsConnected,
     wsSendMessage,
+    // Exposed for unit testing the dispatcher's malformed-payload guards
+    // and the firmware-flash handlers' rollback behavior. Production code
+    // never calls this directly — onmessage routes through it.
+    handleMessage,
   };
 }

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -183,9 +183,12 @@ export function useWebsocket() {
       // Learn the MAC↔location mapping so the firmware view can translate
       // FlashJobState's `controllerId` (MAC) back to a slot for the progress
       // projection. The LocationStatus `controllerId` is a DB UUID — the
-      // MAC lives on `controllerAddress`.
+      // MAC lives on `controllerAddress`. After updating the resolver, drain
+      // any flash events that were queued because this MAC wasn't mapped
+      // yet (cold-load / late-join race).
       if (data.controllerAddress) {
         controllerStore.setControllerMac(data.controllerLocation, data.controllerAddress);
+        useFirmwareStore().flushPendingForMac(data.controllerAddress);
       }
     } catch (error) {
       console.error('Error handling status message:', error);

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -250,11 +250,13 @@ export function useWebsocket() {
   }
 
   // Firmware-flash WS handlers. The happy path delegates to the firmwareStore's
-  // apply* actions (sole writer of server-pushed flash state). On a malformed
-  // payload the dispatcher falls back to a direct phase/flashError write so the
-  // UI exits 'flashing' rather than wedging — the store doesn't see invalid
-  // data so it can't recover by itself. Pin: a swallowed error must still
-  // produce a terminal phase transition for the three handlers that own one.
+  // apply* actions; the catch path may also write `store.flashError` directly
+  // (when the store can't see the malformed input to recover by itself). Pin:
+  // a swallowed error must still produce an operator-visible signal. The job-
+  // lifecycle handlers (Started/Done/Failed) transition phase in their catch
+  // (Started → 'select' rollback; Done → 'done'; Failed → 'failed'); the
+  // mid-stream handlers (controllerUpdate/Result) surface flashError without
+  // rolling phase since the next valid update can recover the row.
   function handleFlashJobStarted(message: BaseWsMessage) {
     const store = useFirmwareStore();
     try {

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -166,18 +166,22 @@ export function useWebsocket() {
         }
       }
 
+      let validLocation = false;
       switch (data.controllerLocation) {
         case Location.DOME:
           controllerStore.domeStatus = status;
           controllerStore.domeFirmware = data.firmwareVersion;
+          validLocation = true;
           break;
         case Location.CORE:
           controllerStore.coreStatus = status;
           controllerStore.coreFirmware = data.firmwareVersion;
+          validLocation = true;
           break;
         case Location.BODY:
           controllerStore.bodyStatus = status;
           controllerStore.bodyFirmware = data.firmwareVersion;
+          validLocation = true;
           break;
         default:
           // An unrecognized location (server contract drift, misrouted
@@ -185,7 +189,7 @@ export function useWebsocket() {
           // this log. Combined with the MAC-mapping skip below, a stuck
           // controller row would otherwise have no breadcrumb.
           console.warn(
-            `[useWebsocket] handleStatusMessage: unrecognized controllerLocation="${data.controllerLocation}". Skipping status update.`,
+            `[useWebsocket] handleStatusMessage: unrecognized controllerLocation="${data.controllerLocation}". Skipping status + MAC mapping.`,
           );
       }
       // Learn the MAC↔location mapping so the firmware view can translate
@@ -197,8 +201,13 @@ export function useWebsocket() {
       // Distinguish undefined (rolling-deploy: old server hasn't been
       // updated to populate the field) from empty string (server bug:
       // populated as ''). Both must skip the resolver write, but empty
-      // string warrants a warn since it's not deploy-skew.
-      if (data.controllerAddress === undefined) {
+      // string warrants a warn since it's not deploy-skew. We also skip
+      // when the location was UNKNOWN/unrecognized: setControllerMac for
+      // UNKNOWN is a no-op, and flushPendingForMac with no resolvable
+      // mapping would re-queue the entries indefinitely.
+      if (!validLocation) {
+        // Skipped above; nothing to learn or flush.
+      } else if (data.controllerAddress === undefined) {
         // Silent: expected during a rolling deploy of the server.
       } else if (data.controllerAddress === '') {
         console.warn(
@@ -267,24 +276,38 @@ export function useWebsocket() {
   }
 
   function handleFlashControllerUpdate(message: BaseWsMessage) {
+    const store = useFirmwareStore();
     try {
       const data = (message as unknown as { data: ControllerFlashState }).data;
-      useFirmwareStore().applyControllerUpdate(data);
+      store.applyControllerUpdate(data);
     } catch (error) {
       console.error('Error handling flashControllerUpdate:', error);
+      // No phase rollback — the next valid update can recover the row —
+      // but surface a flashError so the operator isn't stuck staring at
+      // frozen progress with no signal that something went wrong.
+      store.flashError = {
+        reason: 'internal_server_error',
+        detail: 'Malformed flashControllerUpdate from server',
+      };
     }
   }
 
   function handleFlashControllerResult(message: BaseWsMessage) {
+    const store = useFirmwareStore();
     try {
       const data = (
         message as unknown as {
           data: { jobId: string; controller: ControllerFlashState };
         }
       ).data;
-      useFirmwareStore().applyControllerResult(data);
+      store.applyControllerResult(data);
     } catch (error) {
       console.error('Error handling flashControllerResult:', error);
+      // Mirrors handleFlashControllerUpdate: surface but don't transition.
+      store.flashError = {
+        reason: 'internal_server_error',
+        detail: 'Malformed flashControllerResult from server',
+      };
     }
   }
 
@@ -295,9 +318,11 @@ export function useWebsocket() {
       store.applyJobDone(data);
     } catch (error) {
       console.error('Error handling flashJobDone:', error);
-      // Force terminal: the server has marked the job done and the lock is
-      // released. Without this, an applyJobDone throw would leave phase at
-      // 'flashing' indefinitely. Generic envelope; server logs are truth.
+      // Force terminal: the server has emitted job-done; the lock release
+      // follows asynchronously on the next POLL_ACK heartbeat or the
+      // reboot-timer fallback (per flash_orchestrator.ts). Without this
+      // catch, an applyJobDone throw would leave phase at 'flashing'
+      // indefinitely. Generic envelope; server logs are truth.
       store.setPhase('done');
       store.flashError = {
         reason: 'internal_server_error',

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -34,9 +34,14 @@ function getWsUrl(): string {
 export function useWebsocket() {
   function wsConnect() {
     intentionallyClosed = false;
-    ws.value = new WebSocket(getWsUrl());
+    // IM-9: capture the new socket in a local so handlers don't close
+    // over ws.value (which is mutated by subsequent reconnects). Without
+    // this, a stale onerror from socket A could close socket B during
+    // HMR or an in-flight reconnect.
+    const socket = new WebSocket(getWsUrl());
+    ws.value = socket;
 
-    ws.value.onopen = () => {
+    socket.onopen = () => {
       wsIsConnected.value = true;
       wsHasEverConnected.value = true;
       console.log('WebSocket connected');
@@ -46,7 +51,7 @@ export function useWebsocket() {
       }
     };
 
-    ws.value.onclose = () => {
+    socket.onclose = () => {
       wsIsConnected.value = false;
       if (!intentionallyClosed) {
         console.log('WebSocket disconnected, retrying in 3 seconds...');
@@ -54,12 +59,14 @@ export function useWebsocket() {
       }
     };
 
-    ws.value.onerror = (error) => {
+    socket.onerror = (error) => {
       console.error('WebSocket error:', error);
-      ws.value?.close();
+      // Close the captured socket (not ws.value, which may have been
+      // reassigned to a new socket by a parallel wsConnect call).
+      socket.close();
     };
 
-    ws.value.onmessage = (event) => {
+    socket.onmessage = (event) => {
       handleMessage(event.data);
     };
   }

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -13,6 +13,8 @@ import { useScriptsStore } from '@/stores/scripts';
 import { useScripterStore } from '@/stores/scripter';
 import { useSystemStatusStore } from '@/stores/systemStatus';
 import { useJobLockStore } from '@/stores/jobLock';
+import { useFirmwareStore } from '@/stores/firmware';
+import type { ControllerFlashState, FlashJobFailedData, FlashJobState } from '@/types/firmware';
 
 const ws = ref<WebSocket | null>(null);
 const wsIsConnected = ref(false);
@@ -110,6 +112,26 @@ export function useWebsocket() {
       case WebsocketMessageType.LOCK_STATE_CHANGED:
         handleLockStateChanged(parsedMessage);
         break;
+      case WebsocketMessageType.FLASH_JOB_STARTED:
+        handleFlashJobStarted(parsedMessage);
+        break;
+      case WebsocketMessageType.FLASH_CONTROLLER_UPDATE:
+        handleFlashControllerUpdate(parsedMessage);
+        break;
+      case WebsocketMessageType.FLASH_CONTROLLER_RESULT:
+        handleFlashControllerResult(parsedMessage);
+        break;
+      case WebsocketMessageType.FLASH_JOB_DONE:
+        handleFlashJobDone(parsedMessage);
+        break;
+      case WebsocketMessageType.FLASH_JOB_FAILED:
+        handleFlashJobFailed(parsedMessage);
+        break;
+      case WebsocketMessageType.FLASH_JOB_ACTIVE:
+        // Server-side rejection echo for write-class messages sent during a
+        // flash; the UI doesn't act on this directly (the lock-aware
+        // AstrosWriteButton already disables write actions).
+        break;
       default:
         console.warn('Unhandled message type:', message);
         break;
@@ -187,6 +209,59 @@ export function useWebsocket() {
       });
     } catch (error) {
       console.error('Error handling lock state change:', error);
+    }
+  }
+
+  // Firmware-flash WS handlers. Each delegates to the firmwareStore's apply*
+  // action so the store remains the sole writer of server-pushed flash state.
+  // The try/catch is load-bearing: a malformed payload must not lock the UI
+  // in 'flashing' — store actions handle defensive cases internally.
+  function handleFlashJobStarted(message: BaseWsMessage) {
+    try {
+      const data = (message as unknown as { data: FlashJobState }).data;
+      useFirmwareStore().applyJobStarted(data);
+    } catch (error) {
+      console.error('Error handling flashJobStarted:', error);
+    }
+  }
+
+  function handleFlashControllerUpdate(message: BaseWsMessage) {
+    try {
+      const data = (message as unknown as { data: ControllerFlashState }).data;
+      useFirmwareStore().applyControllerUpdate(data);
+    } catch (error) {
+      console.error('Error handling flashControllerUpdate:', error);
+    }
+  }
+
+  function handleFlashControllerResult(message: BaseWsMessage) {
+    try {
+      const data = (
+        message as unknown as {
+          data: { jobId: string; controller: ControllerFlashState };
+        }
+      ).data;
+      useFirmwareStore().applyControllerResult(data);
+    } catch (error) {
+      console.error('Error handling flashControllerResult:', error);
+    }
+  }
+
+  function handleFlashJobDone(message: BaseWsMessage) {
+    try {
+      const data = (message as unknown as { data: { jobId: string; endedAt: string } }).data;
+      useFirmwareStore().applyJobDone(data);
+    } catch (error) {
+      console.error('Error handling flashJobDone:', error);
+    }
+  }
+
+  function handleFlashJobFailed(message: BaseWsMessage) {
+    try {
+      const data = (message as unknown as { data: FlashJobFailedData }).data;
+      useFirmwareStore().applyJobFailed(data);
+    } catch (error) {
+      console.error('Error handling flashJobFailed:', error);
     }
   }
 

--- a/astros_vue/src/composables/useWebsocket.ts
+++ b/astros_vue/src/composables/useWebsocket.ts
@@ -135,12 +135,23 @@ export function useWebsocket() {
         break;
       case WebsocketMessageType.FLASH_JOB_ACTIVE:
         // Server-side rejection echo for write-class messages sent during a
-        // flash; the UI doesn't act on this directly (the lock-aware
-        // AstrosWriteButton already disables write actions).
+        // flash; the UI doesn't act on this directly. Lock-aware UI
+        // elements (AstrosWriteButton, AstrosServoTestModal) gate writes
+        // during a flash so this rejection should never fire in normal use.
         break;
-      default:
+      default: {
+        // Compile-time exhaustiveness attestation: adding a new
+        // WebsocketMessageType variant the dispatcher doesn't handle should
+        // be visible at refactor time. The `as never` is an attestation
+        // (the switch discriminator is the wide enum, not a true
+        // discriminated union), but it breaks loudly if someone later
+        // refactors to a structural DU. The runtime warn stays for
+        // forward-compat with future server-side values not yet typed.
+        const _exhaustive: never = parsedMessage.type as never;
+        void _exhaustive;
         console.warn('Unhandled message type:', message);
         break;
+      }
     }
   }
 
@@ -250,19 +261,40 @@ export function useWebsocket() {
         owner: data.owner,
         since: data.since,
       });
+      // CR-1b defense-in-depth: if the server has released the lock while
+      // the firmware store still thinks we're 'flashing', a terminal-event
+      // (flashJobDone / flashJobFailed) was lost or arrived out of order.
+      // Force phase='done' so the UI doesn't wedge. Combined with the
+      // fetchCurrentJob endedAt filter (CR-1a), this closes the reboot-
+      // wait wedge identified in the round-7 review.
+      if (!data.locked) {
+        const firmware = useFirmwareStore();
+        if (firmware.phase === 'flashing') {
+          console.warn(
+            '[useWebsocket] handleLockStateChanged: phase=flashing with lock released. ' +
+              'Forcing phase=done as recovery; a terminal-event may have been lost.',
+          );
+          firmware.setPhase('done');
+        }
+      }
     } catch (error) {
       console.error('Error handling lock state change:', error);
     }
   }
 
   // Firmware-flash WS handlers. The happy path delegates to the firmwareStore's
-  // apply* actions; the catch path may also write `store.flashError` directly
-  // (when the store can't see the malformed input to recover by itself). Pin:
-  // a swallowed error must still produce an operator-visible signal. The job-
-  // lifecycle handlers (Started/Done/Failed) transition phase in their catch
-  // (Started → 'select' rollback; Done → 'done'; Failed → 'failed'); the
-  // mid-stream handlers (controllerUpdate/Result) surface flashError without
-  // rolling phase since the next valid update can recover the row.
+  // apply* actions; the catch path may also call `store.setFlashError(...)`
+  // to surface a generic envelope (when the store can't see the malformed
+  // input to recover by itself). All flashError writes route through
+  // setFlashError — the round-6 sole-writer pattern, see firmware.ts
+  // setPhase/setFlashError. Pin: a swallowed error must still produce an
+  // operator-visible signal. The job-lifecycle handlers (Started/Done/Failed)
+  // transition phase in their catch (Started → 'select' rollback; Done →
+  // 'done'; Failed → 'failed'); the mid-stream handlers (controllerUpdate/
+  // Result) surface flashError without rolling phase, AND skip the write
+  // when a terminal flashError is already in place (CR-3 guard — preserves
+  // the specific job-lifecycle reason vs. clobbering with protocol_violation).
+  // The next valid update can still recover the per-row state.
   function handleFlashJobStarted(message: BaseWsMessage) {
     const store = useFirmwareStore();
     try {
@@ -300,10 +332,17 @@ export function useWebsocket() {
       // operator dismisses it or a job-lifecycle event (applyJobStarted,
       // applyJobDone, applyJobFailed) clears flashError. The operator-
       // visible "something went wrong" signal is the load-bearing piece.
-      store.setFlashError({
-        reason: 'protocol_violation',
-        detail: 'Malformed flashControllerUpdate from server',
-      });
+      //
+      // CR-3 guard: don't clobber a terminal flashError that already carries
+      // the actual root cause (applyJobFailed sets specific reasons; a
+      // malformed mid-stream frame's protocol_violation is less informative).
+      // Only write when there's no existing error OR we're still mid-flow.
+      if (store.flashError === null || store.phase === 'flashing') {
+        store.setFlashError({
+          reason: 'protocol_violation',
+          detail: 'Malformed flashControllerUpdate from server',
+        });
+      }
     }
   }
 
@@ -320,10 +359,13 @@ export function useWebsocket() {
       console.error('Error handling flashControllerResult:', error);
       // Mirrors handleFlashControllerUpdate: surface but don't transition.
       // The banner persists until operator-dismiss or a job-lifecycle clear.
-      store.setFlashError({
-        reason: 'protocol_violation',
-        detail: 'Malformed flashControllerResult from server',
-      });
+      // CR-3 guard — see handleFlashControllerUpdate.
+      if (store.flashError === null || store.phase === 'flashing') {
+        store.setFlashError({
+          reason: 'protocol_violation',
+          detail: 'Malformed flashControllerResult from server',
+        });
+      }
     }
   }
 

--- a/astros_vue/src/enums/WebsocketMessageType.ts
+++ b/astros_vue/src/enums/WebsocketMessageType.ts
@@ -1,3 +1,6 @@
+// Mirror of the server's `TransmissionType` enum
+// (`astros_api/src/models/enums.ts:82`). Numeric values must match the wire
+// format. Hand-maintained; keep cross-referenced when either side changes.
 export enum WebsocketMessageType {
   SCRIPT = 0,
   CONFIGURATION_SYNC = 1,
@@ -10,4 +13,10 @@ export enum WebsocketMessageType {
   SERVO_TEST = 8,
   SYSTEM_STATUS = 9,
   LOCK_STATE_CHANGED = 10,
+  FLASH_JOB_ACTIVE = 11,
+  FLASH_JOB_STARTED = 12,
+  FLASH_CONTROLLER_UPDATE = 13,
+  FLASH_CONTROLLER_RESULT = 14,
+  FLASH_JOB_DONE = 15,
+  FLASH_JOB_FAILED = 16,
 }

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -182,6 +182,7 @@
     "mid_flash_error": {
       "title_warning": "Flash warning:",
       "title_failed": "Flash failed:",
+      "title_done_warning": "Flash completed with a warning:",
       "abort_reason": "Abort reason: {reason}",
       "dismiss": "Dismiss"
     }

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -109,6 +109,7 @@
       "result_bar": {
         "all_updated": "✓ All {count} controller(s) updated",
         "failed_summary": "⚠ {label} failed during {stage}",
+        "failed_summary_multi": "⚠ {labels} failed during the flash",
         "view_logs": "View logs",
         "done": "Done"
       },
@@ -176,7 +177,8 @@
       "title": "Firmware update in progress",
       "body": "Another operator started a firmware update at {since}. Wait for it to finish before starting a new one."
     },
-    "current_job_load_failed": "Could not confirm current firmware state. A flash may be in flight — refresh to retry."
+    "current_job_load_failed": "Could not confirm current firmware state. A flash may be in flight — refresh to retry.",
+    "flash_stream_suspended": "Live updates paused — reconnecting to the server. Progress shown may be stale."
   },
   "placeholder": {
     "username": "username",

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -166,7 +166,7 @@
       "source_resolution_failed": "Couldn't fetch the firmware binary from its source. Try again or pick a different release.",
       "controllers_lookup_failed": "The server couldn't look up the selected controllers. Try again.",
       "subscriber_attach_failed": "The server couldn't subscribe to deploy events. Try again or restart the server.",
-      "protocol_violation": "The serial protocol returned an unexpected message. Try again or restart the master controller.",
+      "protocol_violation": "Unexpected message format from the server. Try again or restart the master controller.",
       "streamer_unknown_error": "The firmware streamer failed with an unknown error. Try again.",
       "internal_server_error": "The server hit an unexpected error. Check the server logs and try again.",
       "network_error": "Couldn't reach the server. Check your network connection and try again."
@@ -180,7 +180,8 @@
     "current_job_load_failed": "Could not confirm current firmware state. A flash may be in flight — refresh to retry.",
     "flash_stream_suspended": "Live updates paused — reconnecting to the server. Progress shown may be stale.",
     "mid_flash_error": {
-      "title": "Flash warning:",
+      "title_warning": "Flash warning:",
+      "title_failed": "Flash failed:",
       "dismiss": "Dismiss"
     }
   },

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -66,7 +66,7 @@
       "release_option_prerelease_suffix": "(pre-release)",
       "label_select_release": "Select release",
       "label_upload_file": "Upload firmware file",
-      "releases_load_error": "Failed to load releases. Try again.",
+      "releases_load_error": "Failed to load releases.",
       "releases_stale_warning": "Showing cached releases — couldn't reach GitHub since {since}.",
       "releases_loading": "Loading releases…"
     },

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -175,7 +175,8 @@
     "lock_conflict": {
       "title": "Firmware update in progress",
       "body": "Another operator started a firmware update at {since}. Wait for it to finish before starting a new one."
-    }
+    },
+    "current_job_load_failed": "Could not confirm current firmware state. A flash may be in flight — refresh to retry."
   },
   "placeholder": {
     "username": "username",

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -169,6 +169,12 @@
       "streamer_unknown_error": "The firmware streamer failed with an unknown error. Try again.",
       "internal_server_error": "The server hit an unexpected error. Check the server logs and try again.",
       "network_error": "Couldn't reach the server. Check your network connection and try again."
+    },
+    "lock_active": "A firmware update is in progress — write actions are disabled until it completes.",
+    "lock_banner": "Firmware update in progress — write actions are disabled across the app.",
+    "lock_conflict": {
+      "title": "Firmware update in progress",
+      "body": "Another operator started a firmware update at {since}. Wait for it to finish before starting a new one."
     }
   },
   "placeholder": {

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -182,6 +182,7 @@
     "mid_flash_error": {
       "title_warning": "Flash warning:",
       "title_failed": "Flash failed:",
+      "abort_reason": "Abort reason: {reason}",
       "dismiss": "Dismiss"
     }
   },

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -178,7 +178,11 @@
       "body": "Another operator started a firmware update at {since}. Wait for it to finish before starting a new one."
     },
     "current_job_load_failed": "Could not confirm current firmware state. A flash may be in flight — refresh to retry.",
-    "flash_stream_suspended": "Live updates paused — reconnecting to the server. Progress shown may be stale."
+    "flash_stream_suspended": "Live updates paused — reconnecting to the server. Progress shown may be stale.",
+    "mid_flash_error": {
+      "title": "Flash warning:",
+      "dismiss": "Dismiss"
+    }
   },
   "placeholder": {
     "username": "username",

--- a/astros_vue/src/models/websocket/locationStatus.ts
+++ b/astros_vue/src/models/websocket/locationStatus.ts
@@ -4,6 +4,15 @@ import { Location } from '@/enums/modules/Location';
 export interface LocationStatus extends BaseWsMessage {
   controllerLocation: Location;
   controllerId: string;
+  /**
+   * Hardware MAC address. Distinct from `controllerId` (database UUID).
+   * The firmware flash flow uses this as the per-controller key on the WS
+   * event stream, so the firmware view's MAC→location resolver learns it
+   * from LocationStatus payloads. Optional because rolling deploys may
+   * temporarily yield an older server that hasn't populated the field —
+   * `useWebsocket.handleStatusMessage` skips the MAC mapping in that case.
+   */
+  controllerAddress?: string;
   up: boolean;
   synced: boolean;
   firmwareVersion?: string;

--- a/astros_vue/src/stores/__tests__/controller.spec.ts
+++ b/astros_vue/src/stores/__tests__/controller.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useControllerStore } from '../controller';
+import { Location } from '@/enums';
+
+describe('controller store MAC↔location mapping', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('initial seed', () => {
+    it('seeds body with the master sentinel MAC so cold-load resolves the master before any LocationStatus', () => {
+      const store = useControllerStore();
+      expect(store.bodyMac).toBe('00:00:00:00:00:00');
+      expect(store.coreMac).toBeNull();
+      expect(store.domeMac).toBeNull();
+      // Sentinel must resolve to BODY even on cold-load — the firmware view's
+      // master row depends on this before any padawan POLL_ACK arrives.
+      expect(store.controllerIdToLocation('00:00:00:00:00:00')).toBe(Location.BODY);
+    });
+  });
+
+  describe('setControllerMac', () => {
+    it('sets coreMac for Location.CORE and resolves the MAC back to CORE', () => {
+      const store = useControllerStore();
+      store.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+      expect(store.coreMac).toBe('aa:bb:cc:dd:ee:01');
+      expect(store.controllerIdToLocation('aa:bb:cc:dd:ee:01')).toBe(Location.CORE);
+    });
+
+    it('sets domeMac for Location.DOME and resolves the MAC back to DOME', () => {
+      const store = useControllerStore();
+      store.setControllerMac(Location.DOME, 'aa:bb:cc:dd:ee:02');
+      expect(store.domeMac).toBe('aa:bb:cc:dd:ee:02');
+      expect(store.controllerIdToLocation('aa:bb:cc:dd:ee:02')).toBe(Location.DOME);
+    });
+
+    it('overwrites bodyMac for Location.BODY if a real MAC ever arrives', () => {
+      // Defensive: body is normally seeded with the sentinel and never
+      // overwritten, but if a future firmware reports a real master MAC on
+      // POLL_ACK, the setter must not silently drop the update.
+      const store = useControllerStore();
+      store.setControllerMac(Location.BODY, 'aa:bb:cc:dd:ee:00');
+      expect(store.bodyMac).toBe('aa:bb:cc:dd:ee:00');
+      expect(store.controllerIdToLocation('aa:bb:cc:dd:ee:00')).toBe(Location.BODY);
+    });
+
+    it('is a no-op for Location.UNKNOWN so an unmapped slot does not pollute the table', () => {
+      // Reason: UNKNOWN is the "unassigned location" sentinel. A LocationStatus
+      // with UNKNOWN would otherwise either throw on an exhaustive switch or
+      // (worse) write to one of the three real slots. Verify nothing changes.
+      const store = useControllerStore();
+      const snap = {
+        body: store.bodyMac,
+        core: store.coreMac,
+        dome: store.domeMac,
+      };
+      store.setControllerMac(Location.UNKNOWN, 'aa:bb:cc:dd:ee:ff');
+      expect(store.bodyMac).toBe(snap.body);
+      expect(store.coreMac).toBe(snap.core);
+      expect(store.domeMac).toBe(snap.dome);
+      expect(store.controllerIdToLocation('aa:bb:cc:dd:ee:ff')).toBeNull();
+    });
+  });
+
+  describe('controllerIdToLocation', () => {
+    it('returns null for an unknown MAC so callers can surface a dev warning instead of mis-routing the event', () => {
+      const store = useControllerStore();
+      expect(store.controllerIdToLocation('not-a-known-mac')).toBeNull();
+    });
+
+    it('re-derives the map when a MAC is replaced so stale entries do not persist', () => {
+      // Pins reactivity: a controller swap (RMA / repair) must invalidate the
+      // prior MAC. If we cached the map without depending on coreMac.value,
+      // the old MAC would keep resolving to CORE.
+      const store = useControllerStore();
+      store.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+      expect(store.controllerIdToLocation('aa:bb:cc:dd:ee:01')).toBe(Location.CORE);
+
+      store.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:99');
+      expect(store.controllerIdToLocation('aa:bb:cc:dd:ee:99')).toBe(Location.CORE);
+      expect(store.controllerIdToLocation('aa:bb:cc:dd:ee:01')).toBeNull();
+    });
+  });
+});

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -834,6 +834,37 @@ describe('firmware store', () => {
       expect(store.currentJob?.endedAt).toBe('2026-05-12T08:05:00Z');
     });
 
+    it('normalizes non-terminal per-controller stages to VERSION_CONFIRMED (I4 fix)', () => {
+      // Race: server emits flashJobDone when the LAST VERSION_CONFIRMED
+      // observed, but a flashControllerUpdate carrying that final stage
+      // may not have drained the WS buffer yet. Without this normalize,
+      // the panel renders "✓ all updated" while individual rows still
+      // spin at "updating" — visibly contradictory operator state.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'VERIFYING' });
+      // core is left at QUEUED (initial sample state)
+      store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+
+      expect(store.controllerStates.get('body')?.stage).toBe('VERSION_CONFIRMED');
+      expect(store.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
+    });
+
+    it('does NOT overwrite FAILED stages during the done normalize', () => {
+      // The normalize should only touch in-flight stages, not terminal
+      // ones. A controller that legitimately FAILED should stay FAILED
+      // even if applyJobDone fires (rare, but possible if the server
+      // reports the job done after one of the controllers errored).
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({ controllerId: CORE_MAC, stage: 'FAILED' });
+      store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+
+      expect(store.controllerStates.get('core')?.stage).toBe('FAILED');
+    });
+
     it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto done state (C2 fix)', () => {
       // Round-5 C2: without this clear, a queued entry whose MAC mapping
       // arrives after job-done would mutate controllerStates + currentStage,
@@ -889,6 +920,8 @@ describe('firmware store', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
+      // Set a stage so the failed entry can attribute its failure honestly.
+      store.applyControllerUpdate({ controllerId: CORE_MAC, stage: 'VERIFYING' });
       store.applyControllerUpdate({
         controllerId: CORE_MAC,
         stage: 'FAILED',
@@ -898,6 +931,27 @@ describe('firmware store', () => {
       expect(store.failedControllers).toHaveLength(1);
       expect(store.failedControllers[0]?.id).toBe('core');
       expect(store.failedControllers[0]?.label).toBe('Core');
+      // I2 fix: stage comes from currentStage at failure time, not the
+      // literal 'transfer' fallback. Here VERIFYING set currentStage to
+      // 'verify' before the FAILED update.
+      expect(store.failedControllers[0]?.stage).toBe('verify');
+    });
+
+    it('records stage as null when no currentStage was observed before the FAILED update (I2 fix)', () => {
+      // The previous code fabricated 'transfer' here, silently misattributing
+      // pre-streamer-style failures. Now we record null and let the UI
+      // either render the stages list "—" fallback or omit the stage from
+      // the result bar.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({
+        controllerId: CORE_MAC,
+        stage: 'FAILED',
+        error: 'hash_mismatch',
+      });
+      store.applyJobFailed({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+      expect(store.failedControllers[0]?.stage).toBeNull();
     });
 
     it('collects ALL FAILED entries (multi-failure realistic on bus-wide ESP-NOW errors)', () => {
@@ -905,12 +959,11 @@ describe('firmware store', () => {
       // first FAILED entry by iteration order. With two padawans failing
       // simultaneously (e.g. master loses ESP-NOW), the operator would
       // walk away from a bricked unit. Pin all FAILEDs make the array.
-      // Array order is intentionally unspecified by the contract (Map.values()
-      // iteration is insertion-order, which the test couples to via sort()
-      // to decouple from incidental ordering).
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
+      // Seed a stage so the failed entries get a non-null `stage` field.
+      store.applyControllerUpdate({ controllerId: CORE_MAC, stage: 'SENDING' });
       store.applyControllerUpdate({
         controllerId: CORE_MAC,
         stage: 'FAILED',
@@ -927,14 +980,27 @@ describe('firmware store', () => {
         reason: 'bus_send_failed',
       });
       expect(store.failedControllers).toHaveLength(2);
-      const ids = store.failedControllers.map((c) => c.id).sort();
+      // I-test-1: pin insertion-order preservation (Map.values() is
+      // insertion-order; sampleJobState seeds body, then core). The
+      // FirmwareView's failedControllerLabels join depends on this — a
+      // regression that sorted alphabetically before joining would silently
+      // change the operator-visible message.
+      const ids = store.failedControllers.map((c) => c.id);
       expect(ids).toEqual(['body', 'core']);
       // Pin the full record shape per entry: a mutation that surfaced only
       // {id} (dropping label / stage) would otherwise pass this test.
-      const labels = store.failedControllers.map((c) => c.label).sort();
+      const labels = store.failedControllers.map((c) => c.label);
       expect(labels).toEqual(['Body', 'Core']);
+      // I2 fix: stage reflects the SHARED `currentStage` ref at the moment
+      // applyJobFailed runs (not a per-controller history). Both entries
+      // pick up 'transfer' here because CORE's SENDING update set the
+      // shared currentStage before either FAILED — even though body never
+      // had its own SENDING update. This documents the design: stage is
+      // "what the flash was doing when it failed," not "what each
+      // individual controller was doing." A future change to track stage
+      // per-controller would make body.stage null in this scenario.
       for (const entry of store.failedControllers) {
-        expect(entry.stage).toBeTruthy();
+        expect(entry.stage).toBe('transfer');
       }
     });
 

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -381,19 +381,19 @@ describe('firmware store', () => {
       expect(store.phase).toBe('flashing');
     });
 
-    it("resetToSelect clears currentStage, flashError, failedController and sets phase to 'select'", () => {
+    it("resetToSelect clears currentStage, flashError, failedControllers and sets phase to 'select'", () => {
       const store = useFirmwareStore();
       store.setPhase('failed');
       store.currentStage = 'transfer';
       store.flashError = { reason: 'job_already_running' };
-      store.failedController = { id: 'core', label: 'Core', stage: 'transfer' };
+      store.failedControllers = [{ id: 'core', label: 'Core', stage: 'transfer' }];
 
       store.resetToSelect();
 
       expect(store.phase).toBe('select');
       expect(store.currentStage).toBeNull();
       expect(store.flashError).toBeNull();
-      expect(store.failedController).toBeNull();
+      expect(store.failedControllers).toEqual([]);
     });
 
     it('dismissError clears flashError without changing phase', () => {
@@ -713,14 +713,14 @@ describe('firmware store', () => {
       expect(store.controllerStates.size).toBe(0);
     });
 
-    it('clears flashError and failedController so a previous failure does not bleed into the new job', () => {
+    it('clears flashError and failedControllers so a previous failure does not bleed into the new job', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.flashError = { reason: 'internal_server_error' };
-      store.failedController = { id: 'core', label: 'Core', stage: 'transfer' };
+      store.failedControllers = [{ id: 'core', label: 'Core', stage: 'transfer' }];
       store.applyJobStarted(sampleJobState());
       expect(store.flashError).toBeNull();
-      expect(store.failedController).toBeNull();
+      expect(store.failedControllers).toEqual([]);
     });
   });
 
@@ -822,7 +822,7 @@ describe('firmware store', () => {
       expect(store.flashError?.reason).toBe('release_not_found');
     });
 
-    it('derives failedController from the FAILED entry in controllerStates', () => {
+    it('derives failedControllers from the FAILED entries in controllerStates', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
@@ -832,16 +832,48 @@ describe('firmware store', () => {
         error: 'hash_mismatch',
       });
       store.applyJobFailed({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
-      expect(store.failedController?.id).toBe('core');
-      expect(store.failedController?.label).toBe('Core');
+      expect(store.failedControllers).toHaveLength(1);
+      expect(store.failedControllers[0]?.id).toBe('core');
+      expect(store.failedControllers[0]?.label).toBe('Core');
     });
 
-    it('leaves failedController null when no controller transitioned to FAILED before job-failed (mid-deploy abort)', () => {
+    it('collects ALL FAILED entries (multi-failure realistic on bus-wide ESP-NOW errors)', () => {
+      // C2 fix: a `break` in applyJobFailed previously surfaced only the
+      // first FAILED entry by iteration order. With two padawans failing
+      // simultaneously (e.g. master loses ESP-NOW), the operator would
+      // walk away from a bricked unit. Pin all FAILEDs make the array.
+      // Array order is intentionally unspecified by the contract (Map.values()
+      // iteration is insertion-order, which the test couples to via sort()
+      // to decouple from incidental ordering).
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({
+        controllerId: CORE_MAC,
+        stage: 'FAILED',
+        error: 'bus_send_failed',
+      });
+      store.applyControllerUpdate({
+        controllerId: BODY_MAC,
+        stage: 'FAILED',
+        error: 'bus_send_failed',
+      });
+      store.applyJobFailed({
+        jobId: 'job-1',
+        endedAt: '2026-05-12T08:05:00Z',
+        reason: 'bus_send_failed',
+      });
+      expect(store.failedControllers).toHaveLength(2);
+      const ids = store.failedControllers.map((c) => c.id).sort();
+      expect(ids).toEqual(['body', 'core']);
+    });
+
+    it('leaves failedControllers empty when no controller transitioned to FAILED before job-failed (mid-deploy abort)', () => {
       // Edge case: applyJobStarted runs, no per-controller updates land,
       // then a mid-deploy abort (e.g., bus_send_failed) fires
       // flashJobFailed. The store should still transition phase + set
       // flashError, and the FirmwareView template guards on
-      // `failedController?.stage` so a null is safe to render.
+      // `failedControllers[0]?.stage` so an empty array is safe to render.
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
@@ -853,7 +885,7 @@ describe('firmware store', () => {
       });
       expect(store.phase).toBe('failed');
       expect(store.flashError?.detail).toBe('Worker channel closed during firmware send');
-      expect(store.failedController).toBeNull();
+      expect(store.failedControllers).toEqual([]);
     });
 
     it('does not throw when called with no controllerStates and no currentJob (defensive)', () => {
@@ -1035,6 +1067,73 @@ describe('firmware store', () => {
 
       const after = store.controllers.find((c) => c.id === 'body');
       expect(after?.status).toBe('down');
+    });
+  });
+
+  describe('pending-update replay queue (late-MAC race)', () => {
+    // C1: WS flashControllerUpdate / flashJobStarted entries can arrive for
+    // a padawan before its LocationStatus heartbeat populates the MAC map.
+    // The store queues those payloads keyed by raw MAC and drains them when
+    // controllerStore.setControllerMac is later called (via the dispatcher).
+    const LATE_CORE_MAC = 'aa:bb:cc:dd:ee:01';
+
+    it('queues a flashControllerUpdate whose MAC is not yet mapped (no controllerStates entry produced)', () => {
+      const store = useFirmwareStore();
+      // No seedSampleFleet → core MAC unmapped.
+      store.applyControllerUpdate({ controllerId: LATE_CORE_MAC, stage: 'SENDING' });
+      expect(store.controllerStates.size).toBe(0);
+      expect(store.pendingByMac.get(LATE_CORE_MAC)).toHaveLength(1);
+    });
+
+    it('queues each dropped snapshot entry from applyJobStarted (not just live updates)', () => {
+      // Late-join: snapshot arrives before LocationStatus seeds the padawan
+      // MACs. Without the queue, the snapshot entries are lost and the rows
+      // render with no pill until further events land (which may never come
+      // for a fast-flashing controller).
+      const store = useFirmwareStore();
+      store.applyJobStarted({
+        jobId: 'job-late-join',
+        source: { kind: 'github', version: 'v1.4.2' },
+        controllers: [
+          { controllerId: LATE_CORE_MAC, stage: 'SENDING' },
+          { controllerId: 'aa:bb:cc:dd:ee:02', stage: 'QUEUED' },
+        ],
+        startedAt: '2026-05-13T08:00:00Z',
+      });
+      expect(store.controllerStates.size).toBe(0);
+      expect(store.pendingByMac.size).toBe(2);
+      expect(store.pendingByMac.get(LATE_CORE_MAC)).toHaveLength(1);
+    });
+
+    it('flushPendingForMac drains the queue and applies entries in order so the latest stage wins', () => {
+      // Mutation guard: a non-ordered replay (e.g., Map.values() with later
+      // iteration shuffling) would let an earlier SENDING overwrite the
+      // intended VERIFYING. Pin order.
+      const store = useFirmwareStore();
+      store.applyControllerUpdate({ controllerId: LATE_CORE_MAC, stage: 'SENDING' });
+      store.applyControllerUpdate({ controllerId: LATE_CORE_MAC, stage: 'VERIFYING' });
+      expect(store.pendingByMac.get(LATE_CORE_MAC)).toHaveLength(2);
+
+      // LocationStatus learns the MAC; useWebsocket would call both:
+      useControllerStore().setControllerMac(Location.CORE, LATE_CORE_MAC);
+      store.flushPendingForMac(LATE_CORE_MAC);
+
+      expect(store.controllerStates.get('core')?.stage).toBe('VERIFYING');
+      expect(store.pendingByMac.has(LATE_CORE_MAC)).toBe(false);
+    });
+
+    it('flushPendingForMac is a no-op for a MAC with no queued entries', () => {
+      const store = useFirmwareStore();
+      expect(() => store.flushPendingForMac(LATE_CORE_MAC)).not.toThrow();
+      expect(store.controllerStates.size).toBe(0);
+    });
+
+    it('resetToSelect clears the pending queue so prior-flash drift cannot leak into the next job', () => {
+      const store = useFirmwareStore();
+      store.applyControllerUpdate({ controllerId: LATE_CORE_MAC, stage: 'SENDING' });
+      expect(store.pendingByMac.size).toBe(1);
+      store.resetToSelect();
+      expect(store.pendingByMac.size).toBe(0);
     });
   });
 });

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -599,6 +599,17 @@ describe('firmware store', () => {
       // Did not throw; phase unchanged (WS dispatcher owns terminal state).
       expect(store.phase).toBe('flashing');
     });
+
+    it('IM-10: surfaces a network_error flashError when the cancel HTTP fails', async () => {
+      apiDelete.mockRejectedValueOnce(new Error('network down'));
+      const store = useFirmwareStore();
+      store.setPhase('flashing');
+      await store.cancelFlash();
+      expect(store.flashError?.reason).toBe('network_error');
+      expect(store.flashError?.detail).toContain('Cancel request failed');
+      // Phase still untouched — WS dispatcher owns terminal state.
+      expect(store.phase).toBe('flashing');
+    });
   });
 
   // ------------------------------------------------------------------
@@ -654,18 +665,32 @@ describe('firmware store', () => {
       // FMI hazard: WS reconnect during flash. The server sends a fresh
       // flashJobStarted snapshot; the client must NOT keep stale per-
       // controller stages from before the disconnect.
+      //
+      // IM-8 mutation-resistance: seed BOTH body AND core with a non-
+      // trivial stage before the duplicate flashJobStarted, then verify
+      // both are correctly replaced. A merge-by-id mutation would keep
+      // core at SENDING (since the fresh snapshot omits core entirely),
+      // which is exactly the failure mode this test must catch.
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
       store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
-      // Simulate reconnect with controllers in a different state.
+      store.applyControllerUpdate({ controllerId: CORE_MAC, stage: 'SENDING' });
+      // Both are now SENDING.
+      expect(store.controllerStates.get('body')?.stage).toBe('SENDING');
+      expect(store.controllerStates.get('core')?.stage).toBe('SENDING');
+      // New snapshot contains only body at VERIFYING. Replace semantics:
+      // core must be absent. Merge semantics: core would still be SENDING.
       const fresh: FlashJobState = sampleJobState({
         controllers: [{ controllerId: BODY_MAC, stage: 'VERIFYING' }],
       });
       store.applyJobStarted(fresh);
-      expect(store.controllerStates.size).toBe(1);
       expect(store.controllerStates.get('body')?.stage).toBe('VERIFYING');
       expect(store.controllerStates.get('core')).toBeUndefined();
+      // Pin size at exactly 1 (the new snapshot's count) — belt-and-
+      // suspenders against a merge that adds new entries without
+      // dropping stale ones.
+      expect(store.controllerStates.size).toBe(1);
     });
 
     it('translates MAC controllerIds to slot ids (body/core/dome) via the controllerStore resolver', () => {
@@ -676,11 +701,16 @@ describe('firmware store', () => {
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
       // sampleJobState sends BODY_MAC + CORE_MAC; after translation the Map
-      // is keyed by slot ids, NOT by the raw MAC strings.
+      // is keyed by slot ids, NOT by the raw MAC strings. IM-11 enforces
+      // this at the type level — the Map is now `Map<SlotId, ...>`, so a
+      // MAC-keyed lookup is a compile error. The runtime sanity check below
+      // is preserved via an unsafe cast so a regression that started silently
+      // double-keying by MAC would still be caught.
       expect(store.controllerStates.get('body')?.stage).toBe('QUEUED');
       expect(store.controllerStates.get('core')?.stage).toBe('QUEUED');
-      expect(store.controllerStates.get(BODY_MAC)).toBeUndefined();
-      expect(store.controllerStates.get(CORE_MAC)).toBeUndefined();
+      const mapAsAny = store.controllerStates as unknown as Map<string, unknown>;
+      expect(mapAsAny.get(BODY_MAC)).toBeUndefined();
+      expect(mapAsAny.get(CORE_MAC)).toBeUndefined();
     });
 
     it('drops entries with unknown controllerIds (MAC mapping not yet learned)', () => {
@@ -748,6 +778,85 @@ describe('firmware store', () => {
       store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
 
       expect(store.pendingByMac.size).toBe(0);
+    });
+
+    describe('IM-3: defensive validation of controllers payload', () => {
+      it('returns empty map when controllers is not an array (string)', () => {
+        const store = useFirmwareStore();
+        seedSampleFleet();
+        store.applyJobStarted({
+          jobId: 'job-1',
+          source: { kind: 'github', version: 'v1' },
+          // @ts-expect-error — deliberately passing a non-array to verify
+          // the runtime guard. TS would normally block this; the guard
+          // protects against malformed wire payloads.
+          controllers: 'not-an-array',
+          startedAt: '2026-05-14T08:00:00Z',
+        });
+        expect(store.controllerStates.size).toBe(0);
+        expect(store.pendingByMac.size).toBe(0);
+      });
+
+      it('skips elements with missing controllerId and warns', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const store = useFirmwareStore();
+          seedSampleFleet();
+          store.applyJobStarted({
+            jobId: 'job-1',
+            source: { kind: 'github', version: 'v1' },
+            controllers: [
+              // @ts-expect-error — missing controllerId
+              { stage: 'QUEUED' },
+            ],
+            startedAt: '2026-05-14T08:00:00Z',
+          });
+          expect(store.controllerStates.size).toBe(0);
+          expect(store.pendingByMac.size).toBe(0);
+          expect(warnSpy.mock.calls.flat().join(' ')).toContain('invalid controllerId');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it('skips elements with non-string controllerId and warns', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const store = useFirmwareStore();
+          seedSampleFleet();
+          store.applyJobStarted({
+            jobId: 'job-1',
+            source: { kind: 'github', version: 'v1' },
+            controllers: [
+              // @ts-expect-error — non-string controllerId
+              { controllerId: 123, stage: 'QUEUED' },
+            ],
+            startedAt: '2026-05-14T08:00:00Z',
+          });
+          expect(store.controllerStates.size).toBe(0);
+          expect(warnSpy.mock.calls.flat().join(' ')).toContain('invalid controllerId');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it('skips elements with empty-string controllerId and warns', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const store = useFirmwareStore();
+          seedSampleFleet();
+          store.applyJobStarted({
+            jobId: 'job-1',
+            source: { kind: 'github', version: 'v1' },
+            controllers: [{ controllerId: '', stage: 'QUEUED' }],
+            startedAt: '2026-05-14T08:00:00Z',
+          });
+          expect(store.controllerStates.size).toBe(0);
+          expect(warnSpy.mock.calls.flat().join(' ')).toContain('invalid controllerId');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
     });
   });
 
@@ -903,7 +1012,11 @@ describe('firmware store', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
-      store.applyControllerUpdate({ controllerId: CORE_MAC, stage: 'FAILED' });
+      store.applyControllerUpdate({
+        controllerId: CORE_MAC,
+        stage: 'FAILED',
+        error: 'flash_error',
+      });
       store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
 
       expect(store.controllerStates.get('core')?.stage).toBe('FAILED');
@@ -1127,9 +1240,17 @@ describe('firmware store', () => {
 
       expect(store.controllerStates.get('body')?.stage).toBe('FAILED');
       expect(store.controllerStates.get('core')?.stage).toBe('FAILED');
-      // The demoted entries carry no `error` string — they weren't
-      // server-reported as FAILED, they were normalized.
-      expect(store.controllerStates.get('body')?.error).toBeUndefined();
+      // IM-2 contract: FAILED entries always carry an `error` string.
+      // Demoted (non-server-reported) entries use the 'unattributed:*'
+      // marker so ops can distinguish them from server-reported failures.
+      const bodyState = store.controllerStates.get('body');
+      const coreState = store.controllerStates.get('core');
+      if (bodyState?.stage === 'FAILED') {
+        expect(bodyState.error).toContain('unattributed');
+      }
+      if (coreState?.stage === 'FAILED') {
+        expect(coreState.error).toContain('unattributed');
+      }
       // failedControllers reflects the demoted entries.
       const ids = store.failedControllers.map((c) => c.id);
       expect(ids).toEqual(['body', 'core']);
@@ -1153,9 +1274,22 @@ describe('firmware store', () => {
         reason: 'bus_send_failed',
       });
 
-      // CORE's error string survives; body is demoted with no error.
-      expect(store.controllerStates.get('core')?.error).toBe('hash_mismatch');
-      expect(store.controllerStates.get('body')?.error).toBeUndefined();
+      // CORE's server-reported error string survives; body's demoted
+      // entry carries the IM-2 'unattributed:*' marker (distinguishable
+      // from any server-emitted error reason).
+      const coreState = store.controllerStates.get('core');
+      const bodyState = store.controllerStates.get('body');
+      // Outer-stage assertions pin the post-condition before the narrow
+      // guards below — without these, a regression that left bodyState
+      // at QUEUED would skip the if blocks and pass silently.
+      expect(coreState?.stage).toBe('FAILED');
+      expect(bodyState?.stage).toBe('FAILED');
+      if (coreState?.stage === 'FAILED') {
+        expect(coreState.error).toBe('hash_mismatch');
+      }
+      if (bodyState?.stage === 'FAILED') {
+        expect(bodyState.error).toContain('unattributed');
+      }
     });
 
     it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto failed state (C2 fix)', () => {
@@ -1489,6 +1623,24 @@ describe('firmware store', () => {
       expect(store.pendingByMac.size).toBe(1);
       store.resetToSelect();
       expect(store.pendingByMac.size).toBe(0);
+    });
+
+    it('IM-8: logs a distinct re-queue warning when flushPendingForMac re-enqueues during flush (forensic breadcrumb)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const store = useFirmwareStore();
+        // Queue an entry under an unmapped MAC.
+        store.applyControllerUpdate({ controllerId: 'aa:bb:cc:dd:ee:99', stage: 'SENDING' });
+        expect(store.pendingByMac.size).toBe(1);
+        // Flush without first mapping the MAC — applyControllerUpdate will
+        // re-enqueue because resolveSlot still returns null.
+        store.flushPendingForMac('aa:bb:cc:dd:ee:99');
+        const warnText = warnSpy.mock.calls.flat().join(' ');
+        expect(warnText).toContain('re-queued during flush');
+        expect(warnText).toContain('aa:bb:cc:dd:ee:99');
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -722,6 +722,33 @@ describe('firmware store', () => {
       expect(store.flashError).toBeNull();
       expect(store.failedControllers).toEqual([]);
     });
+
+    it('clears currentJobLoadFailed — WS snapshot supersedes HTTP staleness (I4 fix)', () => {
+      // A failed fetchCurrentJob lit the staleness banner; when the WS late-
+      // join snapshot lands, live state is available again and the banner
+      // is no longer accurate.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.currentJobLoadFailed = true;
+      store.applyJobStarted(sampleJobState());
+      expect(store.currentJobLoadFailed).toBe(false);
+    });
+
+    it('clears pendingByMac so orphan entries from a prior job cannot replay against the new one (I10 fix)', () => {
+      // Operator runs flash A; a padawan's LocationStatus never arrived, so
+      // its entries stay queued. Flash A ends without resetToSelect (e.g.,
+      // server-initiated reconnect mid-job). Flash B's snapshot arrives.
+      // Without this clear, when LocationStatus finally arrives for that
+      // MAC, the queued entries would replay against the new job's state.
+      const store = useFirmwareStore();
+      store.applyControllerUpdate({ controllerId: 'orphan-mac', stage: 'SENDING' });
+      expect(store.pendingByMac.size).toBe(1);
+
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
+
+      expect(store.pendingByMac.size).toBe(0);
+    });
   });
 
   describe('applyControllerUpdate', () => {
@@ -759,6 +786,28 @@ describe('firmware store', () => {
       const before = store.controllerStates;
       store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
       expect(store.controllerStates).not.toBe(before);
+    });
+
+    it('clears currentJobLoadFailed on a successful update — belt-and-suspenders (I4 fix)', () => {
+      // If applyJobStarted was missed (unusual reconnect ordering), a
+      // successful per-controller update is still proof that live state is
+      // flowing for a known controller. Clear the staleness banner.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.currentJobLoadFailed = true;
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
+      expect(store.currentJobLoadFailed).toBe(false);
+    });
+
+    it('does NOT clear currentJobLoadFailed when the update is queued (C1 fix)', () => {
+      // The clear MUST stay below the null-slot return. An unmapped MAC
+      // means we can't trust the update yet; clearing the banner here would
+      // silently dismiss the operator's only "something wrong" signal.
+      const store = useFirmwareStore();
+      // No seedSampleFleet — MAC mappings are absent.
+      store.currentJobLoadFailed = true;
+      store.applyControllerUpdate({ controllerId: 'unmapped-mac', stage: 'SENDING' });
+      expect(store.currentJobLoadFailed).toBe(true);
     });
   });
 
@@ -866,6 +915,13 @@ describe('firmware store', () => {
       expect(store.failedControllers).toHaveLength(2);
       const ids = store.failedControllers.map((c) => c.id).sort();
       expect(ids).toEqual(['body', 'core']);
+      // Pin the full record shape per entry: a mutation that surfaced only
+      // {id} (dropping label / stage) would otherwise pass this test.
+      const labels = store.failedControllers.map((c) => c.label).sort();
+      expect(labels).toEqual(['Body', 'Core']);
+      for (const entry of store.failedControllers) {
+        expect(entry.stage).toBeTruthy();
+      }
     });
 
     it('leaves failedControllers empty when no controller transitioned to FAILED before job-failed (mid-deploy abort)', () => {
@@ -959,12 +1015,31 @@ describe('firmware store', () => {
       expect(store.phase).toBe('idle');
     });
 
-    it('swallows network errors (UI stays in current phase)', async () => {
+    it('swallows network errors (UI stays in current phase) but sets currentJobLoadFailed', async () => {
       apiClientGet.mockRejectedValueOnce(new Error('network'));
       const store = useFirmwareStore();
       seedSampleFleet();
       await store.fetchCurrentJob();
       expect(store.currentJob).toBeNull();
+      expect(store.currentJobLoadFailed).toBe(true);
+    });
+
+    it('treats 404 as expected idle state — does NOT set currentJobLoadFailed (I3 fix)', async () => {
+      // 404 is the healthy idle response from /api/firmware/flash when no
+      // flash is in flight. Surfacing it as "could not confirm state" would
+      // falsely alarm operators on first page load. Only 5xx and network
+      // errors should trigger the staleness banner.
+      apiClientGet.mockRejectedValueOnce({ response: { status: 404 } });
+      const store = useFirmwareStore();
+      await store.fetchCurrentJob();
+      expect(store.currentJobLoadFailed).toBe(false);
+    });
+
+    it('treats 5xx as staleness — sets currentJobLoadFailed', async () => {
+      apiClientGet.mockRejectedValueOnce({ response: { status: 503 } });
+      const store = useFirmwareStore();
+      await store.fetchCurrentJob();
+      expect(store.currentJobLoadFailed).toBe(true);
     });
   });
 

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -386,7 +386,7 @@ describe('firmware store', () => {
       store.setPhase('failed');
       store.currentStage = 'transfer';
       store.flashError = { reason: 'job_already_running' };
-      store.failedControllers = [{ id: 'core', label: 'Core', stage: 'transfer' }];
+      store.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'transfer' }];
 
       store.resetToSelect();
 
@@ -717,7 +717,7 @@ describe('firmware store', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.flashError = { reason: 'internal_server_error' };
-      store.failedControllers = [{ id: 'core', label: 'Core', stage: 'transfer' }];
+      store.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'transfer' }];
       store.applyJobStarted(sampleJobState());
       expect(store.flashError).toBeNull();
       expect(store.failedControllers).toEqual([]);

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -1134,7 +1134,7 @@ describe('firmware store', () => {
       expect(store.failedControllers[0]?.stage).toBeNull();
     });
 
-    it('collects ALL FAILED entries (multi-failure realistic on bus-wide ESP-NOW errors)', () => {
+    it('collects ALL FAILED entries AND attributes stage from the shared currentStage ref (not per-controller history)', () => {
       // C2 fix: a `break` in applyJobFailed previously surfaced only the
       // first FAILED entry by iteration order. With two padawans failing
       // simultaneously (e.g. master loses ESP-NOW), the operator would
@@ -1256,7 +1256,7 @@ describe('firmware store', () => {
       expect(ids).toEqual(['body', 'core']);
     });
 
-    it('preserves server-reported FAILED entries during the failed normalize (preserves their error string)', () => {
+    it('preserves server-reported FAILED error strings AND demoted entries get the unattributed marker (IM-2 normalize attribution)', () => {
       // A controller that legitimately FAILED (with the server's error
       // reason) must keep its error attribute. The normalize must only
       // touch non-terminal stages.

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -6,6 +6,7 @@ vi.mock('@/api/apiService', () => ({
     get: vi.fn(),
   },
   apiClient: {
+    get: vi.fn(),
     post: vi.fn(),
     delete: vi.fn(),
   },
@@ -13,15 +14,33 @@ vi.mock('@/api/apiService', () => ({
 
 import apiService, { apiClient } from '@/api/apiService';
 import { useFirmwareStore } from '../firmware';
-import type { FirmwareControllerView, ReleaseInfo, ReleaseListResult } from '@/types/firmware';
+import { useControllerStore } from '@/stores/controller';
+import { ControllerStatus } from '@/enums';
+import type {
+  ControllerFlashState,
+  FlashJobFailedData,
+  FlashJobState,
+  ReleaseInfo,
+  ReleaseListResult,
+} from '@/types/firmware';
 
-const sampleControllers: FirmwareControllerView[] = [
-  { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
-  { id: 'core', label: 'Core', glyph: 'C', current: 'v1.4.0', status: 'up', isMaster: false },
-  { id: 'dome', label: 'Dome', glyph: 'D', current: 'v1.4.0', status: 'down', isMaster: false },
-];
+/**
+ * Seed the controllerStore so the firmwareStore's `controllers` computed
+ * projects the expected fleet. Replaces direct `store.controllers = ...`
+ * assignments (the computed is read-only).
+ */
+function seedSampleFleet(opts: { domeStatus?: ControllerStatus } = {}) {
+  const cs = useControllerStore();
+  cs.bodyStatus = ControllerStatus.UP;
+  cs.bodyFirmware = 'v1.3.0';
+  cs.coreStatus = ControllerStatus.UP;
+  cs.coreFirmware = 'v1.4.0';
+  cs.domeStatus = opts.domeStatus ?? ControllerStatus.DOWN;
+  cs.domeFirmware = 'v1.4.0';
+}
 
 const apiGet = apiService.get as ReturnType<typeof vi.fn>;
+const apiClientGet = apiClient.get as ReturnType<typeof vi.fn>;
 const apiPost = apiClient.post as ReturnType<typeof vi.fn>;
 const apiDelete = apiClient.delete as ReturnType<typeof vi.fn>;
 
@@ -62,6 +81,7 @@ describe('firmware store', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     apiGet.mockReset();
+    apiClientGet.mockReset();
     apiPost.mockReset();
     apiDelete.mockReset();
   });
@@ -205,7 +225,7 @@ describe('firmware store', () => {
   describe('selection actions', () => {
     it('toggle adds an id when absent and removes it when present', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
 
       store.toggle('body');
       expect([...store.selectedControllerIds]).toEqual(['body']);
@@ -217,7 +237,7 @@ describe('firmware store', () => {
 
     it('toggle replaces the Set reference so Vue reactivity observes the change', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       const before = store.selectedControllerIds;
       store.toggle('body');
       expect(store.selectedControllerIds).not.toBe(before);
@@ -225,7 +245,7 @@ describe('firmware store', () => {
 
     it('selectAll picks every online, non-downgrade controller', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.4.2';
 
@@ -240,7 +260,7 @@ describe('firmware store', () => {
 
     it('selectAll skips controllers whose current version is newer than target (downgrade)', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.3.5';
 
@@ -253,7 +273,7 @@ describe('firmware store', () => {
 
     it('clear empties the selection and replaces the Set reference', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.toggle('body');
       store.toggle('core');
       const before = store.selectedControllerIds;
@@ -266,7 +286,7 @@ describe('firmware store', () => {
   describe('anyDowngradeBlocked', () => {
     it('returns false when nothing is selected', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.3.5';
       expect(store.anyDowngradeBlocked).toBe(false);
@@ -274,7 +294,7 @@ describe('firmware store', () => {
 
     it('returns true when a selected controller would downgrade', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.3.5';
       store.toggle('core'); // core is v1.4.0; v1.4.0 > v1.3.5
@@ -286,7 +306,7 @@ describe('firmware store', () => {
       // mutation to `cmp >= 0` would flag an equal version as a downgrade
       // and this test would fail.
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.4.0';
       store.toggle('core'); // core is v1.4.0; target is v1.4.0
@@ -295,62 +315,27 @@ describe('firmware store', () => {
 
     it('treats a malformed current version as not a downgrade (NaN > 0 is false)', () => {
       const store = useFirmwareStore();
-      store.controllers = [
-        {
-          id: 'weird',
-          label: 'Weird',
-          glyph: 'W',
-          current: 'not-a-version',
-          status: 'up',
-          isMaster: false,
-        },
-      ];
+      const cs = useControllerStore();
+      seedSampleFleet();
+      cs.bodyFirmware = 'not-a-version';
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.4.2';
-      store.toggle('weird');
+      store.toggle('body');
       expect(store.anyDowngradeBlocked).toBe(false);
-    });
-  });
-
-  describe('controllers reconciler', () => {
-    it('prunes selected ids that no longer exist after controllers is reassigned', async () => {
-      const store = useFirmwareStore();
-      store.controllers = sampleControllers;
-      store.toggle('body');
-      store.toggle('core');
-      expect(store.selectedControllerIds.size).toBe(2);
-
-      // Reassign with dome removed and core renamed.
-      store.controllers = [
-        { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
-      ];
-      // watch is async; flush via microtask.
-      await Promise.resolve();
-      expect([...store.selectedControllerIds]).toEqual(['body']);
-    });
-
-    it('does not touch the Set when no ids are orphaned', async () => {
-      const store = useFirmwareStore();
-      store.controllers = sampleControllers;
-      store.toggle('body');
-      const before = store.selectedControllerIds;
-      store.controllers = [...sampleControllers]; // new reference, same ids
-      await Promise.resolve();
-      expect(store.selectedControllerIds).toBe(before);
     });
   });
 
   describe('canFlash', () => {
     it('is false with no target', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.toggle('body');
       expect(store.canFlash).toBe(false);
     });
 
     it('is false with target but no selection', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.4.2';
       expect(store.canFlash).toBe(false);
@@ -358,7 +343,7 @@ describe('firmware store', () => {
 
     it('is true with target + at least one upgrade selection', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.4.2';
       store.toggle('body');
@@ -367,7 +352,7 @@ describe('firmware store', () => {
 
     it('is false with target + selection but any selected controller would downgrade', () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.3.5';
       store.toggle('body'); // upgrade
@@ -418,7 +403,7 @@ describe('firmware store', () => {
   describe('startFlash', () => {
     function readyStore() {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.4.2';
       store.toggle('body');
@@ -444,7 +429,7 @@ describe('firmware store', () => {
     it("POSTs the upload source shape when sourceMode is 'upload'", async () => {
       apiPost.mockResolvedValueOnce({ data: { jobId: 'job-2' } });
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'upload';
       store.uploadedFilename = 'custom.bin';
       store.toggle('body');
@@ -512,7 +497,7 @@ describe('firmware store', () => {
 
     it('is a no-op when canFlash is false (e.g. no controllers selected)', async () => {
       const store = useFirmwareStore();
-      store.controllers = sampleControllers;
+      seedSampleFleet();
       store.sourceMode = 'github';
       store.selectedReleaseTag = 'v1.4.2';
       // No selection.
@@ -555,6 +540,311 @@ describe('firmware store', () => {
       await store.cancelFlash();
       // Did not throw; phase unchanged (WS dispatcher owns terminal state).
       expect(store.phase).toBe('flashing');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // d.6 — WebSocket-driven state
+  // ------------------------------------------------------------------
+
+  function sampleJobState(overrides: Partial<FlashJobState> = {}): FlashJobState {
+    return {
+      jobId: 'job-1',
+      source: { kind: 'github', version: 'v1.4.2' },
+      controllers: [
+        { controllerId: 'body', stage: 'QUEUED' },
+        { controllerId: 'core', stage: 'QUEUED' },
+      ],
+      startedAt: '2026-05-12T08:00:00Z',
+      ...overrides,
+    };
+  }
+
+  describe('applyJobStarted', () => {
+    it("transitions phase 'select' → 'flashing' and seeds controllerStates from data.controllers", () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.setPhase('select');
+
+      store.applyJobStarted(sampleJobState());
+
+      expect(store.phase).toBe('flashing');
+      expect(store.currentJob?.jobId).toBe('job-1');
+      expect(store.controllerStates.size).toBe(2);
+      expect(store.controllerStates.get('body')?.stage).toBe('QUEUED');
+    });
+
+    it('is idempotent when called twice with the same jobId (WS reconnect / late-join)', () => {
+      // FMI hazard: late-join + cold-load fetch race. Both fetchCurrentJob
+      // (HTTP) and the WS replay can fire on view enter; both must converge
+      // on identical state without merging or doubling effects.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyJobStarted(sampleJobState()); // distinct object, same jobId
+      expect(store.currentJob?.jobId).toBe('job-1');
+      expect(store.phase).toBe('flashing');
+      expect(store.controllerStates.size).toBe(2);
+    });
+
+    it('REPLACES (not merges) controllerStates on duplicate — stale entries do not survive', () => {
+      // FMI hazard: WS reconnect during flash. The server sends a fresh
+      // flashJobStarted snapshot; the client must NOT keep stale per-
+      // controller stages from before the disconnect.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({ controllerId: 'body', stage: 'SENDING' });
+      // Simulate reconnect with controllers in a different state.
+      const fresh: FlashJobState = sampleJobState({
+        controllers: [{ controllerId: 'body', stage: 'VERIFYING' }],
+      });
+      store.applyJobStarted(fresh);
+      expect(store.controllerStates.size).toBe(1);
+      expect(store.controllerStates.get('body')?.stage).toBe('VERIFYING');
+      expect(store.controllerStates.get('core')).toBeUndefined();
+    });
+
+    it('clears flashError and failedController so a previous failure does not bleed into the new job', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.flashError = { reason: 'internal_server_error' };
+      store.failedController = { id: 'core', label: 'Core', stage: 'transfer' };
+      store.applyJobStarted(sampleJobState());
+      expect(store.flashError).toBeNull();
+      expect(store.failedController).toBeNull();
+    });
+  });
+
+  describe('applyControllerUpdate', () => {
+    it('replaces the per-controller state in the map and projects the UI stage', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+
+      store.applyControllerUpdate({ controllerId: 'body', stage: 'UPLOADING_TO_MASTER' });
+      expect(store.controllerStates.get('body')?.stage).toBe('UPLOADING_TO_MASTER');
+      expect(store.currentStage).toBe('download');
+
+      store.applyControllerUpdate({ controllerId: 'body', stage: 'VERIFYING' });
+      expect(store.currentStage).toBe('verify');
+    });
+
+    it('leaves currentStage untouched for terminal stages (VERSION_CONFIRMED / FAILED / QUEUED)', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({ controllerId: 'body', stage: 'SENDING' });
+      const before = store.currentStage;
+      store.applyControllerUpdate({
+        controllerId: 'body',
+        stage: 'VERSION_CONFIRMED',
+        finalVersion: 'v1.4.2',
+      });
+      expect(store.currentStage).toBe(before);
+    });
+
+    it('replaces the Map reference (Vue reactivity)', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      const before = store.controllerStates;
+      store.applyControllerUpdate({ controllerId: 'body', stage: 'SENDING' });
+      expect(store.controllerStates).not.toBe(before);
+    });
+  });
+
+  describe('applyControllerResult', () => {
+    it('routes the contained controller state through applyControllerUpdate', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerResult({
+        jobId: 'job-1',
+        controller: { controllerId: 'core', stage: 'VERSION_CONFIRMED', finalVersion: 'v1.4.2' },
+      });
+      expect(store.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
+    });
+  });
+
+  describe('applyJobDone', () => {
+    it("transitions phase 'flashing' → 'done' and stamps endedAt on currentJob", () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+      expect(store.phase).toBe('done');
+      expect(store.currentJob?.endedAt).toBe('2026-05-12T08:05:00Z');
+    });
+  });
+
+  describe('applyJobFailed', () => {
+    it("transitions phase to 'failed', stamps endedAt + abortReason, and surfaces flashError", () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      const data: FlashJobFailedData = {
+        jobId: 'job-1',
+        endedAt: '2026-05-12T08:05:00Z',
+        reason: 'hash_mismatch',
+        detail: 'asset checksum mismatch on Core',
+        abortReason: 'hash_mismatch',
+      };
+      store.applyJobFailed(data);
+      expect(store.phase).toBe('failed');
+      expect(store.currentJob?.endedAt).toBe('2026-05-12T08:05:00Z');
+      expect(store.flashError?.reason).toBe('internal_server_error');
+      expect(store.flashError?.detail).toBe('asset checksum mismatch on Core');
+    });
+
+    it('derives failedController from the FAILED entry in controllerStates', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({
+        controllerId: 'core',
+        stage: 'FAILED',
+        error: 'hash_mismatch',
+      });
+      store.applyJobFailed({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+      expect(store.failedController?.id).toBe('core');
+      expect(store.failedController?.label).toBe('Core');
+    });
+
+    it('leaves failedController null when no controller transitioned to FAILED before job-failed (mid-deploy abort)', () => {
+      // Edge case: applyJobStarted runs, no per-controller updates land,
+      // then a mid-deploy abort (e.g., bus_send_failed) fires
+      // flashJobFailed. The store should still transition phase + set
+      // flashError, and the FirmwareView template guards on
+      // `failedController?.stage` so a null is safe to render.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyJobFailed({
+        jobId: 'job-1',
+        endedAt: '2026-05-12T08:05:00Z',
+        reason: 'bus_send_failed',
+        detail: 'Worker channel closed during firmware send',
+      });
+      expect(store.phase).toBe('failed');
+      expect(store.flashError?.detail).toBe('Worker channel closed during firmware send');
+      expect(store.failedController).toBeNull();
+    });
+
+    it('does not throw when called with no controllerStates and no currentJob (defensive)', () => {
+      // FMI hazard: WS handler errors swallow real bugs. A malformed
+      // flashJobFailed must still transition phase so the UI doesn't lock.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      expect(() =>
+        store.applyJobFailed({ jobId: 'job-x', endedAt: '2026-05-12T08:05:00Z' }),
+      ).not.toThrow();
+      expect(store.phase).toBe('failed');
+      expect(store.flashError).not.toBeNull();
+    });
+  });
+
+  describe('isOwnJob', () => {
+    it('is true when ownJobId matches currentJob.jobId', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.ownJobId = 'job-1';
+      store.applyJobStarted(sampleJobState({ jobId: 'job-1' }));
+      expect(store.isOwnJob).toBe(true);
+    });
+
+    it("is false when ownJobId is null (another operator's job)", () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState({ jobId: 'job-99' }));
+      expect(store.isOwnJob).toBe(false);
+    });
+
+    it('is false when no job is in flight', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.ownJobId = 'job-1';
+      expect(store.isOwnJob).toBe(false);
+    });
+  });
+
+  describe('fetchCurrentJob', () => {
+    it('populates currentJob via applyJobStarted when the server returns a job and store has none', async () => {
+      const data = sampleJobState();
+      apiClientGet.mockResolvedValueOnce({ data });
+      const store = useFirmwareStore();
+      seedSampleFleet();
+
+      await store.fetchCurrentJob();
+
+      expect(apiClientGet).toHaveBeenCalledWith('api/firmware/flash');
+      expect(store.currentJob?.jobId).toBe('job-1');
+      expect(store.phase).toBe('flashing');
+    });
+
+    it('is a no-op when currentJob is already set (idempotent cold-load + late-join race guard)', async () => {
+      // FMI hazard: fetchCurrentJob + WS late-join race. If the WS replay
+      // sets currentJob first, the subsequent HTTP cold-load must not
+      // overwrite it.
+      apiClientGet.mockResolvedValueOnce({ data: sampleJobState({ jobId: 'job-from-http' }) });
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState({ jobId: 'job-from-ws' }));
+      await store.fetchCurrentJob();
+      expect(store.currentJob?.jobId).toBe('job-from-ws');
+    });
+
+    it('returns null without error when the server responds with no active job', async () => {
+      apiClientGet.mockResolvedValueOnce({ data: null });
+      const store = useFirmwareStore();
+      await store.fetchCurrentJob();
+      expect(store.currentJob).toBeNull();
+      expect(store.phase).toBe('idle');
+    });
+
+    it('swallows network errors (UI stays in current phase)', async () => {
+      apiClientGet.mockRejectedValueOnce(new Error('network'));
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      await store.fetchCurrentJob();
+      expect(store.currentJob).toBeNull();
+    });
+  });
+
+  describe('resetToSelect', () => {
+    it('clears controllerStates and ownJobId in addition to phase/currentStage/flashError', () => {
+      // FMI hazard: stale controllerStates after job ends. Operator clicks
+      // Done → next flash must not inherit prior per-controller stages.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.ownJobId = 'job-1';
+      store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+
+      store.resetToSelect();
+
+      expect(store.phase).toBe('select');
+      expect(store.controllerStates.size).toBe(0);
+      expect(store.currentJob).toBeNull();
+      expect(store.ownJobId).toBeNull();
+    });
+  });
+
+  describe('startFlash captures ownJobId from the POST response', () => {
+    it('records ownJobId so isOwnJob resolves once the WS snapshot lands', async () => {
+      apiPost.mockResolvedValueOnce({ data: sampleJobState({ jobId: 'job-mine' }) });
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.sourceMode = 'github';
+      store.selectedReleaseTag = 'v1.4.2';
+      store.toggle('body');
+
+      await store.startFlash();
+
+      expect(store.ownJobId).toBe('job-mine');
+      // applyJobStarted in production would follow; simulate it here.
+      store.applyJobStarted(sampleJobState({ jobId: 'job-mine' }));
+      expect(store.isOwnJob).toBe(true);
     });
   });
 });

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -833,6 +833,20 @@ describe('firmware store', () => {
       expect(store.phase).toBe('done');
       expect(store.currentJob?.endedAt).toBe('2026-05-12T08:05:00Z');
     });
+
+    it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto done state (C2 fix)', () => {
+      // Round-5 C2: without this clear, a queued entry whose MAC mapping
+      // arrives after job-done would mutate controllerStates + currentStage,
+      // visibly contradicting the result bar's "all updated" message.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyControllerUpdate({ controllerId: 'orphan-mac', stage: 'SENDING' });
+      expect(store.pendingByMac.size).toBe(1);
+
+      store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+
+      expect(store.pendingByMac.size).toBe(0);
+    });
   });
 
   describe('applyJobFailed', () => {
@@ -954,6 +968,21 @@ describe('firmware store', () => {
       ).not.toThrow();
       expect(store.phase).toBe('failed');
       expect(store.flashError).not.toBeNull();
+    });
+
+    it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto failed state (C2 fix)', () => {
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyControllerUpdate({ controllerId: 'orphan-mac', stage: 'SENDING' });
+      expect(store.pendingByMac.size).toBe(1);
+
+      store.applyJobFailed({
+        jobId: 'job-1',
+        endedAt: '2026-05-12T08:05:00Z',
+        reason: 'bus_send_failed',
+      });
+
+      expect(store.pendingByMac.size).toBe(0);
     });
   });
 

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -851,6 +851,28 @@ describe('firmware store', () => {
       expect(store.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
     });
 
+    it('emits a console.warn for each non-terminal stage normalized (round-6 C2 forensic breadcrumb)', () => {
+      // The normalize masks a real bug if the server emits flashJobDone
+      // prematurely. The warn is the post-incident breadcrumb so operators'
+      // dev console + production logs surface the contract drift.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const store = useFirmwareStore();
+        seedSampleFleet();
+        store.applyJobStarted(sampleJobState());
+        // Body at SENDING, core left at QUEUED — both non-terminal.
+        store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
+        store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
+
+        const warnText = warnSpy.mock.calls.flat().join(' ');
+        expect(warnText).toContain('normalizing non-terminal stage');
+        expect(warnText).toContain('slot="body"');
+        expect(warnText).toContain('slot="core"');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('does NOT overwrite FAILED stages during the done normalize', () => {
       // The normalize should only touch in-flight stages, not terminal
       // ones. A controller that legitimately FAILED should stay FAILED
@@ -926,6 +948,13 @@ describe('firmware store', () => {
         controllerId: CORE_MAC,
         stage: 'FAILED',
         error: 'hash_mismatch',
+      });
+      // Mark body as VERSION_CONFIRMED so the round-6 C1 normalize doesn't
+      // demote it to FAILED (body would otherwise be QUEUED → demoted).
+      store.applyControllerUpdate({
+        controllerId: BODY_MAC,
+        stage: 'VERSION_CONFIRMED',
+        finalVersion: 'v1.4.2',
       });
       store.applyJobFailed({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
       expect(store.failedControllers).toHaveLength(1);
@@ -1004,15 +1033,18 @@ describe('firmware store', () => {
       }
     });
 
-    it('leaves failedControllers empty when no controller transitioned to FAILED before job-failed (mid-deploy abort)', () => {
-      // Edge case: applyJobStarted runs, no per-controller updates land,
-      // then a mid-deploy abort (e.g., bus_send_failed) fires
-      // flashJobFailed. The store should still transition phase + set
-      // flashError, and the FirmwareView template guards on
-      // `failedControllers[0]?.stage` so an empty array is safe to render.
+    it('leaves failedControllers empty when controllerStates is empty (pre-streamer abort with no snapshot)', () => {
+      // Pre-streamer failure (e.g., release_not_found, bus_send_failed
+      // before any controller-update): no flashJobStarted snapshot landed
+      // first, so controllerStates is empty. Nothing to demote; the array
+      // is empty. The FirmwareView template guards on
+      // `failedControllers[0]?.stage`, and the panel's result bar uses
+      // the multi-failure copy (via failedCount === 0 → multi key per I2).
+      // Note: round-6 C1 changes the post-applyJobStarted behavior — see
+      // the new "normalizes non-terminal stages to FAILED" test for that.
       const store = useFirmwareStore();
       seedSampleFleet();
-      store.applyJobStarted(sampleJobState());
+      // Deliberately skip applyJobStarted to leave controllerStates empty.
       store.applyJobFailed({
         jobId: 'job-1',
         endedAt: '2026-05-12T08:05:00Z',
@@ -1034,6 +1066,58 @@ describe('firmware store', () => {
       ).not.toThrow();
       expect(store.phase).toBe('failed');
       expect(store.flashError).not.toBeNull();
+    });
+
+    it('normalizes non-terminal per-controller stages to FAILED (round-6 C1 fix: parallel to applyJobDone)', () => {
+      // Symmetry: applyJobDone normalizes mid-flow stages to VERSION_CONFIRMED
+      // to prevent the "✓ all updated" result bar contradicting a still-
+      // spinning row. applyJobFailed had the inverse gap — a row stuck at
+      // SENDING when the job failed kept spinning under a "failed" banner.
+      // Now non-terminals are demoted to FAILED (with no error string,
+      // signaling "unattributed" vs server-emitted FAILED entries that
+      // carry the real reason).
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
+      // core left at QUEUED from sampleJobState
+      store.applyJobFailed({
+        jobId: 'job-1',
+        endedAt: '2026-05-12T08:05:00Z',
+        reason: 'bus_send_failed',
+      });
+
+      expect(store.controllerStates.get('body')?.stage).toBe('FAILED');
+      expect(store.controllerStates.get('core')?.stage).toBe('FAILED');
+      // The demoted entries carry no `error` string — they weren't
+      // server-reported as FAILED, they were normalized.
+      expect(store.controllerStates.get('body')?.error).toBeUndefined();
+      // failedControllers reflects the demoted entries.
+      const ids = store.failedControllers.map((c) => c.id);
+      expect(ids).toEqual(['body', 'core']);
+    });
+
+    it('preserves server-reported FAILED entries during the failed normalize (preserves their error string)', () => {
+      // A controller that legitimately FAILED (with the server's error
+      // reason) must keep its error attribute. The normalize must only
+      // touch non-terminal stages.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({
+        controllerId: CORE_MAC,
+        stage: 'FAILED',
+        error: 'hash_mismatch',
+      });
+      store.applyJobFailed({
+        jobId: 'job-1',
+        endedAt: '2026-05-12T08:05:00Z',
+        reason: 'bus_send_failed',
+      });
+
+      // CORE's error string survives; body is demoted with no error.
+      expect(store.controllerStates.get('core')?.error).toBe('hash_mismatch');
+      expect(store.controllerStates.get('body')?.error).toBeUndefined();
     });
 
     it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto failed state (C2 fix)', () => {

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -518,6 +518,58 @@ describe('firmware store', () => {
       await store.startFlash();
       expect(apiPost).not.toHaveBeenCalled();
     });
+
+    it("re-asserts phase='flashing' if a malformed-WS rollback raced the pending POST", async () => {
+      // I5 race: useWebsocket.handleFlashJobStarted defensively calls
+      // setPhase('select') on a malformed WS payload. If that arrives during
+      // the POST window, the success path must re-assert 'flashing' so the
+      // UI reflects that the server actually accepted the job.
+      let resolvePost: (value: { data: { jobId: string } }) => void = () => {};
+      apiPost.mockReturnValueOnce(
+        new Promise((res) => {
+          resolvePost = res;
+        }),
+      );
+      const store = readyStore();
+
+      const inFlight = store.startFlash();
+      // Mid-flight: simulate the malformed-WS rollback.
+      store.setPhase('select');
+      store.flashError = {
+        reason: 'internal_server_error',
+        detail: 'Malformed flashJobStarted from server',
+      };
+
+      resolvePost({ data: { jobId: 'job-race' } });
+      await inFlight;
+
+      expect(store.phase).toBe('flashing');
+      expect(store.flashError).toBeNull();
+      expect(store.ownJobId).toBe('job-race');
+    });
+
+    it("preserves phase='done' if WS completion legitimately raced the pending POST", async () => {
+      // Negative side of the race-fix: if applyJobDone fired between the
+      // POST and the response (legitimate fast-flash), we must NOT clobber
+      // 'done' by re-asserting 'flashing'. The re-assertion only fires when
+      // phase has dropped to 'select'.
+      let resolvePost: (value: { data: { jobId: string } }) => void = () => {};
+      apiPost.mockReturnValueOnce(
+        new Promise((res) => {
+          resolvePost = res;
+        }),
+      );
+      const store = readyStore();
+
+      const inFlight = store.startFlash();
+      store.setPhase('done');
+
+      resolvePost({ data: { jobId: 'job-fast' } });
+      await inFlight;
+
+      expect(store.phase).toBe('done');
+      expect(store.ownJobId).toBe('job-fast');
+    });
   });
 
   describe('cancelFlash', () => {
@@ -918,6 +970,71 @@ describe('firmware store', () => {
       // applyJobStarted in production would follow; simulate it here.
       store.applyJobStarted(sampleJobState({ jobId: 'job-mine' }));
       expect(store.isOwnJob).toBe(true);
+    });
+  });
+
+  describe('progressByControllerId', () => {
+    it('emits an entry per controller with status; stageLabelKey is an i18n key path (not a literal label)', () => {
+      // The panel passes stageLabelKey to AstrosFirmwareControllerRow which
+      // resolves it with t(). If we leak a literal label like "Transfer" the
+      // row renders the raw English even on a non-en locale. The key must be
+      // a dotted path under firmware_view.stages.*.label.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
+
+      const map = store.progressByControllerId;
+      expect(map).toHaveProperty('body');
+      expect(map.body?.status).toBeDefined();
+      // SENDING guarantees controllerStageLabelKey returns a key, so this
+      // assertion is unconditional — a future regression where SENDING starts
+      // returning null would surface here instead of silently passing through
+      // a conditional guard. The dotted-path shape pins the producer/consumer
+      // contract so a literal label like "Transfer" can't slip through.
+      expect(map.body?.stageLabelKey).toMatch(/^firmware_view\.stages\.[a-z_]+\.label$/);
+    });
+
+    it('omits stageLabelKey for terminal states (done / failed) — only "updating" gets a stage label', () => {
+      // Mutation guard: a previous bug surfaced a stage label on done rows
+      // because controllerStageLabelKey wasn't checked against status. Pin
+      // the rule: the row's <span v-if="status === 'updating' && stageLabelKey">
+      // depends on this absence.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyControllerUpdate({
+        controllerId: BODY_MAC,
+        stage: 'VERSION_CONFIRMED',
+        finalVersion: 'v1.4.2',
+      });
+
+      const entry = store.progressByControllerId.body;
+      expect(entry?.status).toBe('done');
+      expect(entry?.stageLabelKey).toBeUndefined();
+    });
+  });
+
+  describe('controllers computed reactivity', () => {
+    it('re-derives FirmwareControllerView entries when controllerStore.bodyStatus flips mid-flow', async () => {
+      // Pins reactivity: the firmware view's row badges (up / down / needs-
+      // synced) are read off the controllerStore but exposed via the firmware
+      // store's `controllers` computed. If the computed didn't depend on the
+      // status refs, a real-time POLL_ACK -> DOWN transition would leave the
+      // row stuck at "up" until a page refresh.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+
+      const before = store.controllers.find((c) => c.id === 'body');
+      expect(before?.status).toBe('up');
+
+      const { useControllerStore } = await import('@/stores/controller');
+      const { ControllerStatus } = await import('@/enums');
+      const controllerStore = useControllerStore();
+      controllerStore.bodyStatus = ControllerStatus.DOWN;
+
+      const after = store.controllers.find((c) => c.id === 'body');
+      expect(after?.status).toBe('down');
     });
   });
 });

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -520,10 +520,10 @@ describe('firmware store', () => {
     });
 
     it("re-asserts phase='flashing' if a malformed-WS rollback raced the pending POST", async () => {
-      // I5 race: useWebsocket.handleFlashJobStarted defensively calls
-      // setPhase('select') on a malformed WS payload. If that arrives during
-      // the POST window, the success path must re-assert 'flashing' so the
-      // UI reflects that the server actually accepted the job.
+      // useWebsocket.handleFlashJobStarted defensively calls
+      // setPhase('select') on a malformed WS payload. If that arrives
+      // during the POST window, the success path must re-assert
+      // 'flashing' so the UI reflects that the server accepted the job.
       let resolvePost: (value: { data: { jobId: string } }) => void = () => {};
       apiPost.mockReturnValueOnce(
         new Promise((res) => {
@@ -600,7 +600,7 @@ describe('firmware store', () => {
       expect(store.phase).toBe('flashing');
     });
 
-    it('IM-10: surfaces a network_error flashError when the cancel HTTP fails', async () => {
+    it('surfaces a network_error flashError when the cancel HTTP fails', async () => {
       apiDelete.mockRejectedValueOnce(new Error('network down'));
       const store = useFirmwareStore();
       store.setPhase('flashing');
@@ -666,11 +666,11 @@ describe('firmware store', () => {
       // flashJobStarted snapshot; the client must NOT keep stale per-
       // controller stages from before the disconnect.
       //
-      // IM-8 mutation-resistance: seed BOTH body AND core with a non-
-      // trivial stage before the duplicate flashJobStarted, then verify
-      // both are correctly replaced. A merge-by-id mutation would keep
-      // core at SENDING (since the fresh snapshot omits core entirely),
-      // which is exactly the failure mode this test must catch.
+      // Seed BOTH body AND core with a non-trivial stage before the
+      // duplicate flashJobStarted, then verify both are replaced. A
+      // merge-by-id mutation would keep core at SENDING (the fresh
+      // snapshot omits core entirely) — exactly the failure mode this
+      // test must catch.
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
@@ -700,12 +700,11 @@ describe('firmware store', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
-      // sampleJobState sends BODY_MAC + CORE_MAC; after translation the Map
-      // is keyed by slot ids, NOT by the raw MAC strings. IM-11 enforces
-      // this at the type level — the Map is now `Map<SlotId, ...>`, so a
-      // MAC-keyed lookup is a compile error. The runtime sanity check below
-      // is preserved via an unsafe cast so a regression that started silently
-      // double-keying by MAC would still be caught.
+      // sampleJobState sends BODY_MAC + CORE_MAC; after translation the
+      // Map is keyed by slot ids, NOT raw MACs. The Map's type
+      // (`Map<SlotId, ...>`) makes a MAC-keyed lookup a compile error;
+      // the unsafe cast below preserves the runtime check so a
+      // regression that started silently double-keying would still fail.
       expect(store.controllerStates.get('body')?.stage).toBe('QUEUED');
       expect(store.controllerStates.get('core')?.stage).toBe('QUEUED');
       const mapAsAny = store.controllerStates as unknown as Map<string, unknown>;
@@ -753,7 +752,7 @@ describe('firmware store', () => {
       expect(store.failedControllers).toEqual([]);
     });
 
-    it('clears currentJobLoadFailed — WS snapshot supersedes HTTP staleness (I4 fix)', () => {
+    it('clears currentJobLoadFailed — WS snapshot supersedes HTTP staleness', () => {
       // A failed fetchCurrentJob lit the staleness banner; when the WS late-
       // join snapshot lands, live state is available again and the banner
       // is no longer accurate.
@@ -780,7 +779,7 @@ describe('firmware store', () => {
       expect(store.pendingByMac.size).toBe(0);
     });
 
-    describe('IM-3: defensive validation of controllers payload', () => {
+    describe('defensive validation of controllers payload', () => {
       it('returns empty map when controllers is not an array (string)', () => {
         const store = useFirmwareStore();
         seedSampleFleet();
@@ -897,7 +896,7 @@ describe('firmware store', () => {
       expect(store.controllerStates).not.toBe(before);
     });
 
-    it('clears currentJobLoadFailed on a successful update — belt-and-suspenders (I4 fix)', () => {
+    it('clears currentJobLoadFailed on a successful update — belt-and-suspenders', () => {
       // If applyJobStarted was missed (unusual reconnect ordering), a
       // successful per-controller update is still proof that live state is
       // flowing for a known controller. Clear the staleness banner.
@@ -908,7 +907,7 @@ describe('firmware store', () => {
       expect(store.currentJobLoadFailed).toBe(false);
     });
 
-    it('does NOT clear currentJobLoadFailed when the update is queued (C1 fix)', () => {
+    it('does NOT clear currentJobLoadFailed when the update is queued', () => {
       // The clear MUST stay below the null-slot return. An unmapped MAC
       // means we can't trust the update yet; clearing the banner here would
       // silently dismiss the operator's only "something wrong" signal.
@@ -919,7 +918,7 @@ describe('firmware store', () => {
       expect(store.currentJobLoadFailed).toBe(true);
     });
 
-    describe('NEW-IM1: element validation (mirror of IM-3 from buildControllerStatesMap)', () => {
+    describe('element validation (mirrors buildControllerStatesMap)', () => {
       it('skips and warns when data.controllerId is missing', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         try {
@@ -952,7 +951,7 @@ describe('firmware store', () => {
       });
     });
 
-    describe('NEW-IM3: terminal-phase guard (drops trailing updates after done/failed)', () => {
+    describe('terminal-phase guard (drops trailing updates after done/failed)', () => {
       it('drops trailing applyControllerUpdate when phase is done', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         try {
@@ -1039,7 +1038,7 @@ describe('firmware store', () => {
       expect(store.currentJob?.endedAt).toBe('2026-05-12T08:05:00Z');
     });
 
-    it('normalizes non-terminal per-controller stages to VERSION_CONFIRMED (I4 fix)', () => {
+    it('normalizes non-terminal per-controller stages to VERSION_CONFIRMED', () => {
       // Race: server emits flashJobDone when the LAST VERSION_CONFIRMED
       // observed, but a flashControllerUpdate carrying that final stage
       // may not have drained the WS buffer yet. Without this normalize,
@@ -1056,7 +1055,7 @@ describe('firmware store', () => {
       expect(store.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
     });
 
-    it('emits a console.warn for each non-terminal stage normalized (round-6 C2 forensic breadcrumb)', () => {
+    it('emits a console.warn for each non-terminal stage normalized (forensic breadcrumb)', () => {
       // The normalize masks a real bug if the server emits flashJobDone
       // prematurely. The warn is the post-incident breadcrumb so operators'
       // dev console + production logs surface the contract drift.
@@ -1096,9 +1095,9 @@ describe('firmware store', () => {
       expect(store.controllerStates.get('core')?.stage).toBe('FAILED');
     });
 
-    it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto done state (C2 fix)', () => {
-      // Round-5 C2: without this clear, a queued entry whose MAC mapping
-      // arrives after job-done would mutate controllerStates + currentStage,
+    it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto done state', () => {
+      // Without this clear, a queued entry whose MAC mapping arrives
+      // after job-done would mutate controllerStates + currentStage,
       // visibly contradicting the result bar's "all updated" message.
       const store = useFirmwareStore();
       seedSampleFleet();
@@ -1110,7 +1109,7 @@ describe('firmware store', () => {
       expect(store.pendingByMac.size).toBe(0);
     });
 
-    it('drops stale flashJobDone whose jobId does not match currentJob (CR-4)', () => {
+    it('drops stale flashJobDone whose jobId does not match currentJob', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
         const store = useFirmwareStore();
@@ -1174,8 +1173,8 @@ describe('firmware store', () => {
         stage: 'FAILED',
         error: 'hash_mismatch',
       });
-      // Mark body as VERSION_CONFIRMED so the round-6 C1 normalize doesn't
-      // demote it to FAILED (body would otherwise be QUEUED → demoted).
+      // Mark body as VERSION_CONFIRMED so applyJobFailed's normalize loop
+      // doesn't demote it to FAILED (body would otherwise be QUEUED).
       store.applyControllerUpdate({
         controllerId: BODY_MAC,
         stage: 'VERSION_CONFIRMED',
@@ -1185,13 +1184,12 @@ describe('firmware store', () => {
       expect(store.failedControllers).toHaveLength(1);
       expect(store.failedControllers[0]?.id).toBe('core');
       expect(store.failedControllers[0]?.label).toBe('Core');
-      // I2 fix: stage comes from currentStage at failure time, not the
-      // literal 'transfer' fallback. Here VERIFYING set currentStage to
-      // 'verify' before the FAILED update.
+      // Stage comes from currentStage at failure time, not a literal
+      // 'transfer' fallback. VERIFYING set currentStage to 'verify'.
       expect(store.failedControllers[0]?.stage).toBe('verify');
     });
 
-    it('records stage as null when no currentStage was observed before the FAILED update (I2 fix)', () => {
+    it('records stage as null when no currentStage was observed before the FAILED update', () => {
       // The previous code fabricated 'transfer' here, silently misattributing
       // pre-streamer-style failures. Now we record null and let the UI
       // either render the stages list "—" fallback or omit the stage from
@@ -1209,10 +1207,10 @@ describe('firmware store', () => {
     });
 
     it('collects ALL FAILED entries AND attributes stage from the shared currentStage ref (not per-controller history)', () => {
-      // C2 fix: a `break` in applyJobFailed previously surfaced only the
-      // first FAILED entry by iteration order. With two padawans failing
-      // simultaneously (e.g. master loses ESP-NOW), the operator would
-      // walk away from a bricked unit. Pin all FAILEDs make the array.
+      // Pin that the iteration collects every FAILED entry, not just the
+      // first — with two padawans failing simultaneously (e.g. master
+      // loses ESP-NOW) the operator should see both, not walk away from
+      // a bricked unit.
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
@@ -1234,25 +1232,24 @@ describe('firmware store', () => {
         reason: 'bus_send_failed',
       });
       expect(store.failedControllers).toHaveLength(2);
-      // I-test-1: pin insertion-order preservation (Map.values() is
-      // insertion-order; sampleJobState seeds body, then core). The
-      // FirmwareView's failedControllerLabels join depends on this — a
-      // regression that sorted alphabetically before joining would silently
-      // change the operator-visible message.
+      // Pin insertion-order preservation: Map.values() is
+      // insertion-order; sampleJobState seeds body, then core. The
+      // FirmwareView's failedControllerLabels join depends on this —
+      // a regression that sorted alphabetically before joining would
+      // silently change the operator-visible message.
       const ids = store.failedControllers.map((c) => c.id);
       expect(ids).toEqual(['body', 'core']);
       // Pin the full record shape per entry: a mutation that surfaced only
       // {id} (dropping label / stage) would otherwise pass this test.
       const labels = store.failedControllers.map((c) => c.label);
       expect(labels).toEqual(['Body', 'Core']);
-      // I2 fix: stage reflects the SHARED `currentStage` ref at the moment
-      // applyJobFailed runs (not a per-controller history). Both entries
-      // pick up 'transfer' here because CORE's SENDING update set the
-      // shared currentStage before either FAILED — even though body never
-      // had its own SENDING update. This documents the design: stage is
-      // "what the flash was doing when it failed," not "what each
-      // individual controller was doing." A future change to track stage
-      // per-controller would make body.stage null in this scenario.
+      // Stage reflects the SHARED currentStage at the moment
+      // applyJobFailed runs, not per-controller history. Both entries
+      // pick up 'transfer' because CORE's SENDING update set
+      // currentStage before either FAILED — even though body never had
+      // its own SENDING update. Design intent: stage means "what the
+      // flash was doing when it failed," not "what each controller was
+      // doing." Per-controller tracking would make body.stage null here.
       for (const entry of store.failedControllers) {
         expect(entry.stage).toBe('transfer');
       }
@@ -1264,9 +1261,9 @@ describe('firmware store', () => {
       // first, so controllerStates is empty. Nothing to demote; the array
       // is empty. The FirmwareView template guards on
       // `failedControllers[0]?.stage`, and the panel's result bar uses
-      // the multi-failure copy (via failedCount === 0 → multi key per I2).
-      // Note: round-6 C1 changes the post-applyJobStarted behavior — see
-      // the new "normalizes non-terminal stages to FAILED" test for that.
+      // the multi-failure copy (via failedCount === 0 → multi key).
+      // Compare with the "normalizes non-terminal stages to FAILED" test
+      // for the post-applyJobStarted behavior.
       const store = useFirmwareStore();
       seedSampleFleet();
       // Deliberately skip applyJobStarted to leave controllerStates empty.
@@ -1293,7 +1290,7 @@ describe('firmware store', () => {
       expect(store.flashError).not.toBeNull();
     });
 
-    it('normalizes non-terminal per-controller stages to FAILED (round-6 C1 fix: parallel to applyJobDone)', () => {
+    it('normalizes non-terminal per-controller stages to FAILED (parallel to applyJobDone)', () => {
       // Symmetry: applyJobDone normalizes mid-flow stages to VERSION_CONFIRMED
       // to prevent the "✓ all updated" result bar contradicting a still-
       // spinning row. applyJobFailed had the inverse gap — a row stuck at
@@ -1314,9 +1311,10 @@ describe('firmware store', () => {
 
       expect(store.controllerStates.get('body')?.stage).toBe('FAILED');
       expect(store.controllerStates.get('core')?.stage).toBe('FAILED');
-      // IM-2 contract: FAILED entries always carry an `error` string.
-      // Demoted (non-server-reported) entries use the 'unattributed:*'
-      // marker so ops can distinguish them from server-reported failures.
+      // The discriminated union requires every FAILED entry to carry an
+      // `error` string. Demoted (non-server-reported) entries use the
+      // 'unattributed:*' marker so ops can distinguish them from
+      // server-reported failures.
       const bodyState = store.controllerStates.get('body');
       const coreState = store.controllerStates.get('core');
       if (bodyState?.stage === 'FAILED') {
@@ -1330,7 +1328,7 @@ describe('firmware store', () => {
       expect(ids).toEqual(['body', 'core']);
     });
 
-    it('preserves server-reported FAILED error strings AND demoted entries get the unattributed marker (IM-2 normalize attribution)', () => {
+    it('preserves server-reported FAILED error strings AND demoted entries get the unattributed marker', () => {
       // A controller that legitimately FAILED (with the server's error
       // reason) must keep its error attribute. The normalize must only
       // touch non-terminal stages.
@@ -1349,8 +1347,8 @@ describe('firmware store', () => {
       });
 
       // CORE's server-reported error string survives; body's demoted
-      // entry carries the IM-2 'unattributed:*' marker (distinguishable
-      // from any server-emitted error reason).
+      // entry carries the 'unattributed:*' marker, distinguishable from
+      // any server-emitted error reason.
       const coreState = store.controllerStates.get('core');
       const bodyState = store.controllerStates.get('body');
       // Outer-stage assertions pin the post-condition before the narrow
@@ -1366,7 +1364,7 @@ describe('firmware store', () => {
       }
     });
 
-    it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto failed state (C2 fix)', () => {
+    it('clears pendingByMac so a late LocationStatus cannot replay stale entries onto failed state', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyControllerUpdate({ controllerId: 'orphan-mac', stage: 'SENDING' });
@@ -1381,7 +1379,7 @@ describe('firmware store', () => {
       expect(store.pendingByMac.size).toBe(0);
     });
 
-    it('drops stale flashJobFailed whose jobId does not match currentJob (CR-4)', () => {
+    it('drops stale flashJobFailed whose jobId does not match currentJob', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
         const store = useFirmwareStore();
@@ -1400,7 +1398,7 @@ describe('firmware store', () => {
       }
     });
 
-    it('preserves FAILED entries from pendingByMac in failedControllers (CR-2: bus-wide failure with unmapped MAC)', () => {
+    it('preserves FAILED entries from pendingByMac in failedControllers (bus-wide failure with unmapped MAC)', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
         const store = useFirmwareStore();
@@ -1493,7 +1491,7 @@ describe('firmware store', () => {
       expect(store.currentJobLoadFailed).toBe(true);
     });
 
-    it('treats 404 as expected idle state — does NOT set currentJobLoadFailed (I3 fix)', async () => {
+    it('treats 404 as expected idle state — does NOT set currentJobLoadFailed', async () => {
       // 404 is the healthy idle response from /api/firmware/flash when no
       // flash is in flight. Surfacing it as "could not confirm state" would
       // falsely alarm operators on first page load. Only 5xx and network
@@ -1511,7 +1509,7 @@ describe('firmware store', () => {
       expect(store.currentJobLoadFailed).toBe(true);
     });
 
-    it('skips applying a body with endedAt set (CR-1: mirrors server late-join filter for reboot-wait window)', async () => {
+    it('skips applying a body with endedAt set (mirrors server late-join filter for reboot-wait window)', async () => {
       // Server's decideLateJoinSnapshot skips emitting flashJobStarted on
       // WS reconnect when currentJob.endedAt is set (the 15s reboot-wait
       // window). HTTP must mirror that filter; otherwise a refresh during
@@ -1530,7 +1528,7 @@ describe('firmware store', () => {
       expect(store.currentJobLoadFailed).toBe(false);
     });
 
-    it('NEW-IM2: skips and warns when body.jobId is empty string (server contract violation)', async () => {
+    it('skips and warns when body.jobId is empty string (server contract violation)', async () => {
       // Pre-fix, the `body.jobId` truthy check let empty-string fall
       // through silently — no apply, no warn. A server contract bug
       // emitting `{jobId: ''}` would be invisible. Tightened to an
@@ -1654,10 +1652,11 @@ describe('firmware store', () => {
   });
 
   describe('pending-update replay queue (late-MAC race)', () => {
-    // C1: WS flashControllerUpdate / flashJobStarted entries can arrive for
-    // a padawan before its LocationStatus heartbeat populates the MAC map.
-    // The store queues those payloads keyed by raw MAC and drains them when
-    // controllerStore.setControllerMac is later called (via the dispatcher).
+    // WS flashControllerUpdate / flashJobStarted entries can arrive
+    // for a padawan before its LocationStatus heartbeat populates the
+    // MAC map. The store queues those payloads keyed by raw MAC and
+    // drains them when controllerStore.setControllerMac is later
+    // called (via the dispatcher).
     const LATE_CORE_MAC = 'aa:bb:cc:dd:ee:01';
 
     it('queues a flashControllerUpdate whose MAC is not yet mapped (no controllerStates entry produced)', () => {
@@ -1719,7 +1718,7 @@ describe('firmware store', () => {
       expect(store.pendingByMac.size).toBe(0);
     });
 
-    it('IM-8: logs a distinct re-queue warning when flushPendingForMac re-enqueues during flush (forensic breadcrumb)', () => {
+    it('logs a distinct re-queue warning when flushPendingForMac re-enqueues during flush (forensic breadcrumb)', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
         const store = useFirmwareStore();

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -918,6 +918,80 @@ describe('firmware store', () => {
       store.applyControllerUpdate({ controllerId: 'unmapped-mac', stage: 'SENDING' });
       expect(store.currentJobLoadFailed).toBe(true);
     });
+
+    describe('NEW-IM1: element validation (mirror of IM-3 from buildControllerStatesMap)', () => {
+      it('skips and warns when data.controllerId is missing', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const store = useFirmwareStore();
+          seedSampleFleet();
+          store.applyJobStarted(sampleJobState());
+          const sizeBefore = store.pendingByMac.size;
+          // @ts-expect-error — deliberately omit controllerId
+          store.applyControllerUpdate({ stage: 'SENDING' });
+          expect(store.pendingByMac.size).toBe(sizeBefore);
+          expect(warnSpy.mock.calls.flat().join(' ')).toContain('invalid controllerId');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it('skips and warns when data.controllerId is empty string', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const store = useFirmwareStore();
+          seedSampleFleet();
+          store.applyJobStarted(sampleJobState());
+          const sizeBefore = store.pendingByMac.size;
+          store.applyControllerUpdate({ controllerId: '', stage: 'SENDING' });
+          expect(store.pendingByMac.size).toBe(sizeBefore);
+          expect(warnSpy.mock.calls.flat().join(' ')).toContain('invalid controllerId');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+    });
+
+    describe('NEW-IM3: terminal-phase guard (drops trailing updates after done/failed)', () => {
+      it('drops trailing applyControllerUpdate when phase is done', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const store = useFirmwareStore();
+          seedSampleFleet();
+          store.applyJobStarted(sampleJobState());
+          store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-14T08:05:00Z' });
+          expect(store.phase).toBe('done');
+          const bodyBefore = store.controllerStates.get('body');
+          store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
+          // State unchanged.
+          expect(store.controllerStates.get('body')).toEqual(bodyBefore);
+          expect(warnSpy.mock.calls.flat().join(' ')).toContain('terminal phase');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+
+      it('drops trailing applyControllerUpdate when phase is failed', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+          const store = useFirmwareStore();
+          seedSampleFleet();
+          store.applyJobStarted(sampleJobState());
+          store.applyJobFailed({
+            jobId: 'job-1',
+            endedAt: '2026-05-14T08:05:00Z',
+            reason: 'internal_server_error',
+          });
+          expect(store.phase).toBe('failed');
+          const bodyBefore = store.controllerStates.get('body');
+          store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'REBOOTING' });
+          expect(store.controllerStates.get('body')).toEqual(bodyBefore);
+          expect(warnSpy.mock.calls.flat().join(' ')).toContain('terminal phase');
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+    });
   });
 
   describe('applyControllerResult', () => {
@@ -1454,6 +1528,26 @@ describe('firmware store', () => {
       expect(store.currentJob).toBeNull();
       expect(store.phase).toBe('idle');
       expect(store.currentJobLoadFailed).toBe(false);
+    });
+
+    it('NEW-IM2: skips and warns when body.jobId is empty string (server contract violation)', async () => {
+      // Pre-fix, the `body.jobId` truthy check let empty-string fall
+      // through silently — no apply, no warn. A server contract bug
+      // emitting `{jobId: ''}` would be invisible. Tightened to an
+      // explicit non-empty-string check + forensic warn.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        apiClientGet.mockResolvedValueOnce({
+          data: { ...sampleJobState(), jobId: '' },
+        });
+        const store = useFirmwareStore();
+        seedSampleFleet();
+        await store.fetchCurrentJob();
+        expect(store.currentJob).toBeNull();
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('empty jobId');
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -15,7 +15,7 @@ vi.mock('@/api/apiService', () => ({
 import apiService, { apiClient } from '@/api/apiService';
 import { useFirmwareStore } from '../firmware';
 import { useControllerStore } from '@/stores/controller';
-import { ControllerStatus } from '@/enums';
+import { ControllerStatus, Location } from '@/enums';
 import type {
   ControllerFlashState,
   FlashJobFailedData,
@@ -37,6 +37,12 @@ function seedSampleFleet(opts: { domeStatus?: ControllerStatus } = {}) {
   cs.coreFirmware = 'v1.4.0';
   cs.domeStatus = opts.domeStatus ?? ControllerStatus.DOWN;
   cs.domeFirmware = 'v1.4.0';
+  // Body uses the master sentinel MAC; padawan MACs would normally arrive
+  // via LocationStatus messages. Seed deterministic test MACs so the
+  // firmwareStore's resolver can translate WS controllerIds to slots.
+  cs.setControllerMac(Location.BODY, '00:00:00:00:00:00');
+  cs.setControllerMac(Location.CORE, 'aa:bb:cc:dd:ee:01');
+  cs.setControllerMac(Location.DOME, 'aa:bb:cc:dd:ee:02');
 }
 
 const apiGet = apiService.get as ReturnType<typeof vi.fn>;
@@ -544,16 +550,21 @@ describe('firmware store', () => {
   });
 
   // ------------------------------------------------------------------
-  // d.6 — WebSocket-driven state
+  // WebSocket-driven state
   // ------------------------------------------------------------------
+
+  // MAC values must match seedSampleFleet's setControllerMac() seeding so the
+  // firmwareStore's resolver translates them to body/core slot ids.
+  const BODY_MAC = '00:00:00:00:00:00';
+  const CORE_MAC = 'aa:bb:cc:dd:ee:01';
 
   function sampleJobState(overrides: Partial<FlashJobState> = {}): FlashJobState {
     return {
       jobId: 'job-1',
       source: { kind: 'github', version: 'v1.4.2' },
       controllers: [
-        { controllerId: 'body', stage: 'QUEUED' },
-        { controllerId: 'core', stage: 'QUEUED' },
+        { controllerId: BODY_MAC, stage: 'QUEUED' },
+        { controllerId: CORE_MAC, stage: 'QUEUED' },
       ],
       startedAt: '2026-05-12T08:00:00Z',
       ...overrides,
@@ -594,15 +605,60 @@ describe('firmware store', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
-      store.applyControllerUpdate({ controllerId: 'body', stage: 'SENDING' });
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
       // Simulate reconnect with controllers in a different state.
       const fresh: FlashJobState = sampleJobState({
-        controllers: [{ controllerId: 'body', stage: 'VERIFYING' }],
+        controllers: [{ controllerId: BODY_MAC, stage: 'VERIFYING' }],
       });
       store.applyJobStarted(fresh);
       expect(store.controllerStates.size).toBe(1);
       expect(store.controllerStates.get('body')?.stage).toBe('VERIFYING');
       expect(store.controllerStates.get('core')).toBeUndefined();
+    });
+
+    it('translates MAC controllerIds to slot ids (body/core/dome) via the controllerStore resolver', () => {
+      // Server sends MAC addresses as controllerId; the firmwareStore must
+      // translate them to slot ids so the panel's progressByControllerId[c.id]
+      // lookup (where c.id is 'body'/'core'/'dome') resolves correctly.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      // sampleJobState sends BODY_MAC + CORE_MAC; after translation the Map
+      // is keyed by slot ids, NOT by the raw MAC strings.
+      expect(store.controllerStates.get('body')?.stage).toBe('QUEUED');
+      expect(store.controllerStates.get('core')?.stage).toBe('QUEUED');
+      expect(store.controllerStates.get(BODY_MAC)).toBeUndefined();
+      expect(store.controllerStates.get(CORE_MAC)).toBeUndefined();
+    });
+
+    it('drops entries with unknown controllerIds (MAC mapping not yet learned)', () => {
+      // Edge: applyJobStarted arrives BEFORE LocationStatus has populated
+      // MACs (e.g., cold-load with no prior status). Unknown MACs are
+      // dropped rather than silently keyed by raw MAC.
+      const store = useFirmwareStore();
+      // No seedSampleFleet() — no MAC mappings exist.
+      store.applyJobStarted({
+        ...sampleJobState(),
+        controllers: [{ controllerId: 'unknown-mac', stage: 'QUEUED' }],
+      });
+      expect(store.controllerStates.size).toBe(0);
+    });
+
+    it('does not throw when data.controllers is missing or malformed (defensive)', () => {
+      // FMI hazard: malformed flashJobStarted payload must not lock the UI
+      // in 'flashing' forever. buildControllerStatesMap accepts undefined.
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      expect(() =>
+        store.applyJobStarted({
+          jobId: 'job-malformed',
+          source: { kind: 'github', version: 'v1.4.2' },
+          startedAt: '2026-05-12T08:00:00Z',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any),
+      ).not.toThrow();
+      expect(store.phase).toBe('flashing');
+      expect(store.controllerStates.size).toBe(0);
     });
 
     it('clears flashError and failedController so a previous failure does not bleed into the new job', () => {
@@ -622,11 +678,11 @@ describe('firmware store', () => {
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
 
-      store.applyControllerUpdate({ controllerId: 'body', stage: 'UPLOADING_TO_MASTER' });
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'UPLOADING_TO_MASTER' });
       expect(store.controllerStates.get('body')?.stage).toBe('UPLOADING_TO_MASTER');
       expect(store.currentStage).toBe('download');
 
-      store.applyControllerUpdate({ controllerId: 'body', stage: 'VERIFYING' });
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'VERIFYING' });
       expect(store.currentStage).toBe('verify');
     });
 
@@ -634,10 +690,10 @@ describe('firmware store', () => {
       const store = useFirmwareStore();
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
-      store.applyControllerUpdate({ controllerId: 'body', stage: 'SENDING' });
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
       const before = store.currentStage;
       store.applyControllerUpdate({
-        controllerId: 'body',
+        controllerId: BODY_MAC,
         stage: 'VERSION_CONFIRMED',
         finalVersion: 'v1.4.2',
       });
@@ -649,7 +705,7 @@ describe('firmware store', () => {
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
       const before = store.controllerStates;
-      store.applyControllerUpdate({ controllerId: 'body', stage: 'SENDING' });
+      store.applyControllerUpdate({ controllerId: BODY_MAC, stage: 'SENDING' });
       expect(store.controllerStates).not.toBe(before);
     });
   });
@@ -661,7 +717,7 @@ describe('firmware store', () => {
       store.applyJobStarted(sampleJobState());
       store.applyControllerResult({
         jobId: 'job-1',
-        controller: { controllerId: 'core', stage: 'VERSION_CONFIRMED', finalVersion: 'v1.4.2' },
+        controller: { controllerId: CORE_MAC, stage: 'VERSION_CONFIRMED', finalVersion: 'v1.4.2' },
       });
       expect(store.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
     });
@@ -686,15 +742,32 @@ describe('firmware store', () => {
       const data: FlashJobFailedData = {
         jobId: 'job-1',
         endedAt: '2026-05-12T08:05:00Z',
-        reason: 'hash_mismatch',
+        reason: 'hash_mismatch', // post-streamer reason — not in FlashErrorReason
         detail: 'asset checksum mismatch on Core',
         abortReason: 'hash_mismatch',
       };
       store.applyJobFailed(data);
       expect(store.phase).toBe('failed');
       expect(store.currentJob?.endedAt).toBe('2026-05-12T08:05:00Z');
+      // Unrecognized reason falls back to internal_server_error so the banner
+      // shows generic copy rather than a missing-i18n-key path.
       expect(store.flashError?.reason).toBe('internal_server_error');
       expect(store.flashError?.detail).toBe('asset checksum mismatch on Core');
+    });
+
+    it('maps recognized server reasons through to FlashErrorReason verbatim', () => {
+      // Pre-streamer reasons in FlashErrorReason should reach the banner so
+      // the operator sees specific copy (e.g., "Pick at least one controller"
+      // for `no_controllers`).
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      store.applyJobStarted(sampleJobState());
+      store.applyJobFailed({
+        jobId: 'job-1',
+        endedAt: '2026-05-12T08:05:00Z',
+        reason: 'release_not_found',
+      });
+      expect(store.flashError?.reason).toBe('release_not_found');
     });
 
     it('derives failedController from the FAILED entry in controllerStates', () => {
@@ -702,7 +775,7 @@ describe('firmware store', () => {
       seedSampleFleet();
       store.applyJobStarted(sampleJobState());
       store.applyControllerUpdate({
-        controllerId: 'core',
+        controllerId: CORE_MAC,
         stage: 'FAILED',
         error: 'hash_mismatch',
       });

--- a/astros_vue/src/stores/__tests__/firmware.spec.ts
+++ b/astros_vue/src/stores/__tests__/firmware.spec.ts
@@ -822,6 +822,28 @@ describe('firmware store', () => {
       });
       expect(store.controllerStates.get('core')?.stage).toBe('VERSION_CONFIRMED');
     });
+
+    it('drops stale events whose jobId does not match currentJob (post-reconnect race protection)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const store = useFirmwareStore();
+        seedSampleFleet();
+        store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
+        const beforeStage = store.controllerStates.get('core')?.stage;
+        store.applyControllerResult({
+          jobId: 'job-A',
+          controller: {
+            controllerId: CORE_MAC,
+            stage: 'VERSION_CONFIRMED',
+            finalVersion: 'v9.9.9',
+          },
+        });
+        expect(store.controllerStates.get('core')?.stage).toBe(beforeStage);
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('jobId mismatch');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   describe('applyJobDone', () => {
@@ -899,6 +921,22 @@ describe('firmware store', () => {
       store.applyJobDone({ jobId: 'job-1', endedAt: '2026-05-12T08:05:00Z' });
 
       expect(store.pendingByMac.size).toBe(0);
+    });
+
+    it('drops stale flashJobDone whose jobId does not match currentJob (CR-4)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const store = useFirmwareStore();
+        seedSampleFleet();
+        store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
+        expect(store.phase).toBe('flashing');
+        store.applyJobDone({ jobId: 'job-A', endedAt: '2026-05-14T08:00:00Z' });
+        expect(store.phase).toBe('flashing');
+        expect(store.currentJob?.endedAt).toBeUndefined();
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('jobId mismatch');
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 
@@ -1134,6 +1172,50 @@ describe('firmware store', () => {
 
       expect(store.pendingByMac.size).toBe(0);
     });
+
+    it('drops stale flashJobFailed whose jobId does not match currentJob (CR-4)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const store = useFirmwareStore();
+        seedSampleFleet();
+        store.applyJobStarted(sampleJobState({ jobId: 'job-B' }));
+        store.applyJobFailed({
+          jobId: 'job-A',
+          endedAt: '2026-05-14T08:00:00Z',
+          reason: 'internal_server_error',
+        });
+        expect(store.phase).toBe('flashing');
+        expect(store.flashError).toBeNull();
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('jobId mismatch');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('preserves FAILED entries from pendingByMac in failedControllers (CR-2: bus-wide failure with unmapped MAC)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const store = useFirmwareStore();
+        seedSampleFleet();
+        store.applyJobStarted(sampleJobState({ jobId: 'job-1' }));
+        store.applyControllerUpdate({
+          controllerId: 'aa:bb:cc:dd:ee:99',
+          stage: 'FAILED',
+          error: 'esp_now timeout',
+        });
+        expect(store.pendingByMac.get('aa:bb:cc:dd:ee:99')?.length).toBe(1);
+        store.applyJobFailed({
+          jobId: 'job-1',
+          endedAt: '2026-05-14T08:01:00Z',
+          reason: 'internal_server_error',
+        });
+        const failedIds = store.failedControllers.map((c) => c.id);
+        expect(failedIds).toContain('aa:bb:cc:dd:ee:99');
+        expect(warnSpy.mock.calls.flat().join(' ')).toContain('FAILED entry for unmapped MAC');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   describe('isOwnJob', () => {
@@ -1219,6 +1301,25 @@ describe('firmware store', () => {
       const store = useFirmwareStore();
       await store.fetchCurrentJob();
       expect(store.currentJobLoadFailed).toBe(true);
+    });
+
+    it('skips applying a body with endedAt set (CR-1: mirrors server late-join filter for reboot-wait window)', async () => {
+      // Server's decideLateJoinSnapshot skips emitting flashJobStarted on
+      // WS reconnect when currentJob.endedAt is set (the 15s reboot-wait
+      // window). HTTP must mirror that filter; otherwise a refresh during
+      // reboot-wait would populate the store at phase='flashing' with no
+      // subsequent WS event to transition us out, wedging the UI.
+      const endedJob = sampleJobState({
+        jobId: 'job-completed',
+        endedAt: '2026-05-14T08:00:15Z',
+      });
+      apiClientGet.mockResolvedValueOnce({ data: endedJob });
+      const store = useFirmwareStore();
+      seedSampleFleet();
+      await store.fetchCurrentJob();
+      expect(store.currentJob).toBeNull();
+      expect(store.phase).toBe('idle');
+      expect(store.currentJobLoadFailed).toBe(false);
     });
   });
 

--- a/astros_vue/src/stores/controller.ts
+++ b/astros_vue/src/stores/controller.ts
@@ -1,9 +1,15 @@
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 import type { ControllerModule, ControllerSync } from '@/models';
 import apiService from '@/api/apiService';
 import { SYNC_CONTROLLERS } from '@/api/endpoints';
-import { ControllerStatus } from '@/enums';
+import { ControllerStatus, Location } from '@/enums';
+
+// Master controllers always report POLL_ACK with this MAC sentinel; padawan
+// MACs are learned at LocationStatus time. See project memory
+// `project_master_esp_sentinel_mac`. Used to seed body's MAC → location
+// resolution on cold-load, before any LocationStatus has arrived.
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
 
 export const useControllerStore = defineStore('controller', () => {
   const controllers = ref<ControllerModule[]>([]);
@@ -18,6 +24,41 @@ export const useControllerStore = defineStore('controller', () => {
   const domeFirmware = ref<string | undefined>();
   const coreFirmware = ref<string | undefined>();
   const bodyFirmware = ref<string | undefined>();
+
+  // Per-location MAC tracking. Padawan MACs are learned from LocationStatus
+  // messages; body's MAC is the well-known sentinel. The firmware view needs
+  // this to translate WS `controllerId` (MAC) back to a slot.
+  const bodyMac = ref<string>(MASTER_SENTINEL_MAC);
+  const coreMac = ref<string | null>(null);
+  const domeMac = ref<string | null>(null);
+
+  /**
+   * Resolve a wire-level controller id (MAC) to a Location slot. Returns null
+   * for unknown MACs (fleet drift, server contract change, etc.) so callers
+   * can surface a dev warning instead of silently dropping events.
+   */
+  const controllerIdToLocation = computed<(mac: string) => Location | null>(() => {
+    const map = new Map<string, Location>();
+    map.set(bodyMac.value, Location.BODY);
+    if (coreMac.value !== null) map.set(coreMac.value, Location.CORE);
+    if (domeMac.value !== null) map.set(domeMac.value, Location.DOME);
+    return (mac: string) => map.get(mac) ?? null;
+  });
+
+  function setControllerMac(location: Location, mac: string): void {
+    switch (location) {
+      case Location.BODY:
+        bodyMac.value = mac;
+        break;
+      case Location.CORE:
+        coreMac.value = mac;
+        break;
+      case Location.DOME:
+        domeMac.value = mac;
+        break;
+      // Location.UNKNOWN → no-op.
+    }
+  }
 
   async function syncControllers() {
     isSyncing.value = true;
@@ -73,6 +114,11 @@ export const useControllerStore = defineStore('controller', () => {
     domeFirmware,
     coreFirmware,
     bodyFirmware,
+    bodyMac,
+    coreMac,
+    domeMac,
+    controllerIdToLocation,
+    setControllerMac,
     syncControllers,
     setControllers,
     controllerSyncResponse,

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -71,7 +71,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
   const phase = ref<FirmwarePhase>('idle');
   const currentStage = ref<FirmwareStage | null>(null);
   const flashError = ref<FlashErrorEnvelope | null>(null);
-  const failedController = ref<{ id: string; label: string; stage: FirmwareStage } | null>(null);
+  // All controllers that ended this job in stage='FAILED'. Multi-failure is
+  // realistic (e.g. ESP-NOW bus failure fails both padawans simultaneously);
+  // surfacing only the first would let the operator walk away from a bricked
+  // controller. Empty array means no FAILED entries were observed.
+  const failedControllers = ref<Array<{ id: string; label: string; stage: FirmwareStage }>>([]);
 
   // WS-pushed state. Apply* handlers below are the sole writers.
   const currentJob = ref<FlashJobState | null>(null);
@@ -79,6 +83,16 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // Set by `startFlash` from the POST response so the UI can tell whether the
   // active flash belongs to us vs. another operator (lock-conflict UI).
   const ownJobId = ref<string | null>(null);
+
+  // Queue of ControllerFlashState payloads dropped because their MAC wasn't
+  // yet in the controllerStore's resolver. The cold-load / late-join race:
+  // flashJobStarted (or flashControllerUpdate) for a padawan can arrive
+  // before its LocationStatus heartbeat has populated the MAC mapping.
+  // Without this queue, the dropped event is lost forever and the row
+  // freezes at its last-seen stage (or never gets a pill at all). The queue
+  // is keyed by raw MAC; `flushPendingForMac` replays on setControllerMac.
+  // Cleared on resetToSelect so stale drift from a prior flash can't bleed in.
+  const pendingByMac = ref<Map<string, ControllerFlashState[]>>(new Map());
 
   // Project the per-location controller store into a fleet shape the firmware
   // view consumes. Reads are reactive through useControllerStore — changes
@@ -169,10 +183,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
     phase.value = 'select';
     currentStage.value = null;
     flashError.value = null;
-    failedController.value = null;
+    failedControllers.value = [];
     currentJob.value = null;
     controllerStates.value = new Map();
     ownJobId.value = null;
+    pendingByMac.value = new Map();
   }
 
   function dismissError(): void {
@@ -193,6 +208,12 @@ export const useFirmwareStore = defineStore('firmware', () => {
     return loc;
   }
 
+  function enqueuePending(state: ControllerFlashState): void {
+    const queue = pendingByMac.value.get(state.controllerId) ?? [];
+    queue.push(state);
+    pendingByMac.value.set(state.controllerId, queue);
+  }
+
   function buildControllerStatesMap(
     states: ReadonlyArray<ControllerFlashState> | undefined,
   ): ReadonlyMap<string, ControllerFlashState> {
@@ -204,12 +225,14 @@ export const useFirmwareStore = defineStore('firmware', () => {
     for (const s of states) {
       const slot = resolveSlot(s.controllerId);
       if (slot === null) {
-        if (import.meta.env.DEV) {
-          console.warn(
-            `[firmwareStore] applyJobStarted: unknown controllerId="${s.controllerId}" ` +
-              `(no MAC → location mapping yet). Dropping this entry; LocationStatus must arrive first.`,
-          );
-        }
+        // Queue for replay when LocationStatus eventually learns this MAC.
+        // Without queuing, late-arriving LocationStatus would never recover
+        // the dropped snapshot entry and the row would render with no pill.
+        enqueuePending(s);
+        console.warn(
+          `[firmwareStore] applyJobStarted: unknown controllerId="${s.controllerId}" ` +
+            `(no MAC → location mapping yet). Queued for replay.`,
+        );
         continue;
       }
       // Re-key by slot so the panel's progressByControllerId[c.id] lookup
@@ -230,18 +253,18 @@ export const useFirmwareStore = defineStore('firmware', () => {
     controllerStates.value = buildControllerStatesMap(data.controllers);
     if (phase.value !== 'flashing') phase.value = 'flashing';
     flashError.value = null;
-    failedController.value = null;
+    failedControllers.value = [];
   }
 
   function applyControllerUpdate(data: ControllerFlashState): void {
     const slot = resolveSlot(data.controllerId);
     if (slot === null) {
-      if (import.meta.env.DEV) {
-        console.warn(
-          `[firmwareStore] applyControllerUpdate: unknown controllerId="${data.controllerId}". ` +
-            `Update ignored. LocationStatus must populate the MAC mapping first.`,
-        );
-      }
+      // Queue for replay; see pendingByMac comment above.
+      enqueuePending(data);
+      console.warn(
+        `[firmwareStore] applyControllerUpdate: unknown controllerId="${data.controllerId}". ` +
+          `Queued for replay; LocationStatus must arrive to drain the queue.`,
+      );
       return;
     }
     const next = new Map(controllerStates.value);
@@ -249,6 +272,33 @@ export const useFirmwareStore = defineStore('firmware', () => {
     controllerStates.value = next;
     const ui = mapServerStageToUiStage(data.stage);
     if (ui !== null) currentStage.value = ui;
+  }
+
+  /**
+   * Drain queued ControllerFlashState payloads for `mac` and re-apply them.
+   * Called by `useWebsocket.handleStatusMessage` right after the controller
+   * store learns a new MAC mapping. Idempotent: a flush with no pending
+   * entries is a no-op. Replays in insertion order so the final state
+   * reflects the most recent server-pushed stage.
+   */
+  function flushPendingForMac(mac: string): void {
+    const queue = pendingByMac.value.get(mac);
+    if (!queue || queue.length === 0) return;
+    pendingByMac.value.delete(mac);
+    for (const entry of queue) {
+      applyControllerUpdate(entry);
+    }
+    // Re-queue detection: if applyControllerUpdate re-enqueued because
+    // resolveSlot still returned null (controllerStore/firmwareStore race
+    // gap), the entries are stuck. Distinct log so a production stuck-replay
+    // loop is visible — the bare warn in applyControllerUpdate can't
+    // distinguish first-queue from re-queue-during-flush.
+    if (pendingByMac.value.has(mac)) {
+      console.warn(
+        `[firmwareStore] flushPendingForMac: re-queued during flush for mac="${mac}". ` +
+          `MAC mapping inconsistency between controllerStore and firmwareStore.`,
+      );
+    }
   }
 
   function applyControllerResult(payload: {
@@ -289,19 +339,22 @@ export const useFirmwareStore = defineStore('firmware', () => {
         ? (data.reason as FlashErrorReason)
         : 'internal_server_error';
     flashError.value = { reason, detail: data.detail };
-    // Find the controller that ended in FAILED; surface its label + UI stage.
+    // Collect ALL controllers that ended in FAILED. Multi-failure is realistic
+    // (e.g. bus-wide ESP-NOW failure fails both padawans at once); surfacing
+    // only the first would let the operator walk away from a bricked unit.
+    const failed: Array<{ id: string; label: string; stage: FirmwareStage }> = [];
     for (const state of controllerStates.value.values()) {
       if (state.stage === 'FAILED') {
         const c = controllers.value.find((x) => x.id === state.controllerId);
         const uiStage = mapServerStageToUiStage(state.stage) ?? currentStage.value ?? 'transfer';
-        failedController.value = {
+        failed.push({
           id: state.controllerId,
           label: c?.label ?? state.controllerId,
           stage: uiStage,
-        };
-        break;
+        });
       }
     }
+    failedControllers.value = failed;
     currentStage.value = null;
   }
 
@@ -430,10 +483,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
     phase,
     currentStage,
     flashError,
-    failedController,
+    failedControllers,
     currentJob,
     controllerStates,
     ownJobId,
+    pendingByMac,
     target,
     anyDowngradeBlocked,
     canFlash,
@@ -450,6 +504,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     applyControllerResult,
     applyJobDone,
     applyJobFailed,
+    flushPendingForMac,
     startFlash,
     cancelFlash,
     fetchCurrentJob,

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -356,14 +356,25 @@ export const useFirmwareStore = defineStore('firmware', () => {
     currentStage.value = null;
     // Normalize any per-controller state that's still mid-flow to
     // VERSION_CONFIRMED. The server emits flashJobDone when the LAST
-    // VERSION_CONFIRMED is observed, but a flashControllerUpdate carrying
-    // that final stage may not have drained the WS buffer yet (or may
-    // never arrive in some race orderings). Without this normalize, the
-    // panel renders the "✓ all updated" result bar while individual rows
-    // still spin at "updating" — visibly contradictory operator state.
+    // VERSION_CONFIRMED is observed, but the carrying flashControllerResult
+    // may not have drained the WS buffer yet (or may never arrive in some
+    // race orderings). Without this normalize, the panel renders the "✓
+    // all updated" result bar while individual rows still spin at
+    // "updating" — visibly contradictory operator state.
+    //
+    // Trade-off: this MASKS a real bug if the server emits flashJobDone
+    // prematurely (orchestrator race, dropped final POLL_ACK, etc.). A
+    // non-terminal row would silently be relabeled VERSION_CONFIRMED. The
+    // console.warn below is the post-incident breadcrumb — operators
+    // won't see it, but server logs + dev console will surface drift.
     const normalized = new Map(controllerStates.value);
     for (const [slot, state] of normalized) {
       if (state.stage !== 'VERSION_CONFIRMED' && state.stage !== 'FAILED') {
+        console.warn(
+          `[firmwareStore] applyJobDone: normalizing non-terminal stage="${state.stage}" ` +
+            `for slot="${slot}" to VERSION_CONFIRMED. ` +
+            `Server emitted job-done before this controller reached terminal — verify the controller actually flashed.`,
+        );
         normalized.set(slot, { ...state, stage: 'VERSION_CONFIRMED' });
       }
     }
@@ -403,14 +414,31 @@ export const useFirmwareStore = defineStore('firmware', () => {
         ? (data.reason as FlashErrorReason)
         : 'internal_server_error';
     flashError.value = { reason, detail: data.detail };
-    // Collect ALL controllers that ended in FAILED. Multi-failure is realistic
-    // (e.g. bus-wide ESP-NOW failure fails both padawans at once); surfacing
-    // only the first would let the operator walk away from a bricked unit.
-    // The stage is taken from `currentStage` at the time of failure if known;
-    // otherwise null. The previous 'transfer' literal fallback misattributed
-    // every unknown-stage failure to the transfer step.
+    // Normalize any per-controller state still mid-flow to FAILED. Mirrors
+    // applyJobDone's normalize (round-5 I4) but for the failure path: a
+    // controller stuck at QUEUED/SENDING when the job ends has by
+    // definition NOT confirmed, so showing a spinning "updating" pill
+    // beneath the "failed" result bar is contradictory. Demote to FAILED
+    // with no `error` string — the absence signals "unattributed" vs the
+    // server-emitted FAILED entries that carry the real `error` reason.
+    const normalized = new Map(controllerStates.value);
+    for (const [slot, state] of normalized) {
+      if (state.stage !== 'VERSION_CONFIRMED' && state.stage !== 'FAILED') {
+        console.warn(
+          `[firmwareStore] applyJobFailed: demoting non-terminal stage="${state.stage}" ` +
+            `for slot="${slot}" to FAILED (unattributed). Job ended before this controller reached a terminal stage.`,
+        );
+        normalized.set(slot, { ...state, stage: 'FAILED' });
+      }
+    }
+    controllerStates.value = normalized;
+    // Collect ALL controllers that ended in FAILED (including the ones we
+    // just demoted). Multi-failure is realistic (bus-wide ESP-NOW failure
+    // fails both padawans); surfacing only the first would let the
+    // operator walk away from a bricked unit. The stage reflects
+    // `currentStage` at failure time — null when no stage was current.
     const failed: Array<{ id: string; label: string; stage: FirmwareStage | null }> = [];
-    for (const state of controllerStates.value.values()) {
+    for (const state of normalized.values()) {
       if (state.stage === 'FAILED') {
         const c = controllers.value.find((x) => x.id === state.controllerId);
         failed.push({

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -354,10 +354,24 @@ export const useFirmwareStore = defineStore('firmware', () => {
     jobId: string;
     controller: ControllerFlashState;
   }): void {
+    if (currentJob.value !== null && payload.jobId !== currentJob.value.jobId) {
+      console.warn(
+        `[firmwareStore] applyControllerResult: jobId mismatch ` +
+          `(payload="${payload.jobId}" current="${currentJob.value.jobId}"). Dropping stale event.`,
+      );
+      return;
+    }
     applyControllerUpdate(payload.controller);
   }
 
   function applyJobDone(data: { jobId: string; endedAt: string }): void {
+    if (currentJob.value !== null && data.jobId !== currentJob.value.jobId) {
+      console.warn(
+        `[firmwareStore] applyJobDone: jobId mismatch ` +
+          `(event="${data.jobId}" current="${currentJob.value.jobId}"). Dropping stale event.`,
+      );
+      return;
+    }
     if (currentJob.value) {
       currentJob.value = { ...currentJob.value, endedAt: data.endedAt };
     }
@@ -401,6 +415,13 @@ export const useFirmwareStore = defineStore('firmware', () => {
   }
 
   function applyJobFailed(data: FlashJobFailedData): void {
+    if (currentJob.value !== null && data.jobId !== currentJob.value.jobId) {
+      console.warn(
+        `[firmwareStore] applyJobFailed: jobId mismatch ` +
+          `(event="${data.jobId}" current="${currentJob.value.jobId}"). Dropping stale event.`,
+      );
+      return;
+    }
     // Pre-streamer failures (release_not_found, variant_mismatch, etc.)
     // arrive without a prior flashJobStarted, so currentJob may be null.
     // We deliberately do NOT synthesize a currentJob in that case — the
@@ -450,9 +471,13 @@ export const useFirmwareStore = defineStore('firmware', () => {
     for (const state of normalized.values()) {
       if (state.stage === 'FAILED') {
         // state.controllerId has been re-keyed to a SlotId by
-        // buildControllerStatesMap / applyControllerUpdate. The cast is the
-        // single attestation site — see types/firmware.ts ControllerFlashState
-        // doc comment for the pre/post-translation contract.
+        // buildControllerStatesMap / applyControllerUpdate — this cast
+        // attests the post-translation type. See types/firmware.ts
+        // ControllerFlashState doc comment for the pre/post-translation
+        // contract. A second `as SlotId` cast lives below (the CR-2
+        // unmapped-MAC sweep) — that one has different semantics: a raw
+        // MAC string is forced into the SlotId slot because the operator
+        // is better served seeing a real MAC than no entry at all.
         const slot = state.controllerId as SlotId;
         const c = controllers.value.find((x) => x.id === slot);
         failed.push({
@@ -460,6 +485,29 @@ export const useFirmwareStore = defineStore('firmware', () => {
           label: c?.label ?? slot,
           stage: currentStage.value,
         });
+      }
+    }
+    // CR-2 sweep: pendingByMac may hold FAILED entries that never got
+    // LocationStatus mapping (bus-wide ESP-NOW failures can mark a
+    // padawan FAILED before its heartbeat arrives). Surface them via
+    // MAC as the label so the operator sees the full bricked-controller
+    // list, not just the mapped subset.
+    for (const [mac, queue] of pendingByMac.value) {
+      for (const entry of queue) {
+        if (entry.stage === 'FAILED') {
+          console.warn(
+            `[firmwareStore] applyJobFailed: FAILED entry for unmapped MAC="${mac}" ` +
+              `surfaced from pendingByMac. LocationStatus never arrived; using MAC as label.`,
+          );
+          // Second `as SlotId` cast site — IM-11 (Phase B) splits the
+          // wire vs slot views and removes this cast. Until then, the
+          // runtime warn above is the forensic breadcrumb.
+          failed.push({
+            id: mac as SlotId,
+            label: mac,
+            stage: currentStage.value,
+          });
+        }
       }
     }
     failedControllers.value = failed;
@@ -555,8 +603,17 @@ export const useFirmwareStore = defineStore('firmware', () => {
     try {
       const response = await apiClient.get(FIRMWARE_FLASH);
       const body = response.data as FlashJobState | null;
-      if (body && body.jobId && currentJob.value === null) {
+      // Mirror server-side decideLateJoinSnapshot: a job with endedAt is in
+      // the reboot-wait window. The server will NOT emit a subsequent
+      // flashJobStarted on the WS, so populating the store here would
+      // wedge phase at 'flashing' indefinitely until the next refresh.
+      if (body && body.jobId && body.endedAt === undefined && currentJob.value === null) {
         applyJobStarted(body);
+      } else if (body && body.jobId && body.endedAt !== undefined) {
+        console.info(
+          `[firmwareStore] fetchCurrentJob: server returned job in reboot-wait window ` +
+            `(jobId="${body.jobId}", endedAt="${body.endedAt}"). Skipping apply to avoid wedge.`,
+        );
       }
       currentJobLoadFailed.value = false;
     } catch (error) {

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -76,8 +76,12 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // All controllers that ended this job in stage='FAILED'. Multi-failure is
   // realistic (e.g. ESP-NOW bus failure fails both padawans simultaneously);
   // surfacing only the first would let the operator walk away from a bricked
-  // controller. Empty array means no FAILED entries were observed.
-  const failedControllers = ref<Array<{ id: string; label: string; stage: FirmwareStage }>>([]);
+  // controller. Empty array means no FAILED entries were observed. `stage`
+  // is `FirmwareStage | null` — null when we can't honestly attribute the
+  // failure to a specific stage (rather than fabricating 'transfer').
+  const failedControllers = ref<Array<{ id: string; label: string; stage: FirmwareStage | null }>>(
+    [],
+  );
 
   // WS-pushed state. Apply* handlers below are the sole writers.
   const currentJob = ref<FlashJobState | null>(null);
@@ -195,6 +199,18 @@ export const useFirmwareStore = defineStore('firmware', () => {
 
   function dismissError(): void {
     flashError.value = null;
+  }
+
+  /**
+   * Single writer for `flashError`. The dispatcher's malformed-payload
+   * catch blocks route through this rather than mutating the ref directly
+   * so a future "who wrote this flashError" investigation has one site to
+   * audit. The store's apply* handlers manage flashError internally per
+   * job-lifecycle (cleared on applyJobStarted; not auto-cleared by
+   * subsequent successful updates).
+   */
+  function setFlashError(envelope: FlashErrorEnvelope): void {
+    flashError.value = envelope;
   }
 
   // ---------- WS handlers (the sole writers of server-pushed fields) ----------
@@ -338,6 +354,20 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
     phase.value = 'done';
     currentStage.value = null;
+    // Normalize any per-controller state that's still mid-flow to
+    // VERSION_CONFIRMED. The server emits flashJobDone when the LAST
+    // VERSION_CONFIRMED is observed, but a flashControllerUpdate carrying
+    // that final stage may not have drained the WS buffer yet (or may
+    // never arrive in some race orderings). Without this normalize, the
+    // panel renders the "✓ all updated" result bar while individual rows
+    // still spin at "updating" — visibly contradictory operator state.
+    const normalized = new Map(controllerStates.value);
+    for (const [slot, state] of normalized) {
+      if (state.stage !== 'VERSION_CONFIRMED' && state.stage !== 'FAILED') {
+        normalized.set(slot, { ...state, stage: 'VERSION_CONFIRMED' });
+      }
+    }
+    controllerStates.value = normalized;
     // Terminal state — the staleness banner is no longer relevant. Without
     // this clear, a fetchCurrentJob failure earlier in the session would
     // leave the warning visible on top of the legitimate done-flash UI.
@@ -376,15 +406,17 @@ export const useFirmwareStore = defineStore('firmware', () => {
     // Collect ALL controllers that ended in FAILED. Multi-failure is realistic
     // (e.g. bus-wide ESP-NOW failure fails both padawans at once); surfacing
     // only the first would let the operator walk away from a bricked unit.
-    const failed: Array<{ id: string; label: string; stage: FirmwareStage }> = [];
+    // The stage is taken from `currentStage` at the time of failure if known;
+    // otherwise null. The previous 'transfer' literal fallback misattributed
+    // every unknown-stage failure to the transfer step.
+    const failed: Array<{ id: string; label: string; stage: FirmwareStage | null }> = [];
     for (const state of controllerStates.value.values()) {
       if (state.stage === 'FAILED') {
         const c = controllers.value.find((x) => x.id === state.controllerId);
-        const uiStage = mapServerStageToUiStage(state.stage) ?? currentStage.value ?? 'transfer';
         failed.push({
           id: state.controllerId,
           label: c?.label ?? state.controllerId,
-          stage: uiStage,
+          stage: currentStage.value,
         });
       }
     }
@@ -572,6 +604,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     setPhase,
     resetToSelect,
     dismissError,
+    setFlashError,
     applyJobStarted,
     applyControllerUpdate,
     applyControllerResult,

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -86,10 +86,9 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // WS-pushed state. Apply* handlers + resetToSelect are the writers
   // (resetToSelect for the operator-driven clear; apply* for live state).
   const currentJob = ref<FlashJobState | null>(null);
-  // IM-11: in-store view is keyed by SlotId and uses the by-slot variant
-  // (controllerId is also SlotId). The wire-side ControllerFlashState
-  // (controllerId: MAC string) is translated to ControllerFlashStateBySlot
-  // at the buildControllerStatesMap / applyControllerUpdate boundary.
+  // Keyed by SlotId. Wire-side ControllerFlashState carries a MAC string
+  // for controllerId; that's translated to a SlotId at the
+  // buildControllerStatesMap / applyControllerUpdate boundary.
   const controllerStates = ref<ReadonlyMap<SlotId, ControllerFlashStateBySlot>>(new Map());
   // Set by `startFlash` from the POST response so the UI can tell whether the
   // active flash belongs to us vs. another operator (lock-conflict UI).
@@ -250,25 +249,23 @@ export const useFirmwareStore = defineStore('firmware', () => {
     pendingByMac.value.set(state.controllerId, queue);
   }
 
-  // IM-11: this is the ONLY MAC -> SlotId translation site. Returns the
-  // by-slot view; the wire-side ControllerFlashState's MAC `controllerId`
-  // is replaced by the resolved SlotId so downstream consumers don't need
-  // to cast.
+  // The single MAC → SlotId translation site. The returned map and
+  // every embedded controllerId is keyed by SlotId; downstream consumers
+  // don't need to translate.
   function buildControllerStatesMap(
     states: ReadonlyArray<ControllerFlashState> | undefined,
   ): ReadonlyMap<SlotId, ControllerFlashStateBySlot> {
     const m = new Map<SlotId, ControllerFlashStateBySlot>();
-    // IM-3 defensive: reject non-array payloads. Without this guard, a
-    // string flows through `for...of` as per-character iteration and
-    // pollutes pendingByMac with garbage; an object iterates not-at-all
-    // (no Symbol.iterator). The empty Map is a valid intermediate state —
-    // flashControllerUpdate events will populate it as they arrive.
+    // Defensive: a string would iterate per-character via for...of and
+    // populate pendingByMac with garbage one-char entries; an object
+    // throws TypeError (no Symbol.iterator). Empty map is a valid
+    // intermediate state — updates will populate it as they arrive.
     if (!Array.isArray(states)) return m;
     for (const s of states) {
-      // IM-3 element validation: a malformed entry with no/non-string
-      // controllerId would call `resolveSlot(undefined)` and queue under
-      // an `undefined` key, polluting pendingByMac. Skip + warn so ops
-      // can trace the malformed payload back to its server source.
+      // A malformed entry with no/non-string controllerId would call
+      // resolveSlot(undefined) and queue under an undefined key — never
+      // drained, never surfaced. Skip + warn so ops can trace the
+      // malformed payload back to its source.
       if (!s || typeof s.controllerId !== 'string' || s.controllerId.length === 0) {
         console.warn(
           `[firmwareStore] buildControllerStatesMap: skipping element with invalid controllerId`,
@@ -318,11 +315,9 @@ export const useFirmwareStore = defineStore('firmware', () => {
   }
 
   function applyControllerUpdate(data: ControllerFlashState): void {
-    // NEW-IM1: mirror IM-3's element validation from buildControllerStatesMap.
-    // A malformed mid-stream flashControllerUpdate (no controllerId / non-
-    // string / empty) would otherwise call resolveSlot(undefined) and
-    // pollute pendingByMac under an undefined key — the CR-2 sweep then
-    // surfaces `{id: 'undefined', label: 'undefined'}` in failedControllers.
+    // Without this guard, resolveSlot(undefined) returns null and the
+    // entry queues under an undefined key — never drained, polluting
+    // pendingByMac and surfacing as "undefined" in failedControllers.
     if (!data || typeof data.controllerId !== 'string' || data.controllerId.length === 0) {
       console.warn(
         `[firmwareStore] applyControllerUpdate: skipping element with invalid controllerId`,
@@ -330,12 +325,9 @@ export const useFirmwareStore = defineStore('firmware', () => {
       );
       return;
     }
-    // NEW-IM3: terminal-phase guard. After applyJobDone normalizes states
-    // to VERSION_CONFIRMED (or applyJobFailed demotes to FAILED), a trailing
-    // flashControllerUpdate from the same job (server retransmit, buffered
-    // event flush) would mutate controllerStates and silently flip a row's
-    // pill from 'done' back to 'updating' while the footer still claims
-    // "✓ all updated".
+    // Drop trailing updates after terminal phase: a server retransmit or
+    // buffered event flush would otherwise flip a row's pill from 'done'
+    // back to 'updating' beneath a footer claiming "all updated."
     if (phase.value === 'done' || phase.value === 'failed') {
       console.warn(
         `[firmwareStore] applyControllerUpdate: dropping update for controllerId="${data.controllerId}" — job already at terminal phase="${phase.value}"`,
@@ -444,11 +436,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
             `for slot="${slot}" to VERSION_CONFIRMED. ` +
             `Server emitted job-done before this controller reached terminal — verify the controller actually flashed.`,
         );
-        // IM-2 discriminated union: VERSION_CONFIRMED requires finalVersion.
-        // We don't have one (server never emitted the explicit transition),
-        // so use the placeholder string that the renderer can recognize as
-        // unattributed (the leading "unknown:" prefix is searchable in ops
-        // logs and distinct from any real version string).
+        // The discriminated union requires finalVersion on VERSION_CONFIRMED.
+        // No real version available here, so use a searchable marker — the
+        // "unknown:" prefix is distinct from any real version string and
+        // greppable in ops logs.
         normalized.set(slot, {
           controllerId: state.controllerId,
           stage: 'VERSION_CONFIRMED',
@@ -499,13 +490,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
         ? (data.reason as FlashErrorReason)
         : 'internal_server_error';
     setFlashError({ reason, detail: data.detail });
-    // Normalize any per-controller state still mid-flow to FAILED. Mirrors
-    // applyJobDone's normalize (round-5 I4) but for the failure path: a
-    // controller stuck at QUEUED/SENDING when the job ends has by
-    // definition NOT confirmed, so showing a spinning "updating" pill
-    // beneath the "failed" result bar is contradictory. Demote to FAILED
-    // with no `error` string — the absence signals "unattributed" vs the
-    // server-emitted FAILED entries that carry the real `error` reason.
+    // Normalize per-controller states still mid-flow to FAILED. A
+    // controller stuck at QUEUED/SENDING when the job ends has not
+    // confirmed, so showing an "updating" pill beneath a "failed"
+    // result bar is contradictory.
     const normalized = new Map(controllerStates.value);
     for (const [slot, state] of normalized) {
       if (state.stage !== 'VERSION_CONFIRMED' && state.stage !== 'FAILED') {
@@ -513,10 +501,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
           `[firmwareStore] applyJobFailed: demoting non-terminal stage="${state.stage}" ` +
             `for slot="${slot}" to FAILED (unattributed). Job ended before this controller reached a terminal stage.`,
         );
-        // IM-2 discriminated union: FAILED requires `error`. The absence
-        // of an `error` value here signals "unattributed normalize" vs
-        // the server-emitted FAILED entries that carry real `error`
-        // reasons. The marker string is searchable in ops logs.
+        // The discriminated union requires `error` on FAILED. No real
+        // server-emitted reason here, so use a searchable marker — the
+        // "unattributed:" prefix distinguishes these demotion-derived
+        // entries from server-reported failures.
         normalized.set(slot, {
           controllerId: state.controllerId,
           stage: 'FAILED',
@@ -533,11 +521,8 @@ export const useFirmwareStore = defineStore('firmware', () => {
     const failed: FailedControllerSummary[] = [];
     for (const state of normalized.values()) {
       if (state.stage === 'FAILED') {
-        // IM-11: state.controllerId is structurally a SlotId here
-        // (ControllerFlashStateBySlot). No cast needed. A single `as SlotId`
-        // remains in the CR-2 sweep below — that's a known compromise where
-        // a raw MAC string is forced into the SlotId slot so the operator
-        // sees a real MAC rather than no entry at all.
+        // controllerId is structurally a SlotId here (the in-store view
+        // is ControllerFlashStateBySlot).
         const slot = state.controllerId;
         const c = controllers.value.find((x) => x.id === slot);
         failed.push({
@@ -547,11 +532,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
         });
       }
     }
-    // CR-2 sweep: pendingByMac may hold FAILED entries that never got
-    // LocationStatus mapping (bus-wide ESP-NOW failures can mark a
-    // padawan FAILED before its heartbeat arrives). Surface them via
-    // MAC as the label so the operator sees the full bricked-controller
-    // list, not just the mapped subset.
+    // Sweep pendingByMac for FAILED entries that never got LocationStatus
+    // mapping — bus-wide ESP-NOW failures can mark a padawan FAILED before
+    // its heartbeat arrives. Surface them via the raw MAC so the operator
+    // sees the full bricked-controller list, not just the mapped subset.
     for (const [mac, queue] of pendingByMac.value) {
       for (const entry of queue) {
         if (entry.stage === 'FAILED') {
@@ -559,12 +543,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
             `[firmwareStore] applyJobFailed: FAILED entry for unmapped MAC="${mac}" ` +
               `surfaced from pendingByMac. LocationStatus never arrived; using MAC as label.`,
           );
-          // Intentional `as SlotId` cast: a raw MAC string is forced into
-          // the SlotId slot because the operator is better served seeing a
-          // real MAC than no entry at all. The runtime warn above is the
-          // forensic breadcrumb that traces back to the LocationStatus gap.
-          // This is the only remaining cast after IM-11; resolveSlot (the
-          // translation boundary) does the other.
+          // Intentional cast: a raw MAC isn't structurally a SlotId, but
+          // surfacing the MAC string as the row label is more useful to
+          // operators than dropping the entry. The console.warn above is
+          // the forensic breadcrumb.
           failed.push({
             id: mac as SlotId,
             label: mac,
@@ -637,11 +619,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
       // server reads `req.body?.reason`, so the body must transmit.
       await apiClient.delete(FIRMWARE_FLASH, { data: { reason } });
     } catch (error) {
-      // IM-10: cancel failure must reach the operator. Without a visible
-      // signal, clicking Cancel and seeing nothing happen leaves the UI
-      // stuck at 'flashing' with no breadcrumb — phase truth still comes
-      // from the WS surface (don't transition here), but a flashError
-      // tells the operator that the cancel didn't take effect.
+      // Phase truth comes from the WS surface (don't transition here),
+      // but a flashError tells the operator the cancel didn't take effect.
+      // Without this, clicking Cancel and seeing nothing would leave the
+      // UI stuck at 'flashing' with no breadcrumb.
       console.warn('firmware.cancelFlash failed', error);
       setFlashError({
         reason: 'network_error',
@@ -673,10 +654,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
     try {
       const response = await apiClient.get(FIRMWARE_FLASH);
       const body = response.data as FlashJobState | null;
-      // NEW-IM2: explicit non-empty-string check on body.jobId. The prior
-      // truthy short-circuit silently passed `{jobId: ''}` server contract
-      // violations through with no warn and no apply. Now we surface a
-      // forensic warn so ops can trace the bad payload back to its source.
+      // Explicit non-empty-string check on body.jobId. A truthy
+      // short-circuit would silently pass `{jobId: ''}` contract
+      // violations through with no apply AND no warn; the forensic
+      // warn below lets ops trace the bad payload back to its source.
       const hasValidJobId =
         body !== null && typeof body.jobId === 'string' && body.jobId.length > 0;
       if (body !== null && !hasValidJobId) {
@@ -744,7 +725,6 @@ export const useFirmwareStore = defineStore('firmware', () => {
       >
     > = {};
     for (const [id, state] of controllerStates.value) {
-      // IM-11: Map's key type is now SlotId. No cast needed.
       out[id] = { status: controllerStatePillKind(state) };
       const key = controllerStageLabelKey(state);
       if (key !== null) {

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -1,19 +1,55 @@
-import { computed, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import { defineStore } from 'pinia';
 import apiService, { apiClient } from '@/api/apiService';
 import { FIRMWARE_FLASH, FIRMWARE_RELEASES } from '@/api/endpoints';
 import { compareTags } from '@/utils/version';
 import { mapHttpErrorToFlashEnvelope } from '@/utils/firmwareFlashError';
+import { controllerStatePillKind, mapServerStageToUiStage } from '@/utils/firmwareStageMapping';
+import { useControllerStore } from '@/stores/controller';
+import { ControllerStatus } from '@/enums';
 import type {
+  ControllerFlashState,
+  ControllerOnlineStatus,
   FirmwareControllerView,
   FirmwarePhase,
   FirmwareSourceMode,
   FirmwareStage,
   FlashErrorEnvelope,
+  FlashJobFailedData,
+  FlashJobState,
   ReleaseInfo,
   ReleaseListResult,
   ReleasesLoadState,
 } from '@/types/firmware';
+
+// Master designation: Body is the ESP-NOW sentinel master per project
+// convention (see `project_master_esp_sentinel_mac` memory). If this ever
+// flips, the firmware side has to flip first — keep cross-referenced.
+const FLEET_LAYOUT: ReadonlyArray<{
+  id: string;
+  label: string;
+  glyph: string;
+  isMaster: boolean;
+}> = [
+  { id: 'body', label: 'Body', glyph: 'B', isMaster: true },
+  { id: 'core', label: 'Core', glyph: 'C', isMaster: false },
+  { id: 'dome', label: 'Dome', glyph: 'D', isMaster: false },
+];
+
+function projectControllerStatus(status: ControllerStatus): ControllerOnlineStatus {
+  switch (status) {
+    case ControllerStatus.UP:
+      return 'up';
+    case ControllerStatus.DOWN:
+      return 'down';
+    case ControllerStatus.NEEDS_SYNCED:
+    case ControllerStatus.FIRMWARE_INCOMPATIBLE:
+      // FIRMWARE_INCOMPATIBLE collapses to needsSynced for the firmware-view
+      // flow — running the flash IS the sync. The pill copy is appropriate
+      // for both states (controller is reachable but needs operator action).
+      return 'needsSynced';
+  }
+}
 
 export const useFirmwareStore = defineStore('firmware', () => {
   const releases = ref<ReleaseInfo[]>([]);
@@ -24,7 +60,6 @@ export const useFirmwareStore = defineStore('firmware', () => {
   const selectedReleaseTag = ref<string | null>(null);
   const uploadedFilename = ref<string | null>(null);
 
-  const controllers = ref<FirmwareControllerView[]>([]);
   const selectedControllerIds = ref<ReadonlySet<string>>(new Set());
 
   const phase = ref<FirmwarePhase>('idle');
@@ -32,22 +67,43 @@ export const useFirmwareStore = defineStore('firmware', () => {
   const flashError = ref<FlashErrorEnvelope | null>(null);
   const failedController = ref<{ id: string; label: string; stage: FirmwareStage } | null>(null);
 
-  // Reconcile selection against the fleet — when `controllers` is reassigned
-  // (e.g. by a WS-driven refresh), prune any selected ids that no longer
-  // refer to a known controller. Prevents orphan ids from silently passing
-  // `canFlash` (size > 0) and skipping the downgrade check (find returns
-  // undefined → not blocked).
-  watch(controllers, (next) => {
-    if (selectedControllerIds.value.size === 0) return;
-    const known = new Set(next.map((c) => c.id));
-    const filtered = new Set<string>();
-    for (const id of selectedControllerIds.value) {
-      if (known.has(id)) filtered.add(id);
-    }
-    if (filtered.size !== selectedControllerIds.value.size) {
-      selectedControllerIds.value = filtered;
-    }
+  // WS-pushed state (d.6). Apply* handlers below are the sole writers.
+  const currentJob = ref<FlashJobState | null>(null);
+  const controllerStates = ref<ReadonlyMap<string, ControllerFlashState>>(new Map());
+  // Set by `startFlash` from the POST response so the UI can tell whether the
+  // active flash belongs to us vs. another operator (lock-conflict UI).
+  const ownJobId = ref<string | null>(null);
+
+  // Project the per-location controller store into a fleet shape the firmware
+  // view consumes. Replaces d.5's `ref<FirmwareControllerView[]>([])` and the
+  // FirmwareView dev-mock bootstrap. Reads are reactive through useControllerStore.
+  const controllers = computed<FirmwareControllerView[]>(() => {
+    const cs = useControllerStore();
+    const statusByLocation = {
+      body: cs.bodyStatus,
+      core: cs.coreStatus,
+      dome: cs.domeStatus,
+    } as const;
+    const firmwareByLocation = {
+      body: cs.bodyFirmware,
+      core: cs.coreFirmware,
+      dome: cs.domeFirmware,
+    } as const;
+    return FLEET_LAYOUT.map((slot) => ({
+      id: slot.id,
+      label: slot.label,
+      glyph: slot.glyph,
+      isMaster: slot.isMaster,
+      current: firmwareByLocation[slot.id as keyof typeof firmwareByLocation] ?? '—',
+      status: projectControllerStatus(statusByLocation[slot.id as keyof typeof statusByLocation]),
+    }));
   });
+
+  // Selection-vs-fleet reconciliation is unnecessary in d.6: the `controllers`
+  // computed projects a fixed FLEET_LAYOUT (body / core / dome) so orphan
+  // selected ids are structurally impossible. If FLEET_LAYOUT ever becomes
+  // dynamic (e.g. a new controller location is added), add a `watch` here
+  // that prunes selectedControllerIds against the current fleet.
 
   const target = computed<string | null>(() => {
     if (sourceMode.value === 'github') return selectedReleaseTag.value;
@@ -74,6 +130,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
   const canFlash = computed(
     () =>
       target.value !== null && selectedControllerIds.value.size > 0 && !anyDowngradeBlocked.value,
+  );
+
+  const isOwnJob = computed(
+    () => currentJob.value !== null && currentJob.value.jobId === ownJobId.value,
   );
 
   // Selection actions always replace the Set (not mutate in place) so Vue
@@ -104,11 +164,97 @@ export const useFirmwareStore = defineStore('firmware', () => {
     currentStage.value = null;
     flashError.value = null;
     failedController.value = null;
+    currentJob.value = null;
+    controllerStates.value = new Map();
+    ownJobId.value = null;
   }
 
   function dismissError(): void {
     flashError.value = null;
   }
+
+  // ---------- WS handlers (the sole writers of server-pushed fields) ----------
+
+  function buildControllerStatesMap(
+    states: ReadonlyArray<ControllerFlashState>,
+  ): ReadonlyMap<string, ControllerFlashState> {
+    const m = new Map<string, ControllerFlashState>();
+    for (const s of states) m.set(s.controllerId, s);
+    return m;
+  }
+
+  function applyJobStarted(data: FlashJobState): void {
+    // Idempotent + replace-not-merge: on duplicate (reconnect / late-join),
+    // overwrite controllerStates fully so stale entries can't survive.
+    // Snapshot regression hazard (snapshot lands after a more-recent
+    // applyControllerUpdate) is precluded by single-WS in-order delivery —
+    // the server emits flashJobStarted snapshots on connect, before any
+    // post-reconnect flashControllerUpdate.
+    currentJob.value = data;
+    controllerStates.value = buildControllerStatesMap(data.controllers);
+    if (phase.value !== 'flashing') phase.value = 'flashing';
+    flashError.value = null;
+    failedController.value = null;
+  }
+
+  function applyControllerUpdate(data: ControllerFlashState): void {
+    const next = new Map(controllerStates.value);
+    next.set(data.controllerId, data);
+    controllerStates.value = next;
+    const ui = mapServerStageToUiStage(data.stage);
+    if (ui !== null) currentStage.value = ui;
+  }
+
+  function applyControllerResult(payload: {
+    jobId: string;
+    controller: ControllerFlashState;
+  }): void {
+    applyControllerUpdate(payload.controller);
+  }
+
+  function applyJobDone(data: { jobId: string; endedAt: string }): void {
+    if (currentJob.value) {
+      currentJob.value = { ...currentJob.value, endedAt: data.endedAt };
+    }
+    phase.value = 'done';
+    currentStage.value = null;
+  }
+
+  function applyJobFailed(data: FlashJobFailedData): void {
+    // Pre-streamer failures (release_not_found, variant_mismatch, etc.)
+    // arrive without a prior flashJobStarted, so currentJob may be null.
+    // We deliberately do NOT synthesize a currentJob in that case — the
+    // operator's truth source for "no flash started" is the unchanged
+    // null currentJob; the failure surfaces via flashError below.
+    if (currentJob.value) {
+      currentJob.value = {
+        ...currentJob.value,
+        endedAt: data.endedAt,
+        abortReason: data.abortReason,
+      };
+    }
+    phase.value = 'failed';
+    flashError.value = {
+      reason: 'internal_server_error',
+      detail: data.detail,
+    };
+    // Find the controller that ended in FAILED; surface its label + UI stage.
+    for (const state of controllerStates.value.values()) {
+      if (state.stage === 'FAILED') {
+        const c = controllers.value.find((x) => x.id === state.controllerId);
+        const uiStage = mapServerStageToUiStage(state.stage) ?? currentStage.value ?? 'transfer';
+        failedController.value = {
+          id: state.controllerId,
+          label: c?.label ?? state.controllerId,
+          stage: uiStage,
+        };
+        break;
+      }
+    }
+    currentStage.value = null;
+  }
+
+  // ---------- HTTP actions ----------
 
   // 30s timeout on the flash POST. axios's default is no timeout — a hung
   // backend would otherwise leave phase stuck at 'flashing' with no UI
@@ -124,16 +270,20 @@ export const useFirmwareStore = defineStore('firmware', () => {
         : { source: { kind: 'upload' as const } };
     phase.value = 'flashing';
     try {
-      // Direct apiClient call so we can attach a per-request timeout; the
-      // apiService.post wrapper doesn't expose the options bag.
-      await apiClient.post(FIRMWARE_FLASH, body, { timeout: FLASH_POST_TIMEOUT_MS });
-      // HTTP 200 only means orchestrator.start() resolved; per-controller stage
-      // progression, completion, and failure arrive on the WS surface. Until
-      // that dispatcher is wired in, phase stays 'flashing' until the operator
-      // resets.
+      const response = await apiClient.post(FIRMWARE_FLASH, body, {
+        timeout: FLASH_POST_TIMEOUT_MS,
+      });
+      const responseBody = response.data as FlashJobState | undefined;
+      if (responseBody?.jobId) {
+        ownJobId.value = responseBody.jobId;
+      }
+      // From here on the WS surface owns phase transitions, per-controller
+      // stage progression, completion, and failure. applyJobStarted is
+      // idempotent so the matching WS event (which the server emits before
+      // the HTTP response resolves) is safe.
     } catch (error) {
-      // Direct apiClient.post bypasses apiService.post's console.error wrapper,
-      // so log here to preserve the dev breadcrumb for debugging real errors.
+      // Direct apiClient.post bypasses apiService.post's console.error
+      // wrapper, so log here to preserve the dev breadcrumb.
       console.error('firmware.startFlash failed', error);
       phase.value = 'select';
       flashError.value = mapHttpErrorToFlashEnvelope(error);
@@ -153,6 +303,22 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
   }
 
+  // Cold-load resync. Mounted views call this to populate currentJob from
+  // the server if a flash is already in flight (e.g., the operator refreshed
+  // the page mid-flash). The WS late-join snapshot follows on connect; both
+  // paths set the same data so applyJobStarted idempotency keeps state coherent.
+  async function fetchCurrentJob(): Promise<void> {
+    try {
+      const response = await apiClient.get(FIRMWARE_FLASH);
+      const body = response.data as FlashJobState | null;
+      if (body && body.jobId && currentJob.value === null) {
+        applyJobStarted(body);
+      }
+    } catch (error) {
+      console.warn('firmware.fetchCurrentJob failed', error);
+    }
+  }
+
   async function fetchReleases(): Promise<void> {
     releasesLoadState.value = 'loading';
     try {
@@ -168,6 +334,22 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
   }
 
+  // Project the controllerStates Map into the shape the panel expects.
+  const progressByControllerId = computed(() => {
+    const out: Record<
+      string,
+      { status: ReturnType<typeof controllerStatePillKind>; stageLabel?: string }
+    > = {};
+    for (const [id, state] of controllerStates.value) {
+      out[id] = { status: controllerStatePillKind(state) };
+      const uiStage = mapServerStageToUiStage(state.stage);
+      if (uiStage !== null) {
+        out[id].stageLabel = uiStage;
+      }
+    }
+    return out;
+  });
+
   return {
     releases,
     releasesLoadState,
@@ -181,17 +363,28 @@ export const useFirmwareStore = defineStore('firmware', () => {
     currentStage,
     flashError,
     failedController,
+    currentJob,
+    controllerStates,
+    ownJobId,
     target,
     anyDowngradeBlocked,
     canFlash,
+    isOwnJob,
+    progressByControllerId,
     toggle,
     selectAll,
     clear,
     setPhase,
     resetToSelect,
     dismissError,
+    applyJobStarted,
+    applyControllerUpdate,
+    applyControllerResult,
+    applyJobDone,
+    applyJobFailed,
     startFlash,
     cancelFlash,
+    fetchCurrentJob,
     fetchReleases,
   };
 });

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -265,15 +265,13 @@ export const useFirmwareStore = defineStore('firmware', () => {
   }
 
   function applyControllerUpdate(data: ControllerFlashState): void {
-    // Belt-and-suspenders: a WS event arriving by itself (without a prior
-    // flashJobStarted snapshot) is enough proof that live state is flowing.
-    // Clear the staleness banner in case fetchCurrentJob earlier failed and
-    // applyJobStarted never fired (unusual but possible if the reconnect
-    // snapshot arrived as a controllerUpdate due to mid-job ordering).
-    currentJobLoadFailed.value = false;
     const slot = resolveSlot(data.controllerId);
     if (slot === null) {
-      // Queue for replay; see pendingByMac comment above.
+      // Queue for replay; see pendingByMac comment above. Critical: the
+      // staleness-banner clear MUST stay below this return — clearing it
+      // here would silently dismiss the operator-visible warning every
+      // time a WS update arrived for an unmapped controller (UNKNOWN
+      // location, contract drift, etc.).
       enqueuePending(data);
       console.warn(
         `[firmwareStore] applyControllerUpdate: unknown controllerId="${data.controllerId}". ` +
@@ -281,6 +279,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
       );
       return;
     }
+    // Belt-and-suspenders: a successful WS update is proof that live state
+    // is flowing for a known controller. Clear the staleness banner in
+    // case fetchCurrentJob earlier failed and applyJobStarted never fired.
+    currentJobLoadFailed.value = false;
     const next = new Map(controllerStates.value);
     next.set(slot, { ...data, controllerId: slot });
     controllerStates.value = next;

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -190,6 +190,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     controllerStates.value = new Map();
     ownJobId.value = null;
     pendingByMac.value = new Map();
+    currentJobLoadFailed.value = false;
   }
 
   function dismissError(): void {
@@ -255,6 +256,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
     // the server emits flashJobStarted snapshots on connect, before any
     // post-reconnect flashControllerUpdate.
     currentJob.value = data;
+    // Drop any pending entries from a prior job before processing the new
+    // snapshot. Without this clear, orphan entries (a MAC that never got
+    // its LocationStatus during the prior job) would persist and replay
+    // against the wrong job once their LocationStatus finally arrived.
+    pendingByMac.value = new Map();
     controllerStates.value = buildControllerStatesMap(data.controllers);
     if (phase.value !== 'flashing') phase.value = 'flashing';
     flashError.value = null;
@@ -280,8 +286,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
       return;
     }
     // Belt-and-suspenders: a successful WS update is proof that live state
-    // is flowing for a known controller. Clear the staleness banner in
-    // case fetchCurrentJob earlier failed and applyJobStarted never fired.
+    // is flowing for a known controller. The applyJobStarted clear is the
+    // primary path (server emits the snapshot before per-controller updates
+    // on reconnect per applyJobStarted's ordering note); this clear catches
+    // edge cases where HTTP fetch failed AND the snapshot was missed.
     currentJobLoadFailed.value = false;
     const next = new Map(controllerStates.value);
     next.set(slot, { ...data, controllerId: slot });
@@ -330,6 +338,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
     phase.value = 'done';
     currentStage.value = null;
+    // Terminal state — the staleness banner is no longer relevant. Without
+    // this clear, a fetchCurrentJob failure earlier in the session would
+    // leave the warning visible on top of the legitimate done-flash UI.
+    currentJobLoadFailed.value = false;
   }
 
   function applyJobFailed(data: FlashJobFailedData): void {
@@ -372,6 +384,9 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
     failedControllers.value = failed;
     currentStage.value = null;
+    // Terminal state — clear the staleness banner so it can't shadow the
+    // legitimate failed-flash UI.
+    currentJobLoadFailed.value = false;
   }
 
   // ---------- HTTP actions ----------
@@ -434,11 +449,16 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
   }
 
-  // Set true when fetchCurrentJob fails so the FirmwareView can warn that
-  // its phase is unconfirmed. The WS late-join snapshot normally covers
-  // this — but if BOTH HTTP and WS are down, the operator otherwise sees
-  // an apparently-idle page while a job may be in flight server-side.
-  // Cleared on any successful fetchCurrentJob or on the first applyJobStarted.
+  // Set true when fetchCurrentJob fails with a non-404 response so the
+  // FirmwareView can warn that its phase is unconfirmed. The WS late-join
+  // snapshot normally covers this — but if BOTH HTTP and WS are down, the
+  // operator otherwise sees an apparently-idle page while a job may be in
+  // flight server-side. 404 is the expected response from a healthy idle
+  // server and is treated as "no flash," not as staleness.
+  // Cleared on: any successful fetchCurrentJob (or 404), applyJobStarted
+  // (WS snapshot landed), applyControllerUpdate for a known controller
+  // (belt-and-suspenders), and the three terminal states (resetToSelect,
+  // applyJobDone, applyJobFailed) so the banner can't shadow a final state.
   const currentJobLoadFailed = ref(false);
 
   // Cold-load resync. Mounted views call this to populate currentJob from
@@ -455,7 +475,15 @@ export const useFirmwareStore = defineStore('firmware', () => {
       currentJobLoadFailed.value = false;
     } catch (error) {
       console.warn('firmware.fetchCurrentJob failed', error);
-      currentJobLoadFailed.value = true;
+      // 404 is the expected response from a healthy idle server (no flash
+      // in flight). Surfacing it as "could not confirm state" would falsely
+      // alarm operators on cold-load of an unused page. Only treat 5xx and
+      // network-level failures as a genuine staleness signal.
+      const status =
+        typeof error === 'object' && error !== null && 'response' in error
+          ? (error as { response?: { status?: number } }).response?.status
+          : undefined;
+      currentJobLoadFailed.value = status !== 404;
     }
   }
 
@@ -479,18 +507,23 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // that the row component resolves via t() — keeps localization out of the
   // store and prevents the raw lowercase stage values from leaking to the UI.
   const progressByControllerId = computed(() => {
-    const out: Record<
-      string,
-      {
-        status: ReturnType<typeof controllerStatePillKind>;
-        stageLabelKey?: FirmwareStageLabelKey;
-      }
+    const out: Partial<
+      Record<
+        SlotId,
+        {
+          status: ReturnType<typeof controllerStatePillKind>;
+          stageLabelKey?: FirmwareStageLabelKey;
+        }
+      >
     > = {};
     for (const [id, state] of controllerStates.value) {
-      out[id] = { status: controllerStatePillKind(state) };
+      // `id` is `SlotId` (set by buildControllerStatesMap / applyControllerUpdate)
+      // but the Map's key type is `string`, so a cast is required here.
+      const slot = id as SlotId;
+      out[slot] = { status: controllerStatePillKind(state) };
       const key = controllerStageLabelKey(state);
       if (key !== null) {
-        out[id].stageLabelKey = key;
+        out[slot]!.stageLabelKey = key;
       }
     }
     return out;

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -4,7 +4,11 @@ import apiService, { apiClient } from '@/api/apiService';
 import { FIRMWARE_FLASH, FIRMWARE_RELEASES } from '@/api/endpoints';
 import { compareTags } from '@/utils/version';
 import { mapHttpErrorToFlashEnvelope } from '@/utils/firmwareFlashError';
-import { controllerStatePillKind, mapServerStageToUiStage } from '@/utils/firmwareStageMapping';
+import {
+  controllerStageLabelKey,
+  controllerStatePillKind,
+  mapServerStageToUiStage,
+} from '@/utils/firmwareStageMapping';
 import { useControllerStore } from '@/stores/controller';
 import { ControllerStatus } from '@/enums';
 import type {
@@ -22,29 +26,7 @@ import type {
   ReleaseListResult,
   ReleasesLoadState,
 } from '@/types/firmware';
-
-// Recognized server-side flash error reasons. Used by applyJobFailed to
-// validate the WS payload's `reason` field before surfacing it to the UI —
-// unrecognized strings fall back to internal_server_error rather than
-// rendering as a missing-i18n-key path.
-const KNOWN_FLASH_ERROR_REASONS: ReadonlySet<FlashErrorReason> = new Set<FlashErrorReason>([
-  'invalid_body',
-  'job_already_running',
-  'no_controllers',
-  'variant_mismatch',
-  'variant_unknown',
-  'release_not_found',
-  'asset_not_found',
-  'no_upload',
-  'release_lookup_failed',
-  'source_resolution_failed',
-  'controllers_lookup_failed',
-  'subscriber_attach_failed',
-  'protocol_violation',
-  'streamer_unknown_error',
-  'internal_server_error',
-  'network_error',
-]);
+import { KNOWN_FLASH_ERROR_REASONS } from '@/types/firmware';
 
 // Master designation: Body is the ESP-NOW sentinel master per project
 // convention (see `project_master_esp_sentinel_mac` memory). If this ever
@@ -346,6 +328,17 @@ export const useFirmwareStore = defineStore('firmware', () => {
       if (responseBody?.jobId) {
         ownJobId.value = responseBody.jobId;
       }
+      // POST succeeded → the server has accepted the job. If a malformed-WS
+      // flashJobStarted arrived during the POST window, its handler rolled
+      // phase back to 'select' (useWebsocket.handleFlashJobStarted). Re-
+      // assert 'flashing' so the UI matches reality. Legitimate transitions
+      // during this window are 'done' or 'failed' (terminal) — never 'select'.
+      // The cast widens past TS's post-assignment narrowing — a WS handler
+      // can mutate the ref across the await boundary, but TS can't see that.
+      if ((phase.value as FirmwarePhase) === 'select') {
+        phase.value = 'flashing';
+        flashError.value = null;
+      }
       // From here on the WS surface owns phase transitions, per-controller
       // stage progression, completion, and failure. applyJobStarted is
       // idempotent so the matching WS event (which the server emits before
@@ -404,16 +397,22 @@ export const useFirmwareStore = defineStore('firmware', () => {
   }
 
   // Project the controllerStates Map into the shape the panel expects.
+  // `stageLabelKey` is an i18n key path (e.g. firmware_view.stages.transfer.label)
+  // that the row component resolves via t() — keeps localization out of the
+  // store and prevents the raw lowercase stage values from leaking to the UI.
   const progressByControllerId = computed(() => {
     const out: Record<
       string,
-      { status: ReturnType<typeof controllerStatePillKind>; stageLabel?: string }
+      {
+        status: ReturnType<typeof controllerStatePillKind>;
+        stageLabelKey?: string;
+      }
     > = {};
     for (const [id, state] of controllerStates.value) {
       out[id] = { status: controllerStatePillKind(state) };
-      const uiStage = mapServerStageToUiStage(state.stage);
-      if (uiStage !== null) {
-        out[id].stageLabel = uiStage;
+      const key = controllerStageLabelKey(state);
+      if (key !== null) {
+        out[id].stageLabelKey = key;
       }
     }
     return out;

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -10,7 +10,7 @@ import {
   mapServerStageToUiStage,
 } from '@/utils/firmwareStageMapping';
 import { useControllerStore } from '@/stores/controller';
-import { ControllerStatus } from '@/enums';
+import { ControllerStatus, Location } from '@/enums';
 import type {
   ControllerFlashState,
   ControllerOnlineStatus,
@@ -18,6 +18,8 @@ import type {
   FirmwarePhase,
   FirmwareSourceMode,
   FirmwareStage,
+  FirmwareStageLabelKey,
+  SlotId,
   FlashErrorEnvelope,
   FlashErrorReason,
   FlashJobFailedData,
@@ -197,15 +199,18 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // ---------- WS handlers (the sole writers of server-pushed fields) ----------
 
   /**
-   * Translate a wire-level controllerId (MAC) to a fleet slot id
-   * ('body' / 'core' / 'dome'). Returns null for unknown MACs — the caller
-   * surfaces a dev warning and drops the update so the panel can't render
-   * stale per-controller pills against an unknown row.
+   * Translate a wire-level controllerId (MAC) to a fleet `SlotId`. The
+   * underlying resolver returns `Location | null`; `Location.UNKNOWN` is
+   * not a valid slot key, so we map it to null. The returned `SlotId` is
+   * the key the panel uses in `progressByControllerId`. Null callers queue
+   * the payload for replay so the row can recover once LocationStatus
+   * learns the MAC.
    */
-  function resolveSlot(controllerId: string): string | null {
+  function resolveSlot(controllerId: string): SlotId | null {
     const cs = useControllerStore();
     const loc = cs.controllerIdToLocation(controllerId);
-    return loc;
+    if (loc === null || loc === Location.UNKNOWN) return null;
+    return loc as SlotId;
   }
 
   function enqueuePending(state: ControllerFlashState): void {
@@ -254,9 +259,18 @@ export const useFirmwareStore = defineStore('firmware', () => {
     if (phase.value !== 'flashing') phase.value = 'flashing';
     flashError.value = null;
     failedControllers.value = [];
+    // WS late-join landed → the HTTP staleness warning is no longer accurate
+    // even if HTTP itself failed. The store has live state again.
+    currentJobLoadFailed.value = false;
   }
 
   function applyControllerUpdate(data: ControllerFlashState): void {
+    // Belt-and-suspenders: a WS event arriving by itself (without a prior
+    // flashJobStarted snapshot) is enough proof that live state is flowing.
+    // Clear the staleness banner in case fetchCurrentJob earlier failed and
+    // applyJobStarted never fired (unusual but possible if the reconnect
+    // snapshot arrived as a controllerUpdate due to mid-job ordering).
+    currentJobLoadFailed.value = false;
     const slot = resolveSlot(data.controllerId);
     if (slot === null) {
       // Queue for replay; see pendingByMac comment above.
@@ -418,6 +432,13 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
   }
 
+  // Set true when fetchCurrentJob fails so the FirmwareView can warn that
+  // its phase is unconfirmed. The WS late-join snapshot normally covers
+  // this — but if BOTH HTTP and WS are down, the operator otherwise sees
+  // an apparently-idle page while a job may be in flight server-side.
+  // Cleared on any successful fetchCurrentJob or on the first applyJobStarted.
+  const currentJobLoadFailed = ref(false);
+
   // Cold-load resync. Mounted views call this to populate currentJob from
   // the server if a flash is already in flight (e.g., the operator refreshed
   // the page mid-flash). The WS late-join snapshot follows on connect; both
@@ -429,8 +450,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
       if (body && body.jobId && currentJob.value === null) {
         applyJobStarted(body);
       }
+      currentJobLoadFailed.value = false;
     } catch (error) {
       console.warn('firmware.fetchCurrentJob failed', error);
+      currentJobLoadFailed.value = true;
     }
   }
 
@@ -458,7 +481,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
       string,
       {
         status: ReturnType<typeof controllerStatePillKind>;
-        stageLabelKey?: string;
+        stageLabelKey?: FirmwareStageLabelKey;
       }
     > = {};
     for (const [id, state] of controllerStates.value) {
@@ -488,6 +511,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     controllerStates,
     ownJobId,
     pendingByMac,
+    currentJobLoadFailed,
     target,
     anyDowngradeBlocked,
     canFlash,

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -17,6 +17,7 @@ import type {
   FirmwareControllerView,
   FirmwarePhase,
   FirmwareSourceMode,
+  FailedControllerSummary,
   FirmwareStage,
   FirmwareStageLabelKey,
   SlotId,
@@ -34,14 +35,14 @@ import { KNOWN_FLASH_ERROR_REASONS } from '@/types/firmware';
 // convention (see `project_master_esp_sentinel_mac` memory). If this ever
 // flips, the firmware side has to flip first — keep cross-referenced.
 const FLEET_LAYOUT: ReadonlyArray<{
-  id: string;
+  id: SlotId;
   label: string;
   glyph: string;
   isMaster: boolean;
 }> = [
-  { id: 'body', label: 'Body', glyph: 'B', isMaster: true },
-  { id: 'core', label: 'Core', glyph: 'C', isMaster: false },
-  { id: 'dome', label: 'Dome', glyph: 'D', isMaster: false },
+  { id: Location.BODY, label: 'Body', glyph: 'B', isMaster: true },
+  { id: Location.CORE, label: 'Core', glyph: 'C', isMaster: false },
+  { id: Location.DOME, label: 'Dome', glyph: 'D', isMaster: false },
 ];
 
 function projectControllerStatus(status: ControllerStatus): ControllerOnlineStatus {
@@ -79,11 +80,10 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // controller. Empty array means no FAILED entries were observed. `stage`
   // is `FirmwareStage | null` — null when we can't honestly attribute the
   // failure to a specific stage (rather than fabricating 'transfer').
-  const failedControllers = ref<Array<{ id: string; label: string; stage: FirmwareStage | null }>>(
-    [],
-  );
+  const failedControllers = ref<FailedControllerSummary[]>([]);
 
-  // WS-pushed state. Apply* handlers below are the sole writers.
+  // WS-pushed state. Apply* handlers + resetToSelect are the writers
+  // (resetToSelect for the operator-driven clear; apply* for live state).
   const currentJob = ref<FlashJobState | null>(null);
   const controllerStates = ref<ReadonlyMap<string, ControllerFlashState>>(new Map());
   // Set by `startFlash` from the POST response so the UI can tell whether the
@@ -97,7 +97,9 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // Without this queue, the dropped event is lost forever and the row
   // freezes at its last-seen stage (or never gets a pill at all). The queue
   // is keyed by raw MAC; `flushPendingForMac` replays on setControllerMac.
-  // Cleared on resetToSelect so stale drift from a prior flash can't bleed in.
+  // Cleared on resetToSelect, applyJobStarted (replace-not-merge for the
+  // new job), and the two terminal handlers (applyJobDone, applyJobFailed)
+  // — see those sites for the per-call rationale.
   const pendingByMac = ref<Map<string, ControllerFlashState[]>>(new Map());
 
   // Project the per-location controller store into a fleet shape the firmware
@@ -188,7 +190,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
   function resetToSelect(): void {
     phase.value = 'select';
     currentStage.value = null;
-    flashError.value = null;
+    clearFlashError();
     failedControllers.value = [];
     currentJob.value = null;
     controllerStates.value = new Map();
@@ -197,20 +199,27 @@ export const useFirmwareStore = defineStore('firmware', () => {
     currentJobLoadFailed.value = false;
   }
 
-  function dismissError(): void {
-    flashError.value = null;
-  }
-
   /**
-   * Single writer for `flashError`. The dispatcher's malformed-payload
-   * catch blocks route through this rather than mutating the ref directly
-   * so a future "who wrote this flashError" investigation has one site to
-   * audit. The store's apply* handlers manage flashError internally per
-   * job-lifecycle (cleared on applyJobStarted; not auto-cleared by
-   * subsequent successful updates).
+   * Single writer for `flashError`. All sites that need to surface an
+   * error envelope route through this action: the dispatcher's malformed-
+   * payload catches, applyJobFailed's reason mapping, startFlash's HTTP
+   * error path, and the panel banner's retry-clear case. A future
+   * "who wrote this flashError" audit has one site to grep.
    */
   function setFlashError(envelope: FlashErrorEnvelope): void {
     flashError.value = envelope;
+  }
+
+  /**
+   * Paired clear for {@link setFlashError}. Used by the panel's dismiss
+   * button, applyJobStarted's per-job lifecycle reset, and resetToSelect.
+   */
+  function clearFlashError(): void {
+    flashError.value = null;
+  }
+
+  function dismissError(): void {
+    clearFlashError();
   }
 
   // ---------- WS handlers (the sole writers of server-pushed fields) ----------
@@ -279,7 +288,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     pendingByMac.value = new Map();
     controllerStates.value = buildControllerStatesMap(data.controllers);
     if (phase.value !== 'flashing') phase.value = 'flashing';
-    flashError.value = null;
+    clearFlashError();
     failedControllers.value = [];
     // WS late-join landed → the HTTP staleness warning is no longer accurate
     // even if HTTP itself failed. The store has live state again.
@@ -413,7 +422,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
       KNOWN_FLASH_ERROR_REASONS.has(data.reason as FlashErrorReason)
         ? (data.reason as FlashErrorReason)
         : 'internal_server_error';
-    flashError.value = { reason, detail: data.detail };
+    setFlashError({ reason, detail: data.detail });
     // Normalize any per-controller state still mid-flow to FAILED. Mirrors
     // applyJobDone's normalize (round-5 I4) but for the failure path: a
     // controller stuck at QUEUED/SENDING when the job ends has by
@@ -437,13 +446,18 @@ export const useFirmwareStore = defineStore('firmware', () => {
     // fails both padawans); surfacing only the first would let the
     // operator walk away from a bricked unit. The stage reflects
     // `currentStage` at failure time — null when no stage was current.
-    const failed: Array<{ id: string; label: string; stage: FirmwareStage | null }> = [];
+    const failed: FailedControllerSummary[] = [];
     for (const state of normalized.values()) {
       if (state.stage === 'FAILED') {
-        const c = controllers.value.find((x) => x.id === state.controllerId);
+        // state.controllerId has been re-keyed to a SlotId by
+        // buildControllerStatesMap / applyControllerUpdate. The cast is the
+        // single attestation site — see types/firmware.ts ControllerFlashState
+        // doc comment for the pre/post-translation contract.
+        const slot = state.controllerId as SlotId;
+        const c = controllers.value.find((x) => x.id === slot);
         failed.push({
-          id: state.controllerId,
-          label: c?.label ?? state.controllerId,
+          id: slot,
+          label: c?.label ?? slot,
           stage: currentStage.value,
         });
       }
@@ -467,7 +481,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
 
   async function startFlash(): Promise<void> {
     if (!canFlash.value || phase.value === 'flashing') return;
-    flashError.value = null;
+    clearFlashError();
     const body =
       sourceMode.value === 'github'
         ? { source: { kind: 'github' as const, version: selectedReleaseTag.value } }
@@ -490,7 +504,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
       // can mutate the ref across the await boundary, but TS can't see that.
       if ((phase.value as FirmwarePhase) === 'select') {
         phase.value = 'flashing';
-        flashError.value = null;
+        clearFlashError();
       }
       // From here on the WS surface owns phase transitions, per-controller
       // stage progression, completion, and failure. applyJobStarted is
@@ -501,7 +515,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
       // wrapper, so log here to preserve the dev breadcrumb.
       console.error('firmware.startFlash failed', error);
       phase.value = 'select';
-      flashError.value = mapHttpErrorToFlashEnvelope(error);
+      setFlashError(mapHttpErrorToFlashEnvelope(error));
     }
   }
 
@@ -633,6 +647,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     resetToSelect,
     dismissError,
     setFlashError,
+    clearFlashError,
     applyJobStarted,
     applyControllerUpdate,
     applyControllerResult,

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -318,6 +318,30 @@ export const useFirmwareStore = defineStore('firmware', () => {
   }
 
   function applyControllerUpdate(data: ControllerFlashState): void {
+    // NEW-IM1: mirror IM-3's element validation from buildControllerStatesMap.
+    // A malformed mid-stream flashControllerUpdate (no controllerId / non-
+    // string / empty) would otherwise call resolveSlot(undefined) and
+    // pollute pendingByMac under an undefined key — the CR-2 sweep then
+    // surfaces `{id: 'undefined', label: 'undefined'}` in failedControllers.
+    if (!data || typeof data.controllerId !== 'string' || data.controllerId.length === 0) {
+      console.warn(
+        `[firmwareStore] applyControllerUpdate: skipping element with invalid controllerId`,
+        data,
+      );
+      return;
+    }
+    // NEW-IM3: terminal-phase guard. After applyJobDone normalizes states
+    // to VERSION_CONFIRMED (or applyJobFailed demotes to FAILED), a trailing
+    // flashControllerUpdate from the same job (server retransmit, buffered
+    // event flush) would mutate controllerStates and silently flip a row's
+    // pill from 'done' back to 'updating' while the footer still claims
+    // "✓ all updated".
+    if (phase.value === 'done' || phase.value === 'failed') {
+      console.warn(
+        `[firmwareStore] applyControllerUpdate: dropping update for controllerId="${data.controllerId}" — job already at terminal phase="${phase.value}"`,
+      );
+      return;
+    }
     const slot = resolveSlot(data.controllerId);
     if (slot === null) {
       // Queue for replay; see pendingByMac comment above. Critical: the
@@ -649,13 +673,25 @@ export const useFirmwareStore = defineStore('firmware', () => {
     try {
       const response = await apiClient.get(FIRMWARE_FLASH);
       const body = response.data as FlashJobState | null;
+      // NEW-IM2: explicit non-empty-string check on body.jobId. The prior
+      // truthy short-circuit silently passed `{jobId: ''}` server contract
+      // violations through with no warn and no apply. Now we surface a
+      // forensic warn so ops can trace the bad payload back to its source.
+      const hasValidJobId =
+        body !== null && typeof body.jobId === 'string' && body.jobId.length > 0;
+      if (body !== null && !hasValidJobId) {
+        console.warn(
+          `[firmwareStore] fetchCurrentJob: server returned non-null body with empty jobId — contract violation; skipping apply.`,
+          body,
+        );
+      }
       // Mirror server-side decideLateJoinSnapshot: a job with endedAt is in
       // the reboot-wait window. The server will NOT emit a subsequent
       // flashJobStarted on the WS, so populating the store here would
       // wedge phase at 'flashing' indefinitely until the next refresh.
-      if (body && body.jobId && body.endedAt === undefined && currentJob.value === null) {
+      if (hasValidJobId && body.endedAt === undefined && currentJob.value === null) {
         applyJobStarted(body);
-      } else if (body && body.jobId && body.endedAt !== undefined) {
+      } else if (hasValidJobId && body.endedAt !== undefined) {
         console.info(
           `[firmwareStore] fetchCurrentJob: server returned job in reboot-wait window ` +
             `(jobId="${body.jobId}", endedAt="${body.endedAt}"). Skipping apply to avoid wedge.`,

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -15,12 +15,36 @@ import type {
   FirmwareSourceMode,
   FirmwareStage,
   FlashErrorEnvelope,
+  FlashErrorReason,
   FlashJobFailedData,
   FlashJobState,
   ReleaseInfo,
   ReleaseListResult,
   ReleasesLoadState,
 } from '@/types/firmware';
+
+// Recognized server-side flash error reasons. Used by applyJobFailed to
+// validate the WS payload's `reason` field before surfacing it to the UI —
+// unrecognized strings fall back to internal_server_error rather than
+// rendering as a missing-i18n-key path.
+const KNOWN_FLASH_ERROR_REASONS: ReadonlySet<FlashErrorReason> = new Set<FlashErrorReason>([
+  'invalid_body',
+  'job_already_running',
+  'no_controllers',
+  'variant_mismatch',
+  'variant_unknown',
+  'release_not_found',
+  'asset_not_found',
+  'no_upload',
+  'release_lookup_failed',
+  'source_resolution_failed',
+  'controllers_lookup_failed',
+  'subscriber_attach_failed',
+  'protocol_violation',
+  'streamer_unknown_error',
+  'internal_server_error',
+  'network_error',
+]);
 
 // Master designation: Body is the ESP-NOW sentinel master per project
 // convention (see `project_master_esp_sentinel_mac` memory). If this ever
@@ -67,7 +91,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
   const flashError = ref<FlashErrorEnvelope | null>(null);
   const failedController = ref<{ id: string; label: string; stage: FirmwareStage } | null>(null);
 
-  // WS-pushed state (d.6). Apply* handlers below are the sole writers.
+  // WS-pushed state. Apply* handlers below are the sole writers.
   const currentJob = ref<FlashJobState | null>(null);
   const controllerStates = ref<ReadonlyMap<string, ControllerFlashState>>(new Map());
   // Set by `startFlash` from the POST response so the UI can tell whether the
@@ -75,8 +99,8 @@ export const useFirmwareStore = defineStore('firmware', () => {
   const ownJobId = ref<string | null>(null);
 
   // Project the per-location controller store into a fleet shape the firmware
-  // view consumes. Replaces d.5's `ref<FirmwareControllerView[]>([])` and the
-  // FirmwareView dev-mock bootstrap. Reads are reactive through useControllerStore.
+  // view consumes. Reads are reactive through useControllerStore — changes
+  // to per-location refs propagate through this computed automatically.
   const controllers = computed<FirmwareControllerView[]>(() => {
     const cs = useControllerStore();
     const statusByLocation = {
@@ -99,7 +123,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }));
   });
 
-  // Selection-vs-fleet reconciliation is unnecessary in d.6: the `controllers`
+  // Selection-vs-fleet reconciliation is unnecessary: the `controllers`
   // computed projects a fixed FLEET_LAYOUT (body / core / dome) so orphan
   // selected ids are structurally impossible. If FLEET_LAYOUT ever becomes
   // dynamic (e.g. a new controller location is added), add a `watch` here
@@ -175,11 +199,41 @@ export const useFirmwareStore = defineStore('firmware', () => {
 
   // ---------- WS handlers (the sole writers of server-pushed fields) ----------
 
+  /**
+   * Translate a wire-level controllerId (MAC) to a fleet slot id
+   * ('body' / 'core' / 'dome'). Returns null for unknown MACs — the caller
+   * surfaces a dev warning and drops the update so the panel can't render
+   * stale per-controller pills against an unknown row.
+   */
+  function resolveSlot(controllerId: string): string | null {
+    const cs = useControllerStore();
+    const loc = cs.controllerIdToLocation(controllerId);
+    return loc;
+  }
+
   function buildControllerStatesMap(
-    states: ReadonlyArray<ControllerFlashState>,
+    states: ReadonlyArray<ControllerFlashState> | undefined,
   ): ReadonlyMap<string, ControllerFlashState> {
     const m = new Map<string, ControllerFlashState>();
-    for (const s of states) m.set(s.controllerId, s);
+    // Defensive: a malformed flashJobStarted with no `controllers` field
+    // must not throw on iteration. The empty Map is a valid intermediate
+    // state — flashControllerUpdate events will populate it as they arrive.
+    if (!states) return m;
+    for (const s of states) {
+      const slot = resolveSlot(s.controllerId);
+      if (slot === null) {
+        if (import.meta.env.DEV) {
+          console.warn(
+            `[firmwareStore] applyJobStarted: unknown controllerId="${s.controllerId}" ` +
+              `(no MAC → location mapping yet). Dropping this entry; LocationStatus must arrive first.`,
+          );
+        }
+        continue;
+      }
+      // Re-key by slot so the panel's progressByControllerId[c.id] lookup
+      // (where c.id is 'body'/'core'/'dome') resolves correctly.
+      m.set(slot, { ...s, controllerId: slot });
+    }
     return m;
   }
 
@@ -198,8 +252,18 @@ export const useFirmwareStore = defineStore('firmware', () => {
   }
 
   function applyControllerUpdate(data: ControllerFlashState): void {
+    const slot = resolveSlot(data.controllerId);
+    if (slot === null) {
+      if (import.meta.env.DEV) {
+        console.warn(
+          `[firmwareStore] applyControllerUpdate: unknown controllerId="${data.controllerId}". ` +
+            `Update ignored. LocationStatus must populate the MAC mapping first.`,
+        );
+      }
+      return;
+    }
     const next = new Map(controllerStates.value);
-    next.set(data.controllerId, data);
+    next.set(slot, { ...data, controllerId: slot });
     controllerStates.value = next;
     const ui = mapServerStageToUiStage(data.stage);
     if (ui !== null) currentStage.value = ui;
@@ -234,10 +298,15 @@ export const useFirmwareStore = defineStore('firmware', () => {
       };
     }
     phase.value = 'failed';
-    flashError.value = {
-      reason: 'internal_server_error',
-      detail: data.detail,
-    };
+    // Map server-side reason onto FlashErrorReason if recognized, otherwise
+    // fall back to internal_server_error. Forward-compat: a new server-side
+    // reason renders the generic banner until the client union is updated.
+    const reason: FlashErrorReason =
+      typeof data.reason === 'string' &&
+      KNOWN_FLASH_ERROR_REASONS.has(data.reason as FlashErrorReason)
+        ? (data.reason as FlashErrorReason)
+        : 'internal_server_error';
+    flashError.value = { reason, detail: data.detail };
     // Find the controller that ended in FAILED; surface its label + UI stage.
     for (const state of controllerStates.value.values()) {
       if (state.stage === 'FAILED') {

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -13,6 +13,7 @@ import { useControllerStore } from '@/stores/controller';
 import { ControllerStatus, Location } from '@/enums';
 import type {
   ControllerFlashState,
+  ControllerFlashStateBySlot,
   ControllerOnlineStatus,
   FirmwareControllerView,
   FirmwarePhase,
@@ -85,7 +86,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
   // WS-pushed state. Apply* handlers + resetToSelect are the writers
   // (resetToSelect for the operator-driven clear; apply* for live state).
   const currentJob = ref<FlashJobState | null>(null);
-  const controllerStates = ref<ReadonlyMap<string, ControllerFlashState>>(new Map());
+  // IM-11: in-store view is keyed by SlotId and uses the by-slot variant
+  // (controllerId is also SlotId). The wire-side ControllerFlashState
+  // (controllerId: MAC string) is translated to ControllerFlashStateBySlot
+  // at the buildControllerStatesMap / applyControllerUpdate boundary.
+  const controllerStates = ref<ReadonlyMap<SlotId, ControllerFlashStateBySlot>>(new Map());
   // Set by `startFlash` from the POST response so the UI can tell whether the
   // active flash belongs to us vs. another operator (lock-conflict UI).
   const ownJobId = ref<string | null>(null);
@@ -245,15 +250,32 @@ export const useFirmwareStore = defineStore('firmware', () => {
     pendingByMac.value.set(state.controllerId, queue);
   }
 
+  // IM-11: this is the ONLY MAC -> SlotId translation site. Returns the
+  // by-slot view; the wire-side ControllerFlashState's MAC `controllerId`
+  // is replaced by the resolved SlotId so downstream consumers don't need
+  // to cast.
   function buildControllerStatesMap(
     states: ReadonlyArray<ControllerFlashState> | undefined,
-  ): ReadonlyMap<string, ControllerFlashState> {
-    const m = new Map<string, ControllerFlashState>();
-    // Defensive: a malformed flashJobStarted with no `controllers` field
-    // must not throw on iteration. The empty Map is a valid intermediate
-    // state — flashControllerUpdate events will populate it as they arrive.
-    if (!states) return m;
+  ): ReadonlyMap<SlotId, ControllerFlashStateBySlot> {
+    const m = new Map<SlotId, ControllerFlashStateBySlot>();
+    // IM-3 defensive: reject non-array payloads. Without this guard, a
+    // string flows through `for...of` as per-character iteration and
+    // pollutes pendingByMac with garbage; an object iterates not-at-all
+    // (no Symbol.iterator). The empty Map is a valid intermediate state —
+    // flashControllerUpdate events will populate it as they arrive.
+    if (!Array.isArray(states)) return m;
     for (const s of states) {
+      // IM-3 element validation: a malformed entry with no/non-string
+      // controllerId would call `resolveSlot(undefined)` and queue under
+      // an `undefined` key, polluting pendingByMac. Skip + warn so ops
+      // can trace the malformed payload back to its server source.
+      if (!s || typeof s.controllerId !== 'string' || s.controllerId.length === 0) {
+        console.warn(
+          `[firmwareStore] buildControllerStatesMap: skipping element with invalid controllerId`,
+          s,
+        );
+        continue;
+      }
       const slot = resolveSlot(s.controllerId);
       if (slot === null) {
         // Queue for replay when LocationStatus eventually learns this MAC.
@@ -398,7 +420,16 @@ export const useFirmwareStore = defineStore('firmware', () => {
             `for slot="${slot}" to VERSION_CONFIRMED. ` +
             `Server emitted job-done before this controller reached terminal — verify the controller actually flashed.`,
         );
-        normalized.set(slot, { ...state, stage: 'VERSION_CONFIRMED' });
+        // IM-2 discriminated union: VERSION_CONFIRMED requires finalVersion.
+        // We don't have one (server never emitted the explicit transition),
+        // so use the placeholder string that the renderer can recognize as
+        // unattributed (the leading "unknown:" prefix is searchable in ops
+        // logs and distinct from any real version string).
+        normalized.set(slot, {
+          controllerId: state.controllerId,
+          stage: 'VERSION_CONFIRMED',
+          finalVersion: 'unknown:normalize-on-done',
+        });
       }
     }
     controllerStates.value = normalized;
@@ -458,7 +489,15 @@ export const useFirmwareStore = defineStore('firmware', () => {
           `[firmwareStore] applyJobFailed: demoting non-terminal stage="${state.stage}" ` +
             `for slot="${slot}" to FAILED (unattributed). Job ended before this controller reached a terminal stage.`,
         );
-        normalized.set(slot, { ...state, stage: 'FAILED' });
+        // IM-2 discriminated union: FAILED requires `error`. The absence
+        // of an `error` value here signals "unattributed normalize" vs
+        // the server-emitted FAILED entries that carry real `error`
+        // reasons. The marker string is searchable in ops logs.
+        normalized.set(slot, {
+          controllerId: state.controllerId,
+          stage: 'FAILED',
+          error: 'unattributed:normalize-on-failed',
+        });
       }
     }
     controllerStates.value = normalized;
@@ -470,15 +509,12 @@ export const useFirmwareStore = defineStore('firmware', () => {
     const failed: FailedControllerSummary[] = [];
     for (const state of normalized.values()) {
       if (state.stage === 'FAILED') {
-        // state.controllerId has been re-keyed to a SlotId by
-        // buildControllerStatesMap / applyControllerUpdate — this cast
-        // attests the post-translation type. See types/firmware.ts
-        // ControllerFlashState doc comment for the pre/post-translation
-        // contract. A second `as SlotId` cast lives below (the CR-2
-        // unmapped-MAC sweep) — that one has different semantics: a raw
-        // MAC string is forced into the SlotId slot because the operator
-        // is better served seeing a real MAC than no entry at all.
-        const slot = state.controllerId as SlotId;
+        // IM-11: state.controllerId is structurally a SlotId here
+        // (ControllerFlashStateBySlot). No cast needed. A single `as SlotId`
+        // remains in the CR-2 sweep below — that's a known compromise where
+        // a raw MAC string is forced into the SlotId slot so the operator
+        // sees a real MAC rather than no entry at all.
+        const slot = state.controllerId;
         const c = controllers.value.find((x) => x.id === slot);
         failed.push({
           id: slot,
@@ -499,9 +535,12 @@ export const useFirmwareStore = defineStore('firmware', () => {
             `[firmwareStore] applyJobFailed: FAILED entry for unmapped MAC="${mac}" ` +
               `surfaced from pendingByMac. LocationStatus never arrived; using MAC as label.`,
           );
-          // Second `as SlotId` cast site — IM-11 (Phase B) splits the
-          // wire vs slot views and removes this cast. Until then, the
-          // runtime warn above is the forensic breadcrumb.
+          // Intentional `as SlotId` cast: a raw MAC string is forced into
+          // the SlotId slot because the operator is better served seeing a
+          // real MAC than no entry at all. The runtime warn above is the
+          // forensic breadcrumb that traces back to the LocationStatus gap.
+          // This is the only remaining cast after IM-11; resolveSlot (the
+          // translation boundary) does the other.
           failed.push({
             id: mac as SlotId,
             label: mac,
@@ -574,9 +613,16 @@ export const useFirmwareStore = defineStore('firmware', () => {
       // server reads `req.body?.reason`, so the body must transmit.
       await apiClient.delete(FIRMWARE_FLASH, { data: { reason } });
     } catch (error) {
-      // Best-effort: failure here is logged but doesn't transition phase — the
-      // WS surface owns post-cancel state truth.
+      // IM-10: cancel failure must reach the operator. Without a visible
+      // signal, clicking Cancel and seeing nothing happen leaves the UI
+      // stuck at 'flashing' with no breadcrumb — phase truth still comes
+      // from the WS surface (don't transition here), but a flashError
+      // tells the operator that the cancel didn't take effect.
       console.warn('firmware.cancelFlash failed', error);
+      setFlashError({
+        reason: 'network_error',
+        detail: 'Cancel request failed; the flash may still be running. Refresh to recheck status.',
+      });
     }
   }
 
@@ -662,13 +708,11 @@ export const useFirmwareStore = defineStore('firmware', () => {
       >
     > = {};
     for (const [id, state] of controllerStates.value) {
-      // `id` is `SlotId` (set by buildControllerStatesMap / applyControllerUpdate)
-      // but the Map's key type is `string`, so a cast is required here.
-      const slot = id as SlotId;
-      out[slot] = { status: controllerStatePillKind(state) };
+      // IM-11: Map's key type is now SlotId. No cast needed.
+      out[id] = { status: controllerStatePillKind(state) };
       const key = controllerStageLabelKey(state);
       if (key !== null) {
-        out[slot]!.stageLabelKey = key;
+        out[id]!.stageLabelKey = key;
       }
     }
     return out;

--- a/astros_vue/src/stores/firmware.ts
+++ b/astros_vue/src/stores/firmware.ts
@@ -342,6 +342,12 @@ export const useFirmwareStore = defineStore('firmware', () => {
     // this clear, a fetchCurrentJob failure earlier in the session would
     // leave the warning visible on top of the legitimate done-flash UI.
     currentJobLoadFailed.value = false;
+    // Drain the replay queue so a late LocationStatus can't apply stale
+    // entries against terminal state. Without this, a queued entry whose
+    // MAC mapping arrives after job-done would call applyControllerUpdate,
+    // mutate controllerStates and currentStage, and visibly contradict the
+    // result bar.
+    pendingByMac.value = new Map();
   }
 
   function applyJobFailed(data: FlashJobFailedData): void {
@@ -387,6 +393,9 @@ export const useFirmwareStore = defineStore('firmware', () => {
     // Terminal state — clear the staleness banner so it can't shadow the
     // legitimate failed-flash UI.
     currentJobLoadFailed.value = false;
+    // Same rationale as applyJobDone: a late LocationStatus must not
+    // replay stale entries onto a finalized failure state.
+    pendingByMac.value = new Map();
   }
 
   // ---------- HTTP actions ----------
@@ -449,16 +458,19 @@ export const useFirmwareStore = defineStore('firmware', () => {
     }
   }
 
-  // Set true when fetchCurrentJob fails with a non-404 response so the
+  // Set true when fetchCurrentJob fails with a 5xx or network error so the
   // FirmwareView can warn that its phase is unconfirmed. The WS late-join
   // snapshot normally covers this — but if BOTH HTTP and WS are down, the
   // operator otherwise sees an apparently-idle page while a job may be in
-  // flight server-side. 404 is the expected response from a healthy idle
-  // server and is treated as "no flash," not as staleness.
-  // Cleared on: any successful fetchCurrentJob (or 404), applyJobStarted
-  // (WS snapshot landed), applyControllerUpdate for a known controller
-  // (belt-and-suspenders), and the three terminal states (resetToSelect,
-  // applyJobDone, applyJobFailed) so the banner can't shadow a final state.
+  // flight server-side. The server's GET /api/firmware/flash returns
+  // 200 + body:null when idle (handled in the try block); a 404 explicit
+  // fallback below is forward-compat only — no current server route
+  // surfaces it on this endpoint.
+  // Cleared on: any successful fetchCurrentJob, the forward-compat 404
+  // fallback, applyJobStarted (WS snapshot landed), applyControllerUpdate
+  // for a known controller (belt-and-suspenders), and the three terminal
+  // states (resetToSelect, applyJobDone, applyJobFailed) so the banner
+  // can't shadow a final state.
   const currentJobLoadFailed = ref(false);
 
   // Cold-load resync. Mounted views call this to populate currentJob from
@@ -475,10 +487,12 @@ export const useFirmwareStore = defineStore('firmware', () => {
       currentJobLoadFailed.value = false;
     } catch (error) {
       console.warn('firmware.fetchCurrentJob failed', error);
-      // 404 is the expected response from a healthy idle server (no flash
-      // in flight). Surfacing it as "could not confirm state" would falsely
-      // alarm operators on cold-load of an unused page. Only treat 5xx and
-      // network-level failures as a genuine staleness signal.
+      // The server's healthy-idle response is 200 + body:null, handled in
+      // the try block above. The 404 check below is forward-compat only: no
+      // current server route returns 404 on this endpoint, but a future
+      // change should not flip the staleness banner on for a benign idle
+      // response. Treat 5xx and network-level failures as the staleness
+      // signal; treat 404 (if it ever appears) as "no flash, not stale."
       const status =
         typeof error === 'object' && error !== null && 'response' in error
           ? (error as { response?: { status?: number } }).response?.status

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -88,3 +88,59 @@ export interface FlashErrorEnvelope {
   detail?: string;
   currentJobId?: string;
 }
+
+/**
+ * Mirror of the server's `FwStage` enum (string-literal values from
+ * `astros_api/src/models/firmware/firmware_messages.ts`). Hand-maintained;
+ * keep cross-referenced with the server source when either side changes.
+ */
+export type ServerFwStage =
+  | 'QUEUED'
+  | 'UPLOADING_TO_MASTER'
+  | 'SENDING'
+  | 'VERIFYING'
+  | 'REBOOTING'
+  | 'VERSION_CONFIRMED'
+  | 'FAILED';
+
+/**
+ * Mirror of the server's `ControllerFlashState` discriminated union narrowed
+ * to fields the UI reads. Source:
+ * `astros_api/src/models/firmware/flash_job_state.ts`.
+ */
+export interface ControllerFlashState {
+  controllerId: string;
+  stage: ServerFwStage;
+  /** Set when stage === 'VERSION_CONFIRMED'. */
+  finalVersion?: string;
+  /** Set when stage === 'FAILED'. */
+  error?: string;
+}
+
+/**
+ * Mirror of the server's `FlashJobState`. The `source` shape matches the
+ * `FlashRequest` body the client posts.
+ */
+export interface FlashJobState {
+  jobId: string;
+  source: { kind: 'github'; version: string } | { kind: 'upload' };
+  controllers: ControllerFlashState[];
+  startedAt: string;
+  endedAt?: string;
+  abortReason?: string;
+}
+
+/**
+ * Mirror of the server's `FlashJobFailedData` (the payload of
+ * `flashJobFailed` WS events). `reason` may be any server-side
+ * `FlashOrchestratorErrorReason` including post-streamer reasons that
+ * aren't in our `FlashErrorReason` union — keep as string for forward-
+ * compatibility; the renderer falls back to a generic message for unknowns.
+ */
+export interface FlashJobFailedData {
+  jobId: string;
+  endedAt: string;
+  reason?: string;
+  detail?: string;
+  abortReason?: string;
+}

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -141,27 +141,50 @@ export type ServerFwStage =
  * automatically. `Location.UNKNOWN` is excluded because an unknown slot
  * can't key per-controller state.
  */
-export type SlotId = Exclude<Location, Location.UNKNOWN>;
+// Use the template-literal extraction so SlotId is the underlying string
+// union ('body' | 'core' | 'dome') rather than the enum-member union.
+// String literals like 'body' widen to this naturally — important for
+// .get() calls and test assertions that pass string keys.
+export type SlotId = Exclude<`${Location}`, `${Location.UNKNOWN}`>;
 
 /**
- * Mirror of the server's `ControllerFlashState` discriminated union narrowed
- * to fields the UI reads. Source:
- * `astros_api/src/models/firmware/flash_job_state.ts`.
+ * Mirror of the server's `ControllerFlashState` discriminated union, narrowed
+ * to fields the UI reads. The server wire carries `bytesSent`, `totalBytes`,
+ * and `detail` on every variant; we omit those because no UI surface renders
+ * them.
  *
- * NB: `controllerId` semantics depend on data-flow position. On the wire
- * (server → client), it's a MAC. After `buildControllerStatesMap` rewrites
- * it to the slot id, it's a `SlotId`. The field is typed `string` because
- * TS can't enforce nominal MAC-vs-slot distinction across the JSON cast
- * at the WS boundary — see the doc comment in `buildControllerStatesMap`.
+ * Source of truth: `astros_api/src/models/firmware/flash_job_state.ts`.
+ *
+ * Discrimination: IM-2 makes `finalVersion`/`error` STRUCTURALLY required on
+ * their respective stages (matching the server). Reading `state.error` on a
+ * non-FAILED stage is a compile-time error.
+ *
+ * Wire vs slot (IM-11): on the wire, `controllerId` is a MAC. After
+ * `buildControllerStatesMap` / `applyControllerUpdate` re-key, it's a SlotId.
+ * The wire type uses `string` (MAC); the by-slot type uses `SlotId`. The
+ * translation happens at the single boundary in `buildControllerStatesMap`.
  */
-export interface ControllerFlashState {
-  controllerId: string;
-  stage: ServerFwStage;
-  /** Set when stage === 'VERSION_CONFIRMED'. */
-  finalVersion?: string;
-  /** Set when stage === 'FAILED'. */
-  error?: string;
-}
+export type ControllerFlashState =
+  | {
+      controllerId: string;
+      stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING';
+    }
+  | { controllerId: string; stage: 'VERSION_CONFIRMED'; finalVersion: string }
+  | { controllerId: string; stage: 'FAILED'; error: string };
+
+/**
+ * In-store (post-translation) view of `ControllerFlashState`. After
+ * `buildControllerStatesMap`/`applyControllerUpdate` re-key the MAC into a
+ * SlotId, the store keys controllerStates by SlotId and the embedded
+ * controllerId field is also a SlotId. See IM-11 for the rationale.
+ */
+export type ControllerFlashStateBySlot =
+  | {
+      controllerId: SlotId;
+      stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING';
+    }
+  | { controllerId: SlotId; stage: 'VERSION_CONFIRMED'; finalVersion: string }
+  | { controllerId: SlotId; stage: 'FAILED'; error: string };
 
 /**
  * Mirror of the server's `FlashJobState`. The `source` shape matches the

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -187,8 +187,13 @@ export type ControllerFlashStateBySlot =
   | { controllerId: SlotId; stage: 'FAILED'; error: string };
 
 /**
- * Mirror of the server's `FlashJobState`. The `source` shape matches the
- * `FlashRequest` body the client posts.
+ * Mirror of the server's `FlashJobState`, narrowed to UI-readable fields.
+ * The server transmits the full `FlashSource` shape (sha256, sizeBytes,
+ * displayName); we keep only what the UI needs. Source of truth:
+ * `astros_api/src/models/firmware/flash_job_state.ts`.
+ *
+ * Note: `endedAt` is set on both success and failure terminal states.
+ * `abortReason` is set only on cancel/streamer-rejection paths.
  */
 export interface FlashJobState {
   jobId: string;

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -37,7 +37,7 @@ export type ControllerOnlineStatus = 'up' | 'down' | 'needsSynced';
 
 /** Presentation-layer view of a controller for the firmware-update flow. */
 export interface FirmwareControllerView {
-  id: string;
+  id: SlotId;
   label: string;
   /** Single-letter badge glyph: 'B', 'C', 'D'. */
   glyph: string;
@@ -45,6 +45,17 @@ export interface FirmwareControllerView {
   current: string;
   status: ControllerOnlineStatus;
   isMaster: boolean;
+}
+
+/**
+ * Summary record for a controller that ended a flash job in stage='FAILED'.
+ * The `stage` is taken from the shared `currentStage` at failure time
+ * (FirmwareStage | null) — see `applyJobFailed`'s normalize for details.
+ */
+export interface FailedControllerSummary {
+  id: SlotId;
+  label: string;
+  stage: FirmwareStage | null;
 }
 
 export type FirmwareStatusPillKind =

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -60,6 +60,14 @@ export type FirmwarePhase = 'idle' | 'select' | 'flashing' | 'done' | 'failed';
 export type FirmwareStage = 'download' | 'transfer' | 'flash' | 'verify' | 'reboot';
 
 /**
+ * Template-literal type for the i18n key path of a stage label. Producer:
+ * `controllerStageLabelKey()`. Consumer: `AstrosFirmwareControllerRow.vue`
+ * via `t(stageLabelKey)`. Encoding the path as a type catches typos at
+ * the producer and consumer boundaries that a bare `string` would let slip.
+ */
+export type FirmwareStageLabelKey = `firmware_view.stages.${FirmwareStage}.label`;
+
+/**
  * Subset of the server's FlashOrchestratorErrorReason that surfaces via the
  * HTTP error response. Post-streamer failures (hash_mismatch,
  * chunk_retry_exhausted, etc.) are deliberately omitted — those arrive on
@@ -115,9 +123,36 @@ export type ServerFwStage =
   | 'FAILED';
 
 /**
+ * Branded type for a controller's hardware MAC address (e.g.
+ * `"aa:bb:cc:dd:ee:01"`). On the wire, the server uses MAC to identify
+ * controllers in flash-related messages. Inside the firmware store, MAC
+ * is translated to `SlotId` via the controllerStore's resolver.
+ *
+ * The brand is documentation-only — TS can't enforce nominality across
+ * the WS boundary where payloads arrive as untyped JSON. The contract is:
+ * if you see `Mac` in a type, the value is the raw wire identifier; if
+ * you see `SlotId`, it has been translated.
+ */
+export type Mac = string & { readonly __brand: 'Mac' };
+
+/**
+ * Fleet slot identifier — the in-store key for per-controller state.
+ * Matches the runtime values of `Location.BODY` / `Location.CORE` /
+ * `Location.DOME` (which is why those enum values are loose strings).
+ * `Location.UNKNOWN` is excluded by construction: an unknown slot can't
+ * key per-controller state.
+ */
+export type SlotId = 'body' | 'core' | 'dome';
+
+/**
  * Mirror of the server's `ControllerFlashState` discriminated union narrowed
  * to fields the UI reads. Source:
  * `astros_api/src/models/firmware/flash_job_state.ts`.
+ *
+ * NB: `controllerId` semantics depend on data-flow position. On the wire
+ * (server → client), it's a MAC. After `buildControllerStatesMap` rewrites
+ * it to the slot id, it's a `SlotId` (but still typed `string` because the
+ * brand can't survive a `... as ControllerFlashState` JSON cast).
  */
 export interface ControllerFlashState {
   controllerId: string;

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -3,6 +3,8 @@
 // `types/` so neither the store nor the api service has to import from
 // each other to share these shapes.
 
+import { Location } from '@/enums';
+
 export interface AssetInfo {
   variant: string;
   version: string;
@@ -123,26 +125,12 @@ export type ServerFwStage =
   | 'FAILED';
 
 /**
- * Branded type for a controller's hardware MAC address (e.g.
- * `"aa:bb:cc:dd:ee:01"`). On the wire, the server uses MAC to identify
- * controllers in flash-related messages. Inside the firmware store, MAC
- * is translated to `SlotId` via the controllerStore's resolver.
- *
- * The brand is documentation-only — TS can't enforce nominality across
- * the WS boundary where payloads arrive as untyped JSON. The contract is:
- * if you see `Mac` in a type, the value is the raw wire identifier; if
- * you see `SlotId`, it has been translated.
- */
-export type Mac = string & { readonly __brand: 'Mac' };
-
-/**
  * Fleet slot identifier — the in-store key for per-controller state.
- * Matches the runtime values of `Location.BODY` / `Location.CORE` /
- * `Location.DOME` (which is why those enum values are loose strings).
- * `Location.UNKNOWN` is excluded by construction: an unknown slot can't
- * key per-controller state.
+ * Derived from `Location` so adding a new fleet location updates this type
+ * automatically. `Location.UNKNOWN` is excluded because an unknown slot
+ * can't key per-controller state.
  */
-export type SlotId = 'body' | 'core' | 'dome';
+export type SlotId = Exclude<Location, Location.UNKNOWN>;
 
 /**
  * Mirror of the server's `ControllerFlashState` discriminated union narrowed
@@ -151,8 +139,9 @@ export type SlotId = 'body' | 'core' | 'dome';
  *
  * NB: `controllerId` semantics depend on data-flow position. On the wire
  * (server → client), it's a MAC. After `buildControllerStatesMap` rewrites
- * it to the slot id, it's a `SlotId` (but still typed `string` because the
- * brand can't survive a `... as ControllerFlashState` JSON cast).
+ * it to the slot id, it's a `SlotId`. The field is typed `string` because
+ * TS can't enforce nominal MAC-vs-slot distinction across the JSON cast
+ * at the WS boundary — see the doc comment in `buildControllerStatesMap`.
  */
 export interface ControllerFlashState {
   controllerId: string;

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -64,24 +64,35 @@ export type FirmwareStage = 'download' | 'transfer' | 'flash' | 'verify' | 'rebo
  * HTTP error response. Post-streamer failures (hash_mismatch,
  * chunk_retry_exhausted, etc.) are deliberately omitted — those arrive on
  * the WS surface, not via this envelope.
+ *
+ * The tuple is the single source of truth: the `FlashErrorReason` union is
+ * derived from it, and `KNOWN_FLASH_ERROR_REASONS` is the corresponding
+ * runtime Set — both stay in sync because both come from this one list.
  */
-export type FlashErrorReason =
-  | 'invalid_body'
-  | 'job_already_running'
-  | 'no_controllers'
-  | 'variant_mismatch'
-  | 'variant_unknown'
-  | 'release_not_found'
-  | 'asset_not_found'
-  | 'no_upload'
-  | 'release_lookup_failed'
-  | 'source_resolution_failed'
-  | 'controllers_lookup_failed'
-  | 'subscriber_attach_failed'
-  | 'protocol_violation'
-  | 'streamer_unknown_error'
-  | 'internal_server_error'
-  | 'network_error';
+export const FLASH_ERROR_REASONS = [
+  'invalid_body',
+  'job_already_running',
+  'no_controllers',
+  'variant_mismatch',
+  'variant_unknown',
+  'release_not_found',
+  'asset_not_found',
+  'no_upload',
+  'release_lookup_failed',
+  'source_resolution_failed',
+  'controllers_lookup_failed',
+  'subscriber_attach_failed',
+  'protocol_violation',
+  'streamer_unknown_error',
+  'internal_server_error',
+  'network_error',
+] as const;
+
+export type FlashErrorReason = (typeof FLASH_ERROR_REASONS)[number];
+
+export const KNOWN_FLASH_ERROR_REASONS: ReadonlySet<FlashErrorReason> = new Set(
+  FLASH_ERROR_REASONS,
+);
 
 export interface FlashErrorEnvelope {
   reason: FlashErrorReason;

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -148,21 +148,17 @@ export type ServerFwStage =
 export type SlotId = Exclude<`${Location}`, `${Location.UNKNOWN}`>;
 
 /**
- * Mirror of the server's `ControllerFlashState` discriminated union, narrowed
- * to fields the UI reads. The server wire carries `bytesSent`, `totalBytes`,
- * and `detail` on every variant; we omit those because no UI surface renders
- * them.
+ * Wire-side mirror of the server's `ControllerFlashState` discriminated union,
+ * narrowed to fields the UI reads (server wire also carries `bytesSent`,
+ * `totalBytes`, `detail`; we drop those — no UI surface renders them).
  *
  * Source of truth: `astros_api/src/models/firmware/flash_job_state.ts`.
  *
- * Discrimination: IM-2 makes `finalVersion`/`error` STRUCTURALLY required on
- * their respective stages (matching the server). Reading `state.error` on a
- * non-FAILED stage is a compile-time error.
- *
- * Wire vs slot (IM-11): on the wire, `controllerId` is a MAC. After
- * `buildControllerStatesMap` / `applyControllerUpdate` re-key, it's a SlotId.
- * The wire type uses `string` (MAC); the by-slot type uses `SlotId`. The
- * translation happens at the single boundary in `buildControllerStatesMap`.
+ * `finalVersion`/`error` are structurally required on their respective stages,
+ * matching the server. Reading `state.error` on a non-FAILED stage is a
+ * compile error. On the wire `controllerId` is a MAC string; the in-store
+ * variant (ControllerFlashStateBySlot) uses SlotId after translation in
+ * `buildControllerStatesMap`.
  */
 export type ControllerFlashState =
   | {
@@ -173,10 +169,9 @@ export type ControllerFlashState =
   | { controllerId: string; stage: 'FAILED'; error: string };
 
 /**
- * In-store (post-translation) view of `ControllerFlashState`. After
- * `buildControllerStatesMap`/`applyControllerUpdate` re-key the MAC into a
- * SlotId, the store keys controllerStates by SlotId and the embedded
- * controllerId field is also a SlotId. See IM-11 for the rationale.
+ * In-store (post-translation) view. `buildControllerStatesMap` re-keys
+ * the wire MAC into a SlotId; both the Map key and the embedded
+ * controllerId are SlotIds.
  */
 export type ControllerFlashStateBySlot =
   | {

--- a/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
@@ -7,6 +7,15 @@ import {
 import type { ControllerFlashState, ServerFwStage } from '@/types/firmware';
 
 function state(stage: ServerFwStage): ControllerFlashState {
+  // After IM-2 (discriminated union), VERSION_CONFIRMED requires
+  // finalVersion and FAILED requires error. Provide test placeholders
+  // so the function can be invoked with any stage.
+  if (stage === 'VERSION_CONFIRMED') {
+    return { controllerId: 'body', stage, finalVersion: 'v1.0.0-test' };
+  }
+  if (stage === 'FAILED') {
+    return { controllerId: 'body', stage, error: 'test:error' };
+  }
   return { controllerId: 'body', stage };
 }
 
@@ -112,5 +121,21 @@ describe('controllerStageLabelKey', () => {
     expect(controllerStageLabelKey(state('QUEUED'))).toBeNull();
     expect(controllerStageLabelKey(state('VERSION_CONFIRMED'))).toBeNull();
     expect(controllerStageLabelKey(state('FAILED'))).toBeNull();
+  });
+});
+
+describe('FlashErrorReason i18n key contract (IM-8)', () => {
+  // Every FlashErrorReason in the union must have a corresponding
+  // firmware_view.flash_errors.<reason> key in enUS.json. Without this
+  // pin, adding a new reason to the tuple without updating the locale
+  // file would render the literal key path in the operator's UI.
+  it('every FlashErrorReason has a corresponding firmware_view.flash_errors.* i18n key', async () => {
+    const { FLASH_ERROR_REASONS } = await import('@/types/firmware');
+    const enUS = (await import('@/locales/enUS.json')).default as unknown as {
+      firmware_view: { flash_errors: Record<string, string> };
+    };
+    for (const reason of FLASH_ERROR_REASONS) {
+      expect(enUS.firmware_view.flash_errors).toHaveProperty(reason);
+    }
   });
 });

--- a/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
@@ -7,9 +7,9 @@ import {
 import type { ControllerFlashState, ServerFwStage } from '@/types/firmware';
 
 function state(stage: ServerFwStage): ControllerFlashState {
-  // After IM-2 (discriminated union), VERSION_CONFIRMED requires
-  // finalVersion and FAILED requires error. Provide test placeholders
-  // so the function can be invoked with any stage.
+  // The discriminated union requires finalVersion on VERSION_CONFIRMED
+  // and error on FAILED. Provide test placeholders so the helper can
+  // build a valid state for any stage.
   if (stage === 'VERSION_CONFIRMED') {
     return { controllerId: 'body', stage, finalVersion: 'v1.0.0-test' };
   }
@@ -42,16 +42,16 @@ describe('mapServerStageToUiStage', () => {
     expect(mapServerStageToUiStage('FAILED')).toBeNull();
   });
 
-  it('returns null (not undefined) for unknown future server stages (C3 forward-compat)', () => {
-    // Round-5 C3 fix: without the default case, an unknown ServerFwStage
-    // value falls through the switch and returns undefined. Downstream
-    // `if (ui !== null)` guards would then write `undefined` to a
-    // FirmwareStage|null ref. The cast simulates a future enum value.
+  it('returns null (not undefined) for unknown future server stages (forward-compat)', () => {
+    // Without the default case, an unknown stage falls through and
+    // returns undefined; downstream `if (ui !== null)` guards would
+    // then write undefined to a FirmwareStage|null ref. The cast
+    // simulates a future enum value.
     const unknown = 'WAITING_ON_NETWORK' as unknown as ServerFwStage;
     expect(mapServerStageToUiStage(unknown)).toBeNull();
   });
 
-  it('emits a console.warn for unknown stages so contract drift is debuggable (round-6 C3 breadcrumb)', () => {
+  it('emits a console.warn for unknown stages so contract drift is debuggable', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const unknown = 'CANCELLED' as unknown as ServerFwStage;
@@ -84,7 +84,7 @@ describe('controllerStatePillKind', () => {
     expect(controllerStatePillKind(state('FAILED'))).toBe('failed');
   });
 
-  it('emits a console.warn for unknown stages (round-6 C3 breadcrumb)', () => {
+  it('emits a console.warn for unknown stages', () => {
     // A future ServerFwStage like 'CANCELLED' would render an 'updating'
     // pill forever (no terminal stage update will arrive). The warn
     // surfaces the contract drift in dev console + production logs.
@@ -99,7 +99,7 @@ describe('controllerStatePillKind', () => {
     }
   });
 
-  it('returns updating (not undefined) for unknown future server stages (C3 forward-compat)', () => {
+  it('returns updating (not undefined) for unknown future server stages (forward-compat)', () => {
     // Without the default case, an unknown stage returned undefined, which
     // the StatusPill component would receive as kind=undefined. Mapping
     // unknowns to 'updating' keeps the row spinning safely until a
@@ -124,7 +124,7 @@ describe('controllerStageLabelKey', () => {
   });
 });
 
-describe('FlashErrorReason i18n key contract (IM-8)', () => {
+describe('FlashErrorReason i18n key contract', () => {
   // Every FlashErrorReason in the union must have a corresponding
   // firmware_view.flash_errors.<reason> key in enUS.json. Without this
   // pin, adding a new reason to the tuple without updating the locale

--- a/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   controllerStageLabelKey,
   controllerStatePillKind,
@@ -41,6 +41,18 @@ describe('mapServerStageToUiStage', () => {
     const unknown = 'WAITING_ON_NETWORK' as unknown as ServerFwStage;
     expect(mapServerStageToUiStage(unknown)).toBeNull();
   });
+
+  it('emits a console.warn for unknown stages so contract drift is debuggable (round-6 C3 breadcrumb)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const unknown = 'CANCELLED' as unknown as ServerFwStage;
+      mapServerStageToUiStage(unknown);
+      const warnText = warnSpy.mock.calls.flat().join(' ');
+      expect(warnText).toContain('unknown stage="CANCELLED"');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe('controllerStatePillKind', () => {
@@ -61,6 +73,21 @@ describe('controllerStatePillKind', () => {
 
   it('returns failed for FAILED', () => {
     expect(controllerStatePillKind(state('FAILED'))).toBe('failed');
+  });
+
+  it('emits a console.warn for unknown stages (round-6 C3 breadcrumb)', () => {
+    // A future ServerFwStage like 'CANCELLED' would render an 'updating'
+    // pill forever (no terminal stage update will arrive). The warn
+    // surfaces the contract drift in dev console + production logs.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const unknown = 'CANCELLED' as unknown as ServerFwStage;
+      controllerStatePillKind(state(unknown));
+      const warnText = warnSpy.mock.calls.flat().join(' ');
+      expect(warnText).toContain('unknown stage="CANCELLED"');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('returns updating (not undefined) for unknown future server stages (C3 forward-compat)', () => {

--- a/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
@@ -32,6 +32,15 @@ describe('mapServerStageToUiStage', () => {
     expect(mapServerStageToUiStage('VERSION_CONFIRMED')).toBeNull();
     expect(mapServerStageToUiStage('FAILED')).toBeNull();
   });
+
+  it('returns null (not undefined) for unknown future server stages (C3 forward-compat)', () => {
+    // Round-5 C3 fix: without the default case, an unknown ServerFwStage
+    // value falls through the switch and returns undefined. Downstream
+    // `if (ui !== null)` guards would then write `undefined` to a
+    // FirmwareStage|null ref. The cast simulates a future enum value.
+    const unknown = 'WAITING_ON_NETWORK' as unknown as ServerFwStage;
+    expect(mapServerStageToUiStage(unknown)).toBeNull();
+  });
 });
 
 describe('controllerStatePillKind', () => {
@@ -52,6 +61,15 @@ describe('controllerStatePillKind', () => {
 
   it('returns failed for FAILED', () => {
     expect(controllerStatePillKind(state('FAILED'))).toBe('failed');
+  });
+
+  it('returns updating (not undefined) for unknown future server stages (C3 forward-compat)', () => {
+    // Without the default case, an unknown stage returned undefined, which
+    // the StatusPill component would receive as kind=undefined. Mapping
+    // unknowns to 'updating' keeps the row spinning safely until a
+    // recognized stage arrives.
+    const unknown = 'WAITING_ON_NETWORK' as unknown as ServerFwStage;
+    expect(controllerStatePillKind(state(unknown))).toBe('updating');
   });
 });
 

--- a/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  controllerStageLabelKey,
+  controllerStatePillKind,
+  mapServerStageToUiStage,
+} from '../firmwareStageMapping';
+import type { ControllerFlashState, ServerFwStage } from '@/types/firmware';
+
+function state(stage: ServerFwStage): ControllerFlashState {
+  return { controllerId: 'body', stage };
+}
+
+describe('mapServerStageToUiStage', () => {
+  it('maps UPLOADING_TO_MASTER to download', () => {
+    expect(mapServerStageToUiStage('UPLOADING_TO_MASTER')).toBe('download');
+  });
+
+  it('maps SENDING to transfer', () => {
+    expect(mapServerStageToUiStage('SENDING')).toBe('transfer');
+  });
+
+  it('maps VERIFYING to verify', () => {
+    expect(mapServerStageToUiStage('VERIFYING')).toBe('verify');
+  });
+
+  it('maps REBOOTING to reboot', () => {
+    expect(mapServerStageToUiStage('REBOOTING')).toBe('reboot');
+  });
+
+  it('returns null for QUEUED, VERSION_CONFIRMED, FAILED (no specific UI stage row)', () => {
+    expect(mapServerStageToUiStage('QUEUED')).toBeNull();
+    expect(mapServerStageToUiStage('VERSION_CONFIRMED')).toBeNull();
+    expect(mapServerStageToUiStage('FAILED')).toBeNull();
+  });
+});
+
+describe('controllerStatePillKind', () => {
+  it('returns queued for QUEUED', () => {
+    expect(controllerStatePillKind(state('QUEUED'))).toBe('queued');
+  });
+
+  it('returns updating for all in-flight stages', () => {
+    expect(controllerStatePillKind(state('UPLOADING_TO_MASTER'))).toBe('updating');
+    expect(controllerStatePillKind(state('SENDING'))).toBe('updating');
+    expect(controllerStatePillKind(state('VERIFYING'))).toBe('updating');
+    expect(controllerStatePillKind(state('REBOOTING'))).toBe('updating');
+  });
+
+  it('returns done for VERSION_CONFIRMED', () => {
+    expect(controllerStatePillKind(state('VERSION_CONFIRMED'))).toBe('done');
+  });
+
+  it('returns failed for FAILED', () => {
+    expect(controllerStatePillKind(state('FAILED'))).toBe('failed');
+  });
+});
+
+describe('controllerStageLabelKey', () => {
+  it('returns the i18n path for stages with a UI mapping', () => {
+    expect(controllerStageLabelKey(state('UPLOADING_TO_MASTER'))).toBe(
+      'firmware_view.stages.download.label',
+    );
+    expect(controllerStageLabelKey(state('SENDING'))).toBe('firmware_view.stages.transfer.label');
+  });
+
+  it('returns null for stages without a UI mapping', () => {
+    expect(controllerStageLabelKey(state('QUEUED'))).toBeNull();
+    expect(controllerStageLabelKey(state('VERSION_CONFIRMED'))).toBeNull();
+    expect(controllerStageLabelKey(state('FAILED'))).toBeNull();
+  });
+});

--- a/astros_vue/src/utils/firmwareFlashError.ts
+++ b/astros_vue/src/utils/firmwareFlashError.ts
@@ -1,23 +1,8 @@
-import type { FlashErrorEnvelope, FlashErrorReason } from '@/types/firmware';
-
-const KNOWN_REASONS: ReadonlySet<FlashErrorReason> = new Set<FlashErrorReason>([
-  'invalid_body',
-  'job_already_running',
-  'no_controllers',
-  'variant_mismatch',
-  'variant_unknown',
-  'release_not_found',
-  'asset_not_found',
-  'no_upload',
-  'release_lookup_failed',
-  'source_resolution_failed',
-  'controllers_lookup_failed',
-  'subscriber_attach_failed',
-  'protocol_violation',
-  'streamer_unknown_error',
-  'internal_server_error',
-  'network_error',
-]);
+import {
+  KNOWN_FLASH_ERROR_REASONS,
+  type FlashErrorEnvelope,
+  type FlashErrorReason,
+} from '@/types/firmware';
 
 function isAxiosLikeError(value: unknown): value is { response?: { data?: unknown } } {
   return typeof value === 'object' && value !== null && 'response' in value;
@@ -42,7 +27,8 @@ export function mapHttpErrorToFlashEnvelope(error: unknown): FlashErrorEnvelope 
   const detailRaw = (body as { detail?: unknown }).detail;
   const currentJobIdRaw = (body as { currentJobId?: unknown }).currentJobId;
 
-  const isKnown = typeof reasonRaw === 'string' && KNOWN_REASONS.has(reasonRaw as FlashErrorReason);
+  const isKnown =
+    typeof reasonRaw === 'string' && KNOWN_FLASH_ERROR_REASONS.has(reasonRaw as FlashErrorReason);
   if (!isKnown && typeof reasonRaw === 'string') {
     console.warn(
       `[firmwareFlashError] unrecognized server reason "${reasonRaw}"; mapping to internal_server_error`,

--- a/astros_vue/src/utils/firmwareStageMapping.ts
+++ b/astros_vue/src/utils/firmwareStageMapping.ts
@@ -1,0 +1,56 @@
+import type {
+  ControllerFlashState,
+  FirmwareStage,
+  FirmwareStatusPillKind,
+  ServerFwStage,
+} from '@/types/firmware';
+
+/**
+ * Project a server-side stage onto a UI stage row. Returns null for stages
+ * that have no corresponding row (QUEUED — handled via the per-controller
+ * pill; VERSION_CONFIRMED — terminal success; FAILED — terminal failure
+ * surfaced via the row's `!` glyph).
+ */
+export function mapServerStageToUiStage(stage: ServerFwStage): FirmwareStage | null {
+  switch (stage) {
+    case 'UPLOADING_TO_MASTER':
+      return 'download';
+    case 'SENDING':
+      return 'transfer';
+    case 'VERIFYING':
+      return 'verify';
+    case 'REBOOTING':
+      return 'reboot';
+    case 'QUEUED':
+    case 'VERSION_CONFIRMED':
+    case 'FAILED':
+      return null;
+  }
+}
+
+/** Project a per-controller server state onto a `StatusPill` kind. */
+export function controllerStatePillKind(state: ControllerFlashState): FirmwareStatusPillKind {
+  switch (state.stage) {
+    case 'QUEUED':
+      return 'queued';
+    case 'UPLOADING_TO_MASTER':
+    case 'SENDING':
+    case 'VERIFYING':
+    case 'REBOOTING':
+      return 'updating';
+    case 'VERSION_CONFIRMED':
+      return 'done';
+    case 'FAILED':
+      return 'failed';
+  }
+}
+
+/**
+ * Project the i18n key path for the stage label shown under a row's status
+ * pill during `updating` mode. Returns null for stages without a UI stage
+ * (caller renders no label).
+ */
+export function controllerStageLabelKey(state: ControllerFlashState): string | null {
+  const uiStage = mapServerStageToUiStage(state.stage);
+  return uiStage === null ? null : `firmware_view.stages.${uiStage}.label`;
+}

--- a/astros_vue/src/utils/firmwareStageMapping.ts
+++ b/astros_vue/src/utils/firmwareStageMapping.ts
@@ -26,6 +26,19 @@ export function mapServerStageToUiStage(stage: ServerFwStage): FirmwareStage | n
     case 'VERSION_CONFIRMED':
     case 'FAILED':
       return null;
+    default: {
+      // Forward-compat: a future server-side `ServerFwStage` value would
+      // otherwise fall through this switch and return undefined, breaking
+      // downstream `if (ui !== null)` checks (undefined !== null is true).
+      // Treat unknown stages as "no UI stage" so the row simply stays at
+      // its previous pill state rather than mis-rendering.
+      // The `_exhaustive: never` assignment is a compile-time guard: if a
+      // new ServerFwStage value is added to the union without a matching
+      // case above, this line fails type-check. Runtime is unaffected.
+      const _exhaustive: never = stage;
+      void _exhaustive;
+      return null;
+    }
   }
 }
 
@@ -43,6 +56,17 @@ export function controllerStatePillKind(state: ControllerFlashState): FirmwareSt
       return 'done';
     case 'FAILED':
       return 'failed';
+    default: {
+      // Forward-compat: an unknown ServerFwStage would otherwise return
+      // undefined from this switch, and the row would render with an
+      // undefined pill kind. Map to 'updating' as the safest fallback —
+      // the row keeps spinning until a recognized stage arrives. The
+      // `_exhaustive: never` assignment is a compile-time guard mirroring
+      // mapServerStageToUiStage above.
+      const _exhaustive: never = state.stage;
+      void _exhaustive;
+      return 'updating';
+    }
   }
 }
 

--- a/astros_vue/src/utils/firmwareStageMapping.ts
+++ b/astros_vue/src/utils/firmwareStageMapping.ts
@@ -1,6 +1,7 @@
 import type {
   ControllerFlashState,
   FirmwareStage,
+  FirmwareStageLabelKey,
   FirmwareStatusPillKind,
   ServerFwStage,
 } from '@/types/firmware';
@@ -50,7 +51,7 @@ export function controllerStatePillKind(state: ControllerFlashState): FirmwareSt
  * pill during `updating` mode. Returns null for stages without a UI stage
  * (caller renders no label).
  */
-export function controllerStageLabelKey(state: ControllerFlashState): string | null {
+export function controllerStageLabelKey(state: ControllerFlashState): FirmwareStageLabelKey | null {
   const uiStage = mapServerStageToUiStage(state.stage);
   return uiStage === null ? null : `firmware_view.stages.${uiStage}.label`;
 }

--- a/astros_vue/src/utils/firmwareStageMapping.ts
+++ b/astros_vue/src/utils/firmwareStageMapping.ts
@@ -30,11 +30,15 @@ export function mapServerStageToUiStage(stage: ServerFwStage): FirmwareStage | n
       // Forward-compat: a future server-side `ServerFwStage` value would
       // otherwise fall through this switch and return undefined, breaking
       // downstream `if (ui !== null)` checks (undefined !== null is true).
-      // Treat unknown stages as "no UI stage" so the row simply stays at
-      // its previous pill state rather than mis-rendering.
+      // Treat unknown stages as "no UI stage" so the global stage indicator
+      // stays at its previous value rather than flipping to undefined.
       // The `_exhaustive: never` assignment is a compile-time guard: if a
       // new ServerFwStage value is added to the union without a matching
-      // case above, this line fails type-check. Runtime is unaffected.
+      // case above, this line fails type-check.
+      console.warn(
+        `[firmwareStageMapping] mapServerStageToUiStage: unknown stage="${stage}". ` +
+          `Server contract drift — global stage indicator will not advance until a recognized stage arrives.`,
+      );
       const _exhaustive: never = stage;
       void _exhaustive;
       return null;
@@ -60,9 +64,16 @@ export function controllerStatePillKind(state: ControllerFlashState): FirmwareSt
       // Forward-compat: an unknown ServerFwStage would otherwise return
       // undefined from this switch, and the row would render with an
       // undefined pill kind. Map to 'updating' as the safest fallback —
-      // the row keeps spinning until a recognized stage arrives. The
-      // `_exhaustive: never` assignment is a compile-time guard mirroring
-      // mapServerStageToUiStage above.
+      // the row remains in the 'updating' indicator until a recognized
+      // stage arrives. The `_exhaustive: never` assignment is a compile-
+      // time guard mirroring mapServerStageToUiStage above. The warn
+      // surfaces server contract drift in production logs: an unrecognized
+      // terminal stage (e.g. a future 'CANCELLED') would otherwise leave
+      // the row stuck on 'updating' forever with no breadcrumb.
+      console.warn(
+        `[firmwareStageMapping] controllerStatePillKind: unknown stage="${state.stage}" ` +
+          `for controllerId="${state.controllerId}". Server contract drift — row will stay on 'updating' until a recognized stage arrives.`,
+      );
       const _exhaustive: never = state.stage;
       void _exhaustive;
       return 'updating';

--- a/astros_vue/src/utils/firmwareStageMapping.ts
+++ b/astros_vue/src/utils/firmwareStageMapping.ts
@@ -65,16 +65,19 @@ export function controllerStatePillKind(state: ControllerFlashState): FirmwareSt
       // undefined from this switch, and the row would render with an
       // undefined pill kind. Map to 'updating' as the safest fallback —
       // the row remains in the 'updating' indicator until a recognized
-      // stage arrives. The `_exhaustive: never` assignment is a compile-
-      // time guard mirroring mapServerStageToUiStage above. The warn
-      // surfaces server contract drift in production logs: an unrecognized
-      // terminal stage (e.g. a future 'CANCELLED') would otherwise leave
-      // the row stuck on 'updating' forever with no breadcrumb.
+      // stage arrives. The `_exhaustive: never` assignment compiles
+      // because the switch covers all ServerFwStage variants of the
+      // IM-2 discriminated union; the default branch is reachable only
+      // when a runtime payload lies about its `stage` (e.g. a future
+      // 'CANCELLED' value cast through the type at the WS boundary).
+      // Read fields via a pre-narrowing shape so the warn message still
+      // surfaces server contract drift in production logs.
+      const stateAsAny = state as { stage: string; controllerId: string };
       console.warn(
-        `[firmwareStageMapping] controllerStatePillKind: unknown stage="${state.stage}" ` +
-          `for controllerId="${state.controllerId}". Server contract drift — row will stay on 'updating' until a recognized stage arrives.`,
+        `[firmwareStageMapping] controllerStatePillKind: unknown stage="${stateAsAny.stage}" ` +
+          `for controllerId="${stateAsAny.controllerId}". Server contract drift — row will stay on 'updating' until a recognized stage arrives.`,
       );
-      const _exhaustive: never = state.stage;
+      const _exhaustive: never = state;
       void _exhaustive;
       return 'updating';
     }

--- a/astros_vue/src/utils/firmwareStageMapping.ts
+++ b/astros_vue/src/utils/firmwareStageMapping.ts
@@ -61,17 +61,12 @@ export function controllerStatePillKind(state: ControllerFlashState): FirmwareSt
     case 'FAILED':
       return 'failed';
     default: {
-      // Forward-compat: an unknown ServerFwStage would otherwise return
-      // undefined from this switch, and the row would render with an
-      // undefined pill kind. Map to 'updating' as the safest fallback —
-      // the row remains in the 'updating' indicator until a recognized
-      // stage arrives. The `_exhaustive: never` assignment compiles
-      // because the switch covers all ServerFwStage variants of the
-      // IM-2 discriminated union; the default branch is reachable only
-      // when a runtime payload lies about its `stage` (e.g. a future
-      // 'CANCELLED' value cast through the type at the WS boundary).
-      // Read fields via a pre-narrowing shape so the warn message still
-      // surfaces server contract drift in production logs.
+      // Forward-compat for future server stages. The `never` exhaustiveness
+      // covers every ServerFwStage variant, so this branch only fires when
+      // a runtime payload lies about its `stage` (e.g. a future 'CANCELLED'
+      // cast through the type at the WS boundary). Fall back to 'updating'
+      // so the row stays in an unambiguous in-progress indicator until a
+      // recognized stage arrives; the warn surfaces the contract drift.
       const stateAsAny = state as { stage: string; controllerId: string };
       console.warn(
         `[firmwareStageMapping] controllerStatePillKind: unknown stage="${stateAsAny.stage}" ` +

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -41,19 +41,41 @@ const { locked: lockLocked, since: lockSince } = storeToRefs(jobLock);
 // WS connection state. Drives the "live updates suspended" banner when a
 // flash is in flight but the socket is down — without this signal the
 // operator would stare at frozen progress with no indication that the
-// stream has stopped.
-const { wsIsConnected } = useWebsocket();
-const flashStreamSuspended = computed(() => phase.value === 'flashing' && !wsIsConnected.value);
+// stream has stopped. Gated on `wsHasEverConnected` so the banner doesn't
+// flicker during the ~50ms between FirmwareView mount and the first
+// onopen: until the socket has ever connected, "disconnected" isn't yet
+// a meaningful staleness signal — it's the expected pre-connect state.
+const { wsIsConnected, wsHasEverConnected } = useWebsocket();
+const flashStreamSuspended = computed(
+  () => phase.value === 'flashing' && wsHasEverConnected.value && !wsIsConnected.value,
+);
 
-// Mid-flash error region. The panel's `flash_error_banner` is gated on
-// phase==='select' (it surfaces HTTP POST failures before the job lifecycle
-// owns phase). For errors raised by useWebsocket's mid-stream catch blocks
-// (handleFlashControllerUpdate / handleFlashControllerResult set flashError
-// without rolling phase), the panel banner is hidden — so without this
-// region, the store write goes to a ref no template reads.
+// Mid-flash + pre-streamer-abort error region. The panel's
+// `flash_error_banner` is gated on phase==='select' (it surfaces HTTP POST
+// failures before the job lifecycle owns phase). For errors raised by:
+//   - useWebsocket's mid-stream catch blocks (phase==='flashing')
+//   - applyJobFailed with empty failedControllers (pre-streamer abort —
+//     job failed before any controller transitioned to FAILED, so the
+//     panel's "⚠ — failed during the flash" result bar is uselessly vague)
+// the panel banner is hidden — without this region, flashError.detail
+// would go to a ref no template reads.
 const flashErrorDetail = computed(() => {
   if (flashError.value === null) return null;
   return flashError.value.detail ?? t(`firmware_view.flash_errors.${flashError.value.reason}`);
+});
+const showFlashErrorRegion = computed(() => {
+  if (flashError.value === null) return false;
+  if (phase.value === 'flashing') return true;
+  // In 'failed' phase, the panel's result bar carries label + stage but
+  // never surfaces `flashError.detail`. Show this region when either:
+  //   - no controllers were marked FAILED (pre-streamer abort: result bar
+  //     is uselessly vague without the detail), OR
+  //   - flashError has a non-null detail string (operator should see the
+  //     specific reason, not just "Core failed during Verify").
+  return (
+    phase.value === 'failed' &&
+    (failedControllers.value.length === 0 || flashError.value.detail != null)
+  );
 });
 
 const confirmOpen = ref(false);
@@ -193,7 +215,7 @@ onMounted(async () => {
             polite-the-announcement pattern matches WAI-ARIA guidance.
           -->
           <div
-            v-if="phase === 'flashing' && flashError !== null"
+            v-if="showFlashErrorRegion"
             class="firmware-view__flash-error"
             role="alert"
             aria-live="polite"

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -60,9 +60,9 @@ const selectedControllerList = computed<FirmwareControllerView[]>(() =>
 
 const failedControllerId = computed(() => failedController.value?.id);
 
-// A flash is in flight but it isn't ours — show a conflict alert and keep
-// the page in select mode (Flash button is already disabled via the
-// lock-aware AstrosWriteButton + ControllersPanel canFlash check).
+// A flash is in flight but it isn't ours — suppress the working UI. The
+// SourceStrip + grid v-ifs below gate on !lockConflict so the Flash button
+// isn't reachable while a foreign flash is in flight.
 const lockConflict = computed(() => lockLocked.value && !isOwnJob.value);
 
 // Dev-only invariant warning. Surfaces wiring bugs in the controllers-store

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -12,6 +12,7 @@ import {
 } from '@/components';
 import { useFirmwareStore } from '@/stores/firmware';
 import { useJobLockStore } from '@/stores/jobLock';
+import { useWebsocket } from '@/composables/useWebsocket';
 import type { FirmwareControllerView, TopologyFleet } from '@/components';
 
 import '@fontsource/inter/400.css';
@@ -36,6 +37,12 @@ const {
   currentJobLoadFailed,
 } = storeToRefs(firmware);
 const { locked: lockLocked, since: lockSince } = storeToRefs(jobLock);
+// WS connection state. Drives the "live updates suspended" banner when a
+// flash is in flight but the socket is down — without this signal the
+// operator would stare at frozen progress with no indication that the
+// stream has stopped.
+const { wsIsConnected } = useWebsocket();
+const flashStreamSuspended = computed(() => phase.value === 'flashing' && !wsIsConnected.value);
 
 const confirmOpen = ref(false);
 
@@ -81,8 +88,9 @@ const lockSinceFormatter = new Intl.DateTimeFormat(undefined, {
 const lockSinceFormatted = computed(() => {
   const raw = lockSince.value;
   if (raw === null) return '—';
-  // Defensive: a malformed ISO would throw on Date construction's NaN path.
-  // Fall back to the raw string so the operator at least sees something.
+  // Defensive: a malformed ISO produces an Invalid Date whose getTime()
+  // returns NaN. Fall back to the raw string so the operator at least
+  // sees something instead of a NaN/Invalid string from the formatter.
   const d = new Date(raw);
   return Number.isNaN(d.getTime()) ? raw : lockSinceFormatter.format(d);
 });
@@ -157,10 +165,18 @@ onMounted(async () => {
           </div>
 
           <div
+            v-if="flashStreamSuspended"
+            class="firmware-view__stale-warning"
+            role="status"
+            aria-live="polite"
+          >
+            {{ t('firmware_view.flash_stream_suspended') }}
+          </div>
+
+          <div
             v-if="lockConflict"
             class="firmware-view__lock-conflict"
             role="alert"
-            aria-live="polite"
           >
             <span class="firmware-view__lock-conflict-title">{{
               t('firmware_view.lock_conflict.title')
@@ -199,6 +215,7 @@ onMounted(async () => {
               :progress-by-controller-id="progressByControllerId"
               :failed-controller-label="failedControllerLabels || undefined"
               :failed-stage="failedStage ?? undefined"
+              :failed-count="failedControllers.length"
               @flash="openConfirm"
               @done="onResultBarDone"
             />

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -11,6 +11,7 @@ import {
   AstrosFirmwareConfirmModal,
 } from '@/components';
 import { useFirmwareStore } from '@/stores/firmware';
+import { useJobLockStore } from '@/stores/jobLock';
 import type { FirmwareControllerView, TopologyFleet } from '@/components';
 
 import '@fontsource/inter/400.css';
@@ -20,6 +21,7 @@ import '@fontsource/inter/700.css';
 
 const { t } = useI18n();
 const firmware = useFirmwareStore();
+const jobLock = useJobLockStore();
 const {
   phase,
   controllers,
@@ -29,7 +31,10 @@ const {
   failedController,
   sourceMode,
   uploadedFilename,
+  progressByControllerId,
+  isOwnJob,
 } = storeToRefs(firmware);
+const { locked: lockLocked, since: lockSince } = storeToRefs(jobLock);
 
 const confirmOpen = ref(false);
 
@@ -54,6 +59,11 @@ const selectedControllerList = computed<FirmwareControllerView[]>(() =>
 );
 
 const failedControllerId = computed(() => failedController.value?.id);
+
+// A flash is in flight but it isn't ours — show a conflict alert and keep
+// the page in select mode (Flash button is already disabled via the
+// lock-aware AstrosWriteButton + ControllersPanel canFlash check).
+const lockConflict = computed(() => lockLocked.value && !isOwnJob.value);
 
 // Dev-only invariant warning. Surfaces wiring bugs in the controllers-store
 // adapter; production strips the block via Vite tree-shake.
@@ -85,20 +95,13 @@ function onResultBarDone() {
   firmware.resetToSelect();
 }
 
-const DEV_SAMPLE_FLEET: FirmwareControllerView[] = [
-  { id: 'body', label: 'Body', glyph: 'B', current: 'v1.3.0', status: 'up', isMaster: true },
-  { id: 'core', label: 'Core', glyph: 'C', current: 'v1.4.0', status: 'up', isMaster: false },
-  { id: 'dome', label: 'Dome', glyph: 'D', current: 'v1.4.0', status: 'up', isMaster: false },
-];
-
 onMounted(async () => {
-  await firmware.fetchReleases();
-  // Dev-only placeholder fleet. Replace with the real controllers-store
-  // adapter once it exists.
-  if (import.meta.env.DEV && firmware.controllers.length === 0) {
-    firmware.controllers = DEV_SAMPLE_FLEET;
-  }
-  if (firmware.controllers.length > 0 && firmware.phase === 'idle') {
+  // Cold-load resync: if a flash is already in flight (operator refreshed
+  // the page mid-flash), populate currentJob from the server. WS late-join
+  // snapshot follows on connect; both paths set the same data and the
+  // store's applyJobStarted idempotency keeps state coherent.
+  await Promise.all([firmware.fetchReleases(), firmware.fetchCurrentJob()]);
+  if (firmware.phase === 'idle') {
     firmware.setPhase('select');
   }
 });
@@ -117,10 +120,24 @@ onMounted(async () => {
         <div class="firmware-view firmware-view__content">
           <p class="firmware-view__subtitle">{{ subtitle }}</p>
 
-          <AstrosFirmwareSourceStrip v-if="phase === 'select'" />
+          <div
+            v-if="lockConflict"
+            class="firmware-view__lock-conflict"
+            role="alert"
+            aria-live="polite"
+          >
+            <span class="firmware-view__lock-conflict-title">{{
+              t('firmware_view.lock_conflict.title')
+            }}</span>
+            <span class="firmware-view__lock-conflict-body">{{
+              t('firmware_view.lock_conflict.body', { since: lockSince ?? '—' })
+            }}</span>
+          </div>
+
+          <AstrosFirmwareSourceStrip v-if="phase === 'select' && !lockConflict" />
 
           <div
-            v-if="phase !== 'idle'"
+            v-if="phase !== 'idle' && !lockConflict"
             class="firmware-view__grid"
           >
             <div class="firmware-view__left-column">
@@ -143,6 +160,7 @@ onMounted(async () => {
             <AstrosFirmwareControllersPanel
               class="firmware-view__panel"
               :phase="phase"
+              :progress-by-controller-id="progressByControllerId"
               :failed-controller-label="failedController?.label"
               :failed-stage="failedController?.stage"
               @flash="openConfirm"
@@ -183,6 +201,29 @@ onMounted(async () => {
   gap: 16px;
   box-sizing: border-box;
   overflow-y: auto;
+}
+
+.firmware-view__lock-conflict {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  background: #fff8e8;
+  border: 1px solid #e5a93a55;
+  border-radius: 6px;
+}
+
+.firmware-view__lock-conflict-title {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #7d5a14;
+}
+
+.firmware-view__lock-conflict-body {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  color: #7d5a14;
 }
 
 .firmware-view__grid {

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -36,6 +36,7 @@ const {
   isOwnJob,
   currentJobLoadFailed,
   flashError,
+  currentJob,
 } = storeToRefs(firmware);
 const { locked: lockLocked, since: lockSince } = storeToRefs(jobLock);
 // WS connection state. Drives the "live updates suspended" banner when a
@@ -231,6 +232,17 @@ onMounted(async () => {
                 : t('firmware_view.mid_flash_error.title_warning')
             }}</span>
             <span class="firmware-view__flash-error-detail">{{ flashErrorDetail }}</span>
+            <span
+              v-if="phase === 'failed' && currentJob?.abortReason"
+              class="firmware-view__flash-error-abort-reason"
+              data-test="abort-reason"
+            >
+              {{
+                t('firmware_view.mid_flash_error.abort_reason', {
+                  reason: currentJob.abortReason,
+                })
+              }}
+            </span>
             <button
               type="button"
               class="firmware-view__flash-error-dismiss"

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -50,15 +50,19 @@ const flashStreamSuspended = computed(
   () => phase.value === 'flashing' && wsHasEverConnected.value && !wsIsConnected.value,
 );
 
-// Mid-flash + pre-streamer-abort error region. The panel's
-// `flash_error_banner` is gated on phase==='select' (it surfaces HTTP POST
-// failures before the job lifecycle owns phase). For errors raised by:
+// Mid-flash + pre-streamer-abort + failed-with-detail error region. The
+// panel's `flash_error_banner` is gated on phase==='select' (it surfaces
+// HTTP POST failures before the job lifecycle owns phase). This region
+// fires on three additional paths:
 //   - useWebsocket's mid-stream catch blocks (phase==='flashing')
 //   - applyJobFailed with empty failedControllers (pre-streamer abort —
 //     job failed before any controller transitioned to FAILED, so the
 //     panel's "⚠ — failed during the flash" result bar is uselessly vague)
-// the panel banner is hidden — without this region, flashError.detail
-// would go to a ref no template reads.
+//   - applyJobFailed with non-empty failedControllers AND a detail string
+//     (the panel result bar shows the label + stage but never the detail,
+//     so a meaningful reason like "asset checksum mismatch on Core" would
+//     otherwise be dropped)
+// Without this region, flashError.detail would go to a ref no template reads.
 const flashErrorDetail = computed(() => {
   if (flashError.value === null) return null;
   return flashError.value.detail ?? t(`firmware_view.flash_errors.${flashError.value.reason}`);
@@ -222,7 +226,9 @@ onMounted(async () => {
             data-test="mid-flash-error"
           >
             <span class="firmware-view__flash-error-title">{{
-              t('firmware_view.mid_flash_error.title')
+              phase === 'failed'
+                ? t('firmware_view.mid_flash_error.title_failed')
+                : t('firmware_view.mid_flash_error.title_warning')
             }}</span>
             <span class="firmware-view__flash-error-detail">{{ flashErrorDetail }}</span>
             <button

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -77,10 +77,25 @@ const showFlashErrorRegion = computed(() => {
   //     is uselessly vague without the detail), OR
   //   - flashError has a non-null detail string (operator should see the
   //     specific reason, not just "Core failed during Verify").
-  return (
-    phase.value === 'failed' &&
-    (failedControllers.value.length === 0 || flashError.value.detail != null)
-  );
+  if (phase.value === 'failed') {
+    return failedControllers.value.length === 0 || flashError.value.detail != null;
+  }
+  // NEW-IM4: phase='done' with a non-null flashError means a non-blocking
+  // warning landed during/after a successful flash (cancel HTTP failed
+  // but flash completed; malformed mid-stream frame; CR-1b recovery
+  // breadcrumb). Surface the region so the operator sees the signal
+  // alongside the "✓ all updated" footer rather than the flashError
+  // being silently swallowed by phase='done'.
+  return phase.value === 'done';
+});
+
+// NEW-IM4: distinct title for the done-phase warning case so operators
+// don't see a red "Flash failed:" title over a green "✓ all updated"
+// footer. The done variant reads as a warning, not an error.
+const flashErrorTitleKey = computed(() => {
+  if (phase.value === 'failed') return 'firmware_view.mid_flash_error.title_failed';
+  if (phase.value === 'done') return 'firmware_view.mid_flash_error.title_done_warning';
+  return 'firmware_view.mid_flash_error.title_warning';
 });
 
 const confirmOpen = ref(false);
@@ -226,11 +241,7 @@ onMounted(async () => {
             aria-live="polite"
             data-test="mid-flash-error"
           >
-            <span class="firmware-view__flash-error-title">{{
-              phase === 'failed'
-                ? t('firmware_view.mid_flash_error.title_failed')
-                : t('firmware_view.mid_flash_error.title_warning')
-            }}</span>
+            <span class="firmware-view__flash-error-title">{{ t(flashErrorTitleKey) }}</span>
             <span class="firmware-view__flash-error-detail">{{ flashErrorDetail }}</span>
             <span
               v-if="phase === 'failed' && currentJob?.abortReason"

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -80,18 +80,16 @@ const showFlashErrorRegion = computed(() => {
   if (phase.value === 'failed') {
     return failedControllers.value.length === 0 || flashError.value.detail != null;
   }
-  // NEW-IM4: phase='done' with a non-null flashError means a non-blocking
-  // warning landed during/after a successful flash (cancel HTTP failed
-  // but flash completed; malformed mid-stream frame; CR-1b recovery
-  // breadcrumb). Surface the region so the operator sees the signal
-  // alongside the "✓ all updated" footer rather than the flashError
-  // being silently swallowed by phase='done'.
+  // phase='done' with a non-null flashError means a non-blocking warning
+  // landed during/after a successful flash (cancel HTTP failed but flash
+  // completed; lock-release recovery breadcrumb; malformed terminal-event
+  // catch). Surface it alongside the "all updated" footer rather than
+  // swallowing the signal.
   return phase.value === 'done';
 });
 
-// NEW-IM4: distinct title for the done-phase warning case so operators
-// don't see a red "Flash failed:" title over a green "✓ all updated"
-// footer. The done variant reads as a warning, not an error.
+// Distinct title for the done-phase warning case — a red "Flash failed:"
+// over an "all updated" footer would be visually contradictory.
 const flashErrorTitleKey = computed(() => {
   if (phase.value === 'failed') return 'firmware_view.mid_flash_error.title_failed';
   if (phase.value === 'done') return 'firmware_view.mid_flash_error.title_done_warning';

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -35,6 +35,7 @@ const {
   progressByControllerId,
   isOwnJob,
   currentJobLoadFailed,
+  flashError,
 } = storeToRefs(firmware);
 const { locked: lockLocked, since: lockSince } = storeToRefs(jobLock);
 // WS connection state. Drives the "live updates suspended" banner when a
@@ -43,6 +44,17 @@ const { locked: lockLocked, since: lockSince } = storeToRefs(jobLock);
 // stream has stopped.
 const { wsIsConnected } = useWebsocket();
 const flashStreamSuspended = computed(() => phase.value === 'flashing' && !wsIsConnected.value);
+
+// Mid-flash error region. The panel's `flash_error_banner` is gated on
+// phase==='select' (it surfaces HTTP POST failures before the job lifecycle
+// owns phase). For errors raised by useWebsocket's mid-stream catch blocks
+// (handleFlashControllerUpdate / handleFlashControllerResult set flashError
+// without rolling phase), the panel banner is hidden — so without this
+// region, the store write goes to a ref no template reads.
+const flashErrorDetail = computed(() => {
+  if (flashError.value === null) return null;
+  return flashError.value.detail ?? t(`firmware_view.flash_errors.${flashError.value.reason}`);
+});
 
 const confirmOpen = ref(false);
 
@@ -173,6 +185,33 @@ onMounted(async () => {
             {{ t('firmware_view.flash_stream_suspended') }}
           </div>
 
+          <!--
+            role="alert" implies aria-live="assertive" by default. We
+            explicitly override to "polite" because a flapping WS can
+            re-fire malformed events; assertive would announce each one
+            and drown the operator. The keep-the-role-for-semantics +
+            polite-the-announcement pattern matches WAI-ARIA guidance.
+          -->
+          <div
+            v-if="phase === 'flashing' && flashError !== null"
+            class="firmware-view__flash-error"
+            role="alert"
+            aria-live="polite"
+            data-test="mid-flash-error"
+          >
+            <span class="firmware-view__flash-error-title">{{
+              t('firmware_view.mid_flash_error.title')
+            }}</span>
+            <span class="firmware-view__flash-error-detail">{{ flashErrorDetail }}</span>
+            <button
+              type="button"
+              class="firmware-view__flash-error-dismiss"
+              @click="firmware.dismissError()"
+            >
+              {{ t('firmware_view.mid_flash_error.dismiss') }}
+            </button>
+          </div>
+
           <div
             v-if="lockConflict"
             class="firmware-view__lock-conflict"
@@ -254,6 +293,48 @@ onMounted(async () => {
   gap: 16px;
   box-sizing: border-box;
   overflow-y: auto;
+}
+
+.firmware-view__flash-error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: #fbe0e0;
+  border: 1px solid #cf424255;
+  border-radius: 6px;
+}
+
+.firmware-view__flash-error-title {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  color: #9a2828;
+}
+
+.firmware-view__flash-error-detail {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  color: #9a2828;
+  flex: 1;
+}
+
+.firmware-view__flash-error-dismiss {
+  appearance: none;
+  background: transparent;
+  border: 1px solid #9a2828;
+  border-radius: 3px;
+  padding: 4px 10px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  color: #9a2828;
+  cursor: pointer;
+}
+
+.firmware-view__flash-error-dismiss:hover {
+  background: #9a2828;
+  color: #ffffff;
 }
 
 .firmware-view__stale-warning {

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -28,7 +28,7 @@ const {
   selectedControllerIds,
   target,
   currentStage,
-  failedController,
+  failedControllers,
   sourceMode,
   uploadedFilename,
   progressByControllerId,
@@ -58,7 +58,17 @@ const selectedControllerList = computed<FirmwareControllerView[]>(() =>
   controllers.value.filter((c) => selectedControllerIds.value.has(c.id)),
 );
 
-const failedControllerId = computed(() => failedController.value?.id);
+// Topology highlights the first FAILED controller (it animates one node, not
+// a set); the panel result bar joins ALL failed labels so multi-failure is
+// visible to the operator. Stage is taken from the first FAILED — all entries
+// share the same fallback stage in practice (`currentStage` at failure time).
+// `failedControllerLabels` returns `''` on no failures; the template coerces
+// to `undefined` via `|| undefined` so the panel's result bar skips rendering.
+const failedControllerId = computed(() => failedControllers.value[0]?.id);
+const failedControllerLabels = computed(() =>
+  failedControllers.value.map((c) => c.label).join(', '),
+);
+const failedStage = computed(() => failedControllers.value[0]?.stage ?? null);
 
 // A flash is in flight but it isn't ours — suppress the working UI. The
 // SourceStrip + grid v-ifs below gate on !lockConflict so the Flash button
@@ -153,7 +163,7 @@ onMounted(async () => {
                 v-if="phase === 'flashing' || phase === 'done' || phase === 'failed'"
                 :phase="phase"
                 :current-stage="currentStage"
-                :failed-stage="failedController?.stage ?? null"
+                :failed-stage="failedStage"
               />
             </div>
 
@@ -161,8 +171,8 @@ onMounted(async () => {
               class="firmware-view__panel"
               :phase="phase"
               :progress-by-controller-id="progressByControllerId"
-              :failed-controller-label="failedController?.label"
-              :failed-stage="failedController?.stage"
+              :failed-controller-label="failedControllerLabels || undefined"
+              :failed-stage="failedStage ?? undefined"
               @flash="openConfirm"
               @done="onResultBarDone"
             />

--- a/astros_vue/src/views/FirmwareView.vue
+++ b/astros_vue/src/views/FirmwareView.vue
@@ -33,6 +33,7 @@ const {
   uploadedFilename,
   progressByControllerId,
   isOwnJob,
+  currentJobLoadFailed,
 } = storeToRefs(firmware);
 const { locked: lockLocked, since: lockSince } = storeToRefs(jobLock);
 
@@ -69,6 +70,22 @@ const failedControllerLabels = computed(() =>
   failedControllers.value.map((c) => c.label).join(', '),
 );
 const failedStage = computed(() => failedControllers.value[0]?.stage ?? null);
+
+// Formats lockSince's raw ISO timestamp for the operator. Without the
+// formatter, the lock-conflict body would interpolate "2026-05-12T08:00:00Z"
+// directly into the message body — a machine-readable string in operator UX.
+const lockSinceFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+const lockSinceFormatted = computed(() => {
+  const raw = lockSince.value;
+  if (raw === null) return '—';
+  // Defensive: a malformed ISO would throw on Date construction's NaN path.
+  // Fall back to the raw string so the operator at least sees something.
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? raw : lockSinceFormatter.format(d);
+});
 
 // A flash is in flight but it isn't ours — suppress the working UI. The
 // SourceStrip + grid v-ifs below gate on !lockConflict so the Flash button
@@ -131,6 +148,15 @@ onMounted(async () => {
           <p class="firmware-view__subtitle">{{ subtitle }}</p>
 
           <div
+            v-if="currentJobLoadFailed"
+            class="firmware-view__stale-warning"
+            role="status"
+            aria-live="polite"
+          >
+            {{ t('firmware_view.current_job_load_failed') }}
+          </div>
+
+          <div
             v-if="lockConflict"
             class="firmware-view__lock-conflict"
             role="alert"
@@ -140,7 +166,7 @@ onMounted(async () => {
               t('firmware_view.lock_conflict.title')
             }}</span>
             <span class="firmware-view__lock-conflict-body">{{
-              t('firmware_view.lock_conflict.body', { since: lockSince ?? '—' })
+              t('firmware_view.lock_conflict.body', { since: lockSinceFormatted })
             }}</span>
           </div>
 
@@ -211,6 +237,16 @@ onMounted(async () => {
   gap: 16px;
   box-sizing: border-box;
   overflow-y: auto;
+}
+
+.firmware-view__stale-warning {
+  padding: 10px 14px;
+  background: #fff8e8;
+  border: 1px solid #e5a93a55;
+  border-radius: 6px;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 12px;
+  color: #7d5a14;
 }
 
 .firmware-view__lock-conflict {

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -34,6 +34,7 @@ vi.mock('@/composables/useWebsocket', () => ({
 import FirmwareView from '@/views/FirmwareView.vue';
 import { useFirmwareStore } from '@/stores/firmware';
 import { useJobLockStore } from '@/stores/jobLock';
+import { Location } from '@/enums';
 
 function createTestI18n() {
   return createI18n({
@@ -221,6 +222,24 @@ describe('FirmwareView flash-stream-suspended banner (I1)', () => {
     expect(statuses.find((el) => el.text().includes('Live updates paused'))).toBeUndefined();
   });
 
+  it('fires the banner when WS was previously connected and then dropped (positive latch path)', async () => {
+    // I10: complements the pre-connect suppression test below. The latch
+    // is monotonic — once true, a subsequent disconnect SHOULD fire the
+    // banner. A mutation that inverted the gate (`!wsHasEverConnected`)
+    // would pass the pre-connect test but fail this one.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('flashing');
+    mockWsIsConnected.value = false;
+    mockWsHasEverConnected.value = true; // we DID connect before
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const statuses = wrapper.findAll('[role="status"]');
+    const suspended = statuses.find((el) => el.text().includes('Live updates paused'));
+    expect(suspended).toBeTruthy();
+  });
+
   it('does NOT flicker the banner during the pre-connect window before WS first connects (I3 fix)', async () => {
     // Without the wsHasEverConnected gate, FirmwareView's onMounted runs
     // before App.vue's wsConnect resolves the socket, so wsIsConnected is
@@ -320,7 +339,7 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     // specific reason like "asset checksum mismatch on Core".
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('failed');
-    firmwareStore.failedControllers = [{ id: 'core', label: 'Core', stage: 'verify' }];
+    firmwareStore.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'verify' }];
     firmwareStore.flashError = {
       reason: 'internal_server_error',
       detail: 'asset checksum mismatch on Core',
@@ -334,12 +353,25 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(region.text()).toContain('asset checksum mismatch on Core');
   });
 
+  it('hides the region in failed phase when flashError is null (negative baseline)', async () => {
+    // I11: a mutation that swapped `if (flashError.value === null) return false`
+    // to `return true` would render an empty alert region. Pin the null
+    // baseline so the early-return contract is mutation-resistant.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('failed');
+    firmwareStore.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'verify' }];
+    // flashError stays null
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
+  });
+
   it('hides the region in failed phase when failedControllers has entries and flashError has no detail', async () => {
     // When the panel's result bar carries the whole story (label + stage)
     // and there's no additional detail, the region is redundant.
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('failed');
-    firmwareStore.failedControllers = [{ id: 'core', label: 'Core', stage: 'verify' }];
+    firmwareStore.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'verify' }];
     firmwareStore.flashError = { reason: 'internal_server_error' }; // no detail
 
     const wrapper = mountFirmwareView();

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -71,7 +71,7 @@ function mountFirmwareView() {
   });
 }
 
-describe('FirmwareView lock-conflict gating (I7)', () => {
+describe('FirmwareView lock-conflict gating', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
@@ -138,7 +138,7 @@ describe('FirmwareView lock-conflict gating (I7)', () => {
   });
 });
 
-describe('FirmwareView staleness banner (I5)', () => {
+describe('FirmwareView staleness banner', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
@@ -173,7 +173,7 @@ describe('FirmwareView staleness banner (I5)', () => {
   });
 });
 
-describe('FirmwareView flash-stream-suspended banner (I1)', () => {
+describe('FirmwareView flash-stream-suspended banner', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
@@ -181,8 +181,8 @@ describe('FirmwareView flash-stream-suspended banner (I1)', () => {
   });
 
   it('shows the "live updates paused" banner when phase==="flashing" and WS is disconnected', async () => {
-    // I1 fix: without this signal the operator stares at frozen progress
-    // bars with no indication the WS stream has stopped.
+    // Without this signal, the operator stares at frozen progress bars
+    // with no indication the WS stream has stopped.
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('flashing');
     mockWsIsConnected.value = false;
@@ -240,7 +240,7 @@ describe('FirmwareView flash-stream-suspended banner (I1)', () => {
     expect(suspended).toBeTruthy();
   });
 
-  it('does NOT flicker the banner during the pre-connect window before WS first connects (I3 fix)', async () => {
+  it('does NOT flicker the banner during the pre-connect window before WS first connects', async () => {
     // Without the wsHasEverConnected gate, FirmwareView's onMounted runs
     // before App.vue's wsConnect resolves the socket, so wsIsConnected is
     // false. A mid-flash refresh hits applyJobStarted → phase='flashing',
@@ -260,7 +260,7 @@ describe('FirmwareView flash-stream-suspended banner (I1)', () => {
   });
 });
 
-describe('FirmwareView mid-flash error region (C1)', () => {
+describe('FirmwareView mid-flash error region', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
@@ -268,10 +268,10 @@ describe('FirmwareView mid-flash error region (C1)', () => {
   });
 
   it('renders the role="alert" mid-flash error region when flashError is set during flashing phase', async () => {
-    // Round-5 C1 fix: handleFlashControllerUpdate / handleFlashControllerResult
-    // set flashError without rolling phase. The existing panel `flash_error_banner`
-    // is gated on phase==='select' so it never renders during flashing. Without
-    // this region, the store write goes to a ref no template reads.
+    // handleFlashControllerUpdate / handleFlashControllerResult set
+    // flashError without rolling phase. The panel's `flash_error_banner`
+    // is gated on phase==='select' so it never renders during flashing.
+    // Without this region, the store write goes to a ref no template reads.
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('flashing');
     firmwareStore.flashError = {
@@ -331,7 +331,7 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(firmwareStore.flashError).toBeNull();
   });
 
-  it('shows the region in failed phase with detail even when failedControllers has entries (I1 widen)', async () => {
+  it('shows the region in failed phase with detail even when failedControllers has entries', async () => {
     // The panel's result-bar carries label + stage but never surfaces
     // flashError.detail. Without this region firing on the
     // (failed + has-detail + non-empty failedControllers) combination, the
@@ -380,7 +380,7 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
   });
 
-  it('IM-1: renders abortReason in the failed-phase flash-error region when present', async () => {
+  it('renders abortReason in the failed-phase flash-error region when present', async () => {
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('failed');
     firmwareStore.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'verify' }];
@@ -405,7 +405,7 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(abortRegion.text()).toContain('user_cancel');
   });
 
-  it('IM-1: does NOT render abortReason in failed phase when currentJob.abortReason is undefined', async () => {
+  it('does NOT render abortReason in failed phase when currentJob.abortReason is undefined', async () => {
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('failed');
     firmwareStore.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'verify' }];
@@ -427,11 +427,11 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(wrapper.find('[data-test="abort-reason"]').exists()).toBe(false);
   });
 
-  it('NEW-IM4: renders flash-error region in phase="done" when flashError is non-null (done-with-warning)', async () => {
-    // Round-8 NEW-IM4: previously showFlashErrorRegion returned false for
-    // phase='done', silently swallowing any flashError that landed during
-    // a successful flash. The CR-1b recovery, malformed flashJobDone catch,
-    // and cancel-while-completing paths all leave the store in this state.
+  it('renders flash-error region in phase="done" when flashError is non-null (done-with-warning)', async () => {
+    // Without surfacing flashError in done-phase, paths that set it on
+    // an otherwise-successful completion (lock-release recovery,
+    // malformed flashJobDone catch, cancel-while-completing) would
+    // silently swallow the breadcrumb.
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('done');
     firmwareStore.flashError = {
@@ -448,7 +448,7 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(region.text()).toContain('Recovered from lost terminal event');
   });
 
-  it('NEW-IM4: hides flash-error region in phase="done" when flashError is null (negative baseline)', async () => {
+  it('hides flash-error region in phase="done" when flashError is null (negative baseline)', async () => {
     const firmwareStore = useFirmwareStore();
     firmwareStore.setPhase('done');
     firmwareStore.flashError = null;
@@ -460,7 +460,7 @@ describe('FirmwareView mid-flash error region (C1)', () => {
   });
 });
 
-describe('FirmwareView lockSinceFormatted defensive fallback (IM-8)', () => {
+describe('FirmwareView lockSinceFormatted defensive fallback', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
   });

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createI18n } from 'vue-i18n';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import enUS from '@/locales/enUS.json';
+
+// Stub all API/auth-touching modules at the top so FirmwareView's onMounted
+// hooks don't try to hit the network during the test.
+vi.mock('@/api/apiService', () => ({
+  default: { get: vi.fn().mockResolvedValue({ data: null }) },
+  apiClient: {
+    get: vi.fn().mockResolvedValue({ data: null }),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import FirmwareView from '@/views/FirmwareView.vue';
+import { useFirmwareStore } from '@/stores/firmware';
+import { useJobLockStore } from '@/stores/jobLock';
+
+function createTestI18n() {
+  return createI18n({
+    legacy: false,
+    locale: 'enUS',
+    fallbackLocale: 'enUS',
+    messages: { enUS },
+  });
+}
+
+function createTestRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: { template: '<div />' } }],
+  });
+}
+
+function mountFirmwareView() {
+  return mount(FirmwareView, {
+    global: {
+      plugins: [createTestI18n(), createTestRouter()],
+      // Stub the heavy children so we focus on the view's own template/state
+      // gating logic rather than the firmware component graph. The stubs
+      // preserve element identity for selector-based assertions.
+      stubs: {
+        AstrosLayout: { template: '<div><slot name="main" /></div>' },
+        AstrosFirmwareSourceStrip: { template: '<div data-test="source-strip" />' },
+        AstrosFirmwareTopology: { template: '<div data-test="topology" />' },
+        AstrosFirmwareStagesList: { template: '<div data-test="stages-list" />' },
+        AstrosFirmwareControllersPanel: { template: '<div data-test="controllers-panel" />' },
+        AstrosFirmwareConfirmModal: { template: '<div data-test="confirm-modal" />' },
+      },
+    },
+  });
+}
+
+describe('FirmwareView lock-conflict gating (I7)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('shows the in-page role="alert" lock-conflict region when lock is held by another operator', async () => {
+    // lockStore.locked = true and firmwareStore.isOwnJob = false → the
+    // operator is locked out by a foreign flash; the alert region must
+    // render. Inverting `!isOwnJob` in the source would silently let the
+    // operator interact with a foreign-owned flash UI.
+    const lockStore = useJobLockStore();
+    lockStore.locked = true;
+    // isOwnJob is false because firmwareStore.currentJob is null.
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text()).toContain('Firmware update in progress');
+  });
+
+  it('hides the source-strip and grid while the lock-conflict alert is shown', async () => {
+    const lockStore = useJobLockStore();
+    lockStore.locked = true;
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('select');
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-test="source-strip"]').exists()).toBe(false);
+  });
+
+  it('does NOT show the lock-conflict region when the firmware view owns the active job', async () => {
+    // lockStore.locked = true BUT isOwnJob = true (ownJobId matches currentJob)
+    // → the operator started this flash; the in-page UI shows progress, not
+    // a lockout alert. Pin: isOwnJob suppresses the alert.
+    const lockStore = useJobLockStore();
+    lockStore.locked = true;
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.applyJobStarted({
+      jobId: 'own-job',
+      source: { kind: 'github', version: 'v1.4.2' },
+      controllers: [],
+      startedAt: '2026-05-13T08:00:00Z',
+    });
+    firmwareStore.ownJobId = 'own-job';
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(false);
+  });
+
+  it('does NOT show the lock-conflict region when the lock is idle', async () => {
+    // Both flags false → no alert. Negative-branch baseline.
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+  });
+});

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -216,3 +216,74 @@ describe('FirmwareView flash-stream-suspended banner (I1)', () => {
     expect(statuses.find((el) => el.text().includes('Live updates paused'))).toBeUndefined();
   });
 });
+
+describe('FirmwareView mid-flash error region (C1)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockWsIsConnected.value = true;
+  });
+
+  it('renders the role="alert" mid-flash error region when flashError is set during flashing phase', async () => {
+    // Round-5 C1 fix: handleFlashControllerUpdate / handleFlashControllerResult
+    // set flashError without rolling phase. The existing panel `flash_error_banner`
+    // is gated on phase==='select' so it never renders during flashing. Without
+    // this region, the store write goes to a ref no template reads.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('flashing');
+    firmwareStore.flashError = {
+      reason: 'internal_server_error',
+      detail: 'Malformed flashControllerUpdate from server',
+    };
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const region = wrapper.find('[data-test="mid-flash-error"]');
+    expect(region.exists()).toBe(true);
+    expect(region.attributes('role')).toBe('alert');
+    expect(region.text()).toContain('Malformed flashControllerUpdate from server');
+  });
+
+  it('hides the mid-flash error region when flashError is null', async () => {
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('flashing');
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
+  });
+
+  it('hides the mid-flash error region during select phase (panel banner owns that case)', async () => {
+    // The panel's flash_error_banner handles select-phase HTTP errors. This
+    // region must not double up.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('select');
+    firmwareStore.flashError = {
+      reason: 'job_already_running',
+      currentJobId: 'job-x',
+    };
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
+  });
+
+  it('dismiss button clears flashError via firmware.dismissError', async () => {
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('flashing');
+    firmwareStore.flashError = {
+      reason: 'internal_server_error',
+      detail: 'Malformed flashControllerUpdate from server',
+    };
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const region = wrapper.find('[data-test="mid-flash-error"]');
+    expect(region.exists()).toBe(true);
+    await region.find('button').trigger('click');
+    expect(firmwareStore.flashError).toBeNull();
+  });
+});

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -380,3 +380,59 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
   });
 });
+
+describe('FirmwareView lockSinceFormatted defensive fallback (IM-8)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('renders a dash placeholder when jobLock.since is null', async () => {
+    const lock = useJobLockStore();
+    lock.setState({
+      locked: true,
+      owner: 'someone-else',
+      since: null,
+    });
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+    // The conflict banner body interpolates {since}; null path produces "—".
+    expect(wrapper.text()).not.toContain('Invalid Date');
+    expect(wrapper.text()).not.toContain('NaN');
+  });
+
+  it('falls back to the raw string when jobLock.since is malformed ISO', async () => {
+    const lock = useJobLockStore();
+    lock.setState({
+      locked: true,
+      owner: 'someone-else',
+      since: 'not-a-date',
+    });
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+    // The defensive fallback in lockSinceFormatted returns `raw` when
+    // Date(raw).getTime() is NaN. Positive assertion pins the raw-string
+    // passthrough (a mutation that returned '—' instead would pass the
+    // negative checks below but fail this one).
+    expect(wrapper.text()).toContain('not-a-date');
+    expect(wrapper.text()).not.toContain('Invalid Date');
+    expect(wrapper.text()).not.toContain('NaN');
+  });
+
+  it('renders a formatted date when jobLock.since is a valid ISO', async () => {
+    const lock = useJobLockStore();
+    lock.setState({
+      locked: true,
+      owner: 'someone-else',
+      since: '2026-05-14T08:00:00Z',
+    });
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+    // Positive assertion: the Intl.DateTimeFormat output should include
+    // a recognizable date segment (year or month). A mutation that fell
+    // through to the raw-string fallback would fail this because the
+    // raw ISO contains 'T08:00:00Z' which is the unformatted form.
+    expect(wrapper.text()).toMatch(/2026|May/);
+    expect(wrapper.text()).not.toContain('Invalid Date');
+    expect(wrapper.text()).not.toContain('NaN');
+  });
+});

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -379,6 +379,53 @@ describe('FirmwareView mid-flash error region (C1)', () => {
 
     expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
   });
+
+  it('IM-1: renders abortReason in the failed-phase flash-error region when present', async () => {
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('failed');
+    firmwareStore.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'verify' }];
+    firmwareStore.flashError = {
+      reason: 'internal_server_error',
+      detail: 'asset checksum mismatch',
+    };
+    firmwareStore.currentJob = {
+      jobId: 'job-1',
+      source: { kind: 'github', version: 'v1.4.2' },
+      controllers: [],
+      startedAt: '2026-05-14T08:00:00Z',
+      endedAt: '2026-05-14T08:05:00Z',
+      abortReason: 'user_cancel',
+    };
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const abortRegion = wrapper.find('[data-test="abort-reason"]');
+    expect(abortRegion.exists()).toBe(true);
+    expect(abortRegion.text()).toContain('user_cancel');
+  });
+
+  it('IM-1: does NOT render abortReason in failed phase when currentJob.abortReason is undefined', async () => {
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('failed');
+    firmwareStore.failedControllers = [{ id: Location.CORE, label: 'Core', stage: 'verify' }];
+    firmwareStore.flashError = {
+      reason: 'internal_server_error',
+      detail: 'something failed',
+    };
+    firmwareStore.currentJob = {
+      jobId: 'job-1',
+      source: { kind: 'github', version: 'v1.4.2' },
+      controllers: [],
+      startedAt: '2026-05-14T08:00:00Z',
+      // no abortReason
+    };
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-test="abort-reason"]').exists()).toBe(false);
+  });
 });
 
 describe('FirmwareView lockSinceFormatted defensive fallback (IM-8)', () => {

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { createI18n } from 'vue-i18n';
 import { createRouter, createMemoryHistory } from 'vue-router';
@@ -14,6 +15,18 @@ vi.mock('@/api/apiService', () => ({
     post: vi.fn(),
     delete: vi.fn(),
   },
+}));
+
+// Controllable WS state for the flash-stream-suspended banner tests.
+const mockWsIsConnected = ref(true);
+vi.mock('@/composables/useWebsocket', () => ({
+  useWebsocket: () => ({
+    wsIsConnected: mockWsIsConnected,
+    wsConnect: vi.fn(),
+    wsDisconnect: vi.fn(),
+    wsSendMessage: vi.fn(),
+    handleMessage: vi.fn(),
+  }),
 }));
 
 import FirmwareView from '@/views/FirmwareView.vue';
@@ -58,6 +71,7 @@ function mountFirmwareView() {
 describe('FirmwareView lock-conflict gating (I7)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    mockWsIsConnected.value = true;
   });
 
   it('shows the in-page role="alert" lock-conflict region when lock is held by another operator', async () => {
@@ -117,5 +131,88 @@ describe('FirmwareView lock-conflict gating (I7)', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+  });
+});
+
+describe('FirmwareView staleness banner (I5)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockWsIsConnected.value = true;
+  });
+
+  it('shows the role="status" staleness region when currentJobLoadFailed is true', async () => {
+    // Pin role="status" specifically (not "alert") — a regression that
+    // swapped the role would pass the lock-conflict alert tests above
+    // because they only assert visibility on `[role="alert"]`. The
+    // staleness banner is ambient, not interrupting.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.currentJobLoadFailed = true;
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    // findAll + text-match: there are two role="status" banners now
+    // (current-job-load-failed + flash-stream-suspended). Match by text
+    // so a future banner-order change doesn't flake this test.
+    const statuses = wrapper.findAll('[role="status"]');
+    const stale = statuses.find((el) => el.text().includes('Could not confirm'));
+    expect(stale).toBeTruthy();
+  });
+
+  it('hides the staleness region when currentJobLoadFailed is false (negative baseline)', async () => {
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const statuses = wrapper.findAll('[role="status"]');
+    expect(statuses.find((el) => el.text().includes('Could not confirm'))).toBeUndefined();
+  });
+});
+
+describe('FirmwareView flash-stream-suspended banner (I1)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockWsIsConnected.value = true;
+  });
+
+  it('shows the "live updates paused" banner when phase==="flashing" and WS is disconnected', async () => {
+    // I1 fix: without this signal the operator stares at frozen progress
+    // bars with no indication the WS stream has stopped.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('flashing');
+    mockWsIsConnected.value = false;
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const statuses = wrapper.findAll('[role="status"]');
+    const suspended = statuses.find((el) => el.text().includes('Live updates paused'));
+    expect(suspended).toBeTruthy();
+  });
+
+  it('hides the banner when WS is connected even if phase==="flashing"', async () => {
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('flashing');
+    mockWsIsConnected.value = true;
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const statuses = wrapper.findAll('[role="status"]');
+    expect(statuses.find((el) => el.text().includes('Live updates paused'))).toBeUndefined();
+  });
+
+  it('hides the banner when WS is disconnected but phase is not flashing', async () => {
+    // The banner is scoped to mid-flash: a disconnected WS during select/
+    // idle phases is recovered by reconnect with no operator action; the
+    // alarm cost would be too high.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('select');
+    mockWsIsConnected.value = false;
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const statuses = wrapper.findAll('[role="status"]');
+    expect(statuses.find((el) => el.text().includes('Live updates paused'))).toBeUndefined();
   });
 });

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -426,6 +426,38 @@ describe('FirmwareView mid-flash error region (C1)', () => {
 
     expect(wrapper.find('[data-test="abort-reason"]').exists()).toBe(false);
   });
+
+  it('NEW-IM4: renders flash-error region in phase="done" when flashError is non-null (done-with-warning)', async () => {
+    // Round-8 NEW-IM4: previously showFlashErrorRegion returned false for
+    // phase='done', silently swallowing any flashError that landed during
+    // a successful flash. The CR-1b recovery, malformed flashJobDone catch,
+    // and cancel-while-completing paths all leave the store in this state.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('done');
+    firmwareStore.flashError = {
+      reason: 'protocol_violation',
+      detail: 'Recovered from lost terminal event — verify each controller actually flashed.',
+    };
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const region = wrapper.find('[data-test="mid-flash-error"]');
+    expect(region.exists()).toBe(true);
+    expect(region.text()).toContain('Flash completed with a warning');
+    expect(region.text()).toContain('Recovered from lost terminal event');
+  });
+
+  it('NEW-IM4: hides flash-error region in phase="done" when flashError is null (negative baseline)', async () => {
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('done');
+    firmwareStore.flashError = null;
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
+  });
 });
 
 describe('FirmwareView lockSinceFormatted defensive fallback (IM-8)', () => {

--- a/astros_vue/src/views/__tests__/FirmwareView.spec.ts
+++ b/astros_vue/src/views/__tests__/FirmwareView.spec.ts
@@ -19,9 +19,11 @@ vi.mock('@/api/apiService', () => ({
 
 // Controllable WS state for the flash-stream-suspended banner tests.
 const mockWsIsConnected = ref(true);
+const mockWsHasEverConnected = ref(true);
 vi.mock('@/composables/useWebsocket', () => ({
   useWebsocket: () => ({
     wsIsConnected: mockWsIsConnected,
+    wsHasEverConnected: mockWsHasEverConnected,
     wsConnect: vi.fn(),
     wsDisconnect: vi.fn(),
     wsSendMessage: vi.fn(),
@@ -72,6 +74,7 @@ describe('FirmwareView lock-conflict gating (I7)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
+    mockWsHasEverConnected.value = true;
   });
 
   it('shows the in-page role="alert" lock-conflict region when lock is held by another operator', async () => {
@@ -138,6 +141,7 @@ describe('FirmwareView staleness banner (I5)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
+    mockWsHasEverConnected.value = true;
   });
 
   it('shows the role="status" staleness region when currentJobLoadFailed is true', async () => {
@@ -172,6 +176,7 @@ describe('FirmwareView flash-stream-suspended banner (I1)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
+    mockWsHasEverConnected.value = true;
   });
 
   it('shows the "live updates paused" banner when phase==="flashing" and WS is disconnected', async () => {
@@ -215,12 +220,32 @@ describe('FirmwareView flash-stream-suspended banner (I1)', () => {
     const statuses = wrapper.findAll('[role="status"]');
     expect(statuses.find((el) => el.text().includes('Live updates paused'))).toBeUndefined();
   });
+
+  it('does NOT flicker the banner during the pre-connect window before WS first connects (I3 fix)', async () => {
+    // Without the wsHasEverConnected gate, FirmwareView's onMounted runs
+    // before App.vue's wsConnect resolves the socket, so wsIsConnected is
+    // false. A mid-flash refresh hits applyJobStarted → phase='flashing',
+    // and the banner fires for ~50ms until the WS handshake completes.
+    // Training operators to dismiss it. The sentinel says "we've never
+    // connected yet, so disconnected is the expected state, not a signal."
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('flashing');
+    mockWsIsConnected.value = false;
+    mockWsHasEverConnected.value = false; // never connected yet
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const statuses = wrapper.findAll('[role="status"]');
+    expect(statuses.find((el) => el.text().includes('Live updates paused'))).toBeUndefined();
+  });
 });
 
 describe('FirmwareView mid-flash error region (C1)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     mockWsIsConnected.value = true;
+    mockWsHasEverConnected.value = true;
   });
 
   it('renders the role="alert" mid-flash error region when flashError is set during flashing phase', async () => {
@@ -285,5 +310,41 @@ describe('FirmwareView mid-flash error region (C1)', () => {
     expect(region.exists()).toBe(true);
     await region.find('button').trigger('click');
     expect(firmwareStore.flashError).toBeNull();
+  });
+
+  it('shows the region in failed phase with detail even when failedControllers has entries (I1 widen)', async () => {
+    // The panel's result-bar carries label + stage but never surfaces
+    // flashError.detail. Without this region firing on the
+    // (failed + has-detail + non-empty failedControllers) combination, the
+    // operator sees e.g. "Core failed during Verify" but misses the
+    // specific reason like "asset checksum mismatch on Core".
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('failed');
+    firmwareStore.failedControllers = [{ id: 'core', label: 'Core', stage: 'verify' }];
+    firmwareStore.flashError = {
+      reason: 'internal_server_error',
+      detail: 'asset checksum mismatch on Core',
+    };
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    const region = wrapper.find('[data-test="mid-flash-error"]');
+    expect(region.exists()).toBe(true);
+    expect(region.text()).toContain('asset checksum mismatch on Core');
+  });
+
+  it('hides the region in failed phase when failedControllers has entries and flashError has no detail', async () => {
+    // When the panel's result bar carries the whole story (label + stage)
+    // and there's no additional detail, the region is redundant.
+    const firmwareStore = useFirmwareStore();
+    firmwareStore.setPhase('failed');
+    firmwareStore.failedControllers = [{ id: 'core', label: 'Core', stage: 'verify' }];
+    firmwareStore.flashError = { reason: 'internal_server_error' }; // no detail
+
+    const wrapper = mountFirmwareView();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-test="mid-flash-error"]').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
# d.6 — WebSocket dispatcher + live firmwareStore + lock-aware UI

Final PR of phase d. Wires the server's `FlashOrchestratorWsMessage` stream into the Vue UI, replaces the dev-mock fleet bootstrap with a live controllers-store adapter, and surfaces the firmware-flash write-lock across the operator UI.

## Summary

- **WebSocket dispatcher** — 5 new cases in `useWebsocket` route `flashJobStarted` / `flashControllerUpdate` / `flashControllerResult` / `flashJobDone` / `flashJobFailed` (TransmissionType 12–16) into `firmwareStore.apply*` handlers. Numeric wire values are pinned by a contract test.
- **Live firmwareStore** — adds `currentJob`, `controllerStates` (`ReadonlyMap<SlotId, ControllerFlashStateBySlot>`), `ownJobId`, and 5 `apply*` actions. Replaces d.5's `DEV_SAMPLE_FLEET` ref with a computed projection over `useControllerStore()`. `currentJob.jobId === ownJobId` is the "this is ours" predicate; lock owner is informational only.
- **Lock-aware UI** — `AstrosWriteButton` disables on lock; new `AstrosLockStateBanner` shows owner + since; `FirmwareView` renders a lock-conflict alert when another operator holds the lock; `AstrosServoTestModal` gates its slider + Enable button.
- **Stage mapper** — sibling helper at `utils/firmwareStageMapping.ts` translates server `FwStage` (7 string values) to UI `FirmwareStage` (5-value union) with forensic-warn fallback for forward-compat.
- **Discriminated unions** — `ControllerFlashState` now mirrors the server's DU shape (VERSION_CONFIRMED requires `finalVersion: string`, FAILED requires `error: string`). `ControllerFlashStateBySlot` is the post-translation view used in-store; `buildControllerStatesMap` is the single MAC→SlotId translation site.
- **E2E** — Playwright spec drives the full operator flow against a stubbed WS.

## Architecture highlights

**Late-join + reconnect contract.** The server emits one `flashJobStarted` snapshot on every WS connect when a job is in flight, EXCEPT during the 15s reboot-wait window after `flashJobDone` (when `currentJob.endedAt` is set). The client's `useWebsocket` reconnects every 3s on disconnect, so every reconnect mid-flash receives a fresh snapshot. `applyJobStarted` is idempotent and replace-not-merge. `fetchCurrentJob` (HTTP cold-load on mount) mirrors the same `endedAt` filter so a page refresh during reboot-wait doesn't wedge the UI at `phase='flashing'`.

**jobId disambiguation.** `applyControllerResult` / `applyJobDone` / `applyJobFailed` early-return with a forensic warn when `data.jobId !== currentJob.jobId`. Prevents stale events from a prior job (post-reconnect WS buffer flush) from silently mutating the active job's state.

**Lock-release recovery.** If the server releases the lock while the client still has `phase='flashing'` (terminal event lost or out-of-order), `handleLockStateChanged` delegates to `applyJobDone` so per-controller stages normalize, then surfaces a `protocol_violation` flashError as an operator-visible "verify each controller actually flashed" breadcrumb.

**Mid-stream catch isolation.** `handleFlashControllerUpdate` / `handleFlashControllerResult` only write `protocol_violation` to `flashError` when BOTH `phase === 'flashing'` AND no existing flashError is set — preserves specific job-lifecycle error reasons and prevents stray malformed frames from clobbering a "done" UI.

**Done-phase warning visibility.** `showFlashErrorRegion` renders in `phase='done'` when `flashError !== null` (under a distinct "Flash completed with a warning:" title) so cancel-while-completing, lock-release recovery, and malformed terminal-event paths don't silently swallow operator-visible signals.

**Multi-failure surfacing.** `applyJobFailed` collects every controller that ended in FAILED, including entries still queued in `pendingByMac` for unmapped MACs (bus-wide ESP-NOW failures can mark a padawan FAILED before its LocationStatus heartbeat arrives). Result bar joins all labels comma-separated.

## File map

**Server (3 files)**
- `astros_api/src/api_server.ts` — `controllerAddress` added to StatusResponse + late-join `flashJobStarted` snapshot
- `astros_api/src/models/networking/status_response.ts` — new field
- `astros_api/src/models/enums.ts` — explicit `= N` annotations on `TransmissionType` so client mirror drift is visible in diffs

**Vue — composables / stores / utils / types (8 files)**
- `composables/useWebsocket.ts` + spec — 5 new dispatcher cases, socket-capture closure refactor, lock-state recovery
- `stores/firmware.ts` + spec — apply* handlers, `ownJobId`, computed controllers adapter, `fetchCurrentJob`, cancel-error surface
- `stores/controller.ts` + spec — `controllerAddress` round-trip
- `utils/firmwareStageMapping.ts` + spec — `FwStage → FirmwareStage` translation
- `utils/firmwareFlashError.ts` — HTTP error mapping
- `types/firmware.ts` — `FirmwareStage`, `ServerFwStage`, `ControllerFlashState` (DU), `ControllerFlashStateBySlot`, `SlotId` (template-literal extraction)
- `enums/WebsocketMessageType.ts` — client mirror of TransmissionType
- `models/websocket/locationStatus.ts` — optional `controllerAddress` for rolling-deploy tolerance

**Vue — components / views (10 files)**
- `views/FirmwareView.vue` + spec — lock-conflict alert, flash-error region, stages list integration, abortReason render
- `components/common/AstrosWriteButton.vue` + spec — lock-aware disable + tooltip
- `components/common/lockStateBanner/AstrosLockStateBanner.vue` + spec — new page-level banner
- `components/common/layout/AstrosLayout.vue` — wires the banner
- `components/firmware/firmwareControllerRow/` (.vue + types + selectModePillKind spec + stories) — pill rendering updates
- `components/firmware/firmwareControllersPanel/` (.vue + types + spec + stories) — failed-result-bar predicate + discriminated phase props
- `components/firmware/firmwareSourceStrip/` + `firmwareConfirmModal/` stories — updated to new types
- `components/modals/modules/AstrosServoTestModal.vue` + spec — write-lock gating

**i18n / E2E / docs**
- `locales/enUS.json` — new keys for lock banner, flash errors, mid-flash error titles, abort reason
- `e2e/C_01_firmware-page.spec.ts` — Playwright smoke for the firmware page
- `.docs/plans/20260512-0735-firmware-ota-d-6-live-wiring.md` — design + FMI inventory
- `.docs/qa/firmware-ota-flash-ui.md` — manual QA scenarios

## Test plan

**Automated (run by CI):**
- `cd astros_vue && npm run build && npx vitest run` — 273 unit tests; build + type-check clean
- `cd astros_api && npm run build && npx vitest run` — 739 unit tests; build clean
- `cd astros_vue && npx playwright test e2e/C_01_firmware-page.spec.ts` — operator-flow smoke (requires running server)

**Manual QA before merge** — follow `.docs/qa/firmware-ota-flash-ui.md`. Key scenarios:

- [ ] Cold-load: `/firmware` mounts cleanly with no flash in flight; controller list reflects live controllerStore state
- [ ] Happy-path flash: select → confirm → progress through stages → "All updated" footer; per-row pills match phase
- [ ] Failure-path flash: server-emitted FAILED → red banner with detail + abortReason; failed-row labels listed
- [ ] Late-join: refresh mid-flash → page reflects current job + per-controller stages from the WS snapshot
- [ ] WS reconnect: kill + restart server mid-flash → "live updates paused" banner appears, then progress resumes
- [ ] Lock conflict: second operator starts flash → first operator sees lock-conflict alert + disabled write buttons; banner clears on lock release
- [ ] Reboot-wait refresh: refresh during the 15s window after a successful flash → page shows idle / select (not wedged at flashing)
- [ ] Cancel: click Cancel mid-flash with network failure → operator sees "Cancel request failed" error envelope; phase truth still flows from WS
- [ ] ServoTest during flash: open the modal mid-flash → slider + Enable button disabled with lock-active notice
- [ ] Reduced motion: prefers-reduced-motion correctly suppresses stage-list animations
- [ ] Dev-only invariants: console shows no unexpected warns in normal happy-path flows

## Risk & mitigations

This is the highest-risk PR of phase d — every concurrency hazard from the FMI inventory lands here. Mitigations:

- **8 FMI hazards** documented in the plan file with their fixes; every hazard has at least one unit test pinning the contract
- **Mutation-resistant tests** — assertions designed so reverting the production guard would fail the test
- **Forensic console.warn breadcrumbs** at every silent-skip / drop-stale / re-queue site so ops can trace unexpected behavior in production logs
- **i18n key contract test** ensures every `FlashErrorReason` has a corresponding locale entry — adding a new reason without updating the locale file fails the test
- **Wire-numeric pinning test** ensures the client `WebsocketMessageType` numeric values stay aligned with the server `TransmissionType`
- **Compile-time discriminated unions** on `ControllerFlashState` make `state.error` reads on non-FAILED stages a build error, not a runtime crash

## Reviewer notes

- Comment style: comments explain WHY (hidden constraints, subtle invariants, forensic-breadcrumb rationale) and don't reference fix-history. Git log carries the change history if needed.
- The handful of `as SlotId` casts in `firmware.ts` are documented with the data-flow rationale. The remaining cast in `applyJobFailed`'s `pendingByMac` sweep is intentional (forcing a raw MAC string into the SlotId slot so the operator sees the actual hardware address rather than no entry at all).
- The `'unknown:normalize-on-done'` / `'unattributed:normalize-on-failed'` marker strings inside `ControllerFlashStateBySlot` satisfy the discriminated-union requirements when the demote-to-terminal path has no real value to provide. No UI surface reads these; they're only visible in dev console / ops logs.
- Plan files in `.docs/plans/` document iterative design + review cycles and can be skimmed for design rationale, but the production code is the source of truth for current behavior.
