### PR TITLE
Fix Pixi.js render issue

### DIFF
--- a/astros_vue/src/components/scripter/AstrosPixiView.vue
+++ b/astros_vue/src/components/scripter/AstrosPixiView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Application, Container, Graphics } from 'pixi.js';
-import { onUnmounted, ref, watch } from 'vue';
+import { onUnmounted, ref, shallowRef, watch } from 'vue';
 
 // Import composables
 import { useZoomState, ZOOM_LEVELS } from '@/composables/useZoomState';
@@ -57,7 +57,11 @@ import type { ScriptEvent } from '@/models';
 // APPLICATION REFS
 // ============================================================================
 
-const app = ref<Application | null>(null);
+// Pixi objects must use shallowRef. Deep reactive proxies (from ref()) wrap
+// every nested property access through Vue's Proxy machinery, which breaks
+// PixiJS internal identity checks like `texture === Texture.WHITE` at render
+// time and causes `createPattern` to be called with a raw Uint8Array fallback.
+const app = shallowRef<Application | null>(null);
 const pixiContainer = ref<HTMLDivElement | null>(null);
 const channels = ref<Channel[]>([]);
 
@@ -65,20 +69,20 @@ const channels = ref<Channel[]>([]);
 // PIXI CONTAINERS & GRAPHICS REFS
 // ============================================================================
 
-const mainContainer = ref<Container | null>(null);
-const scrollableContentContainer = ref<Container | null>(null);
-const uiLayer = ref<Container | null>(null);
-const channelListContainer = ref<PixiChannelList | null>(null);
-const timeline = ref<PixiTimeline | null>(null);
-const channelRowContainers = ref(new Map<string, PixiChannelEventRow>());
+const mainContainer = shallowRef<Container | null>(null);
+const scrollableContentContainer = shallowRef<Container | null>(null);
+const uiLayer = shallowRef<Container | null>(null);
+const channelListContainer = shallowRef<PixiChannelList | null>(null);
+const timeline = shallowRef<PixiTimeline | null>(null);
+const channelRowContainers = shallowRef(new Map<string, PixiChannelEventRow>());
 
 // Scrollbar graphics
-const horizontalScrollBar = ref<PixiScrollBar | null>(null);
-const verticalScrollBar = ref<PixiScrollBar | null>(null);
+const horizontalScrollBar = shallowRef<PixiScrollBar | null>(null);
+const verticalScrollBar = shallowRef<PixiScrollBar | null>(null);
 
 // UI buttons
-const plusButton = ref<Container | null>(null);
-const minusButton = ref<Container | null>(null);
+const plusButton = shallowRef<Container | null>(null);
+const minusButton = shallowRef<Container | null>(null);
 
 // ============================================================================
 // Exposed Methods
@@ -418,10 +422,14 @@ onUnmounted(() => {
   }
   channelRowContainers.value.clear();
 
+  // Do NOT pass texture/textureSource — the SVG icons (swapIcon, deleteIcon,
+  // etc.) are owned by PixiJS's Assets cache and must be released through
+  // `Assets.unload*()`, not destroyed via the app cascade. The cache also
+  // intentionally outlives this Application instance so revisits to the
+  // scripter don't re-decode every SVG. `children: true` still tears down
+  // every Container/Graphics/Sprite we created.
   app.value?.destroy(true, {
     children: true,
-    texture: true,
-    textureSource: true,
     context: true,
   });
   app.value = null;
@@ -620,7 +628,6 @@ function createChannelRowContainer(
 
   scrollableContentContainer.value.addChild(eventRow as unknown as Container);
 
-  // @ts-expect-error - Vue ref unwrapping causes type incompatibility with nested Ref types
   channelRowContainers.value.set(channelId, eventRow);
 
   // Update positions of any existing event boxes for this channel

--- a/astros_vue/src/pixiComponents/assets/assetLoader.ts
+++ b/astros_vue/src/pixiComponents/assets/assetLoader.ts
@@ -14,23 +14,32 @@ import none from '@/pixiComponents/assets/none.svg';
 import servo from '@/pixiComponents/assets/servo.svg';
 import servo_arm from '@/pixiComponents/assets/servo_arm.svg';
 
+// PixiJS `Assets` is a global singleton — its bundle/resolver registry
+// persists across Application instances and across Vue route navigations.
+// Register the bundle once per page lifetime to avoid "Resolver already has
+// key" warnings on every revisit to the scripter.
+let bundleRegistered = false;
+
 export async function loadAssets() {
-  Assets.addBundle('assets', [
-    { alias: 'swapIcon', src: swapIcon },
-    { alias: 'deleteIcon', src: deleteIcon },
-    { alias: 'playIcon', src: playIcon },
-    { alias: 'arrowDown', src: arrowDown },
-    { alias: 'arrowUp', src: arrowUp },
-    { alias: 'home', src: home },
-    { alias: 'i2c', src: i2c },
-    { alias: 'start', src: start },
-    { alias: 'serial', src: serial },
-    { alias: 'dial', src: dial },
-    { alias: 'pointer', src: pointer },
-    { alias: 'none', src: none },
-    { alias: 'servo', src: servo },
-    { alias: 'servo_arm', src: servo_arm },
-  ]);
+  if (!bundleRegistered) {
+    Assets.addBundle('assets', [
+      { alias: 'swapIcon', src: swapIcon },
+      { alias: 'deleteIcon', src: deleteIcon },
+      { alias: 'playIcon', src: playIcon },
+      { alias: 'arrowDown', src: arrowDown },
+      { alias: 'arrowUp', src: arrowUp },
+      { alias: 'home', src: home },
+      { alias: 'i2c', src: i2c },
+      { alias: 'start', src: start },
+      { alias: 'serial', src: serial },
+      { alias: 'dial', src: dial },
+      { alias: 'pointer', src: pointer },
+      { alias: 'none', src: none },
+      { alias: 'servo', src: servo },
+      { alias: 'servo_arm', src: servo_arm },
+    ]);
+    bundleRegistered = true;
+  }
 
   await Assets.loadBundle('assets');
 }

--- a/astros_vue/src/pixiComponents/helpers.ts
+++ b/astros_vue/src/pixiComponents/helpers.ts
@@ -1,4 +1,4 @@
-import { CanvasTextMetrics, FillGradient, TextStyle, Text } from 'pixi.js';
+import { CanvasTextMetrics, TextStyle, Text } from 'pixi.js';
 
 export function getText(text: string, color: number, size: number): Text {
   const style = new TextStyle({
@@ -20,33 +20,18 @@ export function getTruncatedText(
   maxWidth: number,
   size: number,
 ): Text {
-  return getTruncatedGradientText(text, color, color, maxWidth, size);
-}
-
-export function getTruncatedGradientText(
-  text: string,
-  colorStart: number,
-  colorEnd: number,
-  maxWidth: number,
-  size: number,
-): Text {
-  const fill = new FillGradient(0, 0, 1, 1);
-  fill.addColorStop(0, colorStart);
-  fill.addColorStop(1, colorEnd);
-
   const style = new TextStyle({
     fontFamily: 'Arial',
     fontSize: size,
-    fill: fill,
+    fill: color,
   });
 
   const t = truncateText(text, style, maxWidth);
 
-  const rowText = new Text({
+  return new Text({
     text: t,
     style: style,
   });
-  return rowText;
 }
 
 export function truncateText(text: string, style: TextStyle, maxWidth: number) {

--- a/astros_vue/src/pixiComponents/pixiChannelList.ts
+++ b/astros_vue/src/pixiComponents/pixiChannelList.ts
@@ -1,4 +1,4 @@
-import { Container, TextStyle, Text, Graphics, FillGradient } from 'pixi.js';
+import { Container, TextStyle, Text, Graphics } from 'pixi.js';
 import type { PixiChannelData } from './pixiChannelData';
 
 export interface PixiChannelListOptions {
@@ -67,15 +67,11 @@ export class PixiChannelList extends Container {
       this.options.emitAddChannel();
     });
 
-    const fill = new FillGradient(0, 0, 1, 1);
-    fill.addColorStop(0, this.buttonTextColor);
-    fill.addColorStop(1, this.buttonTextColor);
-
     const style = new TextStyle({
       fontFamily: 'Arial',
       fontSize: 20,
       fontWeight: 'bold',
-      fill: fill,
+      fill: this.buttonTextColor,
     });
 
     const buttonText = new Text({
@@ -95,7 +91,7 @@ export class PixiChannelList extends Container {
     buttonText.y = buttonHeight / 2 - 8;
 
     buttonContainer.addChild(buttonText);
-    buttonContainer.zIndex = 10; // Ensure it's on top
+    buttonContainer.zIndex = 10;
     this.addChild(buttonContainer);
   }
 

--- a/astros_vue/src/pixiComponents/pixiTimeline.ts
+++ b/astros_vue/src/pixiComponents/pixiTimeline.ts
@@ -1,4 +1,4 @@
-import { Container, FillGradient, Graphics, TextStyle, Text } from 'pixi.js';
+import { Container, Graphics, TextStyle, Text } from 'pixi.js';
 import { ZOOM_LEVELS, type ZoomLevelConfig } from '@/composables/useZoomState';
 
 export interface PixiTimelineOptions {
@@ -86,14 +86,10 @@ export class PixiTimeline extends Container {
       const seconds = second % 60;
       const timeString = `${minutes}:${seconds.toString().padStart(2, '0')}`;
 
-      const fill = new FillGradient(0, 0, 1, 1);
-      fill.addColorStop(0, 0xffffff);
-      fill.addColorStop(1, 0xffffff);
-
       const style = new TextStyle({
         fontFamily: 'Arial',
         fontSize: 20,
-        fill: fill,
+        fill: 0xffffff,
       });
 
       const timeLabel = new Text({


### PR DESCRIPTION
wrap Pixi objects in shallowRef to unblock Text render

PIXI's canvas text renderer crashed in the scripter view with "createPattern: provided value is not of type [...]". Root cause: Vue's `ref()` deeply wraps nested objects with reactive Proxies. When the renderer walked the scene graph it received proxy-wrapped textures, so the internal `fillStyle.texture === Texture.WHITE` identity check failed, the canvas path fell into "basic texture fill", and `createPattern` was called with the raw WHITE Uint8Array buffer — not a valid image source.

Switching the 11 Pixi-typed refs in AstrosPixiView (Application, Containers, PixiChannelList/Timeline/ScrollBar, the row-container Map, zoom buttons) to `shallowRef` keeps top-level reactivity but stops the deep proxying. Removed the `@ts-expect-error` that was masking the same class of unwrapping mismatch.

Drive-by cleanups surfaced during debugging:

- helpers.ts / pixiTimeline.ts / pixiChannelList.ts: replace three degenerate `FillGradient(0,0,1,1)` call sites (same colour for both stops) with direct solid-colour fills. Removes the v8.5.2 deprecation warning and one canvas-backed Texture allocation per text node.
- assetLoader.ts: guard `Assets.addBundle('assets', ...)` so the bundle registers once per page lifetime. Fixes "Resolver already has key" warnings on every scripter revisit (Assets is a global singleton).
- AstrosPixiView unmount: drop `texture: true` / `textureSource: true` from `app.destroy()` options. The SVG icons are owned by Assets and must be released via `Assets.unload*()`, not the destroy cascade. Fixes "TextureSource managed by Assets was destroyed" warnings on unmount and lets the cache survive route changes.