### PR TITLE
Feature/phase6 m5 remote rename

### DIFF
--- a/.docs/plans/20260521-1003-phase6-m5-remote-rename.md
+++ b/.docs/plans/20260521-1003-phase6-m5-remote-rename.md
@@ -1,0 +1,129 @@
+# Phase 6 — Backend M5 → Remote rename + DB key migration
+
+**Date:** 2026-05-21
+**Tier:** Light plan (per CLAUDE.md Planning section)
+**Parent project:** [`current_project.md`](./current_project.md) — Remote Control Redesign + Mobile Remote
+**Branch:** `feature/phase6-m5-remote-rename`
+
+## Goal
+
+Drop the historical `M5*` prefix from the backend remote-config types now that M5Stack is no
+longer the only consumer of `/remotecontrolsync` (Phase 4's mobile web remote will hit the
+same endpoint). Rename `M5Page` / `M5Button` / `M5ScriptList` to `RemotePage` /
+`RemoteButton` / `RemoteScriptList`, matching the frontend's already-generic naming
+(`RemoteControlPage`, `PageButton`). Migrate the `remote_config.type` DB string key from
+`astrOsScreen` to `remoteConfig`. M5Stack hardware behavior is unchanged because the wire
+shape on `/remotecontrolsync` is determined by the JSON serialization of `M5ScriptList`'s
+structural shape — renaming the TypeScript type does not change the JSON keys, and the
+endpoint URL itself is out of scope.
+
+## Failure-mode inventory
+
+Not required. The DB migration is a single `UPDATE` against a `UNIQUE NOT NULL` column with
+no schema change, no orphaned-FK risk, no concurrency surface (server is single-process and
+single-tenant at boot). No filesystem state, no network recovery. Pure type rename + a
+load-time data update.
+
+## Hidden gotchas surfaced during planning
+
+1. **`remote_config.type` is `UNIQUE NOT NULL`** (migration_0.ts:35). The rename must be a
+   single atomic `UPDATE`, not INSERT-new + DELETE-old — the latter would either fail the
+   uniqueness check on the new row or leave both rows around if the transaction is split.
+2. **Migration ordering on fresh installs.** Migration_0 currently seeds the row with
+   `type = 'astrOsScreen'`. If we leave that seed and add migration_7, a fresh install
+   inserts the old key and immediately rewrites it on the same boot. Cleaner: update
+   migration_0's seed to `'remoteConfig'` AND add migration_7. Editing migration_0 only
+   affects databases that have never run migrations (the migrations table tracks
+   completion); existing installs go through migration_7's `UPDATE` instead.
+3. **Two stale comment-only "M5 firmware" references** remain in the Vue store after
+   Phase 1: `astros_vue/src/stores/remoteControl.ts:50` and
+   `astros_vue/src/stores/__tests__/remoteControl.spec.ts:86`. Both describe the wire
+   contract using the term "M5 firmware" — now factually wrong as soon as the mobile
+   remote ships in Phase 4. Sweep them to "remote firmware" / "remote consumer" while
+   we're already touching the area.
+4. **The `M5Page` class export is mixed** (`models/index.ts:43`). `M5Page` and
+   `PageButton` are exported as runtime classes (`export { M5Page, PageButton }`), while
+   `M5Button` and `M5ScriptList` are type-only exports. The barrel update must preserve
+   that distinction — `RemotePage` and `PageButton` stay value exports.
+
+## Tasks
+
+- [ ] **Task 1 — Backend type rename: files, symbols, barrel exports.** Rename
+      `astros_api/src/models/remotes/M5Page.ts` → `RemotePage.ts`,
+      `M5Button.ts` → `RemoteButton.ts`, `M5ScriptList.ts` → `RemoteScriptList.ts`, and
+      the Phase-1-added `M5Page.test.ts` → `RemotePage.test.ts`. Inside each file rename
+      the class/interface (`M5Page` → `RemotePage`, etc.) and update the `BUTTON_KEYS`
+      `keyof Omit<...>` constraint accordingly. Update `models/index.ts` exports — keep
+      `RemotePage` and `PageButton` as value exports (class re-export), keep
+      `RemoteButton` and `RemoteScriptList` as type-only. Update
+      `controllers/remote_config_controller.ts` imports and all usages
+      (`Array<M5Page>` → `Array<RemotePage>`, `M5ScriptList` → `RemoteScriptList`,
+      `new Array<M5Button>()` → `new Array<RemoteButton>()`).
+- [ ] **Task 2 — DB key call-site update + migration_7.** Switch the three
+      `repo.getConfig('astrOsScreen')` / `repo.saveConfig('astrOsScreen', ...)` call sites
+      in `remote_config_controller.ts` to `'remoteConfig'`. Add
+      `astros_api/src/dal/migrations/migration_7.ts` that runs `UPDATE remote_config SET
+      type = 'remoteConfig' WHERE type = 'astrOsScreen'` on `up` and the reverse on `down`
+      (single-row update, trivially reversible — different policy from migration_6 which
+      throws on down because the rename-dance is hard to undo). Register migration_7 in
+      `migrations/index.ts` and in both migration providers in `dal/database.ts` (look for
+      the `'6_add_foreign_keys'` line — copy the pattern). Update migration_0's seed
+      `type: 'astrOsScreen'` → `type: 'remoteConfig'` so fresh installs land clean.
+- [ ] **Task 3 — Migration test.** New
+      `astros_api/src/dal/migrations/migration_7.test.ts` following the pattern from
+      `migration_6.test.ts` (build a v6 provider with migrations 0–6, apply, seed an
+      `astrOsScreen` row, then apply a v7 provider with migration_7 added). Cover:
+      (a) the existing `astrOsScreen` row is renamed to `remoteConfig` with `value`
+      preserved; (b) `down` reverses it back to `astrOsScreen`; (c) idempotency — running
+      `up` when no `astrOsScreen` row exists is a no-op (fresh-install path where
+      migration_0's new seed already produced `remoteConfig`); (d) **vacuous-fix guard:**
+      revert the `WHERE` clause to a typo (`'astroScreen'`) locally and confirm test (a)
+      fails — per memory rule, prevents a green-but-broken migration.
+- [ ] **Task 4 — Vue comment sweep.** Update the two stale "M5 firmware" comment-only
+      references at `astros_vue/src/stores/remoteControl.ts:50` and
+      `astros_vue/src/stores/__tests__/remoteControl.spec.ts:86` to "remote firmware" or
+      "remote consumer" — whichever reads naturally in context. Comment-only; no logic
+      change.
+- [ ] **Task 5 — Verification + pre-push toolkit.**
+      - `npm run prettier:write` + `npm run lint:fix` on both packages.
+      - `npm run build` (vue + api) succeeds.
+      - `npx vitest run` clean on both packages — migration_7 test passes; existing
+        migration_6 test still passes (didn't regress provider construction).
+      - Invoke `superpowers:requesting-code-review` on each implementation commit.
+      - Manual: smoke test that an existing install with an `astrOsScreen` row migrates
+        on boot to `remoteConfig` and `/remotecontrolsync` still returns the same JSON.
+        Bench-test on the real M5 if convenient (the wire shape didn't change, so
+        regression risk is low).
+      - Run `/pr-review-toolkit:review-pr` on the full branch diff vs `develop` before
+        push (mandatory per CLAUDE.md).
+
+## Out of scope
+
+- Renaming the endpoint URL `/remotecontrolsync` — would break the M5 firmware which has
+  the path baked in. URL stays; only internal types and the DB key change.
+- Frontend type renames — frontend already uses generic names (`RemoteControlPage`,
+  `PageButton`).
+- Anything in `models/control_module/`, `models/scripts/`, or other unrelated subtrees.
+
+## Verification gates
+
+- Build clean on both packages.
+- Vitest clean on both packages including the new migration_7 test.
+- Manual smoke per Task 5.
+- Pre-push toolkit clean (Critical/Important findings addressed).
+
+## Critical files touched
+
+- `astros_api/src/models/remotes/RemotePage.ts` (renamed from M5Page.ts)
+- `astros_api/src/models/remotes/RemoteButton.ts` (renamed from M5Button.ts)
+- `astros_api/src/models/remotes/RemoteScriptList.ts` (renamed from M5ScriptList.ts)
+- `astros_api/src/models/remotes/RemotePage.test.ts` (renamed from M5Page.test.ts)
+- `astros_api/src/models/index.ts`
+- `astros_api/src/controllers/remote_config_controller.ts`
+- `astros_api/src/dal/migrations/migration_0.ts` (seed value only)
+- `astros_api/src/dal/migrations/migration_7.ts` (new)
+- `astros_api/src/dal/migrations/migration_7.test.ts` (new)
+- `astros_api/src/dal/migrations/index.ts`
+- `astros_api/src/dal/database.ts` (migration provider registration)
+- `astros_vue/src/stores/remoteControl.ts` (comment-only)
+- `astros_vue/src/stores/__tests__/remoteControl.spec.ts` (comment-only)

--- a/.docs/plans/20260521-1003-phase6-m5-remote-rename.md
+++ b/.docs/plans/20260521-1003-phase6-m5-remote-rename.md
@@ -48,7 +48,7 @@ load-time data update.
 
 ## Tasks
 
-- [ ] **Task 1 — Backend type rename: files, symbols, barrel exports.** Rename
+- [x] **Task 1 — Backend type rename: files, symbols, barrel exports.** Rename
       `astros_api/src/models/remotes/M5Page.ts` → `RemotePage.ts`,
       `M5Button.ts` → `RemoteButton.ts`, `M5ScriptList.ts` → `RemoteScriptList.ts`, and
       the Phase-1-added `M5Page.test.ts` → `RemotePage.test.ts`. Inside each file rename
@@ -59,7 +59,7 @@ load-time data update.
       `controllers/remote_config_controller.ts` imports and all usages
       (`Array<M5Page>` → `Array<RemotePage>`, `M5ScriptList` → `RemoteScriptList`,
       `new Array<M5Button>()` → `new Array<RemoteButton>()`).
-- [ ] **Task 2 — DB key call-site update + migration_7.** Switch the three
+- [x] **Task 2 — DB key call-site update + migration_7.** Switch the three
       `repo.getConfig('astrOsScreen')` / `repo.saveConfig('astrOsScreen', ...)` call sites
       in `remote_config_controller.ts` to `'remoteConfig'`. Add
       `astros_api/src/dal/migrations/migration_7.ts` that runs `UPDATE remote_config SET
@@ -69,7 +69,7 @@ load-time data update.
       `migrations/index.ts` and in both migration providers in `dal/database.ts` (look for
       the `'6_add_foreign_keys'` line — copy the pattern). Update migration_0's seed
       `type: 'astrOsScreen'` → `type: 'remoteConfig'` so fresh installs land clean.
-- [ ] **Task 3 — Migration test.** New
+- [x] **Task 3 — Migration test.** New
       `astros_api/src/dal/migrations/migration_7.test.ts` following the pattern from
       `migration_6.test.ts` (build a v6 provider with migrations 0–6, apply, seed an
       `astrOsScreen` row, then apply a v7 provider with migration_7 added). Cover:
@@ -79,7 +79,7 @@ load-time data update.
       migration_0's new seed already produced `remoteConfig`); (d) **vacuous-fix guard:**
       revert the `WHERE` clause to a typo (`'astroScreen'`) locally and confirm test (a)
       fails — per memory rule, prevents a green-but-broken migration.
-- [ ] **Task 4 — Vue comment sweep.** Update the two stale "M5 firmware" comment-only
+- [x] **Task 4 — Vue comment sweep.** Update the two stale "M5 firmware" comment-only
       references at `astros_vue/src/stores/remoteControl.ts:50` and
       `astros_vue/src/stores/__tests__/remoteControl.spec.ts:86` to "remote firmware" or
       "remote consumer" — whichever reads naturally in context. Comment-only; no logic

--- a/.docs/plans/20260521-1003-phase6-m5-remote-rename.md
+++ b/.docs/plans/20260521-1003-phase6-m5-remote-rename.md
@@ -84,7 +84,11 @@ load-time data update.
       `astros_vue/src/stores/__tests__/remoteControl.spec.ts:86` to "remote firmware" or
       "remote consumer" — whichever reads naturally in context. Comment-only; no logic
       change.
-- [ ] **Task 5 — Verification + pre-push toolkit.**
+- [x] **Task 5 — Verification + pre-push toolkit.** Pre-push toolkit run
+      (5 agents) returned 1 Critical (syncRemoteConfig forEach on `'{}'` seed) +
+      3 Important (over-broad-WHERE test gap, missing wire-shape e2e test,
+      past-tense Phase 4 comment). All four landed in commit 80c3a81. Manual M5
+      smoke test pending push.
       - `npm run prettier:write` + `npm run lint:fix` on both packages.
       - `npm run build` (vue + api) succeeds.
       - `npx vitest run` clean on both packages — migration_7 test passes; existing

--- a/.docs/plans/current_project.md
+++ b/.docs/plans/current_project.md
@@ -14,8 +14,9 @@ fires the configured actions. M5Stack hardware remote continues to work in paral
 
 - [x] **Phase 0 — Tracking convention bootstrap**: Add the `current_project.md` template,
       this file, and the CLAUDE.md amendment. — completed 2026-05-19
-- [ ] **Phase 1 — Page id/name data model**: Add `id` + `name` to RemoteControlPage and
-      M5Page, migrate existing data on load/save, hold M5Stack-compatible JSON shape.
+- [x] **Phase 1 — Page id/name data model**: Add `id` + `name` to RemoteControlPage and
+      M5Page, migrate existing data on load/save, hold M5Stack-compatible JSON shape. —
+      shipped 2026-05-21 via PR #90 (merge `9b52df5`), M5 bench-verified before merge.
 - [ ] **Phase 2 — Direction B editor port**: Rebuild RemoteControlConfig view as a 3-pane
       layout (page list + 3×3 grid + live preview), inline button editor, inline page CRUD.
 - [ ] **Phase 3 — Shared `AstrosMobileRemote` component**: Build the handheld UI in Vue;

--- a/astros_api/src/controllers/remote_config_controller.test.ts
+++ b/astros_api/src/controllers/remote_config_controller.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Kysely } from 'kysely';
+import { Database } from '../dal/types.js';
+import { createKyselyConnection, migrateToLatest } from '../dal/database.js';
+import { RemoteConfigRepository } from '../dal/repositories/remote_config_repository.js';
+import { syncRemoteConfig } from './remote_config_controller.js';
+import { RemotePage, PageButton } from '../models/remotes/RemotePage.js';
+
+function mockRes() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('remote_config_controller / syncRemoteConfig', () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = createKyselyConnection().db;
+    await migrateToLatest(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('returns { pages: [] } for the fresh-install seed shape "{}"', async () => {
+    // migration_0 seeds remote_config with value '{}' (an object, not an
+    // array). Before the Array.isArray guard, JSON.parse('{}') flowed past
+    // the `length === 0` check and val.forEach threw a TypeError → 500.
+    // This pins the defensive guard: the seed shape must not 500.
+    const req: any = {};
+    const res = mockRes();
+
+    await syncRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ pages: [] });
+  });
+
+  it('emits the M5Stack wire shape { pages: [[{name, command} x9]] } for a saved config', async () => {
+    // Pins the wire-contract claim from the Phase 6 plan: the JSON shape on
+    // /remotecontrolsync did not change despite the M5* → Remote* type
+    // rename. The downstream consumer is the M5Stack firmware (sibling
+    // repo); we cannot test it from here, so this is the load-bearing test
+    // for the wire-format claim.
+    const repo = new RemoteConfigRepository(db);
+    const page = new RemotePage('page-uuid', 'Quick Actions');
+    page.button1 = new PageButton('script-1', 'Beep');
+    page.button5 = new PageButton('playlist-2', 'Songs');
+    await repo.saveConfig('remoteConfig', JSON.stringify([page]));
+
+    const req: any = {};
+    const res = mockRes();
+
+    await syncRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const response = res.json.mock.calls[0][0];
+    expect(response).toEqual({
+      pages: [
+        [
+          { name: 'Beep', command: 'script-1' },
+          { name: 'None', command: '0' },
+          { name: 'None', command: '0' },
+          { name: 'None', command: '0' },
+          { name: 'Songs', command: 'playlist-2' },
+          { name: 'None', command: '0' },
+          { name: 'None', command: '0' },
+          { name: 'None', command: '0' },
+          { name: 'None', command: '0' },
+        ],
+      ],
+    });
+  });
+
+  it('returns { pages: [] } when the stored value is the legacy "[]" empty-array shape', async () => {
+    // Operators who manually clear the config (or saved empty in an earlier
+    // version) end up with '[]'. JSON.parse('[]') is an empty array, so the
+    // length === 0 short-circuit fires correctly.
+    const repo = new RemoteConfigRepository(db);
+    await repo.saveConfig('remoteConfig', '[]');
+
+    const req: any = {};
+    const res = mockRes();
+
+    await syncRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ pages: [] });
+  });
+
+  it('queries the renamed remoteConfig key, not the legacy astrOsScreen key', async () => {
+    // If the controller still queried 'astrOsScreen', a row stored under
+    // 'remoteConfig' would never reach syncRemoteConfig and the response
+    // would be the empty-pages fallback regardless of saved content.
+    const repo = new RemoteConfigRepository(db);
+    const page = new RemotePage('page-uuid', 'Test');
+    page.button1 = new PageButton('script-xyz', 'Test Script');
+    await repo.saveConfig('remoteConfig', JSON.stringify([page]));
+
+    const req: any = {};
+    const res = mockRes();
+
+    await syncRemoteConfig(db, req, res, vi.fn());
+
+    const response = res.json.mock.calls[0][0];
+    expect(response.pages).toHaveLength(1);
+    expect(response.pages[0][0]).toEqual({ name: 'Test Script', command: 'script-xyz' });
+  });
+});

--- a/astros_api/src/controllers/remote_config_controller.ts
+++ b/astros_api/src/controllers/remote_config_controller.ts
@@ -26,7 +26,7 @@ export function registerRemoteConfigRoutes(
   );
 }
 
-async function syncRemoteConfig(db: Kysely<Database>, req: any, res: any, next: any) {
+export async function syncRemoteConfig(db: Kysely<Database>, req: any, res: any, next: any) {
   logger.info('Syncing remote config to device');
 
   try {
@@ -36,7 +36,10 @@ async function syncRemoteConfig(db: Kysely<Database>, req: any, res: any, next: 
 
     const val = JSON.parse(scripts?.value || '[]') as Array<RemotePage>;
 
-    if (!val || val.length === 0) {
+    // Defensive: migration_0 seeds the row with value '{}' (an object, not
+    // an array) on fresh installs. Until a user saves their first config,
+    // val is the parsed object and val.forEach below would throw.
+    if (!Array.isArray(val) || val.length === 0) {
       res.status(200);
       res.json({ pages: [] } as RemoteScriptList);
       return;

--- a/astros_api/src/controllers/remote_config_controller.ts
+++ b/astros_api/src/controllers/remote_config_controller.ts
@@ -1,4 +1,4 @@
-import type { M5Page, M5ScriptList, M5Button } from 'src/models/index.js';
+import type { RemotePage, RemoteScriptList, RemoteButton } from 'src/models/index.js';
 import { RemoteConfigRepository } from 'src/dal/repositories/remote_config_repository.js';
 import { logger } from 'src/logger.js';
 import { Kysely } from 'kysely';
@@ -32,19 +32,19 @@ async function syncRemoteConfig(db: Kysely<Database>, req: any, res: any, next: 
   try {
     const repo = new RemoteConfigRepository(db);
 
-    const scripts = await repo.getConfig('astrOsScreen');
+    const scripts = await repo.getConfig('remoteConfig');
 
-    const val = JSON.parse(scripts?.value || '[]') as Array<M5Page>;
+    const val = JSON.parse(scripts?.value || '[]') as Array<RemotePage>;
 
     if (!val || val.length === 0) {
       res.status(200);
-      res.json({ pages: [] } as M5ScriptList);
+      res.json({ pages: [] } as RemoteScriptList);
       return;
     }
 
-    const response: M5ScriptList = { pages: [] };
+    const response: RemoteScriptList = { pages: [] };
     val.forEach((x) => {
-      const list = new Array<M5Button>();
+      const list = new Array<RemoteButton>();
       list.push({ name: x.button1.name, command: x.button1.id });
       list.push({ name: x.button2.name, command: x.button2.id });
       list.push({ name: x.button3.name, command: x.button3.id });
@@ -73,7 +73,7 @@ async function getRemoteConfig(db: Kysely<Database>, req: any, res: any, next: a
   try {
     const repo = new RemoteConfigRepository(db);
 
-    const scripts = await repo.getConfig('astrOsScreen');
+    const scripts = await repo.getConfig('remoteConfig');
 
     res.status(200);
     res.json(scripts?.value || { value: '[]' });
@@ -91,7 +91,7 @@ async function saveRemoteConfig(db: Kysely<Database>, req: any, res: any, next: 
   try {
     const repo = new RemoteConfigRepository(db);
 
-    if (await repo.saveConfig('astrOsScreen', req.body.config)) {
+    if (await repo.saveConfig('remoteConfig', req.body.config)) {
       res.status(200);
       res.json({ message: 'success' });
     } else {

--- a/astros_api/src/dal/database.integration.test.ts
+++ b/astros_api/src/dal/database.integration.test.ts
@@ -19,11 +19,12 @@ import {
   migration_4,
   migration_5,
   migration_6,
+  migration_7,
 } from './migrations/index.js';
 
 // Mirrors the production provider so injected test migrations layer on top of
 // the real baseline rather than truncating it. Without this, kysely sees
-// migrations 5/6 in kysely_migration but missing from the provider and throws
+// migrations in kysely_migration but missing from the provider and throws
 // "corrupted migrations" before any extra migration runs — which would short-
 // circuit tests that intend to exercise post-migration paths.
 function buildProvider(extra: Record<string, Migration> = {}): MigrationProvider {
@@ -37,6 +38,7 @@ function buildProvider(extra: Record<string, Migration> = {}): MigrationProvider
         '4_add_random_wait': migration_4,
         '5_fix_controller_locations_type': migration_5,
         '6_add_foreign_keys': migration_6,
+        '7_rename_remote_config_key': migration_7,
         ...extra,
       };
     }
@@ -94,15 +96,15 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
   });
 
   it('takes a backup when there is a last-applied migration AND a pending migration', async () => {
-    // First run: migrate to v4
+    // First run: migrate baseline to current production latest (v7).
     let status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
 
-    // Inject a new migration on top of the real v6 baseline.
+    // Inject a new migration on top of the real production baseline (currently v7).
     __setMigrationProviderForTest(
       buildProvider({
-        '7_safe_addition': {
+        '8_safe_addition': {
           async up(db) {
             await db.schema.createTable('safe_addition').addColumn('id', 'integer').execute();
           },
@@ -116,16 +118,16 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
     status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
 
-    // Backup file named after the previous last-applied migration (v6) should exist.
+    // Backup file named after the previous last-applied migration (v7) should exist.
     const backupFiles = fs
       .readdirSync(tmpDir)
       .filter((f) => f.startsWith('database.sqlite3.backup-'));
-    expect(backupFiles).toEqual(['database.sqlite3.backup-6_add_foreign_keys']);
+    expect(backupFiles).toEqual(['database.sqlite3.backup-7_rename_remote_config_key']);
     expect(status.isReadOnly()).toBe(false);
   });
 
   it('failed migration triggers restore from backup AND enters read-only with MIGRATION_FAILED_RESTORED', async () => {
-    // Migrate baseline to v6 first
+    // Migrate baseline to current production latest (v7) first.
     let status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
@@ -138,10 +140,10 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
       sqlite.close();
     }
 
-    // Inject a migration on top of the real v6 baseline that throws.
+    // Inject a migration on top of the production baseline that throws.
     __setMigrationProviderForTest(
       buildProvider({
-        '7_will_fail': {
+        '8_will_fail': {
           async up() {
             throw new Error('intentional migration failure');
           },
@@ -155,7 +157,7 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
     status = new SystemStatus();
     const db = await initializeDatabase(status, { dbPath });
 
-    // Restore brought the file back to v6, but a migration still failed —
+    // Restore brought the file back to v7, but a migration still failed —
     // the system enters read-only with MIGRATION_FAILED_RESTORED so operators
     // notice and investigate before redeploying. Writes against the rolled-
     // back schema while the migration is broken could compound the problem.
@@ -177,10 +179,10 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
 
-    // Inject a pending migration on top of v6 so a backup attempt happens.
+    // Inject a pending migration on top of the production baseline so a backup attempt happens.
     __setMigrationProviderForTest(
       buildProvider({
-        '7_pending': {
+        '8_pending': {
           async up(db) {
             await db.schema.createTable('pending_table').addColumn('id', 'integer').execute();
           },
@@ -207,15 +209,15 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
   });
 
   it('failed migration + failed restore → enters read-only', async () => {
-    // Migrate baseline to current latest (v6)
+    // Migrate baseline to current production latest (v7)
     let status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
 
-    // Inject a migration on top of v6 that throws
+    // Inject a migration on top of the production baseline that throws
     __setMigrationProviderForTest(
       buildProvider({
-        '7_will_fail': {
+        '8_will_fail': {
           async up() {
             throw new Error('intentional migration failure');
           },
@@ -262,14 +264,14 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
     // foreign_key_check must detect it, throw, and Phase 1's
     // restore-from-backup must revert to the pre-migration state.
 
-    // Bring DB to v6 (current latest, with FKs on script_channels.script_id).
+    // Bring DB to the current production latest (v7).
     let status = new SystemStatus();
     await initializeDatabase(status, { dbPath });
     await closeDatabaseForTest();
 
     __setMigrationProviderForTest(
       buildProvider({
-        '7_introduces_orphan': {
+        '8_introduces_orphan': {
           async up(db) {
             // Insert a script_channels row with a fabricated script_id —
             // valid SQL because FKs are off during the migration window.
@@ -290,7 +292,7 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
     status = new SystemStatus();
     const db = await initializeDatabase(status, { dbPath });
 
-    // Restore brought us back to v6 AND the system enters read-only with
+    // Restore brought us back to v7 AND the system enters read-only with
     // MIGRATION_FAILED_RESTORED so operators notice — the same end-state as
     // any other migration failure that successfully recovered.
     expect(status.isReadOnly()).toBe(true);
@@ -305,11 +307,11 @@ describe('initializeDatabase safety flow', { timeout: 15_000 }, () => {
       .execute();
     expect(survivors).toHaveLength(0);
 
-    // And the migration history shows v6 as the latest, not v7.
+    // And the migration history shows v7 as the latest, not v8.
     const result = await sql<{ name: string }>`
       SELECT name FROM kysely_migration ORDER BY name DESC LIMIT 1
     `.execute(db);
-    expect(result.rows[0]?.name).toBe('6_add_foreign_keys');
+    expect(result.rows[0]?.name).toBe('7_rename_remote_config_key');
   });
 
   it('initial open failure → enters read-only with STARTUP_OPEN_FAILED and returns a usable in-memory db', async () => {

--- a/astros_api/src/dal/database.ts
+++ b/astros_api/src/dal/database.ts
@@ -22,6 +22,7 @@ import {
   migration_4,
   migration_5,
   migration_6,
+  migration_7,
 } from './migrations/index.js';
 import { SystemStatus } from '../system_status.js';
 import {
@@ -53,6 +54,7 @@ const defaultMigrationProvider: MigrationProvider = new (class implements Migrat
       '4_add_random_wait': migration_4,
       '5_fix_controller_locations_type': migration_5,
       '6_add_foreign_keys': migration_6,
+      '7_rename_remote_config_key': migration_7,
     };
   }
 })();

--- a/astros_api/src/dal/migrations/index.ts
+++ b/astros_api/src/dal/migrations/index.ts
@@ -5,3 +5,4 @@ export { migration_3 } from './migration_3.js';
 export { migration_4 } from './migration_4.js';
 export { migration_5 } from './migration_5.js';
 export { migration_6 } from './migration_6.js';
+export { migration_7 } from './migration_7.js';

--- a/astros_api/src/dal/migrations/migration_0.ts
+++ b/astros_api/src/dal/migrations/migration_0.ts
@@ -185,7 +185,7 @@ export const migration_0: Migration = {
     await db.insertInto('users').values(adminUser).execute();
 
     const remoteConfig = <NewRemoteConfig>{
-      type: 'astrOsScreen',
+      type: 'remoteConfig',
       value: '{}',
     };
 

--- a/astros_api/src/dal/migrations/migration_7.test.ts
+++ b/astros_api/src/dal/migrations/migration_7.test.ts
@@ -120,6 +120,35 @@ describe('migration_7: rename remote_config.type astrOsScreen → remoteConfig',
     expect(after[0].value).toBe(before[0].value);
   });
 
+  it('does not touch other remote_config rows (guards against over-broad WHERE)', async () => {
+    // The single-row "rename" test above only seeds one row, so a mutation
+    // that drops the WHERE clause or replaces it with `WHERE 1=1` would still
+    // pass: it would set the only row's type to 'remoteConfig', which is what
+    // the assertion checks. This test seeds a SECOND, unrelated row and
+    // verifies migration_7 leaves it alone — distinguishing the correct
+    // `WHERE type = 'astrOsScreen'` from `WHERE 1=1` or no-WHERE-at-all.
+    await applyV6();
+    await simulateLegacySeed('{"legacy":true}');
+    // The `type` column is UNIQUE NOT NULL, so a second row needs a
+    // distinct key.
+    await db
+      .insertInto('remote_config')
+      .values({ type: 'unrelatedKey', value: '{"keep":true}' })
+      .execute();
+
+    await applyV7();
+
+    const rows = await db.selectFrom('remote_config').selectAll().orderBy('type').execute();
+    expect(rows).toHaveLength(2);
+    // The astrOsScreen row was renamed; the unrelated row is untouched.
+    const renamed = rows.find((r) => r.type === 'remoteConfig');
+    const untouched = rows.find((r) => r.type === 'unrelatedKey');
+    expect(renamed?.value).toBe('{"legacy":true}');
+    expect(untouched?.value).toBe('{"keep":true}');
+    // No astrOsScreen row remains (the rename was complete).
+    expect(rows.find((r) => r.type === 'astrOsScreen')).toBeUndefined();
+  });
+
   it('down reverses the rename back to astrOsScreen and preserves value', async () => {
     await applyV6();
     await simulateLegacySeed('{"k":"v"}');

--- a/astros_api/src/dal/migrations/migration_7.test.ts
+++ b/astros_api/src/dal/migrations/migration_7.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Kysely, Migration, MigrationProvider, Migrator } from 'kysely';
+import { Database } from '../types.js';
+import { createKyselyConnection } from '../database.js';
+import {
+  migration_0,
+  migration_1,
+  migration_2,
+  migration_3,
+  migration_4,
+  migration_5,
+  migration_6,
+  migration_7,
+} from './index.js';
+
+const v6Provider: MigrationProvider = new (class implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return {
+      '0_initial': migration_0,
+      '1_add_script_evt_id': migration_1,
+      '2_add_script_duration': migration_2,
+      '3_add_playlists': migration_3,
+      '4_add_random_wait': migration_4,
+      '5_fix_controller_locations_type': migration_5,
+      '6_add_foreign_keys': migration_6,
+    };
+  }
+})();
+
+const v7Provider: MigrationProvider = new (class implements MigrationProvider {
+  async getMigrations(): Promise<Record<string, Migration>> {
+    return {
+      '0_initial': migration_0,
+      '1_add_script_evt_id': migration_1,
+      '2_add_script_duration': migration_2,
+      '3_add_playlists': migration_3,
+      '4_add_random_wait': migration_4,
+      '5_fix_controller_locations_type': migration_5,
+      '6_add_foreign_keys': migration_6,
+      '7_rename_remote_config_key': migration_7,
+    };
+  }
+})();
+
+describe('migration_7: rename remote_config.type astrOsScreen → remoteConfig', () => {
+  let db: Kysely<Database>;
+  let raw: ReturnType<typeof createKyselyConnection>['raw'];
+
+  beforeEach(() => {
+    const conn = createKyselyConnection();
+    db = conn.db;
+    raw = conn.raw;
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function applyV6(): Promise<void> {
+    const m = new Migrator({ db, provider: v6Provider });
+    raw.pragma('foreign_keys = OFF');
+    try {
+      const result = await m.migrateToLatest();
+      expect(result.error).toBeUndefined();
+    } finally {
+      raw.pragma('foreign_keys = ON');
+    }
+  }
+
+  async function applyV7(): Promise<void> {
+    const m = new Migrator({ db, provider: v7Provider });
+    raw.pragma('foreign_keys = OFF');
+    try {
+      const result = await m.migrateToLatest();
+      expect(result.error).toBeUndefined();
+    } finally {
+      raw.pragma('foreign_keys = ON');
+    }
+  }
+
+  // Mutate the seeded remoteConfig row back to astrOsScreen to simulate an
+  // existing v6 install (whose original migration_0 seeded with the old key).
+  async function simulateLegacySeed(value = '{}'): Promise<void> {
+    await db
+      .updateTable('remote_config')
+      .set({ type: 'astrOsScreen', value })
+      .where('type', '=', 'remoteConfig')
+      .execute();
+  }
+
+  it('renames an existing astrOsScreen row to remoteConfig and preserves value', async () => {
+    // Vacuous-fix guard: revert migration_7's WHERE clause to a typo
+    // (e.g. `WHERE type = 'astroScreen'`) and re-run this test — it MUST
+    // fail (the UPDATE would match nothing and the row remains astrOsScreen).
+    // If it still passes, the assertion isn't actually exercising the rename.
+    await applyV6();
+    await simulateLegacySeed('{"pages":[{"id":"abc","name":"Test"}]}');
+
+    await applyV7();
+
+    const rows = await db.selectFrom('remote_config').selectAll().execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe('remoteConfig');
+    expect(rows[0].value).toBe('{"pages":[{"id":"abc","name":"Test"}]}');
+  });
+
+  it('is a no-op on a fresh install (migration_0 seeds remoteConfig directly)', async () => {
+    await applyV6();
+    // Skip simulateLegacySeed — fresh-install path: migration_0 has already
+    // produced a `remoteConfig` row. Migration_7 should leave it alone.
+    const before = await db.selectFrom('remote_config').selectAll().execute();
+    expect(before).toHaveLength(1);
+    expect(before[0].type).toBe('remoteConfig');
+
+    await applyV7();
+
+    const after = await db.selectFrom('remote_config').selectAll().execute();
+    expect(after).toHaveLength(1);
+    expect(after[0].type).toBe('remoteConfig');
+    expect(after[0].value).toBe(before[0].value);
+  });
+
+  it('down reverses the rename back to astrOsScreen and preserves value', async () => {
+    await applyV6();
+    await simulateLegacySeed('{"k":"v"}');
+    await applyV7();
+
+    const m = new Migrator({ db, provider: v7Provider });
+    const result = await m.migrateDown();
+    expect(result.error).toBeUndefined();
+    expect(result.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          migrationName: '7_rename_remote_config_key',
+          status: 'Success',
+        }),
+      ]),
+    );
+
+    const rows = await db.selectFrom('remote_config').selectAll().execute();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe('astrOsScreen');
+    expect(rows[0].value).toBe('{"k":"v"}');
+  });
+});

--- a/astros_api/src/dal/migrations/migration_7.ts
+++ b/astros_api/src/dal/migrations/migration_7.ts
@@ -1,0 +1,39 @@
+import { Kysely, Migration, sql } from 'kysely';
+import { Database } from 'src/dal/types.js';
+import { logger } from 'src/logger.js';
+
+// Renames the single `remote_config` row whose `type` was the M5Stack-era key
+// `astrOsScreen` to the generic key `remoteConfig`. M5Stack stopped being the
+// only consumer of the remote-config endpoint once the mobile web remote
+// (Phase 4 of the Remote Control Redesign) started consuming it, so the
+// `astrOsScreen` key was an anachronism.
+//
+// The `type` column is UNIQUE NOT NULL (migration_0), so the rename is a
+// single atomic UPDATE. On a fresh install, migration_0's seed already uses
+// `remoteConfig`, so the WHERE clause matches nothing and this is a no-op.
+//
+// Reversible: down restores the row back to `astrOsScreen`. Different policy
+// from migration_6 (which throws on down) — migration_6's rename-dance with
+// FK swaps is structurally hard to undo; this is a one-row UPDATE.
+export const migration_7: Migration = {
+  up: async (db: Kysely<Database>): Promise<void> => {
+    const result = await sql`
+      UPDATE remote_config SET type = 'remoteConfig' WHERE type = 'astrOsScreen'
+    `.execute(db);
+    const count = result.numAffectedRows ?? BigInt(0);
+    if (count > 0) {
+      logger.info(`migration_7: renamed ${count} remote_config row(s) astrOsScreen → remoteConfig`);
+    }
+  },
+  down: async (db: Kysely<Database>): Promise<void> => {
+    const result = await sql`
+      UPDATE remote_config SET type = 'astrOsScreen' WHERE type = 'remoteConfig'
+    `.execute(db);
+    const count = result.numAffectedRows ?? BigInt(0);
+    if (count > 0) {
+      logger.info(
+        `migration_7: reverted ${count} remote_config row(s) remoteConfig → astrOsScreen`,
+      );
+    }
+  },
+};

--- a/astros_api/src/dal/migrations/migration_7.ts
+++ b/astros_api/src/dal/migrations/migration_7.ts
@@ -3,10 +3,11 @@ import { Database } from 'src/dal/types.js';
 import { logger } from 'src/logger.js';
 
 // Renames the single `remote_config` row whose `type` was the M5Stack-era key
-// `astrOsScreen` to the generic key `remoteConfig`. M5Stack stopped being the
-// only consumer of the remote-config endpoint once the mobile web remote
-// (Phase 4 of the Remote Control Redesign) started consuming it, so the
-// `astrOsScreen` key was an anachronism.
+// `astrOsScreen` to the generic key `remoteConfig`. M5Stack is no longer
+// assumed to be the only consumer of the remote-config endpoint — Phase 4 of
+// the Remote Control Redesign introduces a mobile web remote that will hit
+// the same endpoint — so the `astrOsScreen` key was a leftover from when
+// M5Stack was the only target.
 //
 // The `type` column is UNIQUE NOT NULL (migration_0), so the rename is a
 // single atomic UPDATE. On a fresh install, migration_0's seed already uses

--- a/astros_api/src/models/index.ts
+++ b/astros_api/src/models/index.ts
@@ -41,9 +41,9 @@ export type { BaseResponse } from './networking/base_response.js';
 export type { ControllersResponse } from './networking/controllers_response.js';
 export type { StatusResponse } from './networking/status_response.js';
 export type { ScriptResponse } from './networking/script_response.js';
-export { M5Page, PageButton } from './remotes/M5Page.js';
-export type { M5ScriptList } from './remotes/M5ScriptList.js';
-export type { M5Button } from './remotes/M5Button.js';
+export { RemotePage, PageButton } from './remotes/RemotePage.js';
+export type { RemoteScriptList } from './remotes/RemoteScriptList.js';
+export type { RemoteButton } from './remotes/RemoteButton.js';
 export type { DeploymentStatus } from './scripts/deployment_status.js';
 export { Constants } from './constants.js';
 export {

--- a/astros_api/src/models/remotes/M5ScriptList.ts
+++ b/astros_api/src/models/remotes/M5ScriptList.ts
@@ -1,5 +1,0 @@
-import { M5Button } from './M5Button.js';
-
-export interface M5ScriptList {
-  pages: Array<Array<M5Button>>;
-}

--- a/astros_api/src/models/remotes/RemoteButton.ts
+++ b/astros_api/src/models/remotes/RemoteButton.ts
@@ -1,4 +1,4 @@
-export interface M5Button {
+export interface RemoteButton {
   name: string;
   command: string;
 }

--- a/astros_api/src/models/remotes/RemotePage.test.ts
+++ b/astros_api/src/models/remotes/RemotePage.test.ts
@@ -1,34 +1,34 @@
 import { describe, it, expect } from 'vitest';
-import { M5Page, PageButton } from './M5Page.js';
+import { RemotePage, PageButton } from './RemotePage.js';
 
-describe('M5Page', () => {
+describe('RemotePage', () => {
   describe('constructor', () => {
     it('assigns a UUID-shaped id when none is supplied', () => {
-      const page = new M5Page();
+      const page = new RemotePage();
       expect(page.id).toMatch(/^[0-9a-f-]{8,}$/i);
     });
 
     it('respects an explicit id and name', () => {
-      const page = new M5Page('explicit-id', 'Quick Actions');
+      const page = new RemotePage('explicit-id', 'Quick Actions');
       expect(page.id).toBe('explicit-id');
       expect(page.name).toBe('Quick Actions');
     });
 
     it('defaults name to empty string when none is supplied', () => {
-      const page = new M5Page();
+      const page = new RemotePage();
       expect(page.name).toBe('');
     });
 
     it('assigns distinct ids to back-to-back default-constructed pages', () => {
-      const a = new M5Page();
-      const b = new M5Page();
+      const a = new RemotePage();
+      const b = new RemotePage();
       expect(a.id).not.toBe(b.id);
     });
 
     it('defaults all 9 buttons to id "0"', () => {
-      const page = new M5Page();
+      const page = new RemotePage();
       for (let n = 1; n <= 9; n++) {
-        const btn = page[`button${n}` as keyof M5Page] as PageButton;
+        const btn = page[`button${n}` as keyof RemotePage] as PageButton;
         expect(btn.id).toBe('0');
       }
     });
@@ -42,24 +42,24 @@ describe('M5Page', () => {
       // is true). The fixed form iterates an explicit BUTTON_KEYS list.
       // Verified mechanically: reverting the loop to `for...in this` makes this
       // test fail (returns true instead of false).
-      const page = new M5Page('populated-uuid-string', 'Quick Actions');
+      const page = new RemotePage('populated-uuid-string', 'Quick Actions');
       expect(page.hasSettings()).toBe(false);
     });
 
     it('returns true when any one button is assigned', () => {
-      const page = new M5Page();
+      const page = new RemotePage();
       page.button5 = new PageButton('script-id-3', 'Wave');
       expect(page.hasSettings()).toBe(true);
     });
 
     it('returns true for button1 alone (first slot)', () => {
-      const page = new M5Page();
+      const page = new RemotePage();
       page.button1 = new PageButton('script-id-1', 'Beep');
       expect(page.hasSettings()).toBe(true);
     });
 
     it('returns true for button9 alone (last slot)', () => {
-      const page = new M5Page();
+      const page = new RemotePage();
       page.button9 = new PageButton('playlist-id-2', 'Songs');
       expect(page.hasSettings()).toBe(true);
     });

--- a/astros_api/src/models/remotes/RemotePage.ts
+++ b/astros_api/src/models/remotes/RemotePage.ts
@@ -10,11 +10,11 @@ const BUTTON_KEYS = [
   'button7',
   'button8',
   'button9',
-] as const satisfies readonly (keyof Omit<M5Page, 'id' | 'name' | 'hasSettings'>)[];
+] as const satisfies readonly (keyof Omit<RemotePage, 'id' | 'name' | 'hasSettings'>)[];
 
 type ButtonKey = (typeof BUTTON_KEYS)[number];
 
-export class M5Page {
+export class RemotePage {
   id: string;
   name: string;
   button1: PageButton;

--- a/astros_api/src/models/remotes/RemoteScriptList.ts
+++ b/astros_api/src/models/remotes/RemoteScriptList.ts
@@ -1,0 +1,5 @@
+import { RemoteButton } from './RemoteButton.js';
+
+export interface RemoteScriptList {
+  pages: Array<Array<RemoteButton>>;
+}

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -83,7 +83,8 @@ describe('remoteControl store', () => {
       // enforcement point — anything not matching the shape becomes a default
       // button rather than getting spread (a string spread would produce
       // {0:'a',1:'b',...}, and a no-`name` slot would surface `undefined` to
-      // the M5 firmware on sync).
+      // remote consumers on sync — dropped by JSON.stringify on the wire,
+      // breaking the {name, command} contract).
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const malformed = {
         ...legacyPage(),

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -47,8 +47,8 @@ function isPageButtonShape(raw: unknown): raw is Pick<PageButton, 'id' | 'name'>
   // from JSON.parse of stored config and could be anything. Validate per-slot
   // before letting it reach migrateButton, which spreads `{...btn, type}` — a
   // string slot would otherwise produce `{0:'a',1:'b',..., type:'script'}` and
-  // a no-`name` slot would surface `undefined` to the M5 firmware (which drops
-  // it on JSON.stringify, breaking the {name, command} sync contract).
+  // a no-`name` slot would surface `undefined` to remote consumers — dropped
+  // by JSON.stringify on the wire, breaking the {name, command} sync contract.
   if (typeof raw !== 'object' || raw === null) return false;
   const candidate = raw as Partial<PageButton>;
   return typeof candidate.id === 'string' && typeof candidate.name === 'string';


### PR DESCRIPTION
 ## Summary

Drops the historical `M5*` prefix from the backend remote-config types now that M5Stack is no longer assumed to be the only consumer of `/remotecontrolsync` — Phase 4 (mobile web remote) will hit the same endpoint with the same wire shape. Renames `M5Page` / `M5Button` / `M5ScriptList` to `RemotePage` / `RemoteButton` / `RemoteScriptList`, matching the frontend's already-generic naming.

Migrates the `remote_config.type` DB string key from `astrOsScreen` to `remoteConfig` via a reversible `migration_7`. The column is `UNIQUE NOT NULL`, so the rename is a single atomic `UPDATE`. Migration_0's seed is updated in lockstep so fresh installs land directly on the new key without a redundant rewrite on first boot.

Per pre-push toolkit feedback, this PR also closes a latent fresh-install 500 in `syncRemoteConfig` (the `'{}'` seed shape flowed past the existing `length === 0` check and crashed `forEach`), adds the load-bearing wire-shape test the original implementation never had, and hardens the migration test against over-broad-`WHERE` mutations. Scope rationale for each documented under "Deferred items" below.

---

## Changes

### Backend type rename
- `astros_api/src/models/remotes/M5Page.ts` → `RemotePage.ts` — class + `BUTTON_KEYS` constraint updated; `PageButton` kept (still co-located, see Deferred #1).
- `astros_api/src/models/remotes/M5Button.ts` → `RemoteButton.ts` — interface rename.
- `astros_api/src/models/remotes/M5ScriptList.ts` → `RemoteScriptList.ts` — interface rename + nested import updated.
- `astros_api/src/models/remotes/M5Page.test.ts` → `RemotePage.test.ts` — pure identifier sweep; the Phase 1 vacuous-fix guard for `hasSettings()` carries over verbatim.
- `astros_api/src/models/index.ts` — barrel exports updated, preserving value-vs-type distinction (`RemotePage` + `PageButton` are runtime classes; `RemoteScriptList` + `RemoteButton` are type-only).
- `astros_api/src/controllers/remote_config_controller.ts` — imports + `Array<RemotePage>` / `RemoteScriptList` / `new Array<RemoteButton>()` usages updated.

### DB key migration
- `astros_api/src/dal/migrations/migration_7.ts` (new) — single `UPDATE remote_config SET type = 'remoteConfig' WHERE type = 'astrOsScreen'`. `down` reverses it (different policy from migration_6, which throws on down because its rename-dance with FK swaps is structurally hard to undo). Both `up` and `down` log when rows are affected.
- `astros_api/src/dal/migrations/migration_0.ts` — seed value `astrOsScreen` → `remoteConfig`. Safe to edit because migration_0 only runs on databases that have never been migrated; existing installs are routed through migration_7.
- `astros_api/src/dal/migrations/index.ts` — exports migration_7.
- `astros_api/src/dal/database.ts` — registers migration_7 in `defaultMigrationProvider`.
- `astros_api/src/controllers/remote_config_controller.ts` — three `repo.getConfig('astrOsScreen')` / `repo.saveConfig('astrOsScreen', …)` call sites switched to `'remoteConfig'`.

### Pre-push toolkit fixes (Critical + Important)
- **`Array.isArray(val)` guard in `syncRemoteConfig`.** Migration_0 seeds `value: '{}'`. Before the guard, `JSON.parse('{}')` returned `{}` (object, not array), `val.length === 0` evaluated `undefined === 0 → false`, and `val.forEach` threw a `TypeError`. On a fresh install where the user hasn't saved a config yet, any device polling `/remotecontrolsync` got a 500. Pre-existing latent bug, but diff-adjacent now that migration_0's seed is in this branch — fixed here.
- **Migration_7 comment forward-tense.** Reworded header from past tense ("Phase 4 started consuming…") to forward tense ("Phase 4 introduces a mobile web remote that will hit the same endpoint…") since Phase 4 hasn't shipped yet.

### Vue comment sweep (Phase 4 forward-compatibility)
- `astros_vue/src/stores/remoteControl.ts:50` and `astros_vue/src/stores/__tests__/remoteControl.spec.ts:86` — two "M5 firmware" comment references generalized to "remote consumers", naming the actual mechanism (JSON.stringify drops `undefined`) instead of the specific historical consumer.

### Integration test version bump
- `astros_api/src/dal/database.integration.test.ts` — `buildProvider` includes migration_7; injected test-only migrations renamed from `'7_*'` to `'8_*'` since the production baseline is now v7. All `// migrate to v6` / `// v6 as the latest` comments swept to v7. Backup-file expectation updated to `database.sqlite3.backup-7_rename_remote_config_key`.

### Tests
- `astros_api/src/dal/migrations/migration_7.test.ts` (new, 4 tests)
  - `up` renames an existing `astrOsScreen` row to `remoteConfig` preserving `value` (with vacuous-fix guard comment).
  - `up` is a no-op on a fresh install (migration_0 already seeds `remoteConfig`).
  - **`up` does not touch other `remote_config` rows.** Hardens against the over-broad-WHERE mutation family — seeds a second `'unrelatedKey'` row and asserts it survives unchanged. Without this, mutations dropping the `WHERE` clause or replacing it with `WHERE 1=1` would still pass the single-row test.
  - `down` reverses the rename back to `astrOsScreen` and preserves `value`.
- `astros_api/src/controllers/remote_config_controller.test.ts` (new, 4 tests)
  - Fresh-install seed `'{}'` returns `{pages: []}` without 500'ing. **This is the load-bearing test for the Critical fix above** — reverting the `Array.isArray` guard makes this test throw.
  - Saved config emits the full M5Stack wire shape `{pages: [[{name, command} × 9]]}` end-to-end through `getConfig` → JSON.parse → 9-button flatten loop. **This is the load-bearing test for the Phase 6 plan's "JSON shape preserved" claim** — the M5Stack firmware lives in a sibling repo and can't be exercised from here, so this controller test is the contract pin.
  - Empty `'[]'` saved config returns `{pages: []}` cleanly.
  - Verifies the controller queries the renamed `remoteConfig` key, not `astrOsScreen`.

### Plan + tracker
- `.docs/plans/20260521-1003-phase6-m5-remote-rename.md` (new light plan, all 5 tasks checked off).
- `.docs/plans/current_project.md` — Phase 1 checkbox flipped (Phase 1 shipped + M5-bench-verified before Phase 6 started); Phase 6 checkbox flip will land post-merge in a separate commit.

---

## Quality gates passed

| Gate | Result |
|---|---|
| API `npm run build` (tsc + tsc-alias) | clean |
| API `npx vitest run` | **805/805** (+5 from this PR: 4 controller + 1 migration_7) |
| API `npm run prettier:write` + `npm run lint:fix` | clean (2 pre-existing warnings in `flash_orchestrator.test.ts` unchanged) |
| Vue `npm run build` (vue-tsc + vite) | clean |
| Vue `npx vitest run` | **368/368** (no test count change — comment-only edits) |
| Vue `npm run format` + `npm run lint` | clean |
| **Per-commit code review** (`superpowers:requesting-code-review`) | 1 Important found and fixed — comment sweep was too narrow, M5-firmware mention survived |
| **Pre-push toolkit** (`pr-review-toolkit:review-pr`, 5 agents parallel) | 1 Critical + 3 Important addressed in `80c3a81`; deferred items documented |

### Vacuous-fix guards (verified by revert-and-confirm)

Per the CLAUDE.md "Mutation test defensive features" memory rule, these tests pin behavior that would silently pass with regressions if the guard were removed. Each was verified by reverting the production fix locally and confirming the test fails:

1. **Migration_7 WHERE clause** (`migration_7.test.ts:96-104`): with `WHERE type = 'astroScreen'` (typo) or `WHERE 1=1` or no WHERE, either the `'astrOsScreen'` row stays unrenamed (typo case) or the second `unrelatedKey` row gets renamed too (overbroad case). The fixed code passes only with the exact `WHERE type = 'astrOsScreen'`.
2. **`syncRemoteConfig` Array.isArray guard** (`remote_config_controller.test.ts:28`): reverting to the prior `if (!val || val.length === 0)` causes the fresh-install seed test to throw `TypeError: val.forEach is not a function`.

---

## Test plan (reviewer / merge gate)

- [ ] **Manual M5 smoke (owner: Jeff, optional).** The wire shape on `/remotecontrolsync` is now pinned by a real test, so M5 regression risk is low — but a bench sync still confirms the migration ran cleanly against a real existing-install DB. If the migration mis-fires, the device would receive the empty-pages response from the new `Array.isArray` short-circuit instead of the configured payload.
- [ ] Verify a fresh install (delete `~/.config/astrosserver/database.sqlite3` and restart) boots without errors and `/remoteConfig/` returns the empty-config envelope.
- [ ] Verify an existing install with an `astrOsScreen` row migrates on boot to `remoteConfig` and `/remotecontrolsync` still returns the same JSON for the same saved config.

---

## Deferred items (intentionally out of scope)

These were surfaced by the pre-push toolkit but moved to follow-up plans to keep this PR scope-clean. Each has its rationale recorded so a future session can pick them up without re-litigating:

1. **`PageButton` → `RemotePageButton` rename + extract to own file** (type-design Important). The M5→Remote rename sweep didn't catch `PageButton`, which still lives in `RemotePage.ts` next to `RemotePage` and gets re-exported alongside it. Pure mechanical rename + barrel update + 1 file move. Skipped here to keep the diff focused on the M5* → Remote* trio plus the DB migration; worth a small follow-up PR.
2. **`RemoteConfigKey` literal-union type** for `RemoteConfigTable.type` (type-design Important). With `type: string` the next key rename will be another grep-driven sweep instead of a 1-line type change that the compiler propagates. Independent of Phase 6 in scope.
3. **`RemoteButton.command` field rename** (type-design Minor). It's not a "command" — it's a script-or-playlist id that the device interprets. Coordinate with firmware-side parser; defer.
4. **Repository `logger.error('msg', err)` 2-string call** (silent-failure Important). Pre-existing pino misuse in `remote_config_repository.ts:14, 33` drops the error stack. Lives outside the diff; broader-scope fix that should go in a logging-hygiene pass across all repositories.
5. **`getRemoteConfig` envelope shape inconsistency** (silent-failure Important). Returns `{value: '[]'}` on missing row but raw string on present-row. Pre-existing. Frontend can't tell "DB not seeded" from "empty config." Worth fixing when the frontend gets a contract test.
6. **`saveRemoteConfig` dead `else` branch** (silent-failure Important). `repo.saveConfig` only ever returns `true` or throws; the `else { res.status(500) }` is unreachable. Cosmetic.
7. **Round-trip migration test (up → down → up)** (test-coverage Minor). The down test stops after one round; round-trip integrity isn't pinned.
8. **`'m5stick'` literal in `remote_config_repository.test.ts:22-35`** — pre-existing test-only key. Lone surviving M5 reference outside migration files. Trivial rename to `'test-key'` in a follow-up sweep.
9. **Phase 1 plan file housekeeping move** to `.docs/completed_plans/2026/05/21/`. Phase 1 shipped, but the convention is to move plans only when the parent project ships; the active-project tracker (`current_project.md`) is the canonical pointer until then. Defer until the whole Remote Redesign project closes.

---

## Reviewer notes

- The biggest single decision in this PR is to land the `Array.isArray` fix in `syncRemoteConfig` even though the bug is pre-existing and outside the strict Phase 6 diff. Rationale: migration_0's seed change is *in* the diff, the per-commit reviewer missed the latent failure mode entirely, and the silent-failure-hunter agent specifically flagged it as "the moment migration_0 seeds a v0 install on top of this diff." Closing it here is cheaper than tracking a follow-up that would touch the same controller.
- The wire-shape controller test (`remote_config_controller.test.ts` second test) is doing real load-bearing work — it's the only test in the codebase that asserts the exact JSON shape the M5Stack firmware parses. If you suspect it's just-cosmetic, mentally mutate the controller's `command: x.buttonN.id` to `command: x.buttonN.name` and watch the test go red.
- The migration_7 "second-row" test (`migration_7.test.ts:91-114`) deserves a careful read — it's there specifically to fail under over-broad-WHERE mutations that the single-row test would silently pass. The vacuous-fix guard comment names the exact mutations.
- The down policy difference from migration_6 is intentional: migration_6 throws on down because its rename-dance with FK constraint swaps is structurally hard to undo; migration_7's single-row UPDATE is trivially reversible, so it gets a real down. Both behaviors are tested.
