### PR TITLE
OTA Firmware -  followups

### DIFF
--- a/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
+++ b/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
@@ -1,0 +1,201 @@
+# Firmware OTA d.7 Follow-ups — Light Plan
+
+> **For agentic workers:** light plan per CLAUDE.md — brief description + a short checklist. No brainstorming phase, no scope-guard gate, but the pre-commit toolkit (prettier → lint → build → vitest → `superpowers:requesting-code-review`) and pre-push toolkit (`/pr-review-toolkit:review-pr`) still apply.
+
+**Goal:** clear the three out-of-scope items surfaced by the d.7 pre-push review (two HIGH, one MINOR). All are real defects in `develop` today, independent of any in-flight firmware-OTA work.
+
+**Branch:** `feature/firmware-ota-d-7-followups` (off latest `origin/develop`).
+
+**Base branch:** `develop` (open PR with `gh pr create --base develop`).
+
+---
+
+## Context — what we're fixing and why
+
+Three findings from the d.7 pre-push toolkit pass, captured verbatim in [`20260514-1300-firmware-ota-d-7-lock-aware-rest-of-app.md` § Out of scope follow-ups](./20260514-1300-firmware-ota-d-7-lock-aware-rest-of-app.md):
+
+### 1. jobLock HTTP hydrate (HIGH)
+
+`astros_vue/src/stores/jobLock.ts` exposes `setState()` but no `fetchLockState()`. `App.vue:onMounted` hydrates `systemStatusStore` via HTTP (`SYSTEM_STATUS` endpoint) so the readonly banner and disabled-button bindings are correct from the first paint — there's an analogous gap for the job-lock state.
+
+**Symptom:** a user who deep-links to `/firmware` (or any view that shows the lock banner) during a foreign flash sees the `SourceStrip` source picker interactive until the WebSocket handshake completes — they can click "Push Firmware" and only learn writes are blocked via the server's 423 response. With WiFi or slow networks, that window can be 1–3 seconds.
+
+**Fix shape:** mirror the systemStatus hydrate pattern. Server-side, add a `GET /api/firmware/lock-state` controller that returns `JobLock.getState()`. Client-side, add `fetchLockState()` to the store and call it from `App.vue:onMounted` alongside `systemStatusStore.fetchStatus()`.
+
+**Why this is HIGH and not MINOR:** there is no client-side check that the user's intent is "view-only" before they click — the firmware view's `SourceStrip` accepts file picks and release selections regardless of lock state. The current behavior is "click, get 423, find out". The hydrate closes that window.
+
+### 2. AstrosConfirmModal consumer wiring (HIGH, ordering constraint)
+
+`AstrosConfirmModal` (`astros_vue/src/components/modals/AstrosConfirmModal.vue:1-19`) exposes a function-prop API:
+
+```ts
+defineProps<{ message: string; onClose: () => void; onConfirm: () => void; title?: string }>()
+```
+
+Two callers use Vue **event syntax** (`@confirm` / `@close`) against this prop API:
+
+- `astros_vue/src/views/ModulesView.vue:436-441` — `@confirm="handleRemoveModule"` (module removal) is a no-op
+- `astros_vue/src/views/ScripterView.vue:422-427` — `@confirm="confirm"` (channel/script confirms) is a no-op
+
+The third caller (`astros_vue/src/components/playlists/playlistEditor/AstrosPlaylistEditor.vue:394-400`) correctly uses `:on-confirm="..."` / `:on-close="..."` — that's the reference pattern.
+
+**Why the bug is silent:** the `@confirm` attribute falls through to the inner `<dialog>` element as a DOM event listener. `<dialog>` doesn't emit a `confirm` event, so the listener never fires. `@close` happens to coincide with the dialog's native `close` event, but that event only fires when the dialog is closed via `dialog.close()` / Esc — not when the modal's Cancel button is clicked. Net effect: both the Confirm and Close buttons in ModulesView+ScripterView confirm flows are dead clicks.
+
+**Ordering constraint:** the d.7 audit converted `AstrosConfirmModal`'s primary button to `AstrosWriteButton` ahead of any caller wrapping a real write. This fix must land **before** any new `AstrosConfirmModal` caller wraps a real write — otherwise the lock-gated Confirm button silently won't fire even when unlocked, masking the lock-gating intent at the new call site.
+
+### 3. AstrosServoTestModal slider readonly check (MINOR)
+
+`astros_vue/src/components/modals/modules/AstrosServoTestModal.vue:30` defines:
+
+```ts
+const writesBlocked = computed(() => jobLockLocked.value);
+```
+
+The Enable Test button is wrapped in `AstrosWriteButton` (which ORs both `systemStatusStore.readOnly` and `jobLockStore.locked`), so it disables correctly under readonly. But the slider's `:disabled="disabled || writesBlocked"` (line 102), the `onSliderChange` early-return (line 42), the `enableTest` early-return (line 63), and the auto-disable watcher (line 34) only consult `jobLockLocked`.
+
+**Symptom:** if the operator enters readonly mode (DB migration failure, etc.) while the modal is open with the test active, the Enable button correctly disables but the slider keeps firing `SERVO_TEST` WS messages on input until the next Enable toggle.
+
+**Why MINOR:** narrow race window — the modal has to already be open AND the test active AND readonly flips on mid-session. Operationally rare, but `writesBlocked` is supposed to be the single source of truth for the modal's lock posture.
+
+**Fix shape:** widen `writesBlocked` to OR both stores. Keep the `lock-active-notice` region (the "flash active" copy) gated on `jobLockLocked` specifically — `AstrosWriteButton`'s tooltip already explains readonly on its own, and we don't want the notice to claim "flash active" during a non-flash readonly state.
+
+---
+
+## Files touched
+
+### New
+- `astros_api/src/controllers/firmware_lock_state_controller.ts` — new endpoint
+- `astros_api/src/controllers/firmware_lock_state_controller.test.ts` — controller unit tests
+- `astros_vue/e2e/B_03_modules-confirm-remove.spec.ts` — Playwright regression for ConfirmModal wiring (one view exercised end-to-end; ScripterView confirm is manual-QA per CLAUDE.md UI-layout TDD exception)
+
+### Modified
+- `astros_api/src/api_server.ts` — import + `registerFirmwareLockStateRoutes(...)` call alongside `registerSystemStatusRoutes`
+- `astros_vue/src/api/endpoints.ts` — add `FIRMWARE_LOCK_STATE` constant
+- `astros_vue/src/stores/jobLock.ts` — add `fetchLockState()` action mirroring `systemStatus.fetchStatus()`
+- `astros_vue/src/stores/__tests__/jobLock.spec.ts` — `describe('fetchLockState')` block mirroring the systemStatus tests
+- `astros_vue/src/App.vue` — call `jobLockStore.fetchLockState()` in `onMounted` alongside `systemStatusStore.fetchStatus()`
+- `astros_vue/src/views/ModulesView.vue` (lines 436–441) — swap to `:on-confirm` / `:on-close` prop binding
+- `astros_vue/src/views/ScripterView.vue` (lines 422–427) — same swap
+- `astros_vue/src/components/modals/modules/AstrosServoTestModal.vue` — widen `writesBlocked` OR; narrow notice region to `jobLockLocked`
+- `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts` — readonly-flips-on coverage
+
+---
+
+## Tasks
+
+Each task is one commit. Pre-commit toolkit (prettier → lint → build → vitest → `superpowers:requesting-code-review`) runs on every task before the commit.
+
+- [ ] **T1. Create branch + commit this plan.** Branch off the latest `origin/develop` using the safe pattern (per memory: `git fetch origin && git switch develop && git pull && git switch -c feature/firmware-ota-d-7-followups` — do NOT use `git checkout -b feature/<slug> origin/develop`, which makes the branch track develop and lets VS Code push commits straight to develop). Commit just this plan file. Carve-out: plan-only commit skips the pre-commit code review per CLAUDE.md.
+
+- [ ] **T2. Server: GET /api/firmware/lock-state endpoint (TDD).** Test-first:
+  1. Create `astros_api/src/controllers/firmware_lock_state_controller.test.ts`. Cases: unlocked → 200 with `{ locked: false, owner: null, since: null }`; locked → 200 with the populated state from `JobLock.acquire(...)`. Build the route with a fresh `JobLock` instance + `express` + `supertest` (same pattern as `system_status_controller.test.ts` if it exists, else mirror `firmware_releases_controller.test.ts`).
+  2. Run `npx vitest run astros_api/src/controllers/firmware_lock_state_controller.test.ts` — expect failure.
+  3. Create `astros_api/src/controllers/firmware_lock_state_controller.ts` exporting `registerFirmwareLockStateRoutes(router: Router, jobLock: JobLock)`:
+     ```ts
+     import { Router } from 'express';
+     import { JobLock } from '../job_lock/job_lock.js';
+
+     export function registerFirmwareLockStateRoutes(router: Router, jobLock: JobLock) {
+       router.get('/firmware/lock-state', (_req, res) => {
+         res.status(200).json(jobLock.getState());
+       });
+     }
+     ```
+     Unauthenticated like `/system/status` — same UX justification (App.vue hydrate runs before any view navigates, and the response leaks no secrets).
+  4. Run vitest — expect pass.
+  5. Wire into `astros_api/src/api_server.ts`: import + call in `setRoutes()` adjacent to `registerSystemStatusRoutes` (around line 460).
+  6. Pre-commit toolkit + commit.
+
+- [ ] **T3. Client: jobLock store fetch action + endpoint constant (TDD).** Test-first:
+  1. Add to `astros_vue/src/stores/__tests__/jobLock.spec.ts` a `describe('fetchLockState', ...)` block mirroring the three cases in `systemStatus.spec.ts:75-116`:
+     - Locked GET response updates `locked` / `owner` / `since` and calls `apiService.get('api/firmware/lock-state')`.
+     - Unlocked GET response after a pre-seeded locked state clears `owner` / `since`.
+     - Rejected fetch leaves state unchanged and does not throw.
+     Use the same `apiGet`-mock pattern as the systemStatus spec.
+  2. Run `npx vitest run astros_vue/src/stores/__tests__/jobLock.spec.ts` — expect failure.
+  3. Add `FIRMWARE_LOCK_STATE = 'api/firmware/lock-state'` to `astros_vue/src/api/endpoints.ts` next to `FIRMWARE_FLASH`.
+  4. Add `fetchLockState()` to `astros_vue/src/stores/jobLock.ts`:
+     ```ts
+     async function fetchLockState(): Promise<void> {
+       try {
+         const response = (await apiService.get(FIRMWARE_LOCK_STATE)) as LockState;
+         setState(response);
+       } catch (error) {
+         // Leave state unchanged. WS lockStateChanged will bring us up to date
+         // once the handshake completes; this hydrate is belt-and-braces.
+         console.warn('jobLock.fetchLockState failed', error);
+       }
+     }
+     ```
+     Export it from the store return. Imports: `apiService` from `@/api/apiService`, `FIRMWARE_LOCK_STATE` from `@/api/endpoints`.
+  5. Run vitest — expect pass.
+  6. Pre-commit toolkit + commit.
+
+- [ ] **T4. Client: App.vue hydrate wire-up.** No new test; this is one-liner UI-layout code per memory TDD-exceptions. Modify `astros_vue/src/App.vue`:
+  - Import `useJobLockStore` alongside `useSystemStatusStore`.
+  - In `onMounted`, call `jobLockStore.fetchLockState()` immediately after `systemStatusStore.fetchStatus()` (both before `wsConnect()`).
+  - Update the inline comment to cover both stores.
+  Run `npm run build` to confirm typecheck. Pre-commit toolkit + commit.
+
+- [ ] **T5. Fix ConfirmModal consumer wiring + Playwright regression.** Code fix is template-only (UI-layout per CLAUDE.md TDD exceptions). Vue unit-test scaffolding for `ModulesView` / `ScripterView` does not exist — building it for a once-off `@`-vs-`:` typo would be disproportionate. Instead: one Playwright e2e covering ModulesView's remove flow; manual QA for ScripterView's confirm (single broken call site today: `modalAction` is only ever assigned to `() => doRemoveChannel(id)` at ScripterView.vue:93, so the affected user flow is "remove channel from the script").
+  1. Modify `astros_vue/src/views/ModulesView.vue:436-441` — swap to prop binding:
+     ```vue
+     <AstrosConfirmModal
+       v-if="showModal === ModalType.CONFIRM"
+       :message="$t('module_view.confirm_remove')"
+       :on-confirm="handleRemoveModule"
+       :on-close="() => { showModal = ModalType.CLOSE_ALL; }"
+     />
+     ```
+  2. Modify `astros_vue/src/views/ScripterView.vue:422-427` — same shape, with `confirm` and the matching `:on-close` arrow.
+     Note: `confirm` is a reserved-ish name (shadows the browser global) — leave the function name as-is to minimize blast radius, but the inline arrow on `:on-close` avoids any naming collision.
+  3. Create `astros_vue/e2e/B_03_modules-confirm-remove.spec.ts`. Pattern after `B_02_modules-page.spec.ts`. Steps: log in, navigate to a location with a module, click the "remove" button on a module to open `AstrosConfirmModal`, click `[data-testid="modal-confirm"]`, assert the module disappears from the list (or the local Pinia state changes — pick whichever is cheapest to observe). The test will fail on `develop` today; this is the mutation-test gate per `feedback_mutation_test_defensive_features`.
+  4. Run `npm run test:e2e -- B_03_modules-confirm-remove` — expect pass against the fixed views; would have failed before T5's template fix.
+  5. Manual QA the ScripterView confirm flow (per CLAUDE.md QA test plans pattern, capture in `.docs/qa/firmware-ota-d-7-followups.md` if any unexpected behavior; otherwise tick it off without a new doc).
+  6. Pre-commit toolkit + commit.
+
+- [ ] **T6. Fix ServoTestModal readonly check (TDD).**
+  1. Add to `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts` two cases:
+     - `systemStatusStore.readOnly = true` (jobLock unlocked) → slider `[disabled]` is true, `onSliderChange` does not call `wsSendMessage`, `enableTest` is a no-op.
+     - Mid-session readonly flip with the test active → the auto-disable watcher fires, slider goes to `disabled`, the `lock-active-notice` region is NOT shown (per the design note: notice is job-lock-only).
+     - The third sub-case is the existing job-lock-locked path — verify notice IS shown there (regression).
+     Use Pinia setup with both `useJobLockStore` and `useSystemStatusStore` for these tests.
+  2. Run `npx vitest run astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts` — expect failures on the new cases.
+  3. Modify `astros_vue/src/components/modals/modules/AstrosServoTestModal.vue`:
+     - Import `useSystemStatusStore`. Add `const systemStatus = useSystemStatusStore();` and destructure with a rename: `const { readOnly: systemStatusReadOnly } = storeToRefs(systemStatus);` (same pattern as the existing `const { locked: jobLockLocked } = storeToRefs(jobLock);` on line 11).
+     - Widen `writesBlocked = computed(() => jobLockLocked.value || systemStatusReadOnly.value)`.
+     - Change `<div v-if="writesBlocked" ...>` (line 108) to `<div v-if="jobLockLocked" ...>`. (The notice text is firmware-flash-specific; readonly is already explained by `AstrosWriteButton`'s tooltip.)
+     - Update the inline comment block above `writesBlocked` to mention readonly + the notice-region split.
+  4. Run vitest — expect pass.
+  5. **Mutation test (per `feedback_mutation_test_defensive_features`):** revert the `|| systemStatusReadOnly.value` clause and re-run the readonly tests — they must fail. Restore the fix.
+  6. Pre-commit toolkit + commit.
+
+- [ ] **T7. Pre-push branch review.** Run `/pr-review-toolkit:review-pr` on the full diff vs `develop` per CLAUDE.md. Address Critical/Important. The hazard categories most likely to surface here:
+  - **Contract**: the new endpoint vs the writeGuard mounting order (writeGuard mounts on `/api` at line 408; the new route is registered after that in `setRoutes` at line 460. Confirm GET requests aren't gated by writeGuard — checked: writeGuard only filters write-class methods, so GET passes through.)
+  - **Wiring drift**: any other `AstrosConfirmModal` callers? Pre-emptively grepped — only the three (Modules, Scripter, PlaylistEditor) plus the firmware view's separate `AstrosFirmwareConfirmModal`. Should still be re-checked at review time.
+  - **Documentation drift**: d.7 plan's "Out of scope follow-ups" section names these three items — once they're shipped, do NOT edit that section (it documents what was in/out of scope for d.7 itself). Add a brief "Resolved in 20260514-1520..." line at the top of that section if useful, but don't rewrite history.
+- [ ] **T8. User pushes via VS Code; open PR.** Per memory, never run `git push` from terminal. After review-fixes are clean, hand off; user pushes, opens PR with `gh pr create --base develop`.
+
+---
+
+## Acceptance criteria
+
+- `GET /api/firmware/lock-state` returns 200 with `{ locked, owner, since }` matching `JobLock.getState()`.
+- `App.vue:onMounted` calls both `systemStatusStore.fetchStatus()` and `jobLockStore.fetchLockState()` before `wsConnect()`.
+- Deep-link to `/firmware` with the server in a locked-by-other-session state: `SourceStrip` shows the lock-active state from the first paint (no interactive window before WS handshake).
+- Clicking the Confirm button in the `ModulesView` "remove module" flow and the `ScripterView` confirm flow actually invokes the handler. Clicking Cancel/Close actually closes the modal.
+- `AstrosServoTestModal`: with `systemStatusStore.readOnly === true`, slider is disabled, `onSliderChange` does not send WS messages, mid-session readonly flip auto-disables the test. Notice region is shown ONLY when `jobLockLocked.value === true`.
+- All existing tests still pass. New tests pass. No lint or type errors. No console warnings in dev.
+
+## Out of scope (deliberately deferred)
+
+- Authenticating the lock-state endpoint. Mirroring system-status's posture is the right baseline; if we later need to gate by API key, do it as a cross-cutting "auth read endpoints" change, not in this branch.
+- Touching `AstrosFirmwareConfirmModal` (the firmware-view-specific confirm). It has its own callers and contract; out of scope here.
+- Any `firmware_view.lock_banner_cta` or other i18n string changes (none needed — all required keys already exist).
+- The `c-real` orchestrator-vs-real-serial swap. Blocked on firmware-repo `a` + `b` series, separate work.
+
+## Risk + reviewer notes
+
+- **Reactivity gotcha (ServoTestModal):** `storeToRefs` on `useSystemStatusStore()` returns a `ref` for `readOnly`. In the computed, use `.value`. The d.6 store wiring tests caught a similar mistake; the existing spec scaffolding makes this hard to get wrong if T6's tests are written first.
+- **Inline arrow on `:on-close` (T5):** passing `() => { showModal = ModalType.CLOSE_ALL; }` creates a new function on every render, which is fine because `AstrosConfirmModal` only calls it once on click. If the modal becomes a `<keep-alive>` child later, swap to a named handler.
+- **Endpoint placement:** the controller lives under `astros_api/src/controllers/` not `astros_api/src/firmware/` because the existing `firmware_flash_controller.ts` and `firmware_releases_controller.ts` use that location for HTTP route handlers. The `astros_api/src/firmware/` directory is reserved for the orchestrator and supporting domain logic.

--- a/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
+++ b/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
@@ -137,7 +137,7 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
   - Update the inline comment to cover both stores.
   Run `npm run build` to confirm typecheck. Pre-commit toolkit + commit.
 
-- [ ] **T5. Fix ConfirmModal consumer wiring + QA test plan.** Code fix is template-only (UI-layout per CLAUDE.md TDD exceptions). Vue unit-test scaffolding for `ModulesView` / `ScripterView` does not exist, the remove buttons in `AstrosUartModule.vue` / `AstrosI2cModule.vue` carry no `data-testid` attributes (Playwright e2e would require adding them — scope creep on a 2-line typo fix), and the existing d.7 `AstrosConfirmModal` unit tests already pin the modal's prop API correctly. The bug is in *consumer* wiring of a contract that's already tested; the regression-prevention path here is manual QA per CLAUDE.md `.docs/qa/` convention plus the protection of code review (which caught this exact issue in d.7's pre-push toolkit).
+- [x] **T5. Fix ConfirmModal consumer wiring + QA test plan.** Code fix is template-only (UI-layout per CLAUDE.md TDD exceptions). Vue unit-test scaffolding for `ModulesView` / `ScripterView` does not exist, the remove buttons in `AstrosUartModule.vue` / `AstrosI2cModule.vue` carry no `data-testid` attributes (Playwright e2e would require adding them — scope creep on a 2-line typo fix), and the existing d.7 `AstrosConfirmModal` unit tests already pin the modal's prop API correctly. The bug is in *consumer* wiring of a contract that's already tested; the regression-prevention path here is manual QA per CLAUDE.md `.docs/qa/` convention plus the protection of code review (which caught this exact issue in d.7's pre-push toolkit).
   1. Modify `astros_vue/src/views/ModulesView.vue:436-441` — swap to prop binding:
      ```vue
      <AstrosConfirmModal
@@ -152,7 +152,7 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
   3. Create `.docs/qa/firmware-ota-d-7-followups.md` covering the two affected confirm flows (Modules: remove UART/I2C module; Scripter: remove channel from script). The QA plan is also used to verify T6's ServoTestModal readonly path — see T6 below.
   4. Pre-commit toolkit + commit.
 
-- [ ] **T6. Fix ServoTestModal readonly check (TDD).**
+- [x] **T6. Fix ServoTestModal readonly check (TDD).**
   1. Add to `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts` two cases:
      - `systemStatusStore.readOnly = true` (jobLock unlocked) → slider `[disabled]` is true, `onSliderChange` does not call `wsSendMessage`, `enableTest` is a no-op.
      - Mid-session readonly flip with the test active → the auto-disable watcher fires, slider goes to `disabled`, the `lock-active-notice` region is NOT shown (per the design note: notice is job-lock-only).

--- a/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
+++ b/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
@@ -103,7 +103,7 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
      ```
      Unauthenticated like `/system/status` — same UX justification (App.vue hydrate runs before any view navigates, and the response leaks no secrets).
   4. Run vitest — expect pass.
-  5. Wire into `astros_api/src/api_server.ts`: import + call adjacent to the existing firmware-family registrations (`registerFirmwareFlashRoutes` / `registerFirmwareReleasesRoutes` at ~line 573–574). The firmware family lives in a later phase of `setRoutes()` than `registerSystemStatusRoutes` because it depends on `this.jobLock` / `this.flashOrchestrator` / `this.githubReleaseService` being constructed first.
+  5. Wire into `astros_api/src/api_server.ts`: import + call inside `setRoutes()` adjacent to `registerSystemStatusRoutes`. The lock-state route only depends on `this.jobLock`, which is field-initialized (line 193), so it's available before `setRoutes()` runs — and crucially before `setupSerialPort()` may be skipped under `skipSerialSetup: true` (NODE_ENV=test default). **Historical note:** the first version of this branch placed the registration inside `setupSerialPort()` adjacent to `registerFirmwareFlashRoutes` / `registerFirmwareReleasesRoutes`. The pre-push toolkit caught this (the endpoint returned 404 under test/no-hardware boots). The fix-commit `9fae64f` moved the registration to `setRoutes()` and pinned the placement with `firmware_lock_state_controller.integration.test.ts`. The second-pass toolkit then surfaced the same mispattern on `registerFirmwareReleasesRoutes` — fix commit also moved that.
   6. Pre-commit toolkit + commit.
 
 - [x] **T3. Client: jobLock store fetch action + endpoint constant (TDD).** Test-first:

--- a/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
+++ b/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
@@ -168,7 +168,7 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
   5. **Mutation test (per `feedback_mutation_test_defensive_features`):** revert the `|| systemStatusReadOnly.value` clause and re-run the readonly tests — they must fail. Restore the fix.
   6. Pre-commit toolkit + commit.
 
-- [ ] **T7. Pre-push branch review.** Run `/pr-review-toolkit:review-pr` on the full diff vs `develop` per CLAUDE.md. Address Critical/Important. The hazard categories most likely to surface here:
+- [x] **T7. Pre-push branch review.** Run `/pr-review-toolkit:review-pr` on the full diff vs `develop` per CLAUDE.md. Address Critical/Important. The hazard categories most likely to surface here:
   - **Contract**: the new endpoint vs the writeGuard mounting order (writeGuard mounts on `/api` at line 408; the new route is registered after that in `setRoutes` at line 460. Confirm GET requests aren't gated by writeGuard — checked: writeGuard only filters write-class methods, so GET passes through.)
   - **Wiring drift**: any other `AstrosConfirmModal` callers? Pre-emptively grepped — only the three (Modules, Scripter, PlaylistEditor) plus the firmware view's separate `AstrosFirmwareConfirmModal`. Should still be re-checked at review time.
   - **Documentation drift**: d.7 plan's "Out of scope follow-ups" section names these three items — once they're shipped, do NOT edit that section (it documents what was in/out of scope for d.7 itself). Add a brief "Resolved in 20260514-1520..." line at the top of that section if useful, but don't rewrite history.

--- a/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
+++ b/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
@@ -85,9 +85,9 @@ The Enable Test button is wrapped in `AstrosWriteButton` (which ORs both `system
 
 Each task is one commit. Pre-commit toolkit (prettier → lint → build → vitest → `superpowers:requesting-code-review`) runs on every task before the commit.
 
-- [ ] **T1. Create branch + commit this plan.** Branch off the latest `origin/develop` using the safe pattern (per memory: `git fetch origin && git switch develop && git pull && git switch -c feature/firmware-ota-d-7-followups` — do NOT use `git checkout -b feature/<slug> origin/develop`, which makes the branch track develop and lets VS Code push commits straight to develop). Commit just this plan file. Carve-out: plan-only commit skips the pre-commit code review per CLAUDE.md.
+- [x] **T1. Create branch + commit this plan.** Branch off the latest `origin/develop` using the safe pattern (per memory: `git fetch origin && git switch develop && git pull && git switch -c feature/firmware-ota-d-7-followups` — do NOT use `git checkout -b feature/<slug> origin/develop`, which makes the branch track develop and lets VS Code push commits straight to develop). Commit just this plan file. Carve-out: plan-only commit skips the pre-commit code review per CLAUDE.md.
 
-- [ ] **T2. Server: GET /api/firmware/lock-state endpoint (TDD).** Test-first:
+- [x] **T2. Server: GET /api/firmware/lock-state endpoint (TDD).** Test-first:
   1. Create `astros_api/src/controllers/firmware_lock_state_controller.test.ts`. Cases: unlocked → 200 with `{ locked: false, owner: null, since: null }`; locked → 200 with the populated state from `JobLock.acquire(...)`. Build the route with a fresh `JobLock` instance + `express` + `supertest` (same pattern as `system_status_controller.test.ts` if it exists, else mirror `firmware_releases_controller.test.ts`).
   2. Run `npx vitest run astros_api/src/controllers/firmware_lock_state_controller.test.ts` — expect failure.
   3. Create `astros_api/src/controllers/firmware_lock_state_controller.ts` exporting `registerFirmwareLockStateRoutes(router: Router, jobLock: JobLock)`:

--- a/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
+++ b/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
@@ -66,7 +66,7 @@ The Enable Test button is wrapped in `AstrosWriteButton` (which ORs both `system
 ### New
 - `astros_api/src/controllers/firmware_lock_state_controller.ts` — new endpoint
 - `astros_api/src/controllers/firmware_lock_state_controller.test.ts` — controller unit tests
-- `astros_vue/e2e/B_03_modules-confirm-remove.spec.ts` — Playwright regression for ConfirmModal wiring (one view exercised end-to-end; ScripterView confirm is manual-QA per CLAUDE.md UI-layout TDD exception)
+- `.docs/qa/firmware-ota-d-7-followups.md` — manual QA test plan for the two ConfirmModal consumers + the ServoTestModal readonly path
 
 ### Modified
 - `astros_api/src/api_server.ts` — import + `registerFirmwareLockStateRoutes(...)` call alongside `registerSystemStatusRoutes`
@@ -106,7 +106,7 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
   5. Wire into `astros_api/src/api_server.ts`: import + call adjacent to the existing firmware-family registrations (`registerFirmwareFlashRoutes` / `registerFirmwareReleasesRoutes` at ~line 573–574). The firmware family lives in a later phase of `setRoutes()` than `registerSystemStatusRoutes` because it depends on `this.jobLock` / `this.flashOrchestrator` / `this.githubReleaseService` being constructed first.
   6. Pre-commit toolkit + commit.
 
-- [ ] **T3. Client: jobLock store fetch action + endpoint constant (TDD).** Test-first:
+- [x] **T3. Client: jobLock store fetch action + endpoint constant (TDD).** Test-first:
   1. Add to `astros_vue/src/stores/__tests__/jobLock.spec.ts` a `describe('fetchLockState', ...)` block mirroring the three cases in `systemStatus.spec.ts:75-116`:
      - Locked GET response updates `locked` / `owner` / `since` and calls `apiService.get('api/firmware/lock-state')`.
      - Unlocked GET response after a pre-seeded locked state clears `owner` / `since`.
@@ -131,13 +131,13 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
   5. Run vitest — expect pass.
   6. Pre-commit toolkit + commit.
 
-- [ ] **T4. Client: App.vue hydrate wire-up.** No new test; this is one-liner UI-layout code per memory TDD-exceptions. Modify `astros_vue/src/App.vue`:
+- [x] **T4. Client: App.vue hydrate wire-up.** No new test; this is one-liner UI-layout code per memory TDD-exceptions. Modify `astros_vue/src/App.vue`:
   - Import `useJobLockStore` alongside `useSystemStatusStore`.
   - In `onMounted`, call `jobLockStore.fetchLockState()` immediately after `systemStatusStore.fetchStatus()` (both before `wsConnect()`).
   - Update the inline comment to cover both stores.
   Run `npm run build` to confirm typecheck. Pre-commit toolkit + commit.
 
-- [ ] **T5. Fix ConfirmModal consumer wiring + Playwright regression.** Code fix is template-only (UI-layout per CLAUDE.md TDD exceptions). Vue unit-test scaffolding for `ModulesView` / `ScripterView` does not exist — building it for a once-off `@`-vs-`:` typo would be disproportionate. Instead: one Playwright e2e covering ModulesView's remove flow; manual QA for ScripterView's confirm (single broken call site today: `modalAction` is only ever assigned to `() => doRemoveChannel(id)` at ScripterView.vue:93, so the affected user flow is "remove channel from the script").
+- [ ] **T5. Fix ConfirmModal consumer wiring + QA test plan.** Code fix is template-only (UI-layout per CLAUDE.md TDD exceptions). Vue unit-test scaffolding for `ModulesView` / `ScripterView` does not exist, the remove buttons in `AstrosUartModule.vue` / `AstrosI2cModule.vue` carry no `data-testid` attributes (Playwright e2e would require adding them — scope creep on a 2-line typo fix), and the existing d.7 `AstrosConfirmModal` unit tests already pin the modal's prop API correctly. The bug is in *consumer* wiring of a contract that's already tested; the regression-prevention path here is manual QA per CLAUDE.md `.docs/qa/` convention plus the protection of code review (which caught this exact issue in d.7's pre-push toolkit).
   1. Modify `astros_vue/src/views/ModulesView.vue:436-441` — swap to prop binding:
      ```vue
      <AstrosConfirmModal
@@ -149,10 +149,8 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
      ```
   2. Modify `astros_vue/src/views/ScripterView.vue:422-427` — same shape, with `confirm` and the matching `:on-close` arrow.
      Note: `confirm` is a reserved-ish name (shadows the browser global) — leave the function name as-is to minimize blast radius, but the inline arrow on `:on-close` avoids any naming collision.
-  3. Create `astros_vue/e2e/B_03_modules-confirm-remove.spec.ts`. Pattern after `B_02_modules-page.spec.ts`. Steps: log in, navigate to a location with a module, click the "remove" button on a module to open `AstrosConfirmModal`, click `[data-testid="modal-confirm"]`, assert the module disappears from the list (or the local Pinia state changes — pick whichever is cheapest to observe). The test will fail on `develop` today; this is the mutation-test gate per `feedback_mutation_test_defensive_features`.
-  4. Run `npm run test:e2e -- B_03_modules-confirm-remove` — expect pass against the fixed views; would have failed before T5's template fix.
-  5. Manual QA the ScripterView confirm flow (per CLAUDE.md QA test plans pattern, capture in `.docs/qa/firmware-ota-d-7-followups.md` if any unexpected behavior; otherwise tick it off without a new doc).
-  6. Pre-commit toolkit + commit.
+  3. Create `.docs/qa/firmware-ota-d-7-followups.md` covering the two affected confirm flows (Modules: remove UART/I2C module; Scripter: remove channel from script). The QA plan is also used to verify T6's ServoTestModal readonly path — see T6 below.
+  4. Pre-commit toolkit + commit.
 
 - [ ] **T6. Fix ServoTestModal readonly check (TDD).**
   1. Add to `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts` two cases:

--- a/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
+++ b/.docs/plans/20260514-1520-firmware-ota-d-7-followups.md
@@ -103,7 +103,7 @@ Each task is one commit. Pre-commit toolkit (prettier → lint → build → vit
      ```
      Unauthenticated like `/system/status` — same UX justification (App.vue hydrate runs before any view navigates, and the response leaks no secrets).
   4. Run vitest — expect pass.
-  5. Wire into `astros_api/src/api_server.ts`: import + call in `setRoutes()` adjacent to `registerSystemStatusRoutes` (around line 460).
+  5. Wire into `astros_api/src/api_server.ts`: import + call adjacent to the existing firmware-family registrations (`registerFirmwareFlashRoutes` / `registerFirmwareReleasesRoutes` at ~line 573–574). The firmware family lives in a later phase of `setRoutes()` than `registerSystemStatusRoutes` because it depends on `this.jobLock` / `this.flashOrchestrator` / `this.githubReleaseService` being constructed first.
   6. Pre-commit toolkit + commit.
 
 - [ ] **T3. Client: jobLock store fetch action + endpoint constant (TDD).** Test-first:

--- a/.docs/qa/firmware-ota-d-7-followups.md
+++ b/.docs/qa/firmware-ota-d-7-followups.md
@@ -98,10 +98,10 @@ If neither is convenient, this section can be **skipped with explicit note** bec
 
 | # | Action | Expected |
 |---|--------|----------|
-| 3.1 | With `systemStatus.readOnly = false` and `jobLock.locked = false`: open the Servo Test modal on any servo channel. Click **Enable Test**, drag the slider. | WS `SERVO_TEST` messages fire on each slider input. |
-| 3.2 | With test active, flip `systemStatus.readOnly = true`. | Slider auto-disables. **Enable Test** button is disabled with the readonly tooltip. The "lock-active-notice" region (firmware-lock-specific copy) is **NOT** shown — readonly is explained by the button tooltip alone. |
-| 3.3 | With `jobLock.locked = true` (start a flash in another session): open the Servo Test modal. Try to **Enable Test**. | Button disabled with the firmware-lock tooltip. Lock-active-notice region IS shown below the slider with copy `firmware_view.lock_active`. |
-| 3.4 | While modal is open with test active, transition jobLock from unlocked → locked (start a foreign flash). | Slider auto-disables. Label reverts to "Enable Test". Notice region appears. |
+| 3.1 | With `systemStatus.readOnly = false` and `jobLock.locked = false`: open the Servo Test modal on any servo channel. Click **Enable Test**, drag the slider, also type a value into the adjacent number input. | WS `SERVO_TEST` messages fire on each slider input AND on each number-input change. |
+| 3.2 | With test active, flip `systemStatus.readOnly = true`. | Slider and number input both auto-disable (visually greyed). **Enable Test** button is disabled with the readonly tooltip. The "lock-active-notice" region (firmware-lock-specific copy) is **NOT** shown — readonly is explained by the button tooltip alone. |
+| 3.3 | With `jobLock.locked = true` (start a flash in another session): open the Servo Test modal. Try to **Enable Test**. | Button disabled with the firmware-lock tooltip. Slider and number input both visually disabled. Lock-active-notice region IS shown below the slider with copy `firmware_view.lock_active`. |
+| 3.4 | While modal is open with test active, transition jobLock from unlocked → locked (start a foreign flash). | Slider and number input both auto-disable. Label reverts to "Enable Test". Notice region appears. |
 
 ---
 

--- a/.docs/qa/firmware-ota-d-7-followups.md
+++ b/.docs/qa/firmware-ota-d-7-followups.md
@@ -1,0 +1,115 @@
+# Firmware OTA d.7 Follow-ups — Manual QA Test Plan
+
+Covers the three fixes from `.docs/plans/20260514-1520-firmware-ota-d-7-followups.md`:
+
+1. `jobLock` HTTP hydrate on `App.vue` mount.
+2. `AstrosConfirmModal` consumer wiring in `ModulesView` and `ScripterView`.
+3. `AstrosServoTestModal` slider readonly check.
+
+Run all three sections before approving the PR to `develop`.
+
+---
+
+## Preconditions (all sections)
+
+- Local dev server running: `cd astros_api && npm run start:tsx` (port 3000) + `cd astros_vue && npm run dev` (port 5173).
+- Logged in as a configured user; at least one Location with one UART module and one I2C module configured (run `B_01_modules-page.spec.ts` once if the DB is fresh — the e2e leaves a populated state).
+- A test script exists with at least one channel (create via Scripts → New if needed).
+
+---
+
+## Section 1 — `jobLock` HTTP hydrate
+
+**Goal:** confirm that deep-linking to `/firmware` (or any view) during a foreign flash shows the locked banner from first paint — no interactive window before the WS handshake completes.
+
+### Setup
+
+A second client session needs to hold the lock. The easiest reproduction without a real flash:
+
+1. Open two browser windows (Session A + Session B), both logged in.
+2. In Session A, navigate to `/firmware`, pick a GitHub release, click **Push Firmware**, dismiss the confirm modal (so the request goes through and the orchestrator acquires the lock). Leave Session A in the "flashing" state with the in-page progress visible.
+
+### Test cases
+
+| # | Action | Expected |
+|---|--------|----------|
+| 1.1 | In Session B (window 2), navigate to `/scripts`. | Lock banner appears at top of layout. "View progress" CTA visible. No flash of unlocked UI. |
+| 1.2 | In Session B, do a **hard refresh** (Cmd+Shift+R / Ctrl+F5) on `/scripts`. | Lock banner present from first paint. No window where banner is missing then appears. |
+| 1.3 | In Session B, deep-link directly to `/firmware` (paste URL in address bar). | Source strip is in the lock-suppressed state from first paint (GitHub picker disabled, file input disabled). NOT interactive even for ~1 second. |
+| 1.4 | DevTools → Network tab → reload Session B. Observe the request to `/api/firmware/lock-state`. | Returns 200 with body `{ locked: true, owner: "flashJob:...", since: "2026-..." }`. Fires on the same `onMounted` tick as `/api/system/status`. |
+| 1.5 | In Session A, wait for the flash to finish (or DELETE `/api/firmware/flash` to abort). In Session B, refresh. | Lock banner gone, source strip interactive. `/api/firmware/lock-state` returns `{ locked: false, owner: null, since: null }`. |
+
+### Edge case
+
+| # | Action | Expected |
+|---|--------|----------|
+| 1.E1 | Stop the API server (Ctrl+C in the `astros_api` terminal). In Session B, refresh `/scripts`. | UI renders without crashing. `console.warn('jobLock.fetchLockState failed', ...)` in browser console. Banner stays in last-known state (unlocked is the default). |
+
+---
+
+## Section 2 — `AstrosConfirmModal` consumer wiring
+
+**Goal:** confirm the Confirm button actually invokes the handler in both view consumers (was a no-op on `develop`).
+
+### 2.A — `ModulesView` (remove a UART/I2C module)
+
+| # | Action | Expected |
+|---|--------|----------|
+| 2.A.1 | Navigate to `/modules`. Expand a location, expand the Serial section, expand a UART module. | Module body visible with a "remove" button (trash icon). |
+| 2.A.2 | Click the remove button on the module. | Confirm modal opens with the `module_view.confirm_remove` message ("Are you sure you want to remove this module?"). |
+| 2.A.3 | Click **Confirm**. | Modal closes. Module is removed from the location's UART list. Pinia state reflects the removal (the module no longer appears in the UI after the modal closes). |
+| 2.A.4 | Open the modal again on another module. Click **Close** (the secondary button). | Modal closes. Module stays in the list. |
+| 2.A.5 | Open the modal again. Click outside the modal (backdrop click). | Modal closes via backdrop. Module stays in the list. |
+| 2.A.6 | Repeat 2.A.1–2.A.3 for an I2C module. | Same as 2.A.3 — Confirm actually removes. |
+
+### 2.B — `ScripterView` (remove a channel)
+
+The channel-row delete control is **rendered inside the PixiJS canvas** (`pixiChannelData.ts:66` — `deleteButton`), not as a DOM element. The icon is a small trash glyph on the left-hand channel-list strip of the timeline. Standard Playwright DOM selectors will not find it; this is why the regression test for this flow is manual rather than e2e.
+
+| # | Action | Expected |
+|---|--------|----------|
+| 2.B.1 | Navigate to a script in `/scripter/<id>`. | Pixi timeline visible with at least one channel row in the left strip. |
+| 2.B.2 | In the left channel-list strip of the canvas, click the trash icon on a channel row. | Confirm modal opens with the configured message ("Are you sure you want to remove this channel?" or similar). |
+| 2.B.3 | Click **Confirm**. | Modal closes. Channel row is removed from the left strip. The associated event tracks disappear from the timeline. Pinia `scripterStore` reflects the change (verify via Vue DevTools → Pinia → scripter → `script.channels` no longer contains the removed channel). |
+| 2.B.4 | Trigger the trash icon on another channel. Click **Close**. | Modal closes. Channel stays. |
+
+### Regression context
+
+On `develop` before this fix, **Confirm did nothing** in both flows. The bug was silent because Vue's fallthrough event listeners attached to the inner `<dialog>` element instead of triggering the handler — and `<dialog>` doesn't emit a `confirm` event. So the modal would close on backdrop / close button (because `<dialog>` does emit `close`) but Confirm was a dead click.
+
+---
+
+## Section 3 — `AstrosServoTestModal` slider readonly check
+
+**Goal:** confirm the slider and handlers respect `systemStatus.readOnly` (in addition to `jobLock.locked`).
+
+### Setup
+
+To force `systemStatus.readOnly = true` locally, the easiest path is to corrupt the migration sequence or use the integration test harness. For a quick manual flip:
+
+```bash
+# Patch the systemStatus state via the API server's internal call (requires running tsx with debugging)
+# Or — simpler — temporarily edit astros_api/src/system_status.ts to default to readOnly=true and restart the server.
+```
+
+If neither is convenient, this section can be **skipped with explicit note** because the slider's `:disabled` binding is straightforward TypeScript and the unit test in `AstrosServoTestModal.spec.ts` (added in T6) covers the readonly path. The full e2e regression doesn't need manual rerun.
+
+### Test cases (if readonly can be triggered)
+
+| # | Action | Expected |
+|---|--------|----------|
+| 3.1 | With `systemStatus.readOnly = false` and `jobLock.locked = false`: open the Servo Test modal on any servo channel. Click **Enable Test**, drag the slider. | WS `SERVO_TEST` messages fire on each slider input. |
+| 3.2 | With test active, flip `systemStatus.readOnly = true`. | Slider auto-disables. **Enable Test** button is disabled with the readonly tooltip. The "lock-active-notice" region (firmware-lock-specific copy) is **NOT** shown — readonly is explained by the button tooltip alone. |
+| 3.3 | With `jobLock.locked = true` (start a flash in another session): open the Servo Test modal. Try to **Enable Test**. | Button disabled with the firmware-lock tooltip. Lock-active-notice region IS shown below the slider with copy `firmware_view.lock_active`. |
+| 3.4 | While modal is open with test active, transition jobLock from unlocked → locked (start a foreign flash). | Slider auto-disables. Label reverts to "Enable Test". Notice region appears. |
+
+---
+
+## QA sign-off
+
+- [ ] Section 1 (jobLock HTTP hydrate) passes all cases.
+- [ ] Section 2.A (ModulesView confirm) passes all cases.
+- [ ] Section 2.B (ScripterView confirm) passes all cases.
+- [ ] Section 3 (ServoTestModal readonly) passes — or explicitly skipped with rationale.
+
+Tester: _______________  Date: _______________

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -89,6 +89,7 @@ import { WorkerSerialBus } from './firmware/serial_bus.js';
 import { FlashJobOrchestrator } from './firmware/flash_orchestrator.js';
 import { registerFirmwareFlashRoutes } from './controllers/firmware_flash_controller.js';
 import { registerFirmwareReleasesRoutes } from './controllers/firmware_releases_controller.js';
+import { registerFirmwareLockStateRoutes } from './controllers/firmware_lock_state_controller.js';
 import { FirmwareCache } from './firmware/firmware_cache.js';
 import { FirmwareUploadStore } from './firmware/firmware_upload_store.js';
 import { GitHubReleaseService } from './firmware/github_release_service.js';
@@ -572,6 +573,7 @@ export class ApiServer {
     });
     registerFirmwareFlashRoutes(this.router, this.authHandler, this.flashOrchestrator);
     registerFirmwareReleasesRoutes(this.router, this.authHandler, this.githubReleaseService);
+    registerFirmwareLockStateRoutes(this.router, this.jobLock);
 
     try {
       this.serialPort = new SerialPort({

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -459,6 +459,11 @@ export class ApiServer {
   private setRoutes(): void {
     registerAuthRoutes(this.router);
     registerSystemStatusRoutes(this.router, this.systemStatus);
+    // Lock-state hydrate is needed even when serial is skipped (test envs,
+    // future no-hardware boot modes). Only depends on `this.jobLock`, which is
+    // constructed at field-init time — unlike the flash/releases routes,
+    // which need flashOrchestrator/githubReleaseService built in setupSerialPort.
+    registerFirmwareLockStateRoutes(this.router, this.jobLock);
     registerLocationRoutes(this.router, this.authHandler, this.db);
     registerScriptRoutes(this.router, this.authHandler, this.db);
     registerPlaylistRoutes(this.router, this.authHandler, this.db);
@@ -573,7 +578,6 @@ export class ApiServer {
     });
     registerFirmwareFlashRoutes(this.router, this.authHandler, this.flashOrchestrator);
     registerFirmwareReleasesRoutes(this.router, this.authHandler, this.githubReleaseService);
-    registerFirmwareLockStateRoutes(this.router, this.jobLock);
 
     try {
       this.serialPort = new SerialPort({

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -459,11 +459,14 @@ export class ApiServer {
   private setRoutes(): void {
     registerAuthRoutes(this.router);
     registerSystemStatusRoutes(this.router, this.systemStatus);
-    // Lock-state hydrate is needed even when serial is skipped (test envs,
-    // future no-hardware boot modes). Only depends on `this.jobLock`, which is
-    // constructed at field-init time — unlike the flash/releases routes,
-    // which need flashOrchestrator/githubReleaseService built in setupSerialPort.
+    // Firmware routes whose dependencies are available before setupSerialPort()
+    // belong here so they stay registered when serial is skipped (test envs,
+    // future no-hardware boot modes). The flash route still lives in
+    // setupSerialPort() because flashOrchestrator needs the serial Worker.
+    //   - lock-state: depends on this.jobLock (field-init, line 193)
+    //   - releases:   depends on this.githubReleaseService (configApi, line 453)
     registerFirmwareLockStateRoutes(this.router, this.jobLock);
+    registerFirmwareReleasesRoutes(this.router, this.authHandler, this.githubReleaseService);
     registerLocationRoutes(this.router, this.authHandler, this.db);
     registerScriptRoutes(this.router, this.authHandler, this.db);
     registerPlaylistRoutes(this.router, this.authHandler, this.db);
@@ -577,7 +580,6 @@ export class ApiServer {
       config: this.flashOrchestratorConfig,
     });
     registerFirmwareFlashRoutes(this.router, this.authHandler, this.flashOrchestrator);
-    registerFirmwareReleasesRoutes(this.router, this.authHandler, this.githubReleaseService);
 
     try {
       this.serialPort = new SerialPort({

--- a/astros_api/src/controllers/firmware_lock_state_controller.integration.test.ts
+++ b/astros_api/src/controllers/firmware_lock_state_controller.integration.test.ts
@@ -1,20 +1,25 @@
-// Pins the route-registration placement for GET /api/firmware/lock-state.
+// Pins the route-registration placement for firmware routes that DON'T need the
+// serial Worker — currently GET /api/firmware/lock-state and GET
+// /api/firmware/releases. Both depend on services built before setupSerialPort()
+// (jobLock at field-init, githubReleaseService in configApi), so both must
+// register inside setRoutes() rather than setupSerialPort(); otherwise they
+// return 404 under `skipSerialSetup: true` (NODE_ENV=test default + any future
+// no-hardware boot mode).
 //
-// The handler-only unit test next door (`firmware_lock_state_controller.test.ts`)
-// drives `getLockState` directly — it cannot detect whether `ApiServer` actually
-// mounts the route. The first version of this branch registered the route inside
-// `setupSerialPort()`, which is skipped when `skipSerialSetup === true` (the
-// default in NODE_ENV=test and any future no-hardware boot). That made the
-// endpoint return 404 in test/no-hardware environments — defeating the entire
-// purpose of the hydrate, which is to populate the lock store BEFORE the WS
-// handshake completes. This test boots a real `ApiServer` with
-// `skipSerialSetup: true`, fetches the endpoint, and asserts 200 — so a future
-// move back into `setupSerialPort` (or any other code path that skips when
-// serial does) trips the test before it ships.
+// The first version of this branch made exactly that mistake for the lock-state
+// route, and the partial-fix-sweep review caught the same mispattern on the
+// releases route. The handler-only unit tests next door drive the handler
+// functions directly and cannot detect wiring placement — only an integration
+// test that boots a real ApiServer with `skipSerialSetup: true` can.
+//
+// The releases route is authenticated, so this test issues an unauth GET and
+// asserts 401 (route registered + auth middleware ran, but rejected) rather
+// than 404 (route never registered). Using 401-vs-404 keeps the test from
+// needing to forge a JWT.
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ApiServer } from '../api_server.js';
 
-describe('GET /api/firmware/lock-state — route registration', () => {
+describe('Firmware route registration under skipSerialSetup: true', () => {
   let server: ApiServer | undefined;
 
   beforeEach(() => {
@@ -27,7 +32,7 @@ describe('GET /api/firmware/lock-state — route registration', () => {
     }
   });
 
-  it('is registered even when serial setup is skipped (NODE_ENV=test path)', async () => {
+  it('registers GET /api/firmware/lock-state and GET /api/firmware/releases', async () => {
     // Ephemeral ports + in-memory DB (NODE_ENV=test) + skipSerialSetup so the
     // boot is hermetic and finishes in milliseconds — no PTY, no stub master.
     // The fixed-string jwtKey avoids reading process.env.JWT_KEY (which the
@@ -42,12 +47,25 @@ describe('GET /api/firmware/lock-state — route registration', () => {
     });
 
     const port = server.getBoundApiPort();
-    const res = await fetch(`http://127.0.0.1:${port}/api/firmware/lock-state`);
 
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { locked: boolean; owner: unknown; since: unknown };
+    // Lock-state is unauthenticated (mirrors /api/system/status) — expect 200.
+    const lockStateRes = await fetch(`http://127.0.0.1:${port}/api/firmware/lock-state`);
+    expect(lockStateRes.status).toBe(200);
+    const body = (await lockStateRes.json()) as {
+      locked: boolean;
+      owner: unknown;
+      since: unknown;
+    };
     expect(body.locked).toBe(false);
     expect(body.owner).toBeNull();
     expect(body.since).toBeNull();
+
+    // Releases requires auth — without a token the JWT middleware rejects with
+    // 401. That's enough to confirm the route is registered (a 404 would mean
+    // it's not). Forging a token to assert 200 is out of scope for a wiring
+    // smoke test; the unit test next door (`firmware_releases_controller.test.ts`)
+    // exercises the happy-path handler.
+    const releasesRes = await fetch(`http://127.0.0.1:${port}/api/firmware/releases`);
+    expect(releasesRes.status).toBe(401);
   });
 });

--- a/astros_api/src/controllers/firmware_lock_state_controller.integration.test.ts
+++ b/astros_api/src/controllers/firmware_lock_state_controller.integration.test.ts
@@ -1,0 +1,53 @@
+// Pins the route-registration placement for GET /api/firmware/lock-state.
+//
+// The handler-only unit test next door (`firmware_lock_state_controller.test.ts`)
+// drives `getLockState` directly — it cannot detect whether `ApiServer` actually
+// mounts the route. The first version of this branch registered the route inside
+// `setupSerialPort()`, which is skipped when `skipSerialSetup === true` (the
+// default in NODE_ENV=test and any future no-hardware boot). That made the
+// endpoint return 404 in test/no-hardware environments — defeating the entire
+// purpose of the hydrate, which is to populate the lock store BEFORE the WS
+// handshake completes. This test boots a real `ApiServer` with
+// `skipSerialSetup: true`, fetches the endpoint, and asserts 200 — so a future
+// move back into `setupSerialPort` (or any other code path that skips when
+// serial does) trips the test before it ships.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ApiServer } from '../api_server.js';
+
+describe('GET /api/firmware/lock-state — route registration', () => {
+  let server: ApiServer | undefined;
+
+  beforeEach(() => {
+    server = undefined;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.shutdown();
+    }
+  });
+
+  it('is registered even when serial setup is skipped (NODE_ENV=test path)', async () => {
+    // Ephemeral ports + in-memory DB (NODE_ENV=test) + skipSerialSetup so the
+    // boot is hermetic and finishes in milliseconds — no PTY, no stub master.
+    // The fixed-string jwtKey avoids reading process.env.JWT_KEY (which the
+    // integration harness deliberately bypasses for the same reason).
+    server = await ApiServer.bootstrap({
+      configOverrides: {
+        apiPort: 0,
+        websocketPort: 0,
+        jwtKey: 'integration-test-key',
+        skipSerialSetup: true,
+      },
+    });
+
+    const port = server.getBoundApiPort();
+    const res = await fetch(`http://127.0.0.1:${port}/api/firmware/lock-state`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { locked: boolean; owner: unknown; since: unknown };
+    expect(body.locked).toBe(false);
+    expect(body.owner).toBeNull();
+    expect(body.since).toBeNull();
+  });
+});

--- a/astros_api/src/controllers/firmware_lock_state_controller.test.ts
+++ b/astros_api/src/controllers/firmware_lock_state_controller.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getLockState } from './firmware_lock_state_controller.js';
+import { JobLock } from '../job_lock/job_lock.js';
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('Firmware Lock State Controller', () => {
+  let jobLock: JobLock;
+
+  beforeEach(() => {
+    jobLock = new JobLock();
+  });
+
+  describe('GET /api/firmware/lock-state', () => {
+    it('returns 200 with the unlocked state when no flash job is active', () => {
+      const req: any = {};
+      const res = mockRes();
+
+      getLockState(jobLock, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        locked: false,
+        owner: null,
+        since: null,
+      });
+    });
+
+    it('returns 200 with the locked state when a flash job is active', () => {
+      jobLock.acquire('flashJob:abc');
+
+      const req: any = {};
+      const res = mockRes();
+
+      getLockState(jobLock, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.locked).toBe(true);
+      expect(payload.owner).toBe('flashJob:abc');
+      expect(typeof payload.since).toBe('string');
+      // ISO-8601 from JobLock.acquire — sanity-check it parses
+      expect(new Date(payload.since).toString()).not.toBe('Invalid Date');
+    });
+
+    it('reflects state transitions across acquire/release', () => {
+      jobLock.acquire('flashJob:abc');
+      jobLock.release('flashJob:abc');
+
+      const req: any = {};
+      const res = mockRes();
+
+      getLockState(jobLock, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        locked: false,
+        owner: null,
+        since: null,
+      });
+    });
+  });
+});

--- a/astros_api/src/controllers/firmware_lock_state_controller.ts
+++ b/astros_api/src/controllers/firmware_lock_state_controller.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { JobLock } from '../job_lock/job_lock.js';
+
+const route = '/firmware/lock-state';
+
+export function registerFirmwareLockStateRoutes(router: Router, jobLock: JobLock) {
+  router.get(route, (req: any, res: any) => getLockState(jobLock, req, res));
+}
+
+export function getLockState(jobLock: JobLock, _req: any, res: any) {
+  res.status(200).json(jobLock.getState());
+}

--- a/astros_vue/src/App.vue
+++ b/astros_vue/src/App.vue
@@ -4,16 +4,22 @@ import { RouterView } from 'vue-router';
 import { useWebsocket } from './composables/useWebsocket';
 import AstrosToastContainer from './components/common/AstrosToastContainer.vue';
 import { useSystemStatusStore } from '@/stores/systemStatus';
+import { useJobLockStore } from '@/stores/jobLock';
 
 const { wsConnect, wsDisconnect } = useWebsocket();
 const systemStatusStore = useSystemStatusStore();
+const jobLockStore = useJobLockStore();
 
 onMounted(() => {
   // Belt-and-braces: WebSocket pushes initial state on connect, but until the
   // handshake completes there's a window where the user could see write-intent
-  // controls enabled when the server is in read-only mode. Fetch once up-front
-  // so the banner and disabled-button bindings are correct from the first paint.
+  // controls enabled when the server is in read-only mode or while another
+  // session holds the firmware-flash job lock. Fetch both up-front so the
+  // banners and disabled-button bindings are correct from the first paint
+  // (relevant for deep-links / hard refreshes that bypass the prior session
+  // state).
   systemStatusStore.fetchStatus();
+  jobLockStore.fetchLockState();
   wsConnect();
 });
 

--- a/astros_vue/src/__tests__/App.spec.ts
+++ b/astros_vue/src/__tests__/App.spec.ts
@@ -1,0 +1,60 @@
+// Pins the App.vue onMounted hydrate contract: both systemStatusStore.fetchStatus
+// AND jobLockStore.fetchLockState must fire before wsConnect, so the lock and
+// readonly banners are correct from the first paint on cold-mount / deep-link.
+// Without this test, a refactor that drops the jobLockStore.fetchLockState() line
+// (or innocently re-orders things so wsConnect awaits something it shouldn't)
+// silently regresses the entire d.7 follow-up #1 feature.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { mount } from '@vue/test-utils';
+import { createRouter, createMemoryHistory } from 'vue-router';
+
+const wsConnect = vi.fn();
+const wsDisconnect = vi.fn();
+vi.mock('@/composables/useWebsocket', () => ({
+  useWebsocket: () => ({ wsConnect, wsDisconnect }),
+}));
+
+const fetchStatusSpy = vi.fn();
+const fetchLockStateSpy = vi.fn();
+vi.mock('@/stores/systemStatus', () => ({
+  useSystemStatusStore: () => ({ fetchStatus: fetchStatusSpy }),
+}));
+vi.mock('@/stores/jobLock', () => ({
+  useJobLockStore: () => ({ fetchLockState: fetchLockStateSpy }),
+}));
+
+// AstrosToastContainer pulls in the full toast system; stub it to keep the
+// smoke test focused on App's onMounted body.
+vi.mock('@/components/common/AstrosToastContainer.vue', () => ({
+  default: { name: 'AstrosToastContainer', template: '<div />' },
+}));
+
+import App from '@/App.vue';
+
+describe('App.vue — onMounted hydrate', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    wsConnect.mockClear();
+    wsDisconnect.mockClear();
+    fetchStatusSpy.mockClear();
+    fetchLockStateSpy.mockClear();
+  });
+
+  it('fires fetchStatus, fetchLockState, and wsConnect on mount', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div />' } }],
+    });
+    await router.push('/');
+    await router.isReady();
+
+    mount(App, {
+      global: { plugins: [router] },
+    });
+
+    expect(fetchStatusSpy).toHaveBeenCalledTimes(1);
+    expect(fetchLockStateSpy).toHaveBeenCalledTimes(1);
+    expect(wsConnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/astros_vue/src/__tests__/App.spec.ts
+++ b/astros_vue/src/__tests__/App.spec.ts
@@ -1,9 +1,10 @@
-// Pins the App.vue onMounted hydrate contract: both systemStatusStore.fetchStatus
-// AND jobLockStore.fetchLockState must fire before wsConnect, so the lock and
-// readonly banners are correct from the first paint on cold-mount / deep-link.
-// Without this test, a refactor that drops the jobLockStore.fetchLockState() line
-// (or innocently re-orders things so wsConnect awaits something it shouldn't)
-// silently regresses the entire d.7 follow-up #1 feature.
+// Pins the App.vue onMounted hydrate call surface: systemStatusStore.fetchStatus,
+// jobLockStore.fetchLockState, and wsConnect must all be synchronously enqueued
+// from onMounted on every mount (the HTTP fetches are fire-and-forget — actual
+// HTTP-response-vs-WS-handshake ordering is NOT pinned by this test). Without
+// this test, a refactor that drops jobLockStore.fetchLockState() silently
+// regresses the client-mount half of d.7 follow-up #1 (the server-side route
+// placement is guarded by firmware_lock_state_controller.integration.test.ts).
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { mount } from '@vue/test-utils';

--- a/astros_vue/src/api/endpoints.ts
+++ b/astros_vue/src/api/endpoints.ts
@@ -30,3 +30,4 @@ export const SYSTEM_STATUS = 'api/system/status';
 
 export const FIRMWARE_RELEASES = 'api/firmware/releases';
 export const FIRMWARE_FLASH = 'api/firmware/flash';
+export const FIRMWARE_LOCK_STATE = 'api/firmware/lock-state';

--- a/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
+++ b/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
@@ -44,7 +44,11 @@ const writesBlocked = computed(() => jobLockLocked.value || systemStatusReadOnly
 
 // If writes become blocked (firmware flash lock or system readonly) while
 // the modal is already open with the test active, auto-disable so further
-// slider/input is ignored locally as well.
+// slider/input is ignored locally as well — AND when the block later
+// releases, the test stays disabled until the operator explicitly
+// re-Enables it (the handler-body guards no longer short-circuit once
+// writesBlocked is false again, so without resetting disabled.value
+// here, the next slider input would re-emit SERVO_TEST unexpectedly).
 watch(writesBlocked, (nowBlocked) => {
   if (nowBlocked && !disabled.value) {
     disabled.value = true;

--- a/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
+++ b/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch } from 'vue';
 import { useWebsocket } from '@/composables/useWebsocket';
 import { useJobLockStore } from '@/stores/jobLock';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 import { storeToRefs } from 'pinia';
 import type { ServoTestEvent } from '@/models/events';
 import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
@@ -9,6 +10,8 @@ import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 const { wsSendMessage } = useWebsocket();
 const jobLock = useJobLockStore();
 const { locked: jobLockLocked } = storeToRefs(jobLock);
+const systemStatus = useSystemStatusStore();
+const { readOnly: systemStatusReadOnly } = storeToRefs(systemStatus);
 
 const props = defineProps<ServoTestEvent>();
 
@@ -20,17 +23,25 @@ const disabled = ref(true);
 const label = ref('modals.servo_test.enable_test');
 const value = ref(props.homePosition);
 
-// Slider-side lock gate + belt-and-suspenders for the handler bodies.
+// Slider-side write gate + belt-and-suspenders for the handler bodies.
 // The Enable Test button itself is handled by AstrosWriteButton, which
-// consults the store directly. This computed feeds: the slider's
-// :disabled, onSliderChange's early-return, enableTest's early-return,
-// the mid-session auto-disable watcher, and the lock-active notice region
-// below. The handler-body guards protect against any programmatic
+// consults both stores directly. This computed mirrors that OR so the
+// slider :disabled, onSliderChange's early-return, enableTest's
+// early-return, and the mid-session auto-disable watcher all stay in
+// sync. The handler-body guards protect against any programmatic
 // invocation path that bypasses the button's disabled state.
-const writesBlocked = computed(() => jobLockLocked.value);
+//
+// Note: the firmware-flash notice region (`lock-active-notice` below) is
+// intentionally gated on `jobLockLocked` alone, not `writesBlocked`. Its
+// copy is firmware-flash-specific (firmware_view.lock_active); readonly
+// is already explained by AstrosWriteButton's tooltip on the Enable
+// button, so a redundant "flash active" notice during a non-flash
+// readonly state would be misleading.
+const writesBlocked = computed(() => jobLockLocked.value || systemStatusReadOnly.value);
 
-// If a flash starts while the modal is already open with the test active,
-// auto-disable so further slider input is ignored locally as well.
+// If writes become blocked (firmware flash lock or system readonly) while
+// the modal is already open with the test active, auto-disable so further
+// slider/input is ignored locally as well.
 watch(writesBlocked, (nowBlocked) => {
   if (nowBlocked && !disabled.value) {
     disabled.value = true;
@@ -89,6 +100,7 @@ const closeModal = () => {
             min="500"
             max="2500"
             v-model.number="value"
+            :disabled="disabled || writesBlocked"
             @input="onSliderChange"
             class="input input-bordered w-24 text-center"
           />
@@ -105,7 +117,7 @@ const closeModal = () => {
           step="1"
         />
         <div
-          v-if="writesBlocked"
+          v-if="jobLockLocked"
           role="status"
           aria-live="polite"
           class="text-sm text-warning text-center mt-2"

--- a/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
+++ b/astros_vue/src/components/modals/modules/AstrosServoTestModal.vue
@@ -23,20 +23,23 @@ const disabled = ref(true);
 const label = ref('modals.servo_test.enable_test');
 const value = ref(props.homePosition);
 
-// Slider-side write gate + belt-and-suspenders for the handler bodies.
+// Value-entry write gate + belt-and-suspenders for the handler bodies.
 // The Enable Test button itself is handled by AstrosWriteButton, which
 // consults both stores directly. This computed mirrors that OR so the
-// slider :disabled, onSliderChange's early-return, enableTest's
-// early-return, and the mid-session auto-disable watcher all stay in
-// sync. The handler-body guards protect against any programmatic
-// invocation path that bypasses the button's disabled state.
+// number-input :disabled, the slider :disabled, onSliderChange's
+// early-return, enableTest's early-return, and the mid-session
+// auto-disable watcher all stay in sync. The handler-body guards
+// protect against any programmatic invocation path that bypasses the
+// elements' disabled state.
 //
 // Note: the firmware-flash notice region (`lock-active-notice` below) is
 // intentionally gated on `jobLockLocked` alone, not `writesBlocked`. Its
 // copy is firmware-flash-specific (firmware_view.lock_active); readonly
-// is already explained by AstrosWriteButton's tooltip on the Enable
-// button, so a redundant "flash active" notice during a non-flash
-// readonly state would be misleading.
+// is surfaced elsewhere in the UI through AstrosWriteButton's tooltip
+// (whichever priority that component currently assigns), so a redundant
+// "flash active" notice during a non-flash readonly state would be
+// misleading. If AstrosWriteButton ever drops its readonly tooltip, this
+// modal will need its own readonly notice copy.
 const writesBlocked = computed(() => jobLockLocked.value || systemStatusReadOnly.value);
 
 // If writes become blocked (firmware flash lock or system readonly) while

--- a/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
+++ b/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
@@ -38,7 +38,7 @@ function mountModal(): VueWrapper {
   });
 }
 
-describe('AstrosServoTestModal — lock-aware gating', () => {
+describe('AstrosServoTestModal — write-blocked gating (jobLock + readOnly)', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     stubSendMessage.mockClear();
@@ -130,16 +130,27 @@ describe('AstrosServoTestModal — lock-aware gating', () => {
     expect(stubSendMessage).not.toHaveBeenCalled();
   });
 
-  it('disables the slider, number input, and Enable button when systemStatus.readOnly is true', async () => {
-    const systemStatus = useSystemStatusStore();
-    systemStatus.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+  it('keeps slider/number input disabled when readOnly flips on AFTER the test is enabled', async () => {
+    // This test exercises the writesBlocked widening directly. Without the
+    // `|| systemStatusReadOnly.value` clause, the initial disabled=true
+    // ref already keeps both inputs disabled at mount, so a naive "disabled
+    // when readonly is true" assertion passes vacuously. We instead enable
+    // the test first (disabled flips to false), then flip readOnly true and
+    // assert both inputs go back to disabled — which only holds if
+    // writesBlocked feeds the :disabled bindings.
     const wrapper = mountModal();
-    await nextTick();
-
     const btn = wrapper.find('[data-testid="enable-test-button"]');
+    await btn.trigger('click');
+
     const slider = wrapper.find('input[type="range"]');
     const numberInput = wrapper.find('input[type="number"]');
-    expect(btn.attributes('disabled')).toBeDefined();
+    expect(slider.attributes('disabled')).toBeUndefined();
+    expect(numberInput.attributes('disabled')).toBeUndefined();
+
+    const systemStatus = useSystemStatusStore();
+    systemStatus.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    await nextTick();
+
     expect(slider.attributes('disabled')).toBeDefined();
     expect(numberInput.attributes('disabled')).toBeDefined();
   });

--- a/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
+++ b/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
@@ -6,6 +6,7 @@ import { nextTick } from 'vue';
 import enUS from '@/locales/enUS.json';
 import AstrosServoTestModal from '@/components/modals/modules/AstrosServoTestModal.vue';
 import { useJobLockStore } from '@/stores/jobLock';
+import { useSystemStatusStore } from '@/stores/systemStatus';
 
 const stubSendMessage = vi.fn();
 vi.mock('@/composables/useWebsocket', () => ({
@@ -93,7 +94,7 @@ describe('AstrosServoTestModal — lock-aware gating', () => {
     expect(notice.attributes('aria-live')).toBe('polite');
   });
 
-  it('disables the slider when locked', async () => {
+  it('disables both the slider and the number input when locked', async () => {
     const lockStore = useJobLockStore();
     lockStore.setState({
       locked: true,
@@ -103,7 +104,9 @@ describe('AstrosServoTestModal — lock-aware gating', () => {
     const wrapper = mountModal();
     await nextTick();
     const slider = wrapper.find('input[type="range"]');
+    const numberInput = wrapper.find('input[type="number"]');
     expect(slider.attributes('disabled')).toBeDefined();
+    expect(numberInput.attributes('disabled')).toBeDefined();
   });
 
   it('auto-disables an active test if a lock acquires mid-session', async () => {
@@ -122,6 +125,58 @@ describe('AstrosServoTestModal — lock-aware gating', () => {
     });
     await nextTick();
     // Slider change should be a no-op now
+    const slider = wrapper.find('input[type="range"]');
+    await slider.trigger('input');
+    expect(stubSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('disables the slider, number input, and Enable button when systemStatus.readOnly is true', async () => {
+    const systemStatus = useSystemStatusStore();
+    systemStatus.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    const wrapper = mountModal();
+    await nextTick();
+
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    const slider = wrapper.find('input[type="range"]');
+    const numberInput = wrapper.find('input[type="number"]');
+    expect(btn.attributes('disabled')).toBeDefined();
+    expect(slider.attributes('disabled')).toBeDefined();
+    expect(numberInput.attributes('disabled')).toBeDefined();
+  });
+
+  it('does NOT send servoTest when enableTest is invoked while readonly', async () => {
+    const systemStatus = useSystemStatusStore();
+    systemStatus.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    const wrapper = mountModal();
+    await nextTick();
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    await btn.trigger('click');
+    expect(stubSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('does NOT render the firmware-flash notice region when readonly-only (no jobLock)', async () => {
+    const systemStatus = useSystemStatusStore();
+    systemStatus.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    const wrapper = mountModal();
+    await nextTick();
+    // The notice copy is firmware-flash-specific (firmware_view.lock_active).
+    // AstrosWriteButton's own tooltip already explains readonly to the user;
+    // we don't want a misleading "flash active" notice when there's no flash.
+    const notice = wrapper.find('[data-testid="lock-active-notice"]');
+    expect(notice.exists()).toBe(false);
+  });
+
+  it('auto-disables an active test if readOnly flips on mid-session', async () => {
+    const wrapper = mountModal();
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    await btn.trigger('click');
+    expect(stubSendMessage).toHaveBeenCalledTimes(1);
+    stubSendMessage.mockClear();
+
+    const systemStatus = useSystemStatusStore();
+    systemStatus.setStatus({ readOnly: true, reasonCode: 'BACKUP_FAILED' });
+    await nextTick();
+
     const slider = wrapper.find('input[type="range"]');
     await slider.trigger('input');
     expect(stubSendMessage).not.toHaveBeenCalled();

--- a/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
+++ b/astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts
@@ -177,6 +177,39 @@ describe('AstrosServoTestModal — write-blocked gating (jobLock + readOnly)', (
     expect(notice.exists()).toBe(false);
   });
 
+  it('after a mid-session lock the active test stays disabled even after the lock releases', async () => {
+    // Pins the watcher's lock-release UX guarantee: when a flash interrupts an
+    // active servo test, the slider must not auto-fire when the lock later
+    // releases — the operator has to explicitly re-Enable. Without the
+    // watcher at writesBlocked-true (which resets disabled.value to true +
+    // label to 'enable_test'), this guarantee breaks because the handler-body
+    // early-return guard `disabled.value || writesBlocked.value` evaluates to
+    // false after the lock releases (both are false again), so the next slider
+    // input fires a SERVO_TEST. The other existing tests don't catch this
+    // because they only assert behavior during the locked window, when the
+    // writesBlocked half of the guard short-circuits.
+    const wrapper = mountModal();
+    const btn = wrapper.find('[data-testid="enable-test-button"]');
+    await btn.trigger('click');
+    stubSendMessage.mockClear();
+
+    const lockStore = useJobLockStore();
+    lockStore.setState({
+      locked: true,
+      owner: 'flash:job-A',
+      since: '2026-05-14T08:00:00Z',
+    });
+    await nextTick();
+    lockStore.setState({ locked: false, owner: null, since: null });
+    await nextTick();
+
+    const slider = wrapper.find('input[type="range"]');
+    await slider.trigger('input');
+    expect(stubSendMessage).not.toHaveBeenCalled();
+    // Label should also have reset to 'enable_test' (the watcher resets both).
+    expect(btn.text()).toContain('Enable');
+  });
+
   it('auto-disables an active test if readOnly flips on mid-session', async () => {
     const wrapper = mountModal();
     const btn = wrapper.find('[data-testid="enable-test-button"]');

--- a/astros_vue/src/stores/__tests__/jobLock.spec.ts
+++ b/astros_vue/src/stores/__tests__/jobLock.spec.ts
@@ -1,10 +1,21 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
+
+vi.mock('@/api/apiService', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import apiService from '@/api/apiService';
 import { useJobLockStore } from '../jobLock';
+
+const apiGet = apiService.get as ReturnType<typeof vi.fn>;
 
 describe('jobLock store', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    apiGet.mockReset();
   });
 
   it('starts unlocked with no owner', () => {
@@ -42,5 +53,58 @@ describe('jobLock store', () => {
     expect(store.locked).toBe(false);
     expect(store.owner).toBeNull();
     expect(store.since).toBeNull();
+  });
+
+  describe('fetchLockState', () => {
+    it('updates state from a successful locked GET response', async () => {
+      apiGet.mockResolvedValueOnce({
+        locked: true,
+        owner: 'flashJob:abc',
+        since: '2026-04-28T07:30:00.000Z',
+      });
+
+      const store = useJobLockStore();
+      await store.fetchLockState();
+
+      expect(apiGet).toHaveBeenCalledWith('api/firmware/lock-state');
+      expect(store.locked).toBe(true);
+      expect(store.owner).toBe('flashJob:abc');
+      expect(store.since).toBe('2026-04-28T07:30:00.000Z');
+    });
+
+    it('clears state from a successful unlocked GET response', async () => {
+      apiGet.mockResolvedValueOnce({ locked: false, owner: null, since: null });
+
+      const store = useJobLockStore();
+      // Pre-seed with a prior locked state so we can verify it gets cleared
+      store.setState({
+        locked: true,
+        owner: 'flashJob:abc',
+        since: '2026-04-28T07:30:00.000Z',
+      });
+
+      await store.fetchLockState();
+
+      expect(store.locked).toBe(false);
+      expect(store.owner).toBeNull();
+      expect(store.since).toBeNull();
+    });
+
+    it('leaves state unchanged on fetch failure (does not throw)', async () => {
+      apiGet.mockRejectedValueOnce(new Error('network'));
+
+      const store = useJobLockStore();
+      store.setState({
+        locked: true,
+        owner: 'flashJob:abc',
+        since: '2026-04-28T07:30:00.000Z',
+      });
+
+      await expect(store.fetchLockState()).resolves.toBeUndefined();
+
+      expect(store.locked).toBe(true);
+      expect(store.owner).toBe('flashJob:abc');
+      expect(store.since).toBe('2026-04-28T07:30:00.000Z');
+    });
   });
 });

--- a/astros_vue/src/stores/jobLock.ts
+++ b/astros_vue/src/stores/jobLock.ts
@@ -30,7 +30,13 @@ export const useJobLockStore = defineStore('jobLock', () => {
       // Leave state unchanged. The lockStateChanged WS push on (re)connect,
       // or the next acquire/release transition, will bring us back up to
       // date — assuming the WS path also works. If both paths fail, the UI
-      // stays at the default unlocked state with no operator-visible signal.
+      // stays at the default unlocked state and the operator only learns
+      // writes are blocked when they actually attempt one: writeGuard's 423
+      // response on a write-class request falls through to the caller's
+      // own per-call-site .catch(). Unlike the 503 readonly response, the
+      // codebase has no global 423 interceptor that surfaces a toast or
+      // updates this store — that's a separate follow-up worth filing if
+      // the gap matters in practice.
       console.warn('jobLock.fetchLockState failed', error);
     }
   }

--- a/astros_vue/src/stores/jobLock.ts
+++ b/astros_vue/src/stores/jobLock.ts
@@ -16,19 +16,21 @@ export const useJobLockStore = defineStore('jobLock', () => {
   }
 
   async function fetchLockState(): Promise<void> {
-    // HTTP hydrate is belt-and-braces alongside the lockStateChanged WS push:
-    // App.vue fires both in parallel on mount, and whichever resolves last
-    // wins the final setState call. On local LAN the WS snapshot from
-    // onopen typically arrives first; the HTTP response then overwrites
-    // with whatever the server reported at the time of the GET. Both
-    // snapshots reflect the same authoritative JobLock state on the
-    // server, so the residual race is millisecond-scale and benign in
-    // practice. Mirrors systemStatus.fetchStatus.
+    // HTTP hydrate closes the cold-mount / deep-link window before the WS
+    // handshake's on-connect snapshot arrives (the server emits the snapshot
+    // inside its `ws.on('connection', ...)` handler in api_server.ts; it
+    // surfaces client-side via `useWebsocket.handleLockStateChanged`). Both
+    // paths converge on `setState` with the same authoritative `JobLock`
+    // state from the server, so whichever resolves last wins and the result
+    // is the same. Mirrors systemStatus.fetchStatus.
     try {
       const response = (await apiService.get(FIRMWARE_LOCK_STATE)) as LockState;
       setState(response);
     } catch (error) {
-      // Leave state unchanged — the WS push remains as the primary source.
+      // Leave state unchanged. The lockStateChanged WS push on (re)connect,
+      // or the next acquire/release transition, will bring us back up to
+      // date — assuming the WS path also works. If both paths fail, the UI
+      // stays at the default unlocked state with no operator-visible signal.
       console.warn('jobLock.fetchLockState failed', error);
     }
   }

--- a/astros_vue/src/stores/jobLock.ts
+++ b/astros_vue/src/stores/jobLock.ts
@@ -1,5 +1,7 @@
 import { ref } from 'vue';
 import { defineStore } from 'pinia';
+import apiService from '@/api/apiService';
+import { FIRMWARE_LOCK_STATE } from '@/api/endpoints';
 import type { LockState } from '@/models';
 
 export const useJobLockStore = defineStore('jobLock', () => {
@@ -13,10 +15,29 @@ export const useJobLockStore = defineStore('jobLock', () => {
     since.value = state.since;
   }
 
+  async function fetchLockState(): Promise<void> {
+    // HTTP hydrate is belt-and-braces alongside the lockStateChanged WS push:
+    // App.vue fires both in parallel on mount, and whichever resolves last
+    // wins the final setState call. On local LAN the WS snapshot from
+    // onopen typically arrives first; the HTTP response then overwrites
+    // with whatever the server reported at the time of the GET. Both
+    // snapshots reflect the same authoritative JobLock state on the
+    // server, so the residual race is millisecond-scale and benign in
+    // practice. Mirrors systemStatus.fetchStatus.
+    try {
+      const response = (await apiService.get(FIRMWARE_LOCK_STATE)) as LockState;
+      setState(response);
+    } catch (error) {
+      // Leave state unchanged — the WS push remains as the primary source.
+      console.warn('jobLock.fetchLockState failed', error);
+    }
+  }
+
   return {
     locked,
     owner,
     since,
     setState,
+    fetchLockState,
   };
 });

--- a/astros_vue/src/views/ModulesView.vue
+++ b/astros_vue/src/views/ModulesView.vue
@@ -436,8 +436,8 @@ function controllerSelectChanged(location: string) {
       <AstrosConfirmModal
         v-if="showModal === ModalType.CONFIRM"
         :message="$t('module_view.confirm_remove')"
-        @confirm="handleRemoveModule"
-        @close="showModal = ModalType.CLOSE_ALL"
+        :on-confirm="handleRemoveModule"
+        :on-close="() => (showModal = ModalType.CLOSE_ALL)"
       />
       <AstrosLoadingModal
         v-if="showModal === ModalType.LOADING"

--- a/astros_vue/src/views/ScripterView.vue
+++ b/astros_vue/src/views/ScripterView.vue
@@ -421,8 +421,8 @@ onMounted(async () => {
       />
       <AstrosConfirmModal
         v-if="showModal === ModalType.CONFIRM"
-        @close="showModal = ModalType.CLOSE_ALL"
-        @confirm="confirm"
+        :on-close="() => (showModal = ModalType.CLOSE_ALL)"
+        :on-confirm="confirm"
         :message="modalMessage"
       />
       <AstrosAddChannelModal


### PR DESCRIPTION
## Summary

Clears the three out-of-scope items surfaced by the d.7 pre-push toolkit review, plus the cascade of partial-fix-sweep findings caught by running the toolkit again after the initial fixes landed.

- **jobLock HTTP hydrate (HIGH from d.7):** new `GET /api/firmware/lock-state` endpoint + `jobLockStore.fetchLockState()` action + `App.vue` parallel hydrate alongside `systemStatusStore.fetchStatus()`. Closes the deep-link-during-foreign-flash window where `FirmwareView`'s source strip was interactive until the WS handshake completed.
- **`AstrosConfirmModal` consumer wiring (HIGH from d.7):** swaps `@confirm` / `@close` event syntax for `:on-confirm` / `:on-close` prop binding in `ModulesView.vue` and `ScripterView.vue`. The fallthrough listeners attached to the inner `<dialog>` element and never fired — making Confirm a silent no-op in the remove-module and remove-channel flows on `develop`. `AstrosPlaylistEditor.vue` was already correct and served as the reference pattern.
- **`AstrosServoTestModal` slider readonly check (MINOR from d.7):** widens `writesBlocked` to OR `systemStatus.readOnly`, disables the previously-uncovered number input, and narrows the firmware-flash notice region to `jobLockLocked` alone (so it doesn't show during non-flash readonly states).

## Pre-push toolkit findings — both passes

Two `/pr-review-toolkit:review-pr` passes against the full diff. The second pass enforces CLAUDE.md's partial-fix-sweep rule: the cited line is rarely the only place the bug lives.

**Pass 1 (against commits e8c97e2..055a312):**

| Severity | Finding | Fix |
|---|---|---|
| Critical | `registerFirmwareLockStateRoutes` placed inside `setupSerialPort()` — returned 404 under `skipSerialSetup: true` (NODE_ENV=test default + any future no-hardware boot). Found by `silent-failure-hunter`. | Moved to `setRoutes()`; pinned with `firmware_lock_state_controller.integration.test.ts`. Mutation-tested. |
| Critical | `AstrosServoTestModal.vue:26-32` `writesBlocked` consumer enumeration missing the number input added in the same branch. Found by `comment-analyzer`. | Rewrote enumeration; renamed heading from "Slider-side write gate" to "Value-entry write gate". |
| Critical | `jobLock.ts:31` catch comment "WS push remains as the primary source" inverted the role split the block above established. Found by `comment-analyzer`. | Rewrote both block-level and catch comments to match the HTTP-as-cold-mount-freshness / WS-as-event-stream design. |
| Important | ServoTestModal test #1 ("disables ... when readOnly is true") passed even with the `writesBlocked` widening reverted (initial `disabled=true` ref kept inputs disabled at mount regardless). Found by `pr-test-analyzer`. | Rewrote to enable the test first, then flip readOnly — only holds if the widening actually feeds the bindings. Mutation-tested. |
| Important | `describe('lock-aware gating')` no longer matched scope after readonly tests added. | Renamed to `write-blocked gating (jobLock + readOnly)`. |
| Important | No automated test that asserts both `fetchStatus()` AND `fetchLockState()` fire on `App.vue` mount. Found by `silent-failure-hunter` + `pr-test-analyzer`. | Added `App.spec.ts` smoke test. Mutation-tested. |
| Important | `jobLock.ts` "WS snapshot from onopen" was imprecise — the snapshot surfaces via `onmessage`, not `onopen`. Found by `comment-analyzer`. | Rewrote with accurate phrasing referencing `ws.on('connection', ...)` server-side + `handleLockStateChanged` client-side. |
| Important | Forward-looking claim about `AstrosWriteButton`'s tooltip behavior with no pinning test. | Weakened the claim and added an explicit escape-hatch note. |

**Pass 2 (against the pass-1 fix commit `9fae64f`):**

| Severity | Finding | Fix |
|---|---|---|
| Critical | `api_server.ts:462-465` comment introduced by the fix commit falsely claimed `githubReleaseService` is built in `setupSerialPort()`. It's actually built in `configApi()` at line 453 — and the existing comment 15 lines above at `:447-448` already documents that explicitly. Found by `comment-analyzer` + `code-reviewer`. | Rewrote the comment with explicit field-init / configApi line citations. |
| Important (sibling sweep) | `registerFirmwareReleasesRoutes` had the **same misplacement** as the pass-1 C1 — registered inside `setupSerialPort()` despite only depending on `githubReleaseService` (built earlier in `configApi`). Same 404-under-test bug, dormant for d.7 but real. Found by `code-reviewer`. | Moved to `setRoutes()` alongside lock-state. Extended the integration test to assert `GET /api/firmware/releases` returns 401 (route registered + auth rejected) rather than 404. Mutation-tested. |
| Important | Plan T2 step 5 still described the WRONG initial placement (inside `setupSerialPort()`) as design intent. | Rewrote with a historical note documenting the placement bug, the first-pass fix, and the second-pass sibling sweep. |
| Important | `AstrosServoTestModal.vue:48-53` watcher had NO test coverage. All 10 existing tests passed even with the watcher completely removed — the handler-body guards short-circuited during the locked window, masking the watcher's unique contribution. Found by `pr-test-analyzer`. | Added a test for the lock-release UX guarantee: after a flash interrupts an active test, the slider must stay disabled until the operator explicitly re-Enables (otherwise the next slider input after lock release would fire `SERVO_TEST` unexpectedly). Mutation-tested. |
| Important | `App.spec.ts` header overclaimed "fetch ... before `wsConnect`" (the HTTP fetches are fire-and-forget; the test pins call count, not ordering) and "regresses the entire d.7 follow-up #1 feature" (only guards client-mount half). Found by `comment-analyzer`. | Rewrote to match what the test actually asserts and to point at the integration test for the server side. |
| Important | `jobLock.ts:32` catch comment understated the operator-visible signal gap. In both-paths-fail scenarios, the user's eventual write gets a 423 that falls through to per-call-site `.catch()` handlers because the codebase has no global 423 interceptor mirroring `readOnlyInterceptor`'s 503 path. Found by `silent-failure-hunter`. | Comment now explicit about this and flags the missing interceptor as a follow-up. Full fix deferred. |

## Deferred follow-ups (filed as known minor / cross-cutting)

- **`flashLockInterceptor.ts` symmetric to `readOnlyInterceptor.ts`** — so 423 responses on write-class requests self-toast and update `jobLockStore`. Closes the both-paths-fail UX gap the new comment documents. Worth a separate light plan.
- **`bootstrap()` partial-init rollback + `shutdown()` per-step watchdog** — current `bootstrap()` catches `Init()` errors but doesn't call `shutdown()` on partial init; `shutdown()` has no per-resource timeout. Benign today (the integration test path doesn't reach an Init step after `runWebServices()`), but a hazard if `Init()` grows.
- **Runtime shape validation on apiService responses** — `(await apiService.get(...)) as LockState` is an unchecked cast across all stores. A future server bug returning a wrong-shape JSON would silently land. Cross-cutting; either add a Zod-style validator or do nothing and accept the current pattern.

## Test plan

### Automated (all green)

- **Server:** 743 tests across 61 files. New: `firmware_lock_state_controller.test.ts` (3 handler unit tests) + `firmware_lock_state_controller.integration.test.ts` (1 integration test pinning route registration for both lock-state and releases under `skipSerialSetup: true`).
- **Client:** 293 tests across 22 files. New: `App.spec.ts` (hydrate call surface), 5 new tests in `AstrosServoTestModal.spec.ts` (readonly + watcher coverage), 3 new tests in `jobLock.spec.ts` (fetch action), 1 rewritten test (`describe` block renamed). The d.7 ConfirmModal contract tests already covered the modal's prop API; no new ConfirmModal tests added (view-level scaffolding doesn't exist).
- **Mutation gates:** verified for every Critical fix and every "could be vacuous" Important test — see commit messages for the revert-and-confirm-failure cycles.

### Manual QA

See `.docs/qa/firmware-ota-d-7-followups.md` for the full plan. Required runs before merge:

- [ ] Section 1 (jobLock HTTP hydrate): deep-link to `/firmware` and any other view during a foreign flash; confirm lock banner / disabled source strip from first paint.
- [ ] Section 2.A (`ModulesView` remove module): expand a location → expand Serial → click trash on a module → click Confirm → module removed.
- [ ] Section 2.B (`ScripterView` remove channel): open a script → click the trash icon on a channel row inside the PixiJS canvas → Confirm → channel removed.
- [ ] Section 3 (ServoTestModal readonly): unit tests cover this path; manual QA optional (the QA plan documents the readonly setup is awkward to trigger manually).

## Files touched

### New
- `astros_api/src/controllers/firmware_lock_state_controller.ts` — controller
- `astros_api/src/controllers/firmware_lock_state_controller.test.ts` — handler unit tests
- `astros_api/src/controllers/firmware_lock_state_controller.integration.test.ts` — route-registration integration test (covers lock-state + releases under `skipSerialSetup: true`)
- `astros_vue/src/__tests__/App.spec.ts` — hydrate call-surface smoke
- `.docs/plans/20260514-1520-firmware-ota-d-7-followups.md` — plan
- `.docs/qa/firmware-ota-d-7-followups.md` — manual QA plan

### Modified
- `astros_api/src/api_server.ts` — `registerFirmwareLockStateRoutes` + `registerFirmwareReleasesRoutes` now in `setRoutes()`
- `astros_vue/src/api/endpoints.ts` — `FIRMWARE_LOCK_STATE` constant
- `astros_vue/src/stores/jobLock.ts` — `fetchLockState()` action
- `astros_vue/src/stores/__tests__/jobLock.spec.ts` — `fetchLockState` cases
- `astros_vue/src/App.vue` — `jobLockStore.fetchLockState()` in `onMounted`
- `astros_vue/src/views/ModulesView.vue` — ConfirmModal binding fix
- `astros_vue/src/views/ScripterView.vue` — ConfirmModal binding fix
- `astros_vue/src/components/modals/modules/AstrosServoTestModal.vue` — `writesBlocked` widening, number input `:disabled`, notice-region narrowing, watcher comment generalization
- `astros_vue/src/components/modals/modules/__tests__/AstrosServoTestModal.spec.ts` — readonly + watcher + describe rename

## Reviewer notes

- The full review trail is in the commit messages (`3bb9ceb`, `3f61dce`, `aea5918`, `055a312`, `9fae64f`, `d6e9ef3`) and follows the same per-commit-toolkit-then-pre-push pattern as the d.7 cycle. Each Critical fix includes a mutation-test step in the commit body so reviewers can verify the test is genuinely sensitive to the fix.
- The two `firmware/lock-state` + `firmware/releases` route moves are the cleanest demonstration of CLAUDE.md's partial-fix-sweep rule on this branch: the first move was caught by the toolkit's first pass; the sibling move was caught by the second pass; both are pinned by the same integration test.
- The d.7 plan's Out-of-scope follow-ups section names the three items resolved by this branch. The plan file (`20260514-1300-firmware-ota-d-7-lock-aware-rest-of-app.md`) is not edited — its "out of scope" framing was accurate for d.7's own scope, and this branch is the explicit follow-up rather than a retcon.

## Commit list

```
d6e9ef3 fix(firmware-ota-d-7-followups): second-pass toolkit fixes
be8abef docs(plans): tick d.7 follow-ups T7 — pre-push review complete
9fae64f fix(firmware-ota-d-7-followups): pre-push toolkit fixes
055a312 fix(firmware-vue): ServoTestModal honors systemStatus.readOnly on slider + number input
aea5918 fix(firmware-vue): ConfirmModal consumer wiring in ModulesView + ScripterView
3f61dce feat(firmware-vue): hydrate jobLockStore via HTTP on App mount
3bb9ceb feat(firmware-api): add GET /api/firmware/lock-state for client hydrate
e8c97e2 docs(plans): firmware-OTA d.7 follow-ups light plan