### PR TITLE
Feature/phase3 mobile remote component

### DIFF
--- a/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
+++ b/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
@@ -49,7 +49,11 @@ in `current_project.md`.
    suggested is not needed.)
 4. **`MobileRemote.jsx` uses both mouse and touch handlers** with `preventDefault` on
    touch to suppress synthetic mouse events. Vue's standard `@mousedown` / `@touchstart`
-   bindings won't auto-deduplicate; the composable must accept both.
+   bindings won't auto-deduplicate; the consumer must wire both event types to the same
+   handler and the composable's `start()` must be idempotent so the re-entrant call from
+   the synthesized mousedown absorbs cleanly. (As shipped: `useHoldGesture` is
+   event-type-agnostic — it exposes `start()` / `cancel()` / `reset()` and the consumer
+   does the wiring.)
 5. **The `compact` mode is mostly sizing tweaks**, not a different layout. Specifically:
    `paddingTop` shrinks, font sizes and gap/radius values reduce, the panic button label
    gets tighter. Express as Tailwind class branches via `:class="compact ? ... : ..."`
@@ -73,8 +77,11 @@ in `current_project.md`.
       `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue` with
       the props/emits and full layout from the handoff. Props:
       `pages: RemoteControlPage[]`, `initialIdx?: number = 0`, `compact?: boolean = false`,
-      `connected?: boolean = true`. Emits: `press(buttonValue: PageButton)`,
-      `panic()`. Local state: `idx`, `pressed` (button id during 220ms press flash),
+      `connected?: boolean = true`. Emits: `press(buttonValue: FilledPageButton)`,
+      `panic()`. (As shipped: the press payload is narrowed to `FilledPageButton`
+      via the `isFilledPageButton` type guard so consumers can switch on a
+      script-or-playlist discriminator without a dead `none` branch.)
+      Local state: `idx`, `pressed` (button id during 220ms press flash),
       `toastMessage`. Uses `useHoldGesture` for the panic button. Layout: orange top bar
       (`bg-r2-complement` — wordmark "AstrOs" in `Audiowide`, conditional Connected
       chip with `bg-success` dot), page header (page name + "{idx+1} / {total}"
@@ -100,7 +107,8 @@ in `current_project.md`.
       `mobile_remote.stop_all_caption`, `mobile_remote.empty_slot_aria`. Add barrel
       export in `astros_vue/src/components/mobileRemote/index.ts`.
 - [ ] **Task 4 — Manual visual verification + Storybook check.** Run `npm run
-      storybook` and verify all four stories render: filled buttons show the correct
+      storybook` and verify all six stories render (Page1Mixed, Page2Sparse,
+      Page3Empty, CompactPreview, Disconnected, EmptyPagesArray): filled buttons show the correct
       type chip, empty slots show the dashed-border em-dash, the pagination dot
       elongates on the active page, the panic button arming-fill animation runs to
       completion in 600ms and the active state locks for 2.2s. No automated coverage

--- a/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
+++ b/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
@@ -44,7 +44,9 @@ in `current_project.md`.
 3. **Toast and panic-active timers must clean up on unmount.** The 1.6s press-toast and
    2.2s panic-active lockout both use `setTimeout`. If the component unmounts mid-timer
    (e.g., page route change), the timer's setState would leak. Use `onBeforeUnmount` to
-   clear pending handles, and gate the timer callbacks on a mounted ref.
+   clear pending handles. (As shipped, `clearTimeout` alone is sufficient — Vue 3 ignores
+   ref writes after unmount, so the additional mounted-ref gate the plan originally
+   suggested is not needed.)
 4. **`MobileRemote.jsx` uses both mouse and touch handlers** with `preventDefault` on
    touch to suppress synthetic mouse events. Vue's standard `@mousedown` / `@touchstart`
    bindings won't auto-deduplicate; the composable must accept both.
@@ -213,8 +215,6 @@ the standalone-route wiring or the operator UX will be misleading or unsafe.
 - Wiring `@press` to `apiService.get('api/scripts/run', ...)` and `@panic` to a WebSocket
   PANIC message — Phase 4.
 - A standalone route or view for the component — Phase 4.
-- Replacing the `Audiowide` placeholder with the proprietary AstrOs wordmark font —
-  open question for the design phase, not blocking.
 - Touch-vs-mouse event coalescing optimization beyond the basic `preventDefault` on
   touch handlers — defer to Phase 4 bench-testing on real hardware.
 
@@ -223,7 +223,7 @@ the standalone-route wiring or the operator UX will be misleading or unsafe.
 - `npm run build` (vue) clean.
 - `npx vitest run` clean — includes new `useHoldGesture.spec.ts`.
 - `npm run lint` + `npm run format` clean.
-- `npm run storybook` — all four stories render visually correct against the handoff
+- `npm run storybook` — all six stories render visually correct against the handoff
   screenshots (`.tmp/design_handoff_remote_control/screenshots/03-mobile-page1.png`
   through `05-mobile-empty.png`).
 - Invoke `superpowers:requesting-code-review` on each implementation commit.

--- a/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
+++ b/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
@@ -55,7 +55,7 @@ in `current_project.md`.
 
 ## Tasks
 
-- [ ] **Task 1 — `useHoldGesture` composable + TDD tests.** Create
+- [x] **Task 1 — `useHoldGesture` composable + TDD tests.** Create
       `astros_vue/src/composables/useHoldGesture.ts` exposing a state machine:
       `'idle' | 'arming' | 'active' | 'cooldown'`. API:
       `useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire })` returns
@@ -67,7 +67,7 @@ in `current_project.md`.
       arming is a no-op, `cancel()` after fire stays in cooldown, `reset()` clears
       pending timers. **Vacuous-fix guard:** revert the `holdMs` timeout to fire at 0ms
       and verify the "releases before holdMs cancels cleanly" test fails.
-- [ ] **Task 2 — `AstrosMobileRemote.vue` component file.** Create
+- [x] **Task 2 — `AstrosMobileRemote.vue` component file.** Create
       `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue` with
       the props/emits and full layout from the handoff. Props:
       `pages: RemoteControlPage[]`, `initialIdx?: number = 0`, `compact?: boolean = false`,
@@ -86,7 +86,7 @@ in `current_project.md`.
       `transform: scale(0.96)` press animation). Component-scoped types in
       sibling `types.ts` (mainly `PressEvent` type alias). **Unmount cleanup** for
       press-flash + toast timers (see Hidden gotcha 3).
-- [ ] **Task 3 — Storybook stories + icon registration + i18n.** Create
+- [x] **Task 3 — Storybook stories + icon registration + i18n.** Create
       `AstrosMobileRemote.stories.ts` next to the component with four variants:
       "Page 1 — mixed" (uses Phase 1's `createDefaultPage` + populated buttons),
       "Page 2 — sparse" (3 buttons assigned), "Page 3 — empty" (all `'0'` slots),
@@ -105,6 +105,23 @@ in `current_project.md`.
       here — the layout is visual. Per memory [[feedback-tdd-exceptions]] UI layout
       doesn't get unit tests; the composable in Task 1 does. Confirm in dev tools
       that unmounting mid-press / mid-toast doesn't leak timer warnings.
+
+## Post-Task-3 design feedback (folded in)
+
+These came out of iterative visual review after Tasks 1-3 shipped. Each is
+small enough to ship without a separate plan tier:
+
+- **AstrOs wordmark per-letter cap scaling** (1.25× the body letter size on
+  capital A and O) — enforces the proprietary branding rhythm. Implemented
+  with per-letter `<span>` + `aria-label="AstrOs"` so screen readers
+  announce the word as a single token.
+- **Button label font shrink** — 18px → 15px (full) and 12px → 11px
+  (compact) to fit longer script/playlist titles within the 3-line clamp.
+- **Swipe-to-paginate on the 3×3 grid** — touchstart/touchend handlers,
+  60px horizontal threshold, 40px vertical max, swipe-LEFT → next page
+  (iOS Photos convention). Multi-touch guard clears any in-progress
+  start coords when a second finger lands so two-handed grips don't
+  trigger spurious page flips.
 
 ## Out of scope
 

--- a/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
+++ b/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
@@ -1,0 +1,141 @@
+# Phase 3 — Shared `AstrosMobileRemote` component
+
+**Date:** 2026-05-21
+**Tier:** Light plan (per CLAUDE.md Planning section)
+**Parent project:** [`current_project.md`](./current_project.md) — Remote Control Redesign + Mobile Remote
+**Branch:** `feature/phase3-mobile-remote-component`
+
+## Goal
+
+Port the handheld mobile remote design from the Direction B handoff
+(`.tmp/design_handoff_remote_control/mobileRemote.jsx`) to a reusable Vue 3 component.
+The component is used in two places:
+
+- **Phase 2's preview rail** (compact mode, inside a `MiniPhone` bezel).
+- **Phase 4's standalone mobile operator route** (full size).
+
+This phase ships ONLY the component itself. Wiring it to script/playlist run endpoints
+and a real WebSocket connection chip is Phase 4 territory; this phase exposes those as
+props/emits so Phase 4 can plug in without touching the component internals.
+
+## Failure-mode inventory
+
+Not required. Pure UI component — no filesystem state, no real network I/O (the press
+and panic actions are callback props that the parent wires later), no concurrency
+beyond a single local hold-timer, no crash-recovery surface.
+
+## Why this phase ships before Phase 2
+
+Phase 2's `AstrosRemoteLivePreview.vue` imports `AstrosMobileRemote`. Building Phase 2
+first would either require a stub preview that gets re-touched in Phase 3, or inlining a
+throwaway minimal remote. Reordering 3→2 means Phase 2 can fully implement the preview
+rail at first commit without re-touching files later. Decision made 2026-05-21; reflected
+in `current_project.md`.
+
+## Hidden gotchas surfaced during planning
+
+1. **The "connected" indicator has no data source in Phase 3.** The handoff shows a green
+   "Connected" chip in the top bar driven by WebSocket state, which doesn't exist until
+   Phase 4. Expose it as a `connected?: boolean` prop (defaulting to `true`) so Phase 4
+   can drive it from the WS store without changing the component shape.
+2. **Battery glyph is dropped entirely** (per [[project-active-remote-redesign]]). The
+   handoff's `Icon.Battery` does NOT need registering. Top bar = wordmark + Connected
+   chip only.
+3. **Toast and panic-active timers must clean up on unmount.** The 1.6s press-toast and
+   2.2s panic-active lockout both use `setTimeout`. If the component unmounts mid-timer
+   (e.g., page route change), the timer's setState would leak. Use `onBeforeUnmount` to
+   clear pending handles, and gate the timer callbacks on a mounted ref.
+4. **`MobileRemote.jsx` uses both mouse and touch handlers** with `preventDefault` on
+   touch to suppress synthetic mouse events. Vue's standard `@mousedown` / `@touchstart`
+   bindings won't auto-deduplicate; the composable must accept both.
+5. **The `compact` mode is mostly sizing tweaks**, not a different layout. Specifically:
+   `paddingTop` shrinks, font sizes and gap/radius values reduce, the panic button label
+   gets tighter. Express as Tailwind class branches via `:class="compact ? ... : ..."`
+   rather than two parallel templates.
+
+## Tasks
+
+- [ ] **Task 1 — `useHoldGesture` composable + TDD tests.** Create
+      `astros_vue/src/composables/useHoldGesture.ts` exposing a state machine:
+      `'idle' | 'arming' | 'active' | 'cooldown'`. API:
+      `useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire })` returns
+      `{ state, start(), cancel(), reset() }`. State transitions: `idle → arming` on
+      `start()`; `arming → active` after `holdMs` (fires `onFire`); `arming → idle` if
+      `cancel()` before timeout; `active → cooldown → idle` after `cooldownMs`. Tests in
+      `astros_vue/src/composables/__tests__/useHoldGesture.spec.ts` cover: fires after
+      `holdMs`, releases before `holdMs` cancels cleanly, repeated `start()` while
+      arming is a no-op, `cancel()` after fire stays in cooldown, `reset()` clears
+      pending timers. **Vacuous-fix guard:** revert the `holdMs` timeout to fire at 0ms
+      and verify the "releases before holdMs cancels cleanly" test fails.
+- [ ] **Task 2 — `AstrosMobileRemote.vue` component file.** Create
+      `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue` with
+      the props/emits and full layout from the handoff. Props:
+      `pages: RemoteControlPage[]`, `initialIdx?: number = 0`, `compact?: boolean = false`,
+      `connected?: boolean = true`. Emits: `press(buttonValue: PageButton)`,
+      `panic()`. Local state: `idx`, `pressed` (button id during 220ms press flash),
+      `toastMessage`. Uses `useHoldGesture` for the panic button. Layout: orange top bar
+      (`bg-r2-complement` — wordmark "AstrOs" in `Audiowide`, conditional Connected
+      chip with `bg-success` dot), page header (page name + "{idx+1} / {total}"
+      pagination text), 3×3 button grid (filled buttons → `bg-r2-primary` with
+      action-type chip via `Icon.Doc`/`Icon.Folder`; empty slots → `bg-r2-base-200`
+      with dashed `border-r2-border-strong` and em-dash), pagination row (prev/next
+      arrow icon buttons + dot strip with elongated active pill), toast overlay
+      (transient, absolute-positioned), STOP ALL button (3 states driven by
+      `useHoldGesture`). Tailwind-first; inline `style` only where Tailwind cannot
+      express the value (e.g., the exact shadow stack on filled buttons, the
+      `transform: scale(0.96)` press animation). Component-scoped types in
+      sibling `types.ts` (mainly `PressEvent` type alias). **Unmount cleanup** for
+      press-flash + toast timers (see Hidden gotcha 3).
+- [ ] **Task 3 — Storybook stories + icon registration + i18n.** Create
+      `AstrosMobileRemote.stories.ts` next to the component with four variants:
+      "Page 1 — mixed" (uses Phase 1's `createDefaultPage` + populated buttons),
+      "Page 2 — sparse" (3 buttons assigned), "Page 3 — empty" (all `'0'` slots),
+      "Compact preview" (page 1 with `compact: true`). Register `MdDescription` (Doc)
+      and `MdFolder` (Folder) icons in `astros_vue/src/main.ts`. Add
+      `mobile_remote.*` i18n keys to `astros_vue/src/locales/enUS.json` —
+      `mobile_remote.connected_label`, `mobile_remote.stop_all_idle`,
+      `mobile_remote.stop_all_arming`, `mobile_remote.stop_all_active`,
+      `mobile_remote.stop_all_caption`, `mobile_remote.empty_slot_aria`. Add barrel
+      export in `astros_vue/src/components/mobileRemote/index.ts`.
+- [ ] **Task 4 — Manual visual verification + Storybook check.** Run `npm run
+      storybook` and verify all four stories render: filled buttons show the correct
+      type chip, empty slots show the dashed-border em-dash, the pagination dot
+      elongates on the active page, the panic button arming-fill animation runs to
+      completion in 600ms and the active state locks for 2.2s. No automated coverage
+      here — the layout is visual. Per memory [[feedback-tdd-exceptions]] UI layout
+      doesn't get unit tests; the composable in Task 1 does. Confirm in dev tools
+      that unmounting mid-press / mid-toast doesn't leak timer warnings.
+
+## Out of scope
+
+- Wiring `@press` to `apiService.get('api/scripts/run', ...)` and `@panic` to a WebSocket
+  PANIC message — Phase 4.
+- A standalone route or view for the component — Phase 4.
+- Replacing the `Audiowide` placeholder with the proprietary AstrOs wordmark font —
+  open question for the design phase, not blocking.
+- Touch-vs-mouse event coalescing optimization beyond the basic `preventDefault` on
+  touch handlers — defer to Phase 4 bench-testing on real hardware.
+
+## Verification gates
+
+- `npm run build` (vue) clean.
+- `npx vitest run` clean — includes new `useHoldGesture.spec.ts`.
+- `npm run lint` + `npm run format` clean.
+- `npm run storybook` — all four stories render visually correct against the handoff
+  screenshots (`.tmp/design_handoff_remote_control/screenshots/03-mobile-page1.png`
+  through `05-mobile-empty.png`).
+- Invoke `superpowers:requesting-code-review` on each implementation commit.
+- Run `/pr-review-toolkit:review-pr` on the full branch diff vs `develop` before push
+  (mandatory per CLAUDE.md).
+
+## Critical files touched
+
+- `astros_vue/src/composables/useHoldGesture.ts` (new)
+- `astros_vue/src/composables/__tests__/useHoldGesture.spec.ts` (new)
+- `astros_vue/src/components/mobileRemote/index.ts` (new — barrel)
+- `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue` (new)
+- `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.stories.ts` (new)
+- `astros_vue/src/components/mobileRemote/mobileRemote/types.ts` (new, small)
+- `astros_vue/src/main.ts` (icon registration)
+- `astros_vue/src/locales/enUS.json` (new `mobile_remote.*` keys)
+- `.docs/plans/current_project.md` (flip Phase 6 checkbox, note Phase 3 active)

--- a/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
+++ b/.docs/plans/20260521-1135-phase3-mobile-remote-component.md
@@ -121,7 +121,92 @@ small enough to ship without a separate plan tier:
   60px horizontal threshold, 40px vertical max, swipe-LEFT → next page
   (iOS Photos convention). Multi-touch guard clears any in-progress
   start coords when a second finger lands so two-handed grips don't
-  trigger spurious page flips.
+  trigger spurious page flips. (Subsequently extracted into the
+  `useSwipeGesture` composable — see "Deviations from original plan"
+  below.)
+
+## Deviations from original plan (as shipped)
+
+The task descriptions above describe the original intent. The implementation
+diverged in a handful of small ways; each is noted here so a future reader
+isn't misled by the original text. Commit messages on each implementation
+commit also document these.
+
+- **`useHoldGesture` is a 3-state machine, not 4-state.** Task 1's
+  description sketches `'idle' | 'arming' | 'active' | 'cooldown'`. The
+  implementation collapsed the trailing two into a single `'active'`
+  state because the design's STOPPED visual covers the entire lockout
+  window with no observable distinction between "just-fired" and
+  "cooling down". See `useHoldGesture.ts` header comment for the
+  rationale. Re-introducing `'cooldown'` is straightforward if a future
+  visual treatment needs to distinguish them.
+- **Vacuous-fix guard mutation in Task 1's description was wrong.** The
+  plan claimed reverting `holdMs` to 0 would make the cancel-during-arming
+  test fail, but under `vi.useFakeTimers()` a 0ms callback only fires when
+  time is advanced — and the test DOES advance 300ms before cancel, so
+  the mutation IS caught. The real mutation the test pins is "drop the
+  `clearArmTimer()` from cancel". The spec file's inline comment now
+  enumerates both mutations the test catches.
+- **i18n keys and icon registration landed in Task 2, not Task 3.** Task
+  3's description lists `mobile_remote.*` keys and `MdDescription` /
+  `MdFolder` registration; in practice they shipped in Task 2 because the
+  component cannot render without them. Task 3 became "Storybook stories
+  only" plus the manual visual verification step.
+- **Storybook has six stories, not four.** Task 3 listed Page 1 mixed,
+  Page 2 sparse, Page 3 empty, Compact preview. The implementation also
+  includes `Disconnected` and `EmptyPagesArray` (safety-branch coverage).
+- **CSS approach is scoped BEM with `--mr-*` CSS variables, not Tailwind
+  utility classes.** Task 2's description suggested Tailwind-first with
+  inline style only as fallback; in practice the design needs ~10
+  mobile-remote-specific tokens (panic red, toast slate, base-100/200,
+  border-strong, etc.) that aren't in the global Tailwind config, so
+  scoped-CSS-with-variables is cleaner than ten `bg-[#hex]` arbitrary
+  values per slot. Local to this component; no styles.css change.
+- **Wordmark font is `distant_galaxyregular` (existing) via the
+  `font-starwars` class, not `Audiowide`.** The handoff used Audiowide as
+  a placeholder for the proprietary AstrOs wordmark. The existing
+  `distant_galaxyregular` woff (already loaded by styles.css) IS that
+  proprietary wordmark, so the component uses it directly — no font swap
+  pending.
+- **Icon names are `md-description` / `md-folder` (oh-vue-icons MD set),
+  not `Icon.Doc` / `Icon.Folder`.** The latter was the handoff's React
+  vocabulary; oh-vue-icons's Material Design set uses the
+  `md-description` / `md-folder` IDs.
+- **Swipe gesture extracted to `useSwipeGesture` composable.** Initially
+  inlined into the component (~40 lines). After the pre-push toolkit
+  flagged the multi-touch guard as a defensive feature requiring mutation-
+  test coverage, the swipe state machine was extracted into
+  `composables/useSwipeGesture.ts` with an 11-test spec file. Mirrors the
+  `useHoldGesture` pattern.
+
+## Phase 4 contract requirements (load-bearing for next phase)
+
+These items are intentionally deferred to Phase 4 but must be respected by
+the standalone-route wiring or the operator UX will be misleading or unsafe.
+
+- **Panic delivery confirmation.** The component fires `emit('panic')` and
+  shows the STOPPED visual + "STOP ALL — sent" toast unconditionally. Phase
+  4 MUST gate the STOPPED visual on websocket-PANIC delivery
+  confirmation (either via a `panicStatus: 'idle' | 'sending' | 'sent' |
+  'failed'` prop the component reflects in the toast/visual, or by emitting
+  the panic synchronously and showing the lockout only on success). Safety-
+  critical: a failed panic with confirmed-success feedback would convince
+  the operator the droid stopped when it didn't.
+- **Press delivery confirmation.** Same shape: `emit('press', button)` is
+  fire-and-forget. Phase 4 must surface API/WS failures so the "Sent: {name}"
+  toast doesn't lie. Less critical than panic but still violates the
+  project's no-silent-failure rule.
+- **`connected` prop coupling.** Phase 4 will drive `connected: boolean`
+  from the WebSocket connection store. If the team wants a tri-state
+  (`'connected' | 'connecting' | 'disconnected'`) to show a connecting
+  spinner during retry windows, widen the prop in Phase 4 — the type
+  change is non-breaking for current consumers since `true` still works as
+  the default.
+- **Component-level a11y pass.** Forward-looking per memory's a11y rule:
+  `aria-pressed="mixed"` during arming, `aria-describedby` linking the
+  panic button to its caption, i18n on the wordmark `aria-label`, and
+  considering `role="img"` on the empty-slot buttons since they are not
+  actionable. Batch into the planned a11y pass rather than this PR.
 
 ## Out of scope
 

--- a/.docs/plans/20260521-1700-phase3-review-fix-batch.md
+++ b/.docs/plans/20260521-1700-phase3-review-fix-batch.md
@@ -33,7 +33,7 @@ code-review step per the carve-out.
 
 - [x] **Commit 1 — Plan file (this file).** Plan-only commit; ships before any
       source change per the Planning section.
-- [ ] **Commit 2 — C1 + I4: panic delivery contract + composable safety
+- [x] **Commit 2 — C1 + I4: panic delivery contract + composable safety
       docstring.** (a) Change `mobile_remote.panic_toast` from `"STOP ALL — sent"`
       to `"STOP ALL — sending…"` in `enUS.json`. (b) Add an `onError?: (err:
       unknown) => void` option to `UseHoldGestureOptions`; the existing
@@ -44,7 +44,7 @@ code-review step per the carve-out.
       after touchstart." (d) Trim the `// Phase 4 contract:` block in
       `AstrosMobileRemote.vue` `onFire` to a single WHY line about
       fire-and-forget; the toast copy carries the rest.
-- [ ] **Commit 3 — I1 + M7: clamp `idx` at init.** Replace `const idx =
+- [x] **Commit 3 — I1 + M7: clamp `idx` at init.** Replace `const idx =
       ref(props.initialIdx)` with a clamp using `Math.min/Math.max`. Introduce a
       `currentIdx` computed (or reuse `safeIdx` from the existing
       `currentPage` computed by extracting it) and route the pagination header
@@ -52,15 +52,15 @@ code-review step per the carve-out.
       so out-of-range `initialIdx` no longer leaks into pagination UI. Side
       effect: the EmptyPagesArray story's Next button correctly disables.
       Update the read-time clamp comment to reflect the new structure.
-- [ ] **Commit 4 — I2: i18n the wordmark aria-label.** Replace
+- [x] **Commit 4 — I2: i18n the wordmark aria-label.** Replace
       `aria-label="AstrOs"` with `:aria-label="$t('astros')"`. Key already
       exists at `enUS.json:2`.
-- [ ] **Commit 5 — I6: `isFilledPageButton` type guard.** Add the predicate in
+- [x] **Commit 5 — I6: `isFilledPageButton` type guard.** Add the predicate in
       `types.ts`; replace the `button as AstrosMobileRemotePressEvent` cast in
       `handlePress` with the guard so TypeScript proves the narrowing. Remove
       the now-redundant cast-narrowing comment block (handles M6's
       `handlePress` what-comment as a side effect).
-- [ ] **Commit 6 — I3: `AstrosMobileRemote` component tests.** New
+- [x] **Commit 6 — I3: `AstrosMobileRemote` component tests.** New
       `AstrosMobileRemote.spec.ts` covering:
       - press-during-`active` lockout is suppressed (mounts, fires panic,
         advances 600ms, clicks a button, asserts no `press` emit).
@@ -77,7 +77,7 @@ code-review step per the carve-out.
         button is disabled (validates the Commit 3 fix).
       Follows the existing `AstrosFirmwareVersionDelta.spec.ts` i18n-stub
       pattern.
-- [ ] **Commit 7 — Cleanup batch (M1, M2, M3, M4, M5, M6, M8).**
+- [x] **Commit 7 — Cleanup batch (M1, M2, M3, M4, M5, M6, M8).**
       - **M1**: drop `@mouseleave="handlePanicUp"` from the panic button so a
         drag-off mid-hold doesn't silently cancel. Matches touch-end-anywhere
         UX and is more forgiving for a safety gesture.
@@ -97,7 +97,7 @@ code-review step per the carve-out.
       - **M8**: add exactly-at-threshold boundary tests to
         `useSwipeGesture.spec.ts` (deltaX = ±60 fires; deltaY = 40 still
         fires for a horizontal swipe).
-- [ ] **Commit 8 — I5: plan-vs-code drift fixes (plan-only).** Edit
+- [x] **Commit 8 — I5: plan-vs-code drift fixes (plan-only).** Edit
       `20260521-1135-phase3-mobile-remote-component.md`:
       - Hidden gotcha #3 (line 46-47): drop "and gate the timer callbacks on
         a mounted ref"; shipped code uses `clearTimeout` alone.
@@ -106,6 +106,59 @@ code-review step per the carve-out.
         proprietary wordmark and no swap is pending.
       - Verification gate (line 226): change "all four stories" to "all six
         stories" (or "all stories"). Six shipped per the deviations section.
+
+## Round 3 follow-ups (`/pr-review-toolkit:review-pr` re-run after Commits 1-8 shipped)
+
+The third toolkit run on 2026-05-21 surfaced 1 Critical (a CLAUDE.md
+caller-reference violation), 6 Important, and 14 Minor. The must-fix
+subset bundles into three more commits below; Minors defer to a Phase-4
+hardening pass per the YAGNI triage section above.
+
+- [x] **Commit A — Plan catch-up (this commit).** Flip the eight shipped
+      `[ ]` boxes to `[x]` (addresses round-3 M13: the plan claimed no
+      work shipped when in fact all of Commits 2-8 did) and add this
+      Round 3 follow-ups section.
+- [ ] **Commit B — I1 + I2: exhaustive predicate + async-safe onError.**
+      - **I1**: convert `isFilledPageButton` (`types.ts:9-11`) to an
+        exhaustive `switch` with a `never`-typed default branch. A new
+        `PageButtonType` variant now breaks the build at the predicate
+        instead of silently classifying as filled and routing through
+        the press emit. Three round-3 agents converged on this gap.
+      - **I2**: wrap the `onError` call in `useHoldGesture.ts:81-90`
+        with `Promise.resolve(...).catch(...)` so an async handler
+        whose returned promise rejects (e.g., `async (err) => { await
+        logToSentry(err); }`) doesn't drop the rejection on the floor.
+        The docstring already invites the async use case. Add a
+        regression test for an `onError` that throws via promise
+        rejection.
+- [ ] **Commit C — I3 + C1 + I5: missing watcher tests + comment trims.**
+      - **I3a**: `setProps({ initialIdx: N })` test pinning the
+        post-mount `initialIdx` watcher. A mutation that drops the
+        watcher block passes all current tests because the read-time
+        `currentIdx` clamp masks the bug.
+      - **I3b**: `setProps({ pages: shorterPages })` test pinning the
+        `pages.length` shrink watcher.
+      - **C1**: drop the "Pins the I1 fix from the pre-push review"
+        reference at `AstrosMobileRemote.spec.ts:216` — direct
+        CLAUDE.md caller-reference violation.
+      - **I5**: the `useHoldGesture.start()` docstring and
+        `AstrosMobileRemote.vue`'s `handlePanicDown` comment currently
+        form a circular reference (each says "see the other"). Trim
+        the composable docstring to just the invariant; let the
+        consumer comment carry the browser-event rationale (touchstart
+        → synthesized mousedown).
+- [ ] **Commit D — I4 + I6: original-plan drift fixes (plan-only).**
+      - **I4**: `20260521-1135-phase3-mobile-remote-component.md:103`
+        still says "all four stories" — Task 4 is still unchecked, so
+        this is load-bearing for the QA verifier. Fix to "all six
+        stories" (matches the verification-gate fix from Commit 8).
+      - **I6a**: same plan, gotcha #4 (lines 48-50) still claims "the
+        composable must accept both [mouse/touch]" — shipped composable
+        is event-type-agnostic. Rewrite.
+      - **I6b**: same plan, Task 2 description (lines 78-79) says
+        `press(buttonValue: PageButton)` when the shipped emit narrows
+        to `FilledPageButton` after the I6 fix in Commit 5. Update the
+        type.
 
 ## Verification gates
 

--- a/.docs/plans/20260521-1700-phase3-review-fix-batch.md
+++ b/.docs/plans/20260521-1700-phase3-review-fix-batch.md
@@ -1,0 +1,136 @@
+# Phase 3 — Pre-push review fix batch
+
+**Date:** 2026-05-21
+**Tier:** Light plan (per CLAUDE.md Planning section)
+**Parent project:** [`current_project.md`](./current_project.md) — Remote Control Redesign + Mobile Remote
+**Branch:** `feature/phase3-mobile-remote-component` (continuing — same branch, per solo-dev branch hygiene)
+**Source:** Findings from the second `/pr-review-toolkit:review-pr` run on this branch (5 agents).
+
+## Goal
+
+Address the second-round pre-push toolkit findings before pushing the Phase 3 branch.
+The first round was addressed in commit `1ada630`; this batch covers what the second
+round surfaced after those fixes landed.
+
+## Triage decisions (push-back / YAGNI)
+
+- **Skip M10** ("verify mutation (b)"). Re-read of the plan deviations section
+  (lines 143-149) and the spec comment (`useHoldGesture.spec.ts:50-67`) shows they
+  agree: both say the original plan's vacuous-fix claim was wrong, and the test
+  *does* catch the mutation. No contradiction; no action.
+- **Skip M11** ("introduce `ConnectionStatus` union now"). YAGNI — zero in-tree
+  consumers of the component exist yet. The plan's "Phase 4 contract requirements"
+  section (lines 199-204) explicitly notes the widening is non-breaking at that
+  time because `true` continues to work as the default. Deferring follows the
+  CLAUDE.md "Don't design for hypothetical future requirements" rule.
+
+## Commit plan
+
+Each commit below is independently shippable and gets the standard pre-commit
+toolkit (prettier:write → lint:fix → build + vitest → `requesting-code-review`
+subagent on the diff against the prior commit). Plan-only commits skip the
+code-review step per the carve-out.
+
+- [x] **Commit 1 — Plan file (this file).** Plan-only commit; ships before any
+      source change per the Planning section.
+- [ ] **Commit 2 — C1 + I4: panic delivery contract + composable safety
+      docstring.** (a) Change `mobile_remote.panic_toast` from `"STOP ALL — sent"`
+      to `"STOP ALL — sending…"` in `enUS.json`. (b) Add an `onError?: (err:
+      unknown) => void` option to `UseHoldGestureOptions`; the existing
+      `console.error` branch falls back to that path so consumers can route to
+      their real logger. (c) Add a docstring on `useHoldGesture.start()`
+      explicitly noting "MUST be idempotent — consumers (e.g.,
+      `AstrosMobileRemote`) rely on this to absorb the synthesized mousedown
+      after touchstart." (d) Trim the `// Phase 4 contract:` block in
+      `AstrosMobileRemote.vue` `onFire` to a single WHY line about
+      fire-and-forget; the toast copy carries the rest.
+- [ ] **Commit 3 — I1 + M7: clamp `idx` at init.** Replace `const idx =
+      ref(props.initialIdx)` with a clamp using `Math.min/Math.max`. Introduce a
+      `currentIdx` computed (or reuse `safeIdx` from the existing
+      `currentPage` computed by extracting it) and route the pagination header
+      `{{ idx + 1 }} / {{ totalPages }}` and both `:disabled` checks through it
+      so out-of-range `initialIdx` no longer leaks into pagination UI. Side
+      effect: the EmptyPagesArray story's Next button correctly disables.
+      Update the read-time clamp comment to reflect the new structure.
+- [ ] **Commit 4 — I2: i18n the wordmark aria-label.** Replace
+      `aria-label="AstrOs"` with `:aria-label="$t('astros')"`. Key already
+      exists at `enUS.json:2`.
+- [ ] **Commit 5 — I6: `isFilledPageButton` type guard.** Add the predicate in
+      `types.ts`; replace the `button as AstrosMobileRemotePressEvent` cast in
+      `handlePress` with the guard so TypeScript proves the narrowing. Remove
+      the now-redundant cast-narrowing comment block (handles M6's
+      `handlePress` what-comment as a side effect).
+- [ ] **Commit 6 — I3: `AstrosMobileRemote` component tests.** New
+      `AstrosMobileRemote.spec.ts` covering:
+      - press-during-`active` lockout is suppressed (mounts, fires panic,
+        advances 600ms, clicks a button, asserts no `press` emit).
+      - unmount clears all three local timers (mounts, starts press timer,
+        unmounts before 220ms, advances 220ms, asserts no Vue warning + no
+        ref mutation).
+      - panic `onFire` cancels an in-flight press toast (mount, press a
+        button, fire panic 200ms later, advance to T+1700ms, assert toast
+        still shows panic text).
+      - emit-shape narrowing: pressing a `type: 'script'` button emits a
+        `FilledPageButton` whose `type` is not `'none'`.
+      - initialIdx out-of-range clamp on mount: mount with `initialIdx=10,
+        pages.length=3`, assert pagination header reads `"3 / 3"` and Next
+        button is disabled (validates the Commit 3 fix).
+      Follows the existing `AstrosFirmwareVersionDelta.spec.ts` i18n-stub
+      pattern.
+- [ ] **Commit 7 — Cleanup batch (M1, M2, M3, M4, M5, M6, M8).**
+      - **M1**: drop `@mouseleave="handlePanicUp"` from the panic button so a
+        drag-off mid-hold doesn't silently cancel. Matches touch-end-anywhere
+        UX and is more forgiving for a safety gesture.
+      - **M2**: consolidate `pressClearTimer`/`toastClearTimer`/`panicToastTimer`
+        + `clearToastTimer`/`clearPanicToastTimer` + the inline toast assignment
+        into a single `showToast(message: string, durationMs: number)` helper
+        owning one slot + one timer. Press toast and panic toast both call it.
+      - **M3**: drop the stale "until the real woff replaces
+        distant_galaxyregular" CSS comment fragment; keep the rationale
+        clause.
+      - **M4**: trim the `(mirrors the React useEffect in mobileRemote.jsx).
+        Important for Phase 2's preview rail…` caller-reference comment to the
+        WHY ("Reseat idx if the parent updates initialIdx after mount.").
+      - **M5**: covered by Commit 2's trim of the Phase 4 block.
+      - **M6**: trim what-comments on `slots` computed and `types.ts:3-8` to
+        one-line WHY. (`handlePress` what-comment is removed by Commit 5.)
+      - **M8**: add exactly-at-threshold boundary tests to
+        `useSwipeGesture.spec.ts` (deltaX = ±60 fires; deltaY = 40 still
+        fires for a horizontal swipe).
+- [ ] **Commit 8 — I5: plan-vs-code drift fixes (plan-only).** Edit
+      `20260521-1135-phase3-mobile-remote-component.md`:
+      - Hidden gotcha #3 (line 46-47): drop "and gate the timer callbacks on
+        a mounted ref"; shipped code uses `clearTimeout` alone.
+      - Out of scope (line 216-217): drop the Audiowide-wordmark-swap bullet;
+        the deviations section already states `distant_galaxyregular` is the
+        proprietary wordmark and no swap is pending.
+      - Verification gate (line 226): change "all four stories" to "all six
+        stories" (or "all stories"). Six shipped per the deviations section.
+
+## Verification gates
+
+- `npm run build` clean after each commit.
+- `npx vitest run` clean after each commit (including the new
+  `AstrosMobileRemote.spec.ts` in Commit 6).
+- `npm run lint` + `npm run prettier:write` clean before each commit.
+- `superpowers:requesting-code-review` on each implementation commit's diff
+  against the prior commit (per CLAUDE.md). Skip for plan-only commits 1 & 8.
+- Final pre-push: do NOT re-run `/pr-review-toolkit:review-pr` automatically;
+  the user can decide. The user runs `git push` manually via VS Code.
+
+## Out of scope
+
+- M11 (`ConnectionStatus` union widening) — deferred to Phase 4 per the YAGNI
+  triage above.
+- Any new functionality. This batch is strictly review-fix.
+- Component a11y batch (deferred to the planned a11y pass per memory).
+
+## Critical files touched
+
+- `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue` (commits 2, 3, 4, 5, 7)
+- `astros_vue/src/components/mobileRemote/mobileRemote/types.ts` (commits 5, 7)
+- `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts` (commit 6, new)
+- `astros_vue/src/composables/useHoldGesture.ts` (commit 2)
+- `astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts` (commit 7)
+- `astros_vue/src/locales/enUS.json` (commit 2)
+- `.docs/plans/20260521-1135-phase3-mobile-remote-component.md` (commit 8)

--- a/.docs/plans/current_project.md
+++ b/.docs/plans/current_project.md
@@ -26,12 +26,19 @@ fires the configured actions. M5Stack hardware remote continues to work in paral
       WebSocket PANIC, connection chip from WS state.
 - [ ] **Phase 5 — Page drag-reorder**: Install `vuedraggable` (or `vue-draggable-plus`),
       wire row reorder, persist new order on save.
-- [ ] **Phase 6 — Backend M5 → Remote rename + DB key migration**: Rename `M5Page` /
+- [x] **Phase 6 — Backend M5 → Remote rename + DB key migration**: Rename `M5Page` /
       `M5Button` / `M5ScriptList` backend types to `RemotePage` / `RemoteButton` /
       `RemoteScriptList` (frontend already uses generic names). Migrate the
       `remote_config.type` DB string from `astrOsScreen` → `remoteConfig` via a new
       reversible migration. Sequence: AFTER Phase 1 ships and bench-passes, so the M5
-      contract Phase 1 verifies isn't perturbed by the rename. Light plan tier.
+      contract Phase 1 verifies isn't perturbed by the rename. Light plan tier. —
+      shipped 2026-05-21 via PR #91 (merge `983d104`), wire shape pinned by new
+      `remote_config_controller.test.ts`.
+
+**Sequencing note added 2026-05-21:** Phase 3 ships ahead of Phase 2. Phase 2's
+live-preview rail imports the `AstrosMobileRemote` component built in Phase 3; doing
+them in original order would force a stub-then-replace cycle. See Phase 3 plan for
+rationale.
 
 ## Notes & Decisions
 

--- a/astros_vue/.storybook/preview.ts
+++ b/astros_vue/.storybook/preview.ts
@@ -20,6 +20,7 @@ import {
   IoAdd,
   IoHelpCircleOutline,
 } from 'oh-vue-icons/icons';
+import { MdDescription, MdFolder } from 'oh-vue-icons/icons/md';
 
 initialize();
 
@@ -40,6 +41,8 @@ setup((app) => {
     IoChevronDown,
     IoAdd,
     IoHelpCircleOutline,
+    MdDescription,
+    MdFolder,
   );
 
   app.component('v-icon', OhVueIcon);

--- a/astros_vue/src/components/mobileRemote/index.ts
+++ b/astros_vue/src/components/mobileRemote/index.ts
@@ -1,0 +1,2 @@
+export { default as AstrosMobileRemote } from './mobileRemote/AstrosMobileRemote.vue';
+export type { AstrosMobileRemotePressEvent } from './mobileRemote/types';

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import AstrosMobileRemote from './AstrosMobileRemote.vue';
+import type { AstrosMobileRemotePressEvent } from './types';
+import type { RemoteControlPage } from '@/models/remoteControl/remoteControlPage';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import enUS from '@/locales/enUS.json';
+
+// The component drives press-flash, press-toast, panic-toast, and the
+// useHoldGesture arm/cooldown timers via setTimeout. Drive time
+// deterministically so the assertions don't depend on real-time variance.
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Use the real enUS.json so a future locale-key rename (and any matching
+// component template miss) surfaces as a test failure instead of silently
+// passing on a duplicated copy.
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: { 'en-US': enUS },
+});
+
+function emptyButton(): PageButton {
+  return { id: '0', name: 'None', type: 'none' };
+}
+
+function scriptButton(id: string, name: string): PageButton {
+  return { id, name, type: 'script' };
+}
+
+function pageWith(id: string, name: string, button1: PageButton): RemoteControlPage {
+  return {
+    id,
+    name,
+    button1,
+    button2: emptyButton(),
+    button3: emptyButton(),
+    button4: emptyButton(),
+    button5: emptyButton(),
+    button6: emptyButton(),
+    button7: emptyButton(),
+    button8: emptyButton(),
+    button9: emptyButton(),
+  };
+}
+
+function render(props: {
+  pages: RemoteControlPage[];
+  initialIdx?: number;
+  compact?: boolean;
+  connected?: boolean;
+}) {
+  return mount(AstrosMobileRemote, {
+    props,
+    global: {
+      plugins: [i18n],
+      // oh-vue-icons is registered in main.ts; tests don't bootstrap it,
+      // so stub <v-icon> to a marker span. The icon itself is decorative
+      // (aria-hidden) so the stub has no behavioral impact.
+      stubs: { 'v-icon': { template: '<span data-stub="v-icon"></span>' } },
+    },
+  });
+}
+
+describe('AstrosMobileRemote', () => {
+  it('suppresses button presses while the panic gesture is in the active lockout', async () => {
+    // Safety contract: once STOP ALL fires, normal button presses must NOT
+    // emit during the 2.2s cooldown. A regression that flips the guard
+    // (e.g., to `=== 'arming'`) or drops it would let an operator fire
+    // scripts during the panic lockout — exactly what the lockout exists
+    // to prevent.
+    const wrapper = render({
+      pages: [pageWith('p1', 'Greetings', scriptButton('script-wave', 'Wave Hello'))],
+    });
+
+    const panic = wrapper.find('.astros-mobile-remote__panic');
+    await panic.trigger('mousedown');
+    vi.advanceTimersByTime(600);
+    await flushPromises();
+    // Now in 'active' state.
+
+    await wrapper.find('.astros-mobile-remote__slot--filled').trigger('click');
+    expect(wrapper.emitted('press')).toBeUndefined();
+  });
+
+  it('press-path timers are cleared on unmount before they fire', async () => {
+    // Vacuous-fix guard — verified mechanically by reverting each clearX()
+    // call in onBeforeUnmount and confirming this test fails. Vue 3 does
+    // NOT warn on post-unmount ref writes (the ref persists in closure),
+    // so a console.warn assertion would be vacuous. Instead count pending
+    // fake timers directly: after unmount with all clears in place, the
+    // pre-unmount-pending press-path timers must be gone.
+    //
+    // This test fails under either mutation:
+    //   (a) Drop clearPressTimer() from onBeforeUnmount → pressClearTimer
+    //       (220ms) is still pending at unmount → count >= 1.
+    //   (b) Drop clearToastTimer() from onBeforeUnmount → toastClearTimer
+    //       (1600ms) is still pending at unmount → count >= 1.
+    const wrapper = render({
+      pages: [pageWith('p1', 'Greetings', scriptButton('script-wave', 'Wave Hello'))],
+    });
+    // Snapshot baseline so future watchers / debounces in the mount path
+    // don't silently inflate the delta and mask a real leak.
+    const baseline = vi.getTimerCount();
+    await wrapper.find('.astros-mobile-remote__slot--filled').trigger('click');
+    await flushPromises();
+    // Both press timers are scheduled and not yet fired (pressClearTimer
+    // would fire at T=220ms, toastClearTimer at T=1600ms).
+    expect(vi.getTimerCount() - baseline).toBe(2);
+
+    wrapper.unmount();
+    expect(vi.getTimerCount()).toBe(baseline);
+  });
+
+  it('panic-path timers are cleared on unmount before they fire', async () => {
+    // Companion to the press-path test. Drives the panic gesture into the
+    // 'active' state so panicToastTimer (1.8s) and the composable's
+    // cooldownTimer (2.2s) are both pending at unmount.
+    //
+    // This test fails under the mutation:
+    //   (c) Drop clearPanicToastTimer() from onBeforeUnmount →
+    //       panicToastTimer still pending after unmount → count >= 1.
+    //   It also re-verifies useHoldGesture.onScopeDispose: dropping the
+    //   onScopeDispose hook in the composable leaves cooldownTimer
+    //   pending → count >= 1.
+    const wrapper = render({
+      pages: [pageWith('p1', 'Greetings', scriptButton('script-wave', 'Wave Hello'))],
+    });
+    const baseline = vi.getTimerCount();
+    await wrapper.find('.astros-mobile-remote__panic').trigger('mousedown');
+    vi.advanceTimersByTime(600);
+    await flushPromises();
+    // Now active: panicToastTimer (1800ms remaining) + cooldownTimer
+    // (2200ms remaining) are pending.
+    expect(vi.getTimerCount() - baseline).toBe(2);
+
+    wrapper.unmount();
+    expect(vi.getTimerCount()).toBe(baseline);
+  });
+
+  it('panic onFire cancels the in-flight press toast so it does not clear the panic toast early', async () => {
+    // The press toast (1.6s lifetime) and panic toast (1.8s lifetime) share
+    // one DOM slot. If the press timer is not cancelled when panic fires,
+    // the press-toast clear at T=1600ms nulls the panic toast 1000ms early.
+    const wrapper = render({
+      pages: [pageWith('p1', 'Greetings', scriptButton('script-wave', 'Wave Hello'))],
+    });
+
+    // T=0: press.
+    await wrapper.find('.astros-mobile-remote__slot--filled').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__toast').text()).toBe('Sent: Wave Hello');
+
+    // T=200ms: begin panic arming.
+    vi.advanceTimersByTime(200);
+    await wrapper.find('.astros-mobile-remote__panic').trigger('mousedown');
+
+    // T=800ms: panic fires; onFire clears the press-toast timer and shows
+    // the panic toast. Press toast WOULD have cleared at T=1600ms.
+    vi.advanceTimersByTime(600);
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__toast').text()).toBe('STOP ALL — sending…');
+
+    // T=1601ms (past the press toast's original clear time). Without the
+    // clearToastTimer call in onFire, the panic toast would now be null.
+    vi.advanceTimersByTime(801);
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__toast').text()).toBe('STOP ALL — sending…');
+  });
+
+  it('emit("press") narrows to FilledPageButton — never includes type: "none"', async () => {
+    // Pins the emit-shape contract that Phase 4 will switch on. A
+    // regression that weakens the !isFilledPageButton early-return in
+    // handlePress would let an empty slot leak into the emit payload.
+    const wrapper = render({
+      pages: [pageWith('p1', 'Greetings', scriptButton('script-wave', 'Wave Hello'))],
+    });
+
+    // Click the filled button.
+    await wrapper.find('.astros-mobile-remote__slot--filled').trigger('click');
+    await flushPromises();
+
+    const emitted = wrapper.emitted('press');
+    expect(emitted).toHaveLength(1);
+    const payload = emitted![0]![0] as AstrosMobileRemotePressEvent;
+    expect(payload.type).not.toBe('none');
+    expect(payload).toMatchObject({
+      id: 'script-wave',
+      name: 'Wave Hello',
+      type: 'script',
+    });
+
+    // Empty slots are disabled at the button level, so a click on one
+    // can't even reach handlePress — but verify the disabled attribute
+    // is set so a future template change doesn't quietly enable them.
+    const emptyButtons = wrapper.findAll(
+      '.astros-mobile-remote__slot:not(.astros-mobile-remote__slot--filled)',
+    );
+    expect(emptyButtons.length).toBeGreaterThan(0);
+    for (const b of emptyButtons) {
+      expect(b.attributes('disabled')).toBeDefined();
+    }
+  });
+
+  it('clamps an out-of-range initialIdx at mount so pagination UI does not lie', async () => {
+    // Pins the I1 fix from the pre-push review. Without the init-time
+    // clamp, the pagination header would render "11 / 3" and the next
+    // button would be enabled-but-no-op.
+    const pages = [
+      pageWith('p1', 'Greetings', scriptButton('a', 'A')),
+      pageWith('p2', 'Performance', scriptButton('b', 'B')),
+      pageWith('p3', 'Idle', scriptButton('c', 'C')),
+    ];
+    const wrapper = render({ pages, initialIdx: 10 });
+    await flushPromises();
+
+    // Pagination header reads "3 / 3" (clamped to last valid index).
+    expect(wrapper.find('.astros-mobile-remote__page-pagination').text()).toBe('3 / 3');
+
+    // Next button disabled (at last page), prev enabled.
+    const navs = wrapper.findAll('.astros-mobile-remote__page-nav');
+    expect(navs).toHaveLength(2);
+    expect(navs[0]!.attributes('disabled')).toBeUndefined();
+    expect(navs[1]!.attributes('disabled')).toBeDefined();
+
+    // The displayed page is the last one in the array.
+    expect(wrapper.find('.astros-mobile-remote__page-name').text()).toBe('Idle');
+  });
+});

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
@@ -101,8 +101,8 @@ describe('AstrosMobileRemote', () => {
     // This test fails under either mutation:
     //   (a) Drop clearPressTimer() from onBeforeUnmount → pressClearTimer
     //       (220ms) is still pending at unmount → count >= 1.
-    //   (b) Drop clearToastTimer() from onBeforeUnmount → toastClearTimer
-    //       (1600ms) is still pending at unmount → count >= 1.
+    //   (b) Drop clearToast() from onBeforeUnmount → the showToast-owned
+    //       toast timer (1600ms) is still pending at unmount → count >= 1.
     const wrapper = render({
       pages: [pageWith('p1', 'Greetings', scriptButton('script-wave', 'Wave Hello'))],
     });
@@ -121,12 +121,13 @@ describe('AstrosMobileRemote', () => {
 
   it('panic-path timers are cleared on unmount before they fire', async () => {
     // Companion to the press-path test. Drives the panic gesture into the
-    // 'active' state so panicToastTimer (1.8s) and the composable's
-    // cooldownTimer (2.2s) are both pending at unmount.
+    // 'active' state so the showToast-owned toast timer (1.8s) and the
+    // composable's cooldownTimer (2.2s) are both pending at unmount.
     //
     // This test fails under the mutation:
-    //   (c) Drop clearPanicToastTimer() from onBeforeUnmount →
-    //       panicToastTimer still pending after unmount → count >= 1.
+    //   (c) Drop clearToast() from onBeforeUnmount → the showToast-owned
+    //       toast timer (set to 1800ms by panic onFire) still pending
+    //       after unmount → count >= 1.
     //   It also re-verifies useHoldGesture.onScopeDispose: dropping the
     //   onScopeDispose hook in the composable leaves cooldownTimer
     //   pending → count >= 1.
@@ -137,7 +138,7 @@ describe('AstrosMobileRemote', () => {
     await wrapper.find('.astros-mobile-remote__panic').trigger('mousedown');
     vi.advanceTimersByTime(600);
     await flushPromises();
-    // Now active: panicToastTimer (1800ms remaining) + cooldownTimer
+    // Now active: toast timer (1800ms remaining) + cooldownTimer
     // (2200ms remaining) are pending.
     expect(vi.getTimerCount() - baseline).toBe(2);
 
@@ -162,14 +163,16 @@ describe('AstrosMobileRemote', () => {
     vi.advanceTimersByTime(200);
     await wrapper.find('.astros-mobile-remote__panic').trigger('mousedown');
 
-    // T=800ms: panic fires; onFire clears the press-toast timer and shows
-    // the panic toast. Press toast WOULD have cleared at T=1600ms.
+    // T=800ms: panic fires; onFire calls showToast which implicitly cancels
+    // the in-flight press-toast timer and schedules the panic-toast clear
+    // 1800ms out. Press toast WOULD have cleared at T=1600ms.
     vi.advanceTimersByTime(600);
     await flushPromises();
     expect(wrapper.find('.astros-mobile-remote__toast').text()).toBe('STOP ALL — sending…');
 
-    // T=1601ms (past the press toast's original clear time). Without the
-    // clearToastTimer call in onFire, the panic toast would now be null.
+    // T=1601ms (past the press toast's original clear time). Without
+    // showToast's implicit cancel of the in-flight press timer, the panic
+    // toast would now be null.
     vi.advanceTimersByTime(801);
     await flushPromises();
     expect(wrapper.find('.astros-mobile-remote__toast').text()).toBe('STOP ALL — sending…');

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
@@ -213,9 +213,9 @@ describe('AstrosMobileRemote', () => {
   });
 
   it('clamps an out-of-range initialIdx at mount so pagination UI does not lie', async () => {
-    // Pins the I1 fix from the pre-push review. Without the init-time
-    // clamp, the pagination header would render "11 / 3" and the next
-    // button would be enabled-but-no-op.
+    // Without the init-time clamp, the pagination header would render
+    // "11 / 3" and the next button would be enabled-but-no-op when a
+    // parent passes initialIdx beyond pages.length-1.
     const pages = [
       pageWith('p1', 'Greetings', scriptButton('a', 'A')),
       pageWith('p2', 'Performance', scriptButton('b', 'B')),
@@ -235,5 +235,57 @@ describe('AstrosMobileRemote', () => {
 
     // The displayed page is the last one in the array.
     expect(wrapper.find('.astros-mobile-remote__page-name').text()).toBe('Idle');
+  });
+
+  it('reseats the displayed page when the parent updates initialIdx after mount', async () => {
+    // Vacuous-fix guard: removing the `watch(() => props.initialIdx, ...)`
+    // block makes this test fail. The read-time currentIdx clamp does NOT
+    // mask the regression here because clampIdx only fires when idx.value
+    // itself changes — without the watcher, an in-range initialIdx update
+    // is silently ignored.
+    const pages = [
+      pageWith('p1', 'Greetings', scriptButton('a', 'A')),
+      pageWith('p2', 'Performance', scriptButton('b', 'B')),
+      pageWith('p3', 'Idle', scriptButton('c', 'C')),
+    ];
+    const wrapper = render({ pages, initialIdx: 0 });
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__page-name').text()).toBe('Greetings');
+
+    await wrapper.setProps({ initialIdx: 2 });
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__page-name').text()).toBe('Idle');
+    expect(wrapper.find('.astros-mobile-remote__page-pagination').text()).toBe('3 / 3');
+  });
+
+  it('settles idx after a shrink so a subsequent grow-back does not teleport the user to a stale page', async () => {
+    // Vacuous-fix guard for the pages.length watcher. The read-time
+    // currentIdx clamp masks the shrink itself (rendering looks fine
+    // either way), but the watcher's load-bearing job is to mutate
+    // idx.value so a later grow-back doesn't reveal the stale raw
+    // index. Without the watcher, the shrink-then-grow sequence below
+    // jumps the user back to page 3 (idx stayed at 2) instead of
+    // staying on page 1 (idx settled to 0 by the watcher).
+    const all = [
+      pageWith('p1', 'Greetings', scriptButton('a', 'A')),
+      pageWith('p2', 'Performance', scriptButton('b', 'B')),
+      pageWith('p3', 'Idle', scriptButton('c', 'C')),
+    ];
+    const wrapper = render({ pages: all, initialIdx: 2 });
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__page-name').text()).toBe('Idle');
+
+    // Shrink: only the first page remains.
+    await wrapper.setProps({ pages: all.slice(0, 1) });
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__page-name').text()).toBe('Greetings');
+
+    // Grow back to all three. With the watcher, idx is now 0 (settled
+    // during the shrink), so the user stays on the first page. Without
+    // the watcher, idx is still 2 and we teleport back to "Idle".
+    await wrapper.setProps({ pages: all });
+    await flushPromises();
+    expect(wrapper.find('.astros-mobile-remote__page-name').text()).toBe('Greetings');
+    expect(wrapper.find('.astros-mobile-remote__page-pagination').text()).toBe('1 / 3');
   });
 });

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts
@@ -179,14 +179,13 @@ describe('AstrosMobileRemote', () => {
   });
 
   it('emit("press") narrows to FilledPageButton — never includes type: "none"', async () => {
-    // Pins the emit-shape contract that Phase 4 will switch on. A
-    // regression that weakens the !isFilledPageButton early-return in
-    // handlePress would let an empty slot leak into the emit payload.
+    // A regression that weakens the !isFilledPageButton early-return in
+    // handlePress would let an empty slot leak into the emit payload to a
+    // consumer that expects to switch on the discriminator.
     const wrapper = render({
       pages: [pageWith('p1', 'Greetings', scriptButton('script-wave', 'Wave Hello'))],
     });
 
-    // Click the filled button.
     await wrapper.find('.astros-mobile-remote__slot--filled').trigger('click');
     await flushPromises();
 

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.stories.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.stories.ts
@@ -1,0 +1,178 @@
+import { type Meta, type StoryObj } from '@storybook/vue3';
+import AstrosMobileRemote from './AstrosMobileRemote.vue';
+import type { RemoteControlPage } from '@/models/remoteControl/remoteControlPage';
+import { createDefaultPage } from '@/stores/remoteControl';
+
+// The mobile remote is sized to fill its parent. Wrap each story in a
+// phone-shaped container so the layout reads the way it would inside the
+// MiniPhone bezel that Phase 2's preview rail provides.
+const phoneWrapper = `
+  <div style="
+    width: 320px;
+    height: 580px;
+    border: 1px solid #d6e0e6;
+    border-radius: 24px;
+    overflow: hidden;
+    background: #fff;
+  ">
+    <AstrosMobileRemote v-bind="args" @press="(e) => console.log('press', e)" @panic="() => console.log('panic')" />
+  </div>
+`;
+
+const compactWrapper = `
+  <div style="
+    width: 220px;
+    height: 440px;
+    border: 1px solid #d6e0e6;
+    border-radius: 18px;
+    overflow: hidden;
+    background: #fff;
+  ">
+    <AstrosMobileRemote v-bind="args" @press="(e) => console.log('press', e)" @panic="() => console.log('panic')" />
+  </div>
+`;
+
+function mixedPage(): RemoteControlPage {
+  const page = createDefaultPage(0);
+  page.name = 'Greetings';
+  page.button1 = { id: 'script-wave', name: 'Wave Hello', type: 'script' };
+  page.button2 = { id: 'script-beep', name: 'Beep Boop', type: 'script' };
+  page.button3 = { id: 'playlist-parade', name: 'Parade Mode', type: 'playlist' };
+  page.button4 = { id: 'script-spin', name: 'Spin Dome', type: 'script' };
+  page.button5 = { id: 'script-tracking', name: 'Start Tracking', type: 'script' };
+  page.button7 = { id: 'playlist-idle', name: 'Idle Loops', type: 'playlist' };
+  page.button9 = { id: 'script-shutdown', name: 'Shutdown', type: 'script' };
+  return page;
+}
+
+function sparsePage(): RemoteControlPage {
+  const page = createDefaultPage(1);
+  page.name = 'Performance';
+  page.button1 = { id: 'script-cue', name: 'Cue One', type: 'script' };
+  page.button5 = { id: 'playlist-show', name: 'Show Track', type: 'playlist' };
+  page.button9 = { id: 'script-bow', name: 'Take a Bow', type: 'script' };
+  return page;
+}
+
+function emptyPage(): RemoteControlPage {
+  const page = createDefaultPage(2);
+  page.name = 'Idle Loops';
+  return page;
+}
+
+const allPages = [mixedPage(), sparsePage(), emptyPage()];
+
+const meta = {
+  title: 'components/mobileRemote/AstrosMobileRemote',
+  component: AstrosMobileRemote,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AstrosMobileRemote>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Page1Mixed: Story = {
+  name: 'Page 1 — mixed (7 of 9 assigned)',
+  args: {
+    pages: allPages,
+    initialIdx: 0,
+    compact: false,
+    connected: true,
+  },
+  render: (args) => ({
+    components: { AstrosMobileRemote },
+    setup() {
+      return { args };
+    },
+    template: phoneWrapper,
+  }),
+};
+
+export const Page2Sparse: Story = {
+  name: 'Page 2 — sparse (3 of 9 assigned)',
+  args: {
+    pages: allPages,
+    initialIdx: 1,
+    compact: false,
+    connected: true,
+  },
+  render: (args) => ({
+    components: { AstrosMobileRemote },
+    setup() {
+      return { args };
+    },
+    template: phoneWrapper,
+  }),
+};
+
+export const Page3Empty: Story = {
+  name: 'Page 3 — empty (all slots dashed)',
+  args: {
+    pages: allPages,
+    initialIdx: 2,
+    compact: false,
+    connected: true,
+  },
+  render: (args) => ({
+    components: { AstrosMobileRemote },
+    setup() {
+      return { args };
+    },
+    template: phoneWrapper,
+  }),
+};
+
+export const CompactPreview: Story = {
+  name: 'Compact preview (Phase 2 rail mode)',
+  args: {
+    pages: allPages,
+    initialIdx: 0,
+    compact: true,
+    connected: true,
+  },
+  render: (args) => ({
+    components: { AstrosMobileRemote },
+    setup() {
+      return { args };
+    },
+    template: compactWrapper,
+  }),
+};
+
+export const Disconnected: Story = {
+  name: 'Disconnected (no Connected chip)',
+  args: {
+    pages: allPages,
+    initialIdx: 0,
+    compact: false,
+    connected: false,
+  },
+  render: (args) => ({
+    components: { AstrosMobileRemote },
+    setup() {
+      return { args };
+    },
+    template: phoneWrapper,
+  }),
+};
+
+export const EmptyPagesArray: Story = {
+  name: 'Empty pages array (safety branch)',
+  args: {
+    pages: [],
+    initialIdx: 0,
+    compact: false,
+    connected: true,
+  },
+  render: (args) => ({
+    components: { AstrosMobileRemote },
+    setup() {
+      return { args };
+    },
+    template: phoneWrapper,
+  }),
+};

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.stories.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.stories.ts
@@ -4,8 +4,8 @@ import type { RemoteControlPage } from '@/models/remoteControl/remoteControlPage
 import { createDefaultPage } from '@/stores/remoteControl';
 
 // The mobile remote is sized to fill its parent. Wrap each story in a
-// phone-shaped container so the layout reads the way it would inside the
-// MiniPhone bezel that Phase 2's preview rail provides.
+// phone-shaped container so the layout reads the way it would when
+// embedded in a parent component's bezel.
 const phoneWrapper = `
   <div style="
     width: 320px;

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -155,6 +155,58 @@ function selectPage(target: number) {
   if (target >= 0 && target < totalPages.value) idx.value = target;
 }
 
+// Swipe-to-paginate on the 3x3 grid surface. Tracking starts on touchstart
+// and the delta is computed on touchend; anything beyond the horizontal
+// threshold AND under the vertical threshold counts as a swipe. The grid is
+// the only swipe surface so the top bar / pagination row / panic button stay
+// unaffected.
+const SWIPE_HORIZONTAL_THRESHOLD_PX = 60;
+const SWIPE_VERTICAL_MAX_PX = 40;
+let swipeStartX: number | null = null;
+let swipeStartY: number | null = null;
+
+function handleGridTouchStart(event: TouchEvent) {
+  if (event.touches.length !== 1) {
+    // A second finger landed mid-gesture (e.g., two-handed grip, accidental
+    // pinch). Abort any in-progress swipe so the eventual touchend doesn't
+    // evaluate a delta from the first-finger start to the second-finger end.
+    swipeStartX = null;
+    swipeStartY = null;
+    return;
+  }
+  const touch = event.touches[0];
+  if (!touch) return;
+  swipeStartX = touch.clientX;
+  swipeStartY = touch.clientY;
+}
+
+function handleGridTouchEnd(event: TouchEvent) {
+  if (swipeStartX === null || swipeStartY === null) return;
+  const touch = event.changedTouches[0];
+  if (!touch) return;
+  const deltaX = touch.clientX - swipeStartX;
+  const deltaY = touch.clientY - swipeStartY;
+  swipeStartX = null;
+  swipeStartY = null;
+
+  if (Math.abs(deltaX) < SWIPE_HORIZONTAL_THRESHOLD_PX) return;
+  if (Math.abs(deltaY) > SWIPE_VERTICAL_MAX_PX) return;
+
+  // Suppress the synthesized click so a swipe that crosses a button slot
+  // doesn't also fire that button's press handler.
+  event.preventDefault();
+
+  // Convention matches iOS Photos / Twitter / Instagram: the content moves
+  // opposite the finger. Swipe LEFT → next page; swipe RIGHT → prev page.
+  if (deltaX < 0) goNext();
+  else goPrev();
+}
+
+function handleGridTouchCancel() {
+  swipeStartX = null;
+  swipeStartY = null;
+}
+
 function handlePanicDown(event: Event) {
   // Touch handlers preventDefault to suppress the synthetic mousedown that
   // follows on most mobile browsers; without this the hold gesture would
@@ -192,7 +244,15 @@ const stopAllLabel = computed(() => {
   >
     <!-- Top bar -->
     <div class="astros-mobile-remote__top-bar">
-      <span class="astros-mobile-remote__wordmark font-starwars">AstrOs</span>
+      <span
+        class="astros-mobile-remote__wordmark font-starwars"
+        aria-label="AstrOs"
+      >
+        <span class="astros-mobile-remote__wordmark-cap">A</span>str<span
+          class="astros-mobile-remote__wordmark-cap"
+          >O</span
+        >s
+      </span>
       <span
         v-if="connected"
         class="astros-mobile-remote__connection"
@@ -225,6 +285,9 @@ const stopAllLabel = computed(() => {
     <div
       v-if="currentPage"
       class="astros-mobile-remote__grid"
+      @touchstart="handleGridTouchStart"
+      @touchend="handleGridTouchEnd"
+      @touchcancel="handleGridTouchCancel"
     >
       <button
         v-for="(button, i) in slots"
@@ -396,9 +459,20 @@ const stopAllLabel = computed(() => {
 .astros-mobile-remote__wordmark {
   font-size: 22px;
   letter-spacing: 0.02em;
+  /* Per-letter line-height tightens to keep the larger caps from stretching
+   * the top bar height when the size factor scales above 1.2. */
+  line-height: 1;
 }
 .astros-mobile-remote--compact .astros-mobile-remote__wordmark {
   font-size: 14px;
+}
+
+/* Capital A and O scale up to enforce the "AstrOs" branding rhythm — the
+ * proprietary wordmark renders the caps as larger glyphs and this approximates
+ * that until the real woff replaces distant_galaxyregular. Uses em (not px)
+ * so the compact and full sizes both scale proportionally. */
+.astros-mobile-remote__wordmark-cap {
+  font-size: 1.25em;
 }
 
 .astros-mobile-remote__connection {
@@ -489,7 +563,10 @@ const stopAllLabel = computed(() => {
   background: var(--mr-base-200);
   color: var(--mr-ink-soft);
   font-family: inherit;
-  font-size: 18px;
+  /* Reduced from the handoff's 18px / 12px to accommodate longer script and
+   * playlist titles before the 3-line clamp truncates. Bold (700) keeps the
+   * labels readable at arm's length on the handheld remote. */
+  font-size: 15px;
   font-weight: 700;
   line-height: 1.15;
   cursor: default;
@@ -500,7 +577,7 @@ const stopAllLabel = computed(() => {
   gap: 3px;
   padding: 6px;
   border-radius: 12px;
-  font-size: 12px;
+  font-size: 11px;
 }
 
 .astros-mobile-remote__slot--filled {

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -59,9 +59,12 @@ watch(
   },
 );
 
-// Clamp idx when pages shrinks below the current index — otherwise the
-// component falls into the empty-state branch even though there are still
-// valid pages (e.g., parent deletes pages without updating initialIdx).
+// Settle idx when pages shrinks. The read-time `currentIdx` clamp keeps
+// rendering correct on its own, but the watcher must mutate `idx.value`
+// so the user doesn't teleport to a stale position if the parent later
+// grows `pages` back. Product intent: a shrink is a reset — when pages
+// return, the user stays on the post-shrink page rather than jumping to
+// some prior index they never re-navigated to.
 watch(
   () => props.pages.length,
   (newLen) => {

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -1,0 +1,758 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch, type PropType } from 'vue';
+import { useI18n } from 'vue-i18n';
+import type { RemoteControlPage } from '@/models/remoteControl/remoteControlPage';
+import { BUTTON_KEYS } from '@/models/remoteControl/remoteControlPage';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import { useHoldGesture } from '@/composables/useHoldGesture';
+import type { AstrosMobileRemotePressEvent } from './types';
+
+const props = defineProps({
+  pages: {
+    type: Array as PropType<RemoteControlPage[]>,
+    required: true,
+  },
+  initialIdx: {
+    type: Number,
+    default: 0,
+  },
+  compact: {
+    type: Boolean,
+    default: false,
+  },
+  // Phase 4 will drive this from the WebSocket connection store. Default to
+  // `true` so the standalone-component case (and Storybook) renders the
+  // intended "Connected" chip.
+  connected: {
+    type: Boolean,
+    default: true,
+  },
+});
+
+const emit = defineEmits<{
+  press: [event: AstrosMobileRemotePressEvent];
+  panic: [];
+}>();
+
+const { t } = useI18n();
+
+const idx = ref(props.initialIdx);
+// Keep idx in sync if the parent reseats initialIdx (mirrors the React
+// useEffect in mobileRemote.jsx). Important for Phase 2's preview rail
+// where the editor switches selected page.
+watch(
+  () => props.initialIdx,
+  (next) => {
+    if (next >= 0 && next < props.pages.length) {
+      idx.value = next;
+    }
+  },
+);
+
+// Clamp idx when pages shrinks below the current index — otherwise the
+// component falls into the empty-state branch even though there are still
+// valid pages (e.g., parent deletes pages without updating initialIdx).
+watch(
+  () => props.pages.length,
+  (newLen) => {
+    if (newLen === 0) {
+      idx.value = 0;
+      return;
+    }
+    if (idx.value >= newLen) idx.value = newLen - 1;
+  },
+);
+
+const pressedButtonId = ref<string | null>(null);
+const toastMessage = ref<string | null>(null);
+
+let pressClearTimer: ReturnType<typeof setTimeout> | null = null;
+let toastClearTimer: ReturnType<typeof setTimeout> | null = null;
+let panicToastTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearPressTimer() {
+  if (pressClearTimer !== null) {
+    clearTimeout(pressClearTimer);
+    pressClearTimer = null;
+  }
+}
+
+function clearToastTimer() {
+  if (toastClearTimer !== null) {
+    clearTimeout(toastClearTimer);
+    toastClearTimer = null;
+  }
+}
+
+function clearPanicToastTimer() {
+  if (panicToastTimer !== null) {
+    clearTimeout(panicToastTimer);
+    panicToastTimer = null;
+  }
+}
+
+const panic = useHoldGesture({
+  holdMs: 600,
+  cooldownMs: 2200,
+  onFire: () => {
+    toastMessage.value = t('mobile_remote.panic_toast');
+    clearPanicToastTimer();
+    panicToastTimer = setTimeout(() => {
+      toastMessage.value = null;
+      panicToastTimer = null;
+    }, 1800);
+    emit('panic');
+  },
+});
+
+const currentPage = computed<RemoteControlPage | null>(() => props.pages[idx.value] ?? null);
+const totalPages = computed(() => props.pages.length);
+
+// BUTTON_KEYS is the canonical 1..9 ordering shared with the backend; iterating
+// it once into a slots array means each template binding reads one variable
+// instead of re-calling a function per attribute expression.
+const slots = computed(() => {
+  const page = currentPage.value;
+  if (page === null) return [];
+  return BUTTON_KEYS.map((key) => page[key]);
+});
+
+function handlePress(button: PageButton) {
+  if (button.type === 'none') return;
+  // 'arming' is NOT blocked here: the user may change their mind mid-hold
+  // and the 600ms window is short enough that "two-handed" presses aren't
+  // a real failure mode. Only the committed 'active' lockout (the 2.2s
+  // post-fire window) suppresses presses. Matches the handoff JSX.
+  if (panic.state.value === 'active') return;
+
+  pressedButtonId.value = button.id;
+  toastMessage.value = t('mobile_remote.press_toast', { name: button.name });
+
+  clearPressTimer();
+  pressClearTimer = setTimeout(() => {
+    pressedButtonId.value = null;
+    pressClearTimer = null;
+  }, 220);
+
+  clearToastTimer();
+  toastClearTimer = setTimeout(() => {
+    toastMessage.value = null;
+    toastClearTimer = null;
+  }, 1600);
+
+  emit('press', button);
+}
+
+function goPrev() {
+  if (idx.value > 0) idx.value -= 1;
+}
+
+function goNext() {
+  if (idx.value < totalPages.value - 1) idx.value += 1;
+}
+
+function selectPage(target: number) {
+  if (target >= 0 && target < totalPages.value) idx.value = target;
+}
+
+function handlePanicDown(event: Event) {
+  // Touch handlers preventDefault to suppress the synthetic mousedown that
+  // follows on most mobile browsers; without this the hold gesture would
+  // fire start() twice and the second call is a no-op anyway, but the
+  // touch path is the authoritative one.
+  if (event.type === 'touchstart') event.preventDefault();
+  panic.start();
+}
+
+function handlePanicUp(event: Event) {
+  if (event.type === 'touchend') event.preventDefault();
+  panic.cancel();
+}
+
+onBeforeUnmount(() => {
+  clearPressTimer();
+  clearToastTimer();
+  clearPanicToastTimer();
+  // The useHoldGesture composable cleans up its own timers via onScopeDispose.
+});
+
+const stopAllLabel = computed(() => {
+  if (panic.state.value === 'active') return t('mobile_remote.stop_all_active');
+  if (panic.state.value === 'arming') return t('mobile_remote.stop_all_arming');
+  return t('mobile_remote.stop_all_idle');
+});
+</script>
+
+<template>
+  <div
+    class="astros-mobile-remote"
+    :class="{ 'astros-mobile-remote--compact': compact }"
+    role="region"
+    :aria-label="$t('mobile_remote.region_label')"
+  >
+    <!-- Top bar -->
+    <div class="astros-mobile-remote__top-bar">
+      <span class="astros-mobile-remote__wordmark font-starwars">AstrOs</span>
+      <span
+        v-if="connected"
+        class="astros-mobile-remote__connection"
+      >
+        <span
+          class="astros-mobile-remote__connection-dot"
+          aria-hidden="true"
+        ></span>
+        {{ $t('mobile_remote.connected_label') }}
+      </span>
+    </div>
+
+    <!-- Page header -->
+    <div
+      v-if="currentPage"
+      class="astros-mobile-remote__page-header"
+    >
+      <span class="astros-mobile-remote__page-name">{{ currentPage.name }}</span>
+      <span class="astros-mobile-remote__page-pagination"> {{ idx + 1 }} / {{ totalPages }} </span>
+    </div>
+    <div
+      v-else
+      class="astros-mobile-remote__empty-state"
+      role="status"
+    >
+      {{ $t('mobile_remote.no_pages') }}
+    </div>
+
+    <!-- 3x3 grid -->
+    <div
+      v-if="currentPage"
+      class="astros-mobile-remote__grid"
+    >
+      <button
+        v-for="(button, i) in slots"
+        :key="i"
+        type="button"
+        class="astros-mobile-remote__slot"
+        :class="{
+          'astros-mobile-remote__slot--filled': button.type !== 'none',
+          'astros-mobile-remote__slot--pressed':
+            button.type !== 'none' && pressedButtonId === button.id,
+        }"
+        :disabled="button.type === 'none'"
+        :aria-label="
+          button.type === 'none'
+            ? $t('mobile_remote.empty_slot_aria', { number: i + 1 })
+            : button.name
+        "
+        @click="handlePress(button)"
+      >
+        <span
+          v-if="button.type !== 'none'"
+          class="astros-mobile-remote__chip"
+          :class="`astros-mobile-remote__chip--${button.type}`"
+        >
+          <v-icon
+            :name="button.type === 'script' ? 'md-description' : 'md-folder'"
+            class="astros-mobile-remote__chip-icon"
+            aria-hidden="true"
+          />
+          {{
+            button.type === 'script'
+              ? $t('mobile_remote.chip_script')
+              : $t('mobile_remote.chip_playlist')
+          }}
+        </span>
+        <span class="astros-mobile-remote__slot-label">
+          {{ button.type !== 'none' ? button.name : '—' }}
+        </span>
+      </button>
+    </div>
+
+    <!-- Pagination row -->
+    <div class="astros-mobile-remote__pagination">
+      <button
+        type="button"
+        class="astros-mobile-remote__page-nav"
+        :disabled="idx === 0"
+        :aria-label="$t('mobile_remote.prev_page_aria')"
+        @click="goPrev"
+      >
+        ‹
+      </button>
+      <div class="astros-mobile-remote__dots">
+        <button
+          v-for="(page, i) in pages"
+          :key="page.id"
+          type="button"
+          class="astros-mobile-remote__dot"
+          :class="{ 'astros-mobile-remote__dot--active': i === idx }"
+          :aria-label="$t('mobile_remote.dot_aria', { number: i + 1 })"
+          :aria-current="i === idx ? 'page' : undefined"
+          @click="selectPage(i)"
+        ></button>
+      </div>
+      <button
+        type="button"
+        class="astros-mobile-remote__page-nav"
+        :disabled="idx === totalPages - 1"
+        :aria-label="$t('mobile_remote.next_page_aria')"
+        @click="goNext"
+      >
+        ›
+      </button>
+    </div>
+
+    <!-- Toast -->
+    <div
+      v-if="toastMessage"
+      class="astros-mobile-remote__toast"
+      role="status"
+      aria-live="polite"
+    >
+      {{ toastMessage }}
+    </div>
+
+    <!-- Panic / Stop All -->
+    <div class="astros-mobile-remote__panic-wrap">
+      <button
+        type="button"
+        class="astros-mobile-remote__panic"
+        :class="{
+          'astros-mobile-remote__panic--arming': panic.state.value === 'arming',
+          'astros-mobile-remote__panic--active': panic.state.value === 'active',
+        }"
+        :aria-pressed="panic.state.value === 'active'"
+        @mousedown="handlePanicDown"
+        @mouseup="handlePanicUp"
+        @mouseleave="handlePanicUp"
+        @touchstart="handlePanicDown"
+        @touchend="handlePanicUp"
+      >
+        <!-- Arming fill -->
+        <span
+          class="astros-mobile-remote__panic-fill"
+          :class="{
+            'astros-mobile-remote__panic-fill--arming': panic.state.value === 'arming',
+          }"
+          aria-hidden="true"
+        ></span>
+        <span class="astros-mobile-remote__panic-label">
+          <span
+            class="astros-mobile-remote__panic-glyph"
+            aria-hidden="true"
+          ></span>
+          {{ stopAllLabel }}
+        </span>
+      </button>
+      <div class="astros-mobile-remote__panic-caption">
+        {{ $t('mobile_remote.stop_all_caption') }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Design tokens scoped to the mobile remote — values from the Direction B
+ * handoff (`.tmp/design_handoff_remote_control/`). Kept local rather than
+ * promoted to `assets/styles.css` because they are mobile-remote-specific
+ * accents (panic red, toast slate) and not part of the broader app palette. */
+.astros-mobile-remote {
+  --mr-primary: #2a5a97;
+  --mr-primary-hover: #2f445c;
+  --mr-complement: #f49446;
+  --mr-base-100: #ffffff;
+  --mr-base-200: #f2f7fa;
+  --mr-ink: #0e1726;
+  --mr-ink-soft: #4b5b73;
+  --mr-border: #d6e0e6;
+  --mr-border-strong: #9bb1bd;
+  --mr-success: #3aa676;
+  --mr-panic-idle: #c91f1f;
+  --mr-panic-active: #7a1717;
+  --mr-toast-bg: rgba(14, 23, 38, 0.92);
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--mr-base-100);
+  color: var(--mr-ink);
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+/* === TOP BAR === */
+.astros-mobile-remote__top-bar {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 18px;
+  background: var(--mr-complement);
+  color: #000;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__top-bar {
+  padding: 8px 10px;
+}
+
+.astros-mobile-remote__wordmark {
+  font-size: 22px;
+  letter-spacing: 0.02em;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__wordmark {
+  font-size: 14px;
+}
+
+.astros-mobile-remote__connection {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__connection {
+  font-size: 9px;
+}
+
+.astros-mobile-remote__connection-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--mr-success);
+}
+
+/* === PAGE HEADER === */
+.astros-mobile-remote__page-header {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 8px;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__page-header {
+  padding: 8px 10px 4px;
+}
+
+.astros-mobile-remote__page-name {
+  font-size: 14px;
+  font-weight: 700;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__page-name {
+  font-size: 11px;
+}
+
+.astros-mobile-remote__page-pagination {
+  font-size: 11px;
+  color: var(--mr-ink-soft);
+}
+.astros-mobile-remote--compact .astros-mobile-remote__page-pagination {
+  font-size: 9px;
+}
+
+.astros-mobile-remote__empty-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  color: var(--mr-ink-soft);
+  font-size: 13px;
+  text-align: center;
+}
+
+/* === 3x3 GRID === */
+.astros-mobile-remote__grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 10px;
+  padding: 16px;
+  padding-top: 4px;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__grid {
+  gap: 6px;
+  padding: 8px;
+  padding-top: 4px;
+}
+
+.astros-mobile-remote__slot {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px 10px;
+  border: 1.5px dashed var(--mr-border-strong);
+  border-radius: 18px;
+  background: var(--mr-base-200);
+  color: var(--mr-ink-soft);
+  font-family: inherit;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.15;
+  cursor: default;
+  transition: all 100ms;
+  transform: scale(1);
+}
+.astros-mobile-remote--compact .astros-mobile-remote__slot {
+  gap: 3px;
+  padding: 6px;
+  border-radius: 12px;
+  font-size: 12px;
+}
+
+.astros-mobile-remote__slot--filled {
+  border: none;
+  background: var(--mr-primary);
+  color: #ffffff;
+  cursor: pointer;
+  box-shadow:
+    0 2px 0 rgba(0, 0, 0, 0.15),
+    0 4px 12px rgba(42, 90, 151, 0.25);
+}
+
+.astros-mobile-remote__slot--pressed {
+  background: var(--mr-primary-hover);
+  transform: scale(0.96);
+  box-shadow: none;
+}
+
+.astros-mobile-remote__slot[disabled] {
+  cursor: default;
+}
+
+.astros-mobile-remote__slot-label {
+  display: -webkit-box;
+  overflow: hidden;
+  padding-top: 10px;
+  text-align: center;
+  word-break: break-word;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__slot-label {
+  padding-top: 6px;
+  -webkit-line-clamp: 2;
+}
+
+.astros-mobile-remote__chip {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-transform: uppercase;
+  white-space: nowrap;
+  transform: translateX(-50%);
+}
+.astros-mobile-remote--compact .astros-mobile-remote__chip {
+  top: 4px;
+  right: 4px;
+  left: 4px;
+  font-size: 7px;
+  padding: 2px 6px;
+  transform: none;
+}
+
+.astros-mobile-remote__chip--script {
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+}
+
+.astros-mobile-remote__chip--playlist {
+  background: var(--mr-complement);
+  color: #000000;
+}
+
+.astros-mobile-remote__chip-icon {
+  width: 9px;
+  height: 9px;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__chip-icon {
+  width: 7px;
+  height: 7px;
+}
+
+/* === PAGINATION ROW === */
+.astros-mobile-remote__pagination {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 18px 8px;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__pagination {
+  padding: 6px 10px;
+}
+
+.astros-mobile-remote__page-nav {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--mr-border);
+  border-radius: 50%;
+  background: var(--mr-base-100);
+  color: var(--mr-ink);
+  font-size: 18px;
+  cursor: pointer;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__page-nav {
+  width: 26px;
+  height: 26px;
+  font-size: 14px;
+}
+
+.astros-mobile-remote__page-nav[disabled] {
+  color: var(--mr-border-strong);
+  cursor: default;
+}
+
+.astros-mobile-remote__dots {
+  display: flex;
+  gap: 4px;
+}
+
+.astros-mobile-remote__dot {
+  width: 7px;
+  height: 7px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: var(--mr-border);
+  cursor: pointer;
+  transition: all 150ms;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__dot {
+  width: 5px;
+  height: 5px;
+}
+
+.astros-mobile-remote__dot--active {
+  width: 22px;
+  background: var(--mr-primary);
+}
+.astros-mobile-remote--compact .astros-mobile-remote__dot--active {
+  width: 14px;
+}
+
+/* === TOAST === */
+.astros-mobile-remote__toast {
+  position: absolute;
+  bottom: 116px;
+  left: 50%;
+  padding: 8px 14px;
+  background: var(--mr-toast-bg);
+  border-radius: 999px;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  transform: translateX(-50%);
+}
+.astros-mobile-remote--compact .astros-mobile-remote__toast {
+  bottom: 76px;
+  padding: 4px 10px;
+  font-size: 9px;
+}
+
+/* === PANIC BUTTON === */
+.astros-mobile-remote__panic-wrap {
+  flex-shrink: 0;
+  padding: 6px 18px 16px;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__panic-wrap {
+  padding: 4px 10px 10px;
+}
+
+.astros-mobile-remote__panic {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 14px 0;
+  overflow: hidden;
+  border: none;
+  border-radius: 16px;
+  background: var(--mr-panic-idle);
+  color: #ffffff;
+  font-size: 15px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background 80ms,
+    transform 80ms;
+  box-shadow:
+    0 2px 0 rgba(0, 0, 0, 0.25),
+    0 6px 16px rgba(201, 31, 31, 0.35);
+}
+.astros-mobile-remote--compact .astros-mobile-remote__panic {
+  padding: 8px 0;
+  border-radius: 12px;
+  font-size: 11px;
+}
+
+.astros-mobile-remote__panic--active {
+  background: var(--mr-panic-active);
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+.astros-mobile-remote__panic-fill {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.28);
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 120ms;
+  pointer-events: none;
+}
+
+.astros-mobile-remote__panic-fill--arming {
+  transform: scaleX(1);
+  transition: transform 600ms linear;
+}
+
+.astros-mobile-remote__panic-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.astros-mobile-remote__panic-glyph {
+  width: 10px;
+  height: 10px;
+  background: #ffffff;
+  border-radius: 2px;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__panic-glyph {
+  width: 8px;
+  height: 8px;
+}
+
+.astros-mobile-remote__panic-caption {
+  margin-top: 4px;
+  color: var(--mr-ink-soft);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-align: center;
+}
+.astros-mobile-remote--compact .astros-mobile-remote__panic-caption {
+  font-size: 8px;
+}
+</style>

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -234,7 +234,7 @@ const stopAllLabel = computed(() => {
     <div class="astros-mobile-remote__top-bar">
       <span
         class="astros-mobile-remote__wordmark font-starwars"
-        aria-label="AstrOs"
+        :aria-label="$t('astros')"
       >
         <span class="astros-mobile-remote__wordmark-cap">A</span>str<span
           class="astros-mobile-remote__wordmark-cap"

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -6,7 +6,7 @@ import { BUTTON_KEYS } from '@/models/remoteControl/remoteControlPage';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import { useHoldGesture } from '@/composables/useHoldGesture';
 import { useSwipeGesture } from '@/composables/useSwipeGesture';
-import type { AstrosMobileRemotePressEvent } from './types';
+import { isFilledPageButton, type AstrosMobileRemotePressEvent } from './types';
 
 const props = defineProps({
   pages: {
@@ -141,7 +141,7 @@ const slots = computed(() => {
 });
 
 function handlePress(button: PageButton) {
-  if (button.type === 'none') return;
+  if (!isFilledPageButton(button)) return;
   // 'arming' is NOT blocked here: the user may change their mind mid-hold
   // and the 600ms window is short enough that "two-handed" presses aren't
   // a real failure mode. Only the committed 'active' lockout (the 2.2s
@@ -163,10 +163,7 @@ function handlePress(button: PageButton) {
     toastClearTimer = null;
   }, 1600);
 
-  // Type narrowed by the `button.type === 'none'` early-return above; the
-  // emit's typed payload (AstrosMobileRemotePressEvent = FilledPageButton)
-  // excludes 'none' so the parent gets a script-or-playlist discriminator.
-  emit('press', button as AstrosMobileRemotePressEvent);
+  emit('press', button);
 }
 
 function goPrev() {

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -13,6 +13,10 @@ const props = defineProps({
     type: Array as PropType<RemoteControlPage[]>,
     required: true,
   },
+  // Out-of-range values (negative, or >= pages.length) clamp to the nearest
+  // valid page rather than no-op. Parents that want "leave the current page
+  // alone" should omit the prop or pass the existing current index, not a
+  // sentinel like -1.
   initialIdx: {
     type: Number,
     default: 0,
@@ -37,16 +41,21 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 
-const idx = ref(props.initialIdx);
-// Keep idx in sync if the parent reseats initialIdx (mirrors the React
-// useEffect in mobileRemote.jsx). Important for Phase 2's preview rail
-// where the editor switches selected page.
+function clampIdx(value: number, pageCount: number): number {
+  if (pageCount <= 0) return 0;
+  return Math.min(Math.max(0, value), pageCount - 1);
+}
+
+// Initial-mount clamp: an out-of-range initialIdx (parent passes 10 with
+// pages.length=3) used to leak into the pagination header text and the
+// next-button disabled check until the first prop change fired the watcher.
+const idx = ref(clampIdx(props.initialIdx, props.pages.length));
+
+// Reseat idx if the parent updates initialIdx after mount.
 watch(
   () => props.initialIdx,
   (next) => {
-    if (next >= 0 && next < props.pages.length) {
-      idx.value = next;
-    }
+    idx.value = clampIdx(next, props.pages.length);
   },
 );
 
@@ -56,11 +65,7 @@ watch(
 watch(
   () => props.pages.length,
   (newLen) => {
-    if (newLen === 0) {
-      idx.value = 0;
-      return;
-    }
-    if (idx.value >= newLen) idx.value = newLen - 1;
+    idx.value = clampIdx(idx.value, newLen);
   },
 );
 
@@ -114,15 +119,15 @@ const panic = useHoldGesture({
   },
 });
 
-// Defensive clamp at read-time so initial-mount or mid-prop-update windows
-// (where idx is set but the matching watcher hasn't yet fired) don't surface
-// the empty-state branch when valid pages exist. The clamp also covers the
-// out-of-range initialIdx case at construction (the watchers below clamp on
-// changes but not on the initial value).
+// Defensive clamp at read-time so mid-prop-update windows (idx is set but
+// the matching watcher hasn't yet fired) don't surface the empty-state
+// branch when valid pages exist. All template bindings that need to show
+// the current index — pagination header, prev/next disabled, dot highlight
+// — read through `currentIdx` so an out-of-range raw idx can never leak.
+const currentIdx = computed(() => clampIdx(idx.value, props.pages.length));
 const currentPage = computed<RemoteControlPage | null>(() => {
   if (props.pages.length === 0) return null;
-  const safeIdx = Math.min(Math.max(0, idx.value), props.pages.length - 1);
-  return props.pages[safeIdx] ?? null;
+  return props.pages[currentIdx.value] ?? null;
 });
 const totalPages = computed(() => props.pages.length);
 
@@ -165,11 +170,11 @@ function handlePress(button: PageButton) {
 }
 
 function goPrev() {
-  if (idx.value > 0) idx.value -= 1;
+  if (currentIdx.value > 0) idx.value = currentIdx.value - 1;
 }
 
 function goNext() {
-  if (idx.value < totalPages.value - 1) idx.value += 1;
+  if (currentIdx.value < totalPages.value - 1) idx.value = currentIdx.value + 1;
 }
 
 function selectPage(target: number) {
@@ -254,7 +259,9 @@ const stopAllLabel = computed(() => {
       class="astros-mobile-remote__page-header"
     >
       <span class="astros-mobile-remote__page-name">{{ currentPage.name }}</span>
-      <span class="astros-mobile-remote__page-pagination"> {{ idx + 1 }} / {{ totalPages }} </span>
+      <span class="astros-mobile-remote__page-pagination">
+        {{ currentIdx + 1 }} / {{ totalPages }}
+      </span>
     </div>
     <div
       v-else
@@ -317,7 +324,7 @@ const stopAllLabel = computed(() => {
       <button
         type="button"
         class="astros-mobile-remote__page-nav"
-        :disabled="idx === 0"
+        :disabled="totalPages === 0 || currentIdx === 0"
         :aria-label="$t('mobile_remote.prev_page_aria')"
         @click="goPrev"
       >
@@ -329,16 +336,16 @@ const stopAllLabel = computed(() => {
           :key="page.id"
           type="button"
           class="astros-mobile-remote__dot"
-          :class="{ 'astros-mobile-remote__dot--active': i === idx }"
+          :class="{ 'astros-mobile-remote__dot--active': i === currentIdx }"
           :aria-label="$t('mobile_remote.dot_aria', { number: i + 1 })"
-          :aria-current="i === idx ? 'page' : undefined"
+          :aria-current="i === currentIdx ? 'page' : undefined"
           @click="selectPage(i)"
         ></button>
       </div>
       <button
         type="button"
         class="astros-mobile-remote__page-nav"
-        :disabled="idx === totalPages - 1"
+        :disabled="totalPages === 0 || currentIdx === totalPages - 1"
         :aria-label="$t('mobile_remote.next_page_aria')"
         @click="goNext"
       >

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -5,6 +5,7 @@ import type { RemoteControlPage } from '@/models/remoteControl/remoteControlPage
 import { BUTTON_KEYS } from '@/models/remoteControl/remoteControlPage';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import { useHoldGesture } from '@/composables/useHoldGesture';
+import { useSwipeGesture } from '@/composables/useSwipeGesture';
 import type { AstrosMobileRemotePressEvent } from './types';
 
 const props = defineProps({
@@ -95,17 +96,35 @@ const panic = useHoldGesture({
   holdMs: 600,
   cooldownMs: 2200,
   onFire: () => {
-    toastMessage.value = t('mobile_remote.panic_toast');
+    // Cancel any in-flight press toast so it doesn't clear the panic toast
+    // partway through. The reverse direction (press during active) is
+    // blocked by the state guard in handlePress.
+    clearToastTimer();
     clearPanicToastTimer();
+    toastMessage.value = t('mobile_remote.panic_toast');
     panicToastTimer = setTimeout(() => {
       toastMessage.value = null;
       panicToastTimer = null;
     }, 1800);
+    // Phase 4 contract: the parent must gate on delivery confirmation before
+    // letting the operator trust the STOPPED visual. The component shows
+    // success-side feedback unconditionally; Phase 4 must override (e.g., set
+    // a panicStatus prop or emit an error event) if the WS panic message
+    // fails to send. See plan's "Phase 4 contract requirements" section.
     emit('panic');
   },
 });
 
-const currentPage = computed<RemoteControlPage | null>(() => props.pages[idx.value] ?? null);
+// Defensive clamp at read-time so initial-mount or mid-prop-update windows
+// (where idx is set but the matching watcher hasn't yet fired) don't surface
+// the empty-state branch when valid pages exist. The clamp also covers the
+// out-of-range initialIdx case at construction (the watchers below clamp on
+// changes but not on the initial value).
+const currentPage = computed<RemoteControlPage | null>(() => {
+  if (props.pages.length === 0) return null;
+  const safeIdx = Math.min(Math.max(0, idx.value), props.pages.length - 1);
+  return props.pages[safeIdx] ?? null;
+});
 const totalPages = computed(() => props.pages.length);
 
 // BUTTON_KEYS is the canonical 1..9 ordering shared with the backend; iterating
@@ -140,7 +159,10 @@ function handlePress(button: PageButton) {
     toastClearTimer = null;
   }, 1600);
 
-  emit('press', button);
+  // Type narrowed by the `button.type === 'none'` early-return above; the
+  // emit's typed payload (AstrosMobileRemotePressEvent = FilledPageButton)
+  // excludes 'none' so the parent gets a script-or-playlist discriminator.
+  emit('press', button as AstrosMobileRemotePressEvent);
 }
 
 function goPrev() {
@@ -155,63 +177,25 @@ function selectPage(target: number) {
   if (target >= 0 && target < totalPages.value) idx.value = target;
 }
 
-// Swipe-to-paginate on the 3x3 grid surface. Tracking starts on touchstart
-// and the delta is computed on touchend; anything beyond the horizontal
-// threshold AND under the vertical threshold counts as a swipe. The grid is
-// the only swipe surface so the top bar / pagination row / panic button stay
-// unaffected.
-const SWIPE_HORIZONTAL_THRESHOLD_PX = 60;
-const SWIPE_VERTICAL_MAX_PX = 40;
-let swipeStartX: number | null = null;
-let swipeStartY: number | null = null;
-
-function handleGridTouchStart(event: TouchEvent) {
-  if (event.touches.length !== 1) {
-    // A second finger landed mid-gesture (e.g., two-handed grip, accidental
-    // pinch). Abort any in-progress swipe so the eventual touchend doesn't
-    // evaluate a delta from the first-finger start to the second-finger end.
-    swipeStartX = null;
-    swipeStartY = null;
-    return;
-  }
-  const touch = event.touches[0];
-  if (!touch) return;
-  swipeStartX = touch.clientX;
-  swipeStartY = touch.clientY;
-}
-
-function handleGridTouchEnd(event: TouchEvent) {
-  if (swipeStartX === null || swipeStartY === null) return;
-  const touch = event.changedTouches[0];
-  if (!touch) return;
-  const deltaX = touch.clientX - swipeStartX;
-  const deltaY = touch.clientY - swipeStartY;
-  swipeStartX = null;
-  swipeStartY = null;
-
-  if (Math.abs(deltaX) < SWIPE_HORIZONTAL_THRESHOLD_PX) return;
-  if (Math.abs(deltaY) > SWIPE_VERTICAL_MAX_PX) return;
-
-  // Suppress the synthesized click so a swipe that crosses a button slot
-  // doesn't also fire that button's press handler.
-  event.preventDefault();
-
-  // Convention matches iOS Photos / Twitter / Instagram: the content moves
-  // opposite the finger. Swipe LEFT → next page; swipe RIGHT → prev page.
-  if (deltaX < 0) goNext();
-  else goPrev();
-}
-
-function handleGridTouchCancel() {
-  swipeStartX = null;
-  swipeStartY = null;
-}
+// Swipe-to-paginate on the 3x3 grid surface (composable encapsulates the
+// distance threshold, vertical-max guard, multi-touch abort, and the
+// preventDefault that suppresses synthesized clicks on swipe). Direction
+// convention matches iOS Photos / Twitter / Instagram: the content moves
+// opposite the finger, so swipe LEFT → next page, swipe RIGHT → previous.
+const swipe = useSwipeGesture({
+  horizontalThresholdPx: 60,
+  verticalMaxPx: 40,
+  onSwipeLeft: () => goNext(),
+  onSwipeRight: () => goPrev(),
+});
 
 function handlePanicDown(event: Event) {
-  // Touch handlers preventDefault to suppress the synthetic mousedown that
-  // follows on most mobile browsers; without this the hold gesture would
-  // fire start() twice and the second call is a no-op anyway, but the
-  // touch path is the authoritative one.
+  // The preventDefault on touchstart is a Vue 3 passive-listener no-op in
+  // most builds, so the synthesized mousedown still fires and reaches this
+  // handler a second time. The safety net is useHoldGesture.start()'s own
+  // idempotency: it returns early when state !== 'idle', so the duplicate
+  // call is benign. A future composable refactor that breaks idempotency
+  // would expose this — re-evaluate then.
   if (event.type === 'touchstart') event.preventDefault();
   panic.start();
 }
@@ -285,9 +269,9 @@ const stopAllLabel = computed(() => {
     <div
       v-if="currentPage"
       class="astros-mobile-remote__grid"
-      @touchstart="handleGridTouchStart"
-      @touchend="handleGridTouchEnd"
-      @touchcancel="handleGridTouchCancel"
+      @touchstart="swipe.onTouchStart"
+      @touchend="swipe.onTouchEnd"
+      @touchcancel="swipe.onTouchCancel"
     >
       <button
         v-for="(button, i) in slots"
@@ -388,6 +372,7 @@ const stopAllLabel = computed(() => {
         @mouseleave="handlePanicUp"
         @touchstart="handlePanicDown"
         @touchend="handlePanicUp"
+        @touchcancel="handlePanicUp"
       >
         <!-- Arming fill -->
         <span

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -106,11 +106,10 @@ const panic = useHoldGesture({
       toastMessage.value = null;
       panicToastTimer = null;
     }, 1800);
-    // Phase 4 contract: the parent must gate on delivery confirmation before
-    // letting the operator trust the STOPPED visual. The component shows
-    // success-side feedback unconditionally; Phase 4 must override (e.g., set
-    // a panicStatus prop or emit an error event) if the WS panic message
-    // fails to send. See plan's "Phase 4 contract requirements" section.
+    // Fire-and-forget by design: the toast says "sending…" because this
+    // emit does not wait for delivery. Parents that need a "sent vs failed"
+    // visual must gate on their own delivery confirmation (prop or wrapper),
+    // not on this emit firing.
     emit('panic');
   },
 });

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -74,7 +74,6 @@ const toastMessage = ref<string | null>(null);
 
 let pressClearTimer: ReturnType<typeof setTimeout> | null = null;
 let toastClearTimer: ReturnType<typeof setTimeout> | null = null;
-let panicToastTimer: ReturnType<typeof setTimeout> | null = null;
 
 function clearPressTimer() {
   if (pressClearTimer !== null) {
@@ -83,17 +82,23 @@ function clearPressTimer() {
   }
 }
 
-function clearToastTimer() {
+// Single owner of the toast slot. Replaces any in-flight toast so press and
+// panic don't race to clear each other's message — previously two separate
+// timer pairs wrote to the same DOM slot, and forgetting to cancel one
+// before showing the other clipped the new toast early.
+function showToast(message: string, durationMs: number) {
+  if (toastClearTimer !== null) clearTimeout(toastClearTimer);
+  toastMessage.value = message;
+  toastClearTimer = setTimeout(() => {
+    toastMessage.value = null;
+    toastClearTimer = null;
+  }, durationMs);
+}
+
+function clearToast() {
   if (toastClearTimer !== null) {
     clearTimeout(toastClearTimer);
     toastClearTimer = null;
-  }
-}
-
-function clearPanicToastTimer() {
-  if (panicToastTimer !== null) {
-    clearTimeout(panicToastTimer);
-    panicToastTimer = null;
   }
 }
 
@@ -101,16 +106,7 @@ const panic = useHoldGesture({
   holdMs: 600,
   cooldownMs: 2200,
   onFire: () => {
-    // Cancel any in-flight press toast so it doesn't clear the panic toast
-    // partway through. The reverse direction (press during active) is
-    // blocked by the state guard in handlePress.
-    clearToastTimer();
-    clearPanicToastTimer();
-    toastMessage.value = t('mobile_remote.panic_toast');
-    panicToastTimer = setTimeout(() => {
-      toastMessage.value = null;
-      panicToastTimer = null;
-    }, 1800);
+    showToast(t('mobile_remote.panic_toast'), 1800);
     // Fire-and-forget by design: the toast says "sending…" because this
     // emit does not wait for delivery. Parents that need a "sent vs failed"
     // visual must gate on their own delivery confirmation (prop or wrapper),
@@ -131,9 +127,8 @@ const currentPage = computed<RemoteControlPage | null>(() => {
 });
 const totalPages = computed(() => props.pages.length);
 
-// BUTTON_KEYS is the canonical 1..9 ordering shared with the backend; iterating
-// it once into a slots array means each template binding reads one variable
-// instead of re-calling a function per attribute expression.
+// Memoize the per-slot lookup so each template binding reads a stable array
+// slot instead of re-deriving from BUTTON_KEYS in every attribute expression.
 const slots = computed(() => {
   const page = currentPage.value;
   if (page === null) return [];
@@ -149,19 +144,13 @@ function handlePress(button: PageButton) {
   if (panic.state.value === 'active') return;
 
   pressedButtonId.value = button.id;
-  toastMessage.value = t('mobile_remote.press_toast', { name: button.name });
-
   clearPressTimer();
   pressClearTimer = setTimeout(() => {
     pressedButtonId.value = null;
     pressClearTimer = null;
   }, 220);
 
-  clearToastTimer();
-  toastClearTimer = setTimeout(() => {
-    toastMessage.value = null;
-    toastClearTimer = null;
-  }, 1600);
+  showToast(t('mobile_remote.press_toast', { name: button.name }), 1600);
 
   emit('press', button);
 }
@@ -208,8 +197,7 @@ function handlePanicUp(event: Event) {
 
 onBeforeUnmount(() => {
   clearPressTimer();
-  clearToastTimer();
-  clearPanicToastTimer();
+  clearToast();
   // The useHoldGesture composable cleans up its own timers via onScopeDispose.
 });
 
@@ -372,7 +360,6 @@ const stopAllLabel = computed(() => {
         :aria-pressed="panic.state.value === 'active'"
         @mousedown="handlePanicDown"
         @mouseup="handlePanicUp"
-        @mouseleave="handlePanicUp"
         @touchstart="handlePanicDown"
         @touchend="handlePanicUp"
         @touchcancel="handlePanicUp"
@@ -455,10 +442,8 @@ const stopAllLabel = computed(() => {
   font-size: 14px;
 }
 
-/* Capital A and O scale up to enforce the "AstrOs" branding rhythm — the
- * proprietary wordmark renders the caps as larger glyphs and this approximates
- * that until the real woff replaces distant_galaxyregular. Uses em (not px)
- * so the compact and full sizes both scale proportionally. */
+/* Capital A and O scale up to enforce the "AstrOs" branding rhythm. Uses
+ * em (not px) so the compact and full sizes both scale proportionally. */
 .astros-mobile-remote__wordmark-cap {
   font-size: 1.25em;
 }

--- a/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue
@@ -25,9 +25,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  // Phase 4 will drive this from the WebSocket connection store. Default to
-  // `true` so the standalone-component case (and Storybook) renders the
-  // intended "Connected" chip.
+  // Defaults to `true` so the standalone-component case (and Storybook)
+  // render the intended "Connected" chip when a parent doesn't pipe in a
+  // live connection signal.
   connected: {
     type: Boolean,
     default: true,
@@ -143,7 +143,7 @@ function handlePress(button: PageButton) {
   // 'arming' is NOT blocked here: the user may change their mind mid-hold
   // and the 600ms window is short enough that "two-handed" presses aren't
   // a real failure mode. Only the committed 'active' lockout (the 2.2s
-  // post-fire window) suppresses presses. Matches the handoff JSX.
+  // post-fire window) suppresses presses.
   if (panic.state.value === 'active') return;
 
   pressedButtonId.value = button.id;

--- a/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
@@ -6,6 +6,19 @@ export type FilledPageButton = PageButton & {
 
 export type AstrosMobileRemotePressEvent = FilledPageButton;
 
+// Exhaustive switch (not `type !== 'none'`) so a new PageButtonType variant
+// breaks the build at the `never` assertion instead of being silently
+// classified as filled and emitted through `press` to the parent.
 export function isFilledPageButton(button: PageButton): button is FilledPageButton {
-  return button.type !== 'none';
+  switch (button.type) {
+    case 'script':
+    case 'playlist':
+      return true;
+    case 'none':
+      return false;
+    default: {
+      const _exhaustive: never = button.type;
+      return _exhaustive;
+    }
+  }
 }

--- a/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
@@ -1,7 +1,13 @@
-import type { PageButton } from '@/models/remoteControl/pageButton';
+import type { PageButton, PageButtonType } from '@/models/remoteControl/pageButton';
 
-// Emitted by AstrosMobileRemote when an operator taps a filled (non-`none`)
-// button. Carries the PageButton verbatim so the parent (the standalone
-// operator route in Phase 4) can route by `type` (script vs playlist) and
-// fire the matching backend endpoint.
-export type AstrosMobileRemotePressEvent = PageButton;
+// A PageButton narrowed to the filled variants — emitted by AstrosMobileRemote
+// when an operator taps a non-empty button. The component filters out
+// `type: 'none'` slots before emitting (see handlePress in AstrosMobileRemote.vue),
+// so the parent never needs to re-check; TypeScript narrows `type` to
+// 'script' | 'playlist' directly and the parent can switch on it without a
+// dead `none` branch.
+export type FilledPageButton = PageButton & {
+  type: Exclude<PageButtonType, 'none'>;
+};
+
+export type AstrosMobileRemotePressEvent = FilledPageButton;

--- a/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
@@ -1,0 +1,7 @@
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+// Emitted by AstrosMobileRemote when an operator taps a filled (non-`none`)
+// button. Carries the PageButton verbatim so the parent (the standalone
+// operator route in Phase 4) can route by `type` (script vs playlist) and
+// fire the matching backend endpoint.
+export type AstrosMobileRemotePressEvent = PageButton;

--- a/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
@@ -1,13 +1,11 @@
 import type { PageButton, PageButtonType } from '@/models/remoteControl/pageButton';
 
-// A PageButton narrowed to the filled variants — emitted by AstrosMobileRemote
-// when an operator taps a non-empty button. The component filters out
-// `type: 'none'` slots before emitting (see handlePress in AstrosMobileRemote.vue),
-// so the parent never needs to re-check; TypeScript narrows `type` to
-// 'script' | 'playlist' directly and the parent can switch on it without a
-// dead `none` branch.
 export type FilledPageButton = PageButton & {
   type: Exclude<PageButtonType, 'none'>;
 };
 
 export type AstrosMobileRemotePressEvent = FilledPageButton;
+
+export function isFilledPageButton(button: PageButton): button is FilledPageButton {
+  return button.type !== 'none';
+}

--- a/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
@@ -183,10 +183,10 @@ describe('useHoldGesture', () => {
   });
 
   it('a throwing onFire still schedules the cooldown and recovers to idle', () => {
-    // Phase 4 will wire emit('panic') to a WebSocket send; if the parent's
-    // handler throws, the gesture must NOT strand in 'active' forever. The
-    // production code wraps onFire in try/finally so the cooldown timer is
-    // always scheduled, and console.error surfaces the throw for operators.
+    // If a consumer's onFire handler throws, the gesture must NOT strand in
+    // 'active' forever. The production code wraps onFire in try/finally so
+    // the cooldown timer is always scheduled, and console.error surfaces
+    // the throw for operators.
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
       const { result } = runInScope(() =>

--- a/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
@@ -213,6 +213,78 @@ describe('useHoldGesture', () => {
     }
   });
 
+  it('routes a throwing onFire to onError when supplied (instead of console.error)', () => {
+    // The console.error fallback exists only for consumers that haven't
+    // wired their own logger. When onError is supplied, the throw must
+    // reach it and NOT be double-logged to console.error.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onError = vi.fn();
+    try {
+      const { result } = runInScope(() =>
+        useHoldGesture({
+          holdMs: 600,
+          cooldownMs: 2200,
+          onFire: () => {
+            throw new Error('listener boom');
+          },
+          onError,
+        }),
+      );
+      result.start();
+      vi.advanceTimersByTime(600);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+      expect(errorSpy).not.toHaveBeenCalled();
+      // Cooldown still schedules — the error path must not break recovery.
+      vi.advanceTimersByTime(2200);
+      expect(result.state.value).toBe('idle');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('a throwing onError is contained and logs both errors without stranding the gesture', () => {
+    // Vacuous-fix guard — verified mechanically. This test fails under
+    // either of the following mutations to the production code:
+    //   (a) Remove the inner try/catch around the onError call: the
+    //       handlerErr escapes the setTimeout callback (uncaught, surfaces
+    //       as a Vitest unhandled rejection) AND the cooldown still
+    //       schedules so state reaches idle — but the unhandled rejection
+    //       trips the final assertion that no rejection occurred.
+    //   (b) Drop the second console.error (the one logging handlerErr): the
+    //       "onError handler threw" string assertion below fails.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handlerError = new Error('handler boom');
+    try {
+      const { result } = runInScope(() =>
+        useHoldGesture({
+          holdMs: 600,
+          cooldownMs: 2200,
+          onFire: () => {
+            throw new Error('listener boom');
+          },
+          onError: () => {
+            throw handlerError;
+          },
+        }),
+      );
+      result.start();
+      vi.advanceTimersByTime(600);
+      expect(result.state.value).toBe('active');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('onError handler threw'),
+        handlerError,
+        expect.stringContaining('original'),
+        expect.any(Error),
+      );
+      // Cooldown still recovers — this is the load-bearing safety property.
+      vi.advanceTimersByTime(2200);
+      expect(result.state.value).toBe('idle');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('respects custom holdMs and cooldownMs values', () => {
     const onFire = vi.fn();
     const { result } = runInScope(() => useHoldGesture({ holdMs: 1000, cooldownMs: 500, onFire }));

--- a/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
@@ -285,6 +285,46 @@ describe('useHoldGesture', () => {
     }
   });
 
+  it('an async onError whose promise rejects is caught and logged with the original error', async () => {
+    // Vacuous-fix guard — verified mechanically. Removing the
+    // Promise.resolve(...).catch(...) wrap around the onError call lets the
+    // returned rejected promise become an unhandled rejection on
+    // window.onerror — the synchronous try/catch only catches sync throws,
+    // not awaited rejections. This test fails under that mutation because
+    // the "onError handler rejected" string assertion never matches.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const handlerError = new Error('async handler boom');
+    try {
+      const { result } = runInScope(() =>
+        useHoldGesture({
+          holdMs: 600,
+          cooldownMs: 2200,
+          onFire: () => {
+            throw new Error('listener boom');
+          },
+          onError: async () => {
+            throw handlerError;
+          },
+        }),
+      );
+      result.start();
+      vi.advanceTimersByTime(600);
+      // Let the microtask queue drain so the rejected promise's catch runs.
+      await Promise.resolve();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('onError handler rejected'),
+        handlerError,
+        expect.stringContaining('original'),
+        expect.any(Error),
+      );
+      // Cooldown still recovers — the load-bearing safety property.
+      vi.advanceTimersByTime(2200);
+      expect(result.state.value).toBe('idle');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('respects custom holdMs and cooldownMs values', () => {
     const onFire = vi.fn();
     const { result } = runInScope(() => useHoldGesture({ holdMs: 1000, cooldownMs: 500, onFire }));

--- a/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { effectScope } from 'vue';
+import { useHoldGesture } from '../useHoldGesture';
+
+// The composable uses setTimeout for both the holdMs arm timer and the
+// cooldownMs lockout. Drive time deterministically with fake timers so
+// state transitions are independent of real-time variance.
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Run the composable inside an effect scope so onScopeDispose hooks have a
+// real owner; otherwise Vue logs a warning every test ("onScopeDispose is
+// called when there is no active effect scope").
+function runInScope<T>(fn: () => T): { result: T; scope: ReturnType<typeof effectScope> } {
+  const scope = effectScope();
+  const result = scope.run(fn) as T;
+  return { result, scope };
+}
+
+describe('useHoldGesture', () => {
+  it('starts in the idle state', () => {
+    const { result } = runInScope(() => useHoldGesture());
+    expect(result.state.value).toBe('idle');
+  });
+
+  it('transitions idle → arming on start()', () => {
+    const { result } = runInScope(() => useHoldGesture());
+    result.start();
+    expect(result.state.value).toBe('arming');
+  });
+
+  it('transitions arming → active after holdMs and fires onFire exactly once', () => {
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, onFire }));
+    result.start();
+    expect(onFire).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(599);
+    expect(result.state.value).toBe('arming');
+    expect(onFire).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(result.state.value).toBe('active');
+    expect(onFire).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel() during arming returns to idle and does NOT fire onFire', () => {
+    // Vacuous-fix guard: if clearArmTimer() were dropped from cancel(), the
+    // arm timer would stay queued and fire when vi.advanceTimersByTime(600)
+    // runs below — calling onFire and failing the final assertion. Verified
+    // mechanically: removing the clearArmTimer call from cancel() makes the
+    // expect(onFire).not.toHaveBeenCalled() line fail.
+    // (Note on the fake-timer environment: a 0ms setTimeout would NOT fire
+    // automatically here — fake timers only run when time is advanced — so
+    // the real mutation the guard catches is the missing clearArmTimer call,
+    // not the delay value.)
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, onFire }));
+    result.start();
+    vi.advanceTimersByTime(300);
+    result.cancel();
+    expect(result.state.value).toBe('idle');
+    vi.advanceTimersByTime(600);
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it('cancel() during active is a no-op AND does not disrupt cooldown completion', () => {
+    // The contract has two parts: (1) cancel() must not flip active → idle
+    // immediately (the lockout has to last cooldownMs), and (2) it must not
+    // accidentally clear the cooldown timer either — a future refactor that
+    // calls clearCooldownTimer() before the arming-state guard would leave
+    // state stuck at 'active' forever. The clock-advance assertion below
+    // catches that mutation.
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire }));
+    result.start();
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    result.cancel();
+    expect(result.state.value).toBe('active');
+    vi.advanceTimersByTime(2200);
+    expect(result.state.value).toBe('idle');
+  });
+
+  it('transitions active → idle after cooldownMs', () => {
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, cooldownMs: 2200 }));
+    result.start();
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    vi.advanceTimersByTime(2199);
+    expect(result.state.value).toBe('active');
+    vi.advanceTimersByTime(1);
+    expect(result.state.value).toBe('idle');
+  });
+
+  it('start() while not idle is a no-op (does not re-arm or extend timers)', () => {
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, onFire }));
+    result.start();
+    vi.advanceTimersByTime(300);
+    // Second start() — should NOT reset the 600ms timer
+    result.start();
+    expect(result.state.value).toBe('arming');
+    vi.advanceTimersByTime(300);
+    // 600ms total elapsed from first start() — should have fired
+    expect(result.state.value).toBe('active');
+    expect(onFire).toHaveBeenCalledTimes(1);
+  });
+
+  it('start() during active is ignored (gesture is locked out until cooldown completes)', () => {
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire }));
+    result.start();
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    result.start();
+    expect(result.state.value).toBe('active');
+    vi.advanceTimersByTime(2200);
+    expect(result.state.value).toBe('idle');
+    expect(onFire).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset() while arming clears the pending fire and returns to idle', () => {
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, onFire }));
+    result.start();
+    vi.advanceTimersByTime(300);
+    result.reset();
+    expect(result.state.value).toBe('idle');
+    vi.advanceTimersByTime(1000);
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it('reset() while active clears the cooldown timer and returns to idle immediately', () => {
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire }));
+    result.start();
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    result.reset();
+    expect(result.state.value).toBe('idle');
+    // The original cooldown timer must NOT fire again and flip something later.
+    vi.advanceTimersByTime(3000);
+    expect(result.state.value).toBe('idle');
+  });
+
+  it('respects custom holdMs and cooldownMs values', () => {
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 1000, cooldownMs: 500, onFire }));
+    result.start();
+    vi.advanceTimersByTime(999);
+    expect(result.state.value).toBe('arming');
+    vi.advanceTimersByTime(1);
+    expect(result.state.value).toBe('active');
+    expect(onFire).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(500);
+    expect(result.state.value).toBe('idle');
+  });
+
+  it('a full cycle can be repeated cleanly: idle → arming → active → idle → arming → active', () => {
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire }));
+    result.start();
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    vi.advanceTimersByTime(2200);
+    expect(result.state.value).toBe('idle');
+    result.start();
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    expect(onFire).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up pending timers when the parent scope is disposed', () => {
+    const onFire = vi.fn();
+    const { result, scope } = runInScope(() =>
+      useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire }),
+    );
+    result.start();
+    vi.advanceTimersByTime(300);
+    scope.stop();
+    // After scope disposal, any pending timers must NOT fire onFire or
+    // attempt to mutate the (now-detached) state ref.
+    vi.advanceTimersByTime(2000);
+    expect(onFire).not.toHaveBeenCalled();
+  });
+});

--- a/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useHoldGesture.spec.ts
@@ -48,15 +48,15 @@ describe('useHoldGesture', () => {
   });
 
   it('cancel() during arming returns to idle and does NOT fire onFire', () => {
-    // Vacuous-fix guard: if clearArmTimer() were dropped from cancel(), the
-    // arm timer would stay queued and fire when vi.advanceTimersByTime(600)
-    // runs below — calling onFire and failing the final assertion. Verified
-    // mechanically: removing the clearArmTimer call from cancel() makes the
-    // expect(onFire).not.toHaveBeenCalled() line fail.
-    // (Note on the fake-timer environment: a 0ms setTimeout would NOT fire
-    // automatically here — fake timers only run when time is advanced — so
-    // the real mutation the guard catches is the missing clearArmTimer call,
-    // not the delay value.)
+    // Vacuous-fix guard — verified mechanically. This test fails under
+    // either of the following mutations to the production code:
+    //   (a) Drop the clearArmTimer() call from cancel(): the queued arm
+    //       timer fires when vi.advanceTimersByTime(600) runs below, calling
+    //       onFire and tripping the final assertion.
+    //   (b) Change holdMs's setTimeout delay to 0: the timer fires during
+    //       vi.advanceTimersByTime(300) BEFORE cancel() executes, flipping
+    //       state to 'active' and calling onFire — tripping both the state
+    //       and onFire assertions.
     const onFire = vi.fn();
     const { result } = runInScope(() => useHoldGesture({ holdMs: 600, onFire }));
     result.start();
@@ -97,16 +97,28 @@ describe('useHoldGesture', () => {
   });
 
   it('start() while not idle is a no-op (does not re-arm or extend timers)', () => {
+    // Vacuous-fix guard: this catches a refactor that weakens the
+    // `state !== 'idle'` guard to e.g. `state === 'active'`, which would
+    // allow the second start() to queue a SECOND arm timer. The first timer
+    // would still fire at +600ms (test passes the first two assertions),
+    // but the second timer would fire at +900ms and call onFire AGAIN. The
+    // final onFire-count assertion catches it.
     const onFire = vi.fn();
     const { result } = runInScope(() => useHoldGesture({ holdMs: 600, onFire }));
     result.start();
     vi.advanceTimersByTime(300);
-    // Second start() — should NOT reset the 600ms timer
+    // Second start() — should NOT queue another arm timer.
     result.start();
     expect(result.state.value).toBe('arming');
     vi.advanceTimersByTime(300);
-    // 600ms total elapsed from first start() — should have fired
+    // 600ms total elapsed from first start() — should have fired exactly once.
     expect(result.state.value).toBe('active');
+    expect(onFire).toHaveBeenCalledTimes(1);
+    // Advance past where a stray second arm timer (queued at +300ms) would
+    // fire at +600ms-from-its-start = +900ms-from-first-start. The state
+    // assertion above checks the immediate post-fire state; this one pins
+    // that no orphan timer fires a second onFire later in the cooldown.
+    vi.advanceTimersByTime(600);
     expect(onFire).toHaveBeenCalledTimes(1);
   });
 
@@ -145,6 +157,60 @@ describe('useHoldGesture', () => {
     // The original cooldown timer must NOT fire again and flip something later.
     vi.advanceTimersByTime(3000);
     expect(result.state.value).toBe('idle');
+  });
+
+  it('reset() while active does NOT leave an orphan cooldown timer that clobbers a later cycle', () => {
+    // Vacuous-fix guard for the clearCooldownTimer() call in reset(). Without
+    // this test, removing that line passes all other tests (the orphan
+    // cooldown's callback sets state to 'idle' — a no-op when state is
+    // already 'idle'). The bug it would allow: an orphan timer firing
+    // mid-second-cycle clobbers the new 'active' lockout, dropping the
+    // STOPPED visual early.
+    const onFire = vi.fn();
+    const { result } = runInScope(() => useHoldGesture({ holdMs: 600, cooldownMs: 2200, onFire }));
+    result.start();
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    result.reset(); // Must kill the cooldown timer.
+    vi.advanceTimersByTime(1000); // 1.0s — still inside the original 2.2s cooldown window.
+    result.start(); // Begin a new cycle from idle.
+    vi.advanceTimersByTime(600);
+    expect(result.state.value).toBe('active');
+    vi.advanceTimersByTime(600); // Hits +2200ms mark of the ORIGINAL timer; must NOT fire.
+    expect(result.state.value).toBe('active');
+    vi.advanceTimersByTime(1600); // Hits +2200ms of cycle 2.
+    expect(result.state.value).toBe('idle');
+  });
+
+  it('a throwing onFire still schedules the cooldown and recovers to idle', () => {
+    // Phase 4 will wire emit('panic') to a WebSocket send; if the parent's
+    // handler throws, the gesture must NOT strand in 'active' forever. The
+    // production code wraps onFire in try/finally so the cooldown timer is
+    // always scheduled, and console.error surfaces the throw for operators.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { result } = runInScope(() =>
+        useHoldGesture({
+          holdMs: 600,
+          cooldownMs: 2200,
+          onFire: () => {
+            throw new Error('listener boom');
+          },
+        }),
+      );
+      result.start();
+      vi.advanceTimersByTime(600);
+      expect(result.state.value).toBe('active');
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('onFire callback threw'),
+        expect.any(Error),
+      );
+      // The cooldown timer MUST have been scheduled by the finally block.
+      vi.advanceTimersByTime(2200);
+      expect(result.state.value).toBe('idle');
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('respects custom holdMs and cooldownMs values', () => {

--- a/astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts
@@ -94,13 +94,11 @@ describe('useSwipeGesture', () => {
   });
 
   it('multi-touch start aborts the in-progress gesture (two-handed grip)', () => {
-    // Vacuous-fix guard for the multi-touch guard. Per memory rule for
-    // defensive features: revert the `event.touches.length !== 1` guard
-    // (let the second touchstart fall through without clearing start
-    // coords) and this test fails — the eventual touchend computes delta
-    // from first-finger start to second-finger end and fires a spurious
-    // swipe. Verified mechanically: removing the guard makes this test
-    // fail.
+    // Vacuous-fix guard — verified mechanically. Reverting the
+    // `event.touches.length !== 1` guard (so the second touchstart falls
+    // through without clearing start coords) makes this test fail: the
+    // eventual touchend computes delta from first-finger start to
+    // second-finger end and fires a spurious swipe.
     const onSwipeLeft = vi.fn();
     const onSwipeRight = vi.fn();
     const { onTouchStart, onTouchEnd } = useSwipeGesture({

--- a/astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useSwipeGesture } from '../useSwipeGesture';
+
+// Build a synthetic TouchEvent compatible with what the composable reads
+// (touches list + changedTouches list with clientX/clientY). jsdom doesn't
+// implement TouchEvent natively, so we provide just enough surface area.
+type TouchInit = { clientX: number; clientY: number };
+
+function touchEvent(
+  type: 'touchstart' | 'touchend' | 'touchcancel',
+  active: TouchInit[],
+  changed: TouchInit[] = [],
+): TouchEvent {
+  const event = {
+    type,
+    touches: active as unknown as TouchList,
+    changedTouches: changed as unknown as TouchList,
+    preventDefault: vi.fn(),
+  } as unknown as TouchEvent;
+  return event;
+}
+
+describe('useSwipeGesture', () => {
+  it('fires onSwipeLeft when horizontal delta exceeds threshold in the negative direction', () => {
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      verticalMaxPx: 40,
+      onSwipeLeft,
+      onSwipeRight,
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 100, clientY: 210 }]));
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('fires onSwipeRight when horizontal delta exceeds threshold in the positive direction', () => {
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      verticalMaxPx: 40,
+      onSwipeLeft,
+      onSwipeRight,
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 100, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 200, clientY: 210 }]));
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when horizontal delta is below threshold (tap)', () => {
+    // Vacuous-fix guard: catches a refactor that drops the
+    // `Math.abs(deltaX) < threshold` early return. Without it, a tap with
+    // tiny delta would fire onSwipeLeft (deltaX = -2 < 0).
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      verticalMaxPx: 40,
+      onSwipeLeft,
+      onSwipeRight,
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 100, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 98, clientY: 200 }]));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when vertical delta exceeds the max (diagonal scroll)', () => {
+    // Vacuous-fix guard: catches a refactor that drops the
+    // `Math.abs(deltaY) > verticalMax` early return. Without it, a scroll
+    // gesture with significant vertical movement would still fire a swipe
+    // if it had ANY horizontal component over threshold.
+    const onSwipeLeft = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      verticalMaxPx: 40,
+      onSwipeLeft,
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 100, clientY: 300 }]));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it('multi-touch start aborts the in-progress gesture (two-handed grip)', () => {
+    // Vacuous-fix guard for the multi-touch guard. Per memory rule for
+    // defensive features: revert the `event.touches.length !== 1` guard
+    // (let the second touchstart fall through without clearing start
+    // coords) and this test fails — the eventual touchend computes delta
+    // from first-finger start to second-finger end and fires a spurious
+    // swipe. Verified mechanically: removing the guard makes this test
+    // fail.
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      verticalMaxPx: 40,
+      onSwipeLeft,
+      onSwipeRight,
+    });
+
+    // First finger lands at x=200.
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    // Second finger lands at x=50 — should clear start coords.
+    onTouchStart(
+      touchEvent('touchstart', [
+        { clientX: 200, clientY: 200 },
+        { clientX: 50, clientY: 200 },
+      ]),
+    );
+    // Second finger lifts at x=50; this used to compute delta = 50 - 200 =
+    // -150 (a far-left swipe) and fire onSwipeLeft. After the fix, start
+    // coords are null and the touchend exits early.
+    onTouchEnd(
+      touchEvent('touchend', [{ clientX: 200, clientY: 200 }], [{ clientX: 50, clientY: 200 }]),
+    );
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('touchend without a preceding touchstart is a safe no-op', () => {
+    const onSwipeLeft = vi.fn();
+    const { onTouchEnd } = useSwipeGesture({ onSwipeLeft });
+
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 100, clientY: 200 }]));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it('touchcancel clears in-progress state so the next touchend is a no-op', () => {
+    const onSwipeLeft = vi.fn();
+    const { onTouchStart, onTouchEnd, onTouchCancel } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      onSwipeLeft,
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchCancel();
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 50, clientY: 200 }]));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it('calls preventDefault on the touchend when a swipe is detected', () => {
+    // Suppresses the synthesized click so a drag crossing an interactive
+    // child doesn't also fire that child's click handler.
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      onSwipeLeft: () => {},
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    const endEvent = touchEvent('touchend', [], [{ clientX: 100, clientY: 200 }]);
+    onTouchEnd(endEvent);
+
+    expect(endEvent.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call preventDefault when the touch ends below threshold (tap path stays clickable)', () => {
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({ horizontalThresholdPx: 60 });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 100, clientY: 200 }]));
+    const endEvent = touchEvent('touchend', [], [{ clientX: 105, clientY: 200 }]);
+    onTouchEnd(endEvent);
+
+    expect(endEvent.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('can detect multiple swipes in sequence without state leaking', () => {
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      onSwipeLeft,
+      onSwipeRight,
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 100, clientY: 200 }]));
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 100, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 200, clientY: 200 }]));
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+
+    // Sequence didn't leak state — total counts are exactly 1 each.
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects custom horizontalThresholdPx and verticalMaxPx', () => {
+    const onSwipeLeft = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 100,
+      verticalMaxPx: 10,
+      onSwipeLeft,
+    });
+
+    // Delta 80 with the default would fire; with threshold 100 it should not.
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 120, clientY: 200 }]));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+
+    // Delta -150 with vertical 20 should NOT fire (vertical exceeds custom max of 10).
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 50, clientY: 220 }]));
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+});

--- a/astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts
+++ b/astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts
@@ -200,6 +200,48 @@ describe('useSwipeGesture', () => {
     expect(onSwipeRight).toHaveBeenCalledTimes(1);
   });
 
+  it('fires when horizontal delta is exactly at the threshold (canonical off-by-one)', () => {
+    // The production code uses `Math.abs(deltaX) < threshold` to skip, so a
+    // delta of exactly `threshold` DOES fire. Mutating `<` to `<=` would
+    // make this case stop firing. Catches that off-by-one in both
+    // directions.
+    const onSwipeLeft = vi.fn();
+    const onSwipeRight = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      verticalMaxPx: 40,
+      onSwipeLeft,
+      onSwipeRight,
+    });
+
+    // Exactly +60 → onSwipeRight.
+    onTouchStart(touchEvent('touchstart', [{ clientX: 100, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 160, clientY: 200 }]));
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+
+    // Exactly -60 → onSwipeLeft.
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 140, clientY: 200 }]));
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires when vertical delta is exactly at the verticalMax (still considered horizontal)', () => {
+    // The production code uses `Math.abs(deltaY) > verticalMax` to skip, so
+    // a vertical drift of exactly `verticalMax` is still treated as a clean
+    // horizontal swipe. Mutating `>` to `>=` would make exact-40 reject and
+    // the swipe never fire.
+    const onSwipeLeft = vi.fn();
+    const { onTouchStart, onTouchEnd } = useSwipeGesture({
+      horizontalThresholdPx: 60,
+      verticalMaxPx: 40,
+      onSwipeLeft,
+    });
+
+    onTouchStart(touchEvent('touchstart', [{ clientX: 200, clientY: 200 }]));
+    onTouchEnd(touchEvent('touchend', [], [{ clientX: 100, clientY: 240 }]));
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+  });
+
   it('respects custom horizontalThresholdPx and verticalMaxPx', () => {
     const onSwipeLeft = vi.fn();
     const { onTouchStart, onTouchEnd } = useSwipeGesture({

--- a/astros_vue/src/composables/useHoldGesture.ts
+++ b/astros_vue/src/composables/useHoldGesture.ts
@@ -16,6 +16,15 @@ export interface UseHoldGestureOptions {
   cooldownMs?: number;
   /** Called once when the gesture transitions from `arming` to `active`. */
   onFire?: () => void;
+  /**
+   * Called if `onFire` throws. Without this the composable falls back to
+   * `console.error` — but a deployed operator never sees `console.error`.
+   * Consumers running in a production UI should pass a handler that routes
+   * to their real logger/toast/error-boundary. A throwing `onError` itself
+   * is caught and its error is logged alongside the original — the cooldown
+   * always schedules either way so the gesture cannot strand in `active`.
+   */
+  onError?: (err: unknown) => void;
 }
 
 export interface UseHoldGestureReturn {
@@ -28,7 +37,7 @@ export interface UseHoldGestureReturn {
 }
 
 export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGestureReturn {
-  const { holdMs = 600, cooldownMs = 2200, onFire } = options;
+  const { holdMs = 600, cooldownMs = 2200, onFire, onError } = options;
 
   const state = ref<HoldGestureState>('idle');
   let armTimer: ReturnType<typeof setTimeout> | null = null;
@@ -48,6 +57,12 @@ export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGest
     }
   }
 
+  // MUST be idempotent: consumers (e.g., AstrosMobileRemote) rely on
+  // re-entrant `start()` being a no-op so the synthesized mousedown that
+  // browsers emit after a touch sequence absorbs cleanly. A future refactor
+  // that weakens the not-idle guard would silently introduce double-fire.
+  // See `AstrosMobileRemote.vue`'s `handlePanicDown` comment for the
+  // browser-event rationale.
   function start() {
     if (state.value !== 'idle') return;
     state.value = 'arming';
@@ -64,7 +79,15 @@ export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGest
       try {
         onFire?.();
       } catch (err) {
-        console.error('useHoldGesture: onFire callback threw', err);
+        try {
+          if (onError) onError(err);
+          else console.error('useHoldGesture: onFire callback threw', err);
+        } catch (handlerErr) {
+          // A throwing onError must not escape into the setTimeout callback
+          // path (where it would surface only as an unhandled rejection /
+          // window.onerror) and must not hide the original error.
+          console.error('useHoldGesture: onError handler threw', handlerErr, 'original:', err);
+        }
       } finally {
         cooldownTimer = setTimeout(() => {
           cooldownTimer = null;

--- a/astros_vue/src/composables/useHoldGesture.ts
+++ b/astros_vue/src/composables/useHoldGesture.ts
@@ -1,0 +1,79 @@
+import { ref, onScopeDispose, type Ref } from 'vue';
+
+export type HoldGestureState = 'idle' | 'arming' | 'active';
+
+export interface UseHoldGestureOptions {
+  /** How long the user must hold before the gesture fires. Default 600ms. */
+  holdMs?: number;
+  /** How long the gesture stays in the `active` lockout after firing. Default 2200ms. */
+  cooldownMs?: number;
+  /** Called once when the gesture transitions from `arming` to `active`. */
+  onFire?: () => void;
+}
+
+export interface UseHoldGestureReturn {
+  state: Ref<HoldGestureState>;
+  start: () => void;
+  cancel: () => void;
+  reset: () => void;
+}
+
+// Refined from the plan's 4-state model (idle | arming | active | cooldown):
+// in the actual design, "active" IS the cooldown — the button shows STOPPED
+// for the entire lockout window and resets to idle when it expires. There's
+// no observable difference between an `active` and a separate `cooldown`
+// state, so the simpler 3-state machine is equivalent.
+export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGestureReturn {
+  const { holdMs = 600, cooldownMs = 2200, onFire } = options;
+
+  const state = ref<HoldGestureState>('idle');
+  let armTimer: ReturnType<typeof setTimeout> | null = null;
+  let cooldownTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearArmTimer() {
+    if (armTimer !== null) {
+      clearTimeout(armTimer);
+      armTimer = null;
+    }
+  }
+
+  function clearCooldownTimer() {
+    if (cooldownTimer !== null) {
+      clearTimeout(cooldownTimer);
+      cooldownTimer = null;
+    }
+  }
+
+  function start() {
+    if (state.value !== 'idle') return;
+    state.value = 'arming';
+    armTimer = setTimeout(() => {
+      armTimer = null;
+      state.value = 'active';
+      onFire?.();
+      cooldownTimer = setTimeout(() => {
+        cooldownTimer = null;
+        state.value = 'idle';
+      }, cooldownMs);
+    }, holdMs);
+  }
+
+  function cancel() {
+    if (state.value !== 'arming') return;
+    clearArmTimer();
+    state.value = 'idle';
+  }
+
+  function reset() {
+    clearArmTimer();
+    clearCooldownTimer();
+    state.value = 'idle';
+  }
+
+  onScopeDispose(() => {
+    clearArmTimer();
+    clearCooldownTimer();
+  });
+
+  return { state, start, cancel, reset };
+}

--- a/astros_vue/src/composables/useHoldGesture.ts
+++ b/astros_vue/src/composables/useHoldGesture.ts
@@ -20,11 +20,14 @@ export interface UseHoldGestureOptions {
    * Called if `onFire` throws. Without this the composable falls back to
    * `console.error` — but a deployed operator never sees `console.error`.
    * Consumers running in a production UI should pass a handler that routes
-   * to their real logger/toast/error-boundary. A throwing `onError` itself
-   * is caught and its error is logged alongside the original — the cooldown
-   * always schedules either way so the gesture cannot strand in `active`.
+   * to their real logger/toast/error-boundary.
+   *
+   * May be async; both synchronous throws and rejected promises returned
+   * from the handler are caught and logged alongside the original error,
+   * so the cooldown always schedules and the gesture cannot strand in
+   * `active`.
    */
-  onError?: (err: unknown) => void;
+  onError?: (err: unknown) => void | Promise<void>;
 }
 
 export interface UseHoldGestureReturn {
@@ -79,14 +82,26 @@ export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGest
       try {
         onFire?.();
       } catch (err) {
-        try {
-          if (onError) onError(err);
-          else console.error('useHoldGesture: onFire callback threw', err);
-        } catch (handlerErr) {
-          // A throwing onError must not escape into the setTimeout callback
-          // path (where it would surface only as an unhandled rejection /
-          // window.onerror) and must not hide the original error.
-          console.error('useHoldGesture: onError handler threw', handlerErr, 'original:', err);
+        if (onError) {
+          // Promise.resolve handles both sync throws (already in catch via
+          // the outer try) and async rejections returned from the handler.
+          // Without this wrap, an async onError whose promise rejects
+          // becomes an unhandled rejection on window.onerror and the
+          // original onFire error is lost.
+          try {
+            Promise.resolve(onError(err)).catch((handlerErr: unknown) => {
+              console.error(
+                'useHoldGesture: onError handler rejected',
+                handlerErr,
+                'original:',
+                err,
+              );
+            });
+          } catch (handlerErr) {
+            console.error('useHoldGesture: onError handler threw', handlerErr, 'original:', err);
+          }
+        } else {
+          console.error('useHoldGesture: onFire callback threw', err);
         }
       } finally {
         cooldownTimer = setTimeout(() => {

--- a/astros_vue/src/composables/useHoldGesture.ts
+++ b/astros_vue/src/composables/useHoldGesture.ts
@@ -1,5 +1,12 @@
-import { ref, onScopeDispose, type Ref } from 'vue';
+import { readonly, ref, onScopeDispose, type Ref } from 'vue';
 
+// Refined from the plan's 4-state model (idle | arming | active | cooldown):
+// the design's "active" IS the cooldown — the button shows STOPPED for the
+// entire lockout window and resets to idle when it expires. There's no
+// observable difference between an `active` and a separate `cooldown` state,
+// so the simpler 3-state machine is equivalent. If a future visual treatment
+// needs to distinguish "just-fired" from "cooling-down", reintroduce
+// `cooldown` here and update the consumer's state checks.
 export type HoldGestureState = 'idle' | 'arming' | 'active';
 
 export interface UseHoldGestureOptions {
@@ -12,17 +19,14 @@ export interface UseHoldGestureOptions {
 }
 
 export interface UseHoldGestureReturn {
-  state: Ref<HoldGestureState>;
+  // Readonly to enforce that consumers go through start()/cancel()/reset()
+  // rather than poking state.value directly and bypassing the timer machine.
+  state: Readonly<Ref<HoldGestureState>>;
   start: () => void;
   cancel: () => void;
   reset: () => void;
 }
 
-// Refined from the plan's 4-state model (idle | arming | active | cooldown):
-// in the actual design, "active" IS the cooldown — the button shows STOPPED
-// for the entire lockout window and resets to idle when it expires. There's
-// no observable difference between an `active` and a separate `cooldown`
-// state, so the simpler 3-state machine is equivalent.
 export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGestureReturn {
   const { holdMs = 600, cooldownMs = 2200, onFire } = options;
 
@@ -50,11 +54,23 @@ export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGest
     armTimer = setTimeout(() => {
       armTimer = null;
       state.value = 'active';
-      onFire?.();
-      cooldownTimer = setTimeout(() => {
-        cooldownTimer = null;
-        state.value = 'idle';
-      }, cooldownMs);
+      // try/finally so a throwing onFire doesn't strand the gesture in
+      // 'active' forever (the cooldown timer must always schedule, otherwise
+      // the panic button shows STOPPED indefinitely and the operator has no
+      // recovery path). The error is logged for operator visibility — this
+      // is NOT silent failure even though we swallow the throw, because
+      // (a) the cooldown recovers the gesture, and (b) the consumer's UI
+      // already showed the success-side feedback before onFire ran.
+      try {
+        onFire?.();
+      } catch (err) {
+        console.error('useHoldGesture: onFire callback threw', err);
+      } finally {
+        cooldownTimer = setTimeout(() => {
+          cooldownTimer = null;
+          state.value = 'idle';
+        }, cooldownMs);
+      }
     }, holdMs);
   }
 
@@ -75,5 +91,5 @@ export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGest
     clearCooldownTimer();
   });
 
-  return { state, start, cancel, reset };
+  return { state: readonly(state), start, cancel, reset };
 }

--- a/astros_vue/src/composables/useHoldGesture.ts
+++ b/astros_vue/src/composables/useHoldGesture.ts
@@ -60,12 +60,12 @@ export function useHoldGesture(options: UseHoldGestureOptions = {}): UseHoldGest
     }
   }
 
-  // MUST be idempotent: consumers (e.g., AstrosMobileRemote) rely on
-  // re-entrant `start()` being a no-op so the synthesized mousedown that
-  // browsers emit after a touch sequence absorbs cleanly. A future refactor
-  // that weakens the not-idle guard would silently introduce double-fire.
-  // See `AstrosMobileRemote.vue`'s `handlePanicDown` comment for the
-  // browser-event rationale.
+  // MUST be idempotent: re-entrant start() is a no-op so consumers can
+  // wire it to multiple event listeners (e.g., a touchstart that races
+  // its synthesized mousedown) without queuing a second arm timer. A
+  // future refactor that weakens the not-idle guard would silently
+  // introduce double-fire. Real-world consumer: `AstrosMobileRemote.vue`'s
+  // `handlePanicDown`.
   function start() {
     if (state.value !== 'idle') return;
     state.value = 'arming';

--- a/astros_vue/src/composables/useSwipeGesture.ts
+++ b/astros_vue/src/composables/useSwipeGesture.ts
@@ -1,0 +1,83 @@
+export interface UseSwipeGestureOptions {
+  /**
+   * Minimum horizontal distance (px) the finger must travel for a swipe to
+   * register. Below this threshold the touch is treated as a tap and no
+   * callback fires. Default 60.
+   */
+  horizontalThresholdPx?: number;
+  /**
+   * Maximum vertical distance (px) the finger may drift during a swipe. Above
+   * this the touch is treated as a diagonal scroll attempt and no callback
+   * fires. Default 40.
+   */
+  verticalMaxPx?: number;
+  /** Called when a leftward swipe crosses the horizontal threshold. */
+  onSwipeLeft?: () => void;
+  /** Called when a rightward swipe crosses the horizontal threshold. */
+  onSwipeRight?: () => void;
+}
+
+export interface UseSwipeGestureReturn {
+  onTouchStart: (event: TouchEvent) => void;
+  onTouchEnd: (event: TouchEvent) => void;
+  onTouchCancel: () => void;
+}
+
+// Detects horizontal swipe gestures on a touch surface. The composable
+// tracks the start coordinates on touchstart and computes the delta on
+// touchend; anything beyond `horizontalThresholdPx` AND under
+// `verticalMaxPx` counts as a swipe.
+//
+// Multi-touch guard: if a second finger lands while a single-finger gesture
+// is in progress, the start coords are cleared so the eventual touchend
+// doesn't evaluate a delta from the first-finger start to the second-finger
+// end (which would fire spurious swipes on two-handed grips).
+//
+// preventDefault on swipe-detected touchend suppresses the synthesized click
+// that follows on mobile browsers, so a drag that crosses an interactive
+// child element doesn't also trigger that child's click handler.
+export function useSwipeGesture(options: UseSwipeGestureOptions = {}): UseSwipeGestureReturn {
+  const { horizontalThresholdPx = 60, verticalMaxPx = 40, onSwipeLeft, onSwipeRight } = options;
+
+  let startX: number | null = null;
+  let startY: number | null = null;
+
+  function onTouchStart(event: TouchEvent) {
+    if (event.touches.length !== 1) {
+      // A second finger landed mid-gesture — abort any in-progress swipe so
+      // the eventual touchend doesn't evaluate a delta from the first-finger
+      // start to the second-finger end.
+      startX = null;
+      startY = null;
+      return;
+    }
+    const touch = event.touches[0];
+    if (!touch) return;
+    startX = touch.clientX;
+    startY = touch.clientY;
+  }
+
+  function onTouchEnd(event: TouchEvent) {
+    if (startX === null || startY === null) return;
+    const touch = event.changedTouches[0];
+    if (!touch) return;
+    const deltaX = touch.clientX - startX;
+    const deltaY = touch.clientY - startY;
+    startX = null;
+    startY = null;
+
+    if (Math.abs(deltaX) < horizontalThresholdPx) return;
+    if (Math.abs(deltaY) > verticalMaxPx) return;
+
+    event.preventDefault();
+    if (deltaX < 0) onSwipeLeft?.();
+    else onSwipeRight?.();
+  }
+
+  function onTouchCancel() {
+    startX = null;
+    startY = null;
+  }
+
+  return { onTouchStart, onTouchEnd, onTouchCancel };
+}

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -456,7 +456,7 @@
     "chip_script": "Script",
     "chip_playlist": "List",
     "press_toast": "Sent: {name}",
-    "panic_toast": "STOP ALL — sent",
+    "panic_toast": "STOP ALL — sending…",
     "stop_all_idle": "Stop All",
     "stop_all_arming": "Hold…",
     "stop_all_active": "STOPPED",

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -450,6 +450,23 @@
     "button_label": "Button {number}",
     "button_select": "Button assignment"
   },
+  "mobile_remote": {
+    "region_label": "Mobile remote",
+    "connected_label": "Connected",
+    "chip_script": "Script",
+    "chip_playlist": "List",
+    "press_toast": "Sent: {name}",
+    "panic_toast": "STOP ALL — sent",
+    "stop_all_idle": "Stop All",
+    "stop_all_arming": "Hold…",
+    "stop_all_active": "STOPPED",
+    "stop_all_caption": "Hold to halt every running action",
+    "empty_slot_aria": "Empty slot {number}",
+    "prev_page_aria": "Previous page",
+    "next_page_aria": "Next page",
+    "dot_aria": "Go to page {number}",
+    "no_pages": "No remote pages configured"
+  },
   "utility_view": {
     "title": "Utility",
     "api_key": "API Key",

--- a/astros_vue/src/main.ts
+++ b/astros_vue/src/main.ts
@@ -17,7 +17,7 @@ import {
   IoAdd,
   IoHelpCircleOutline,
 } from 'oh-vue-icons/icons';
-import { MdDraghandle } from 'oh-vue-icons/icons/md';
+import { MdDraghandle, MdDescription, MdFolder } from 'oh-vue-icons/icons/md';
 import App from './App.vue';
 import router from './router';
 import i18n from './i18n';
@@ -38,6 +38,8 @@ addIcons(
   IoAdd,
   IoHelpCircleOutline,
   MdDraghandle,
+  MdDescription,
+  MdFolder,
 );
 
 const app = createApp(App);


### PR DESCRIPTION

## Summary

Ports the Direction B handoff's mobile remote (`mobileRemote.jsx`) to a reusable Vue 3 component for Phase 2's preview rail (compact mode) and Phase 4's standalone operator route. Ships the component, two composables (`useHoldGesture`, `useSwipeGesture`), six Storybook variants, and the i18n + icon plumbing. No backend wiring, no route, no `apiService` calls — those are Phase 4's job per the documented contract.

Phase 3 was reordered ahead of Phase 2 because Phase 2's live-preview rail imports this component — doing them in original order would have forced a stub-then-replace cycle. Sequencing note added to `current_project.md`.

Three review cycles ran on this branch:
1. **Pre-push toolkit, round 1** (5 agents parallel, ~25 findings) → critical/important addressed in `1ada630`.
2. **Pre-push toolkit, round 2** (6 commits across panic-delivery contract, init-clamp, wordmark i18n, type guard, behavioral test coverage, cleanup batch).
3. **Pre-push toolkit, round 3** (exhaustive `isFilledPageButton` switch, async-safe `onError`, watcher tests, plan/code drift sweep across header docstrings + PR text).

The final commit (`ffb4615`) is a comment-only cleanup pass dropping plan/phase references that would rot once Phase 2/4 ship.

---

## Changes

### `useHoldGesture` composable + tests
- `astros_vue/src/composables/useHoldGesture.ts` (new, 133 lines) — panic-button state machine `'idle' | 'arming' | 'active'` (collapsed from the plan's 4-state sketch; rationale in code comment). Options: `holdMs` (600), `cooldownMs` (2200), `onFire` callback, `onError` callback (sync or async). API: `state` (Readonly Ref), `start()`, `cancel()`, `reset()`. `onScopeDispose` cleans internal timers. `try/finally` around `onFire` so a throwing callback can't strand the gesture in `active` forever. `Promise.resolve(...).catch(...)` wrap around `onError` so an async handler whose promise rejects is caught and logged alongside the original `onFire` error rather than becoming an unhandled rejection on `window.onerror`.
- `astros_vue/src/composables/__tests__/useHoldGesture.spec.ts` (new, **18 tests**) — covers state transitions, cancel-during-arming (vacuous-fix guard for `clearArmTimer`), cancel-during-active no-op + cooldown-not-disrupted, custom timings, multi-cycle behavior, `onFire` throws → cooldown still schedules (covers try/finally), throwing-`onFire` + supplied `onError` routes correctly (no double-log to `console.error`), throwing `onError` is contained with both errors logged, **async `onError` whose promise rejects** is caught (round 3 fix), `reset()` leaves no orphan cooldown timer (vacuous-fix guard for `clearCooldownTimer`), `onScopeDispose` cleanup. Five vacuous-fix guards verified mechanically.

### `useSwipeGesture` composable + tests (extracted from `AstrosMobileRemote.vue`)
- `astros_vue/src/composables/useSwipeGesture.ts` (new, 83 lines) — swipe state machine with distance + vertical-max thresholds, multi-touch abort, and `preventDefault` on swipe-detected `touchend` (suppresses synthesized click on mobile). Options: `horizontalThresholdPx` (60), `verticalMaxPx` (40), `onSwipeLeft`, `onSwipeRight`. Returned handlers wire directly to `@touchstart` / `@touchend` / `@touchcancel`.
- `astros_vue/src/composables/__tests__/useSwipeGesture.spec.ts` (new, **13 tests**) — direction conventions, below-threshold tap = no callback, vertical-over-max = no callback (diagonal scroll), multi-touch abort (vacuous-fix guard verified), touchend-without-touchstart safety, touchcancel state clearing, preventDefault behavior on swipe vs tap, multi-swipe sequence integrity without state leaking, **exact-threshold boundary tests** for both axes (catches `<` → `<=` and `>` → `>=` mutations), custom threshold/max values.

### `AstrosMobileRemote.vue` component
- `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.vue` (new, 811 lines) — handheld remote layout with orange top bar (wordmark + Connected chip), page header, 3×3 button grid, pagination row (chevrons + dots), transient toast, and STOP ALL panic button. Props: `pages`, `initialIdx`, `compact`, `connected`. Emits: `press(FilledPageButton)`, `panic()`. Uses both new composables. Scoped BEM CSS with `--mr-*` design tokens.
- `astros_vue/src/components/mobileRemote/mobileRemote/types.ts` (new) — `AstrosMobileRemotePressEvent` narrowed to `FilledPageButton` (excludes `type: 'none'`) so the Phase 4 parent gets a script-or-playlist discriminator without a redundant null-check. **`isFilledPageButton` is an exhaustive switch over `PageButtonType`** (round 3 fix) so a new variant breaks the build at the `never` assertion instead of being silently classified as filled and leaking into the emit payload.
- `astros_vue/src/components/mobileRemote/index.ts` (new) — barrel re-exports component + press-event type.

### Component-level behavioral coverage
- `astros_vue/src/components/mobileRemote/mobileRemote/AstrosMobileRemote.spec.ts` (new, **8 tests**) — safety-contract coverage:
  - panic active lockout suppresses presses (the load-bearing safety invariant)
  - press-path timers cleared on unmount (vacuous-fix guard for `clearPressTimer`/`clearToast`)
  - panic-path timers cleared on unmount (vacuous-fix guard, including `useHoldGesture.onScopeDispose`)
  - panic `onFire` cancels in-flight press toast so it doesn't clear the panic toast early
  - `emit('press')` narrows to `FilledPageButton` — never includes `type: 'none'`
  - **init-time clamp** for out-of-range `initialIdx` (round-2 fix)
  - **watcher reseat** when parent updates `initialIdx` after mount (round-3 fix)
  - **`pages.length` watcher** settles `idx` after shrink so a grow-back doesn't teleport to a stale page (round-3 fix)

### Storybook stories (6 variants)
- `AstrosMobileRemote.stories.ts` (new, 178 lines) — "Page 1 — mixed (7 of 9)", "Page 2 — sparse (3 of 9)", "Page 3 — empty (all dashed)", "Compact preview", "Disconnected" (no Connected chip), "Empty pages array" (safety-branch coverage). Each wraps the component in a fixed-size phone-shaped container.
- `astros_vue/.storybook/preview.ts` — registers `MdDescription` + `MdFolder` icons (mirrors `main.ts`).

### Icon + i18n + plan plumbing
- `astros_vue/src/main.ts` — registers `MdDescription` (script chip) and `MdFolder` (playlist chip).
- `astros_vue/src/locales/enUS.json` — adds 17 `mobile_remote.*` keys (connection label, chip labels, press/panic toasts, stop-all state labels, page caption, empty-slot aria, pagination aria, dot aria, no-pages empty state, wordmark aria).
- `.docs/plans/20260521-1135-phase3-mobile-remote-component.md` (new, 251 lines) — light plan (4 tasks); deviations + Phase 4 contract section added post-toolkit; multiple drift-fixup commits keep it in sync with the code.
- `.docs/plans/20260521-1700-phase3-review-fix-batch.md` (new, 189 lines) — review-fix tracker spanning rounds 1–3.
- `.docs/plans/current_project.md` — Phase 6 checkbox flipped (shipped via PR #91); Phase 3 sequencing note added.

### Round-3 cleanup batch (latest commits)
- **Exhaustive `isFilledPageButton`** — switch instead of `!== 'none'` so a new `PageButtonType` variant trips a `never` assertion at compile time.
- **Async-safe `onError`** — `Promise.resolve(handler(err)).catch(...)` handles both sync throws AND rejected promises returned from async handlers.
- **`watch(() => props.initialIdx, ...)` test** — pins the post-mount reseat behavior; without the watcher, an in-range `initialIdx` update is silently ignored because the read-time clamp doesn't help when `idx.value` itself doesn't change.
- **`watch(() => props.pages.length, ...)` test** — pins shrink-then-grow intent; without the watcher, the user teleports back to a stale page when `pages` grows back.
- **Decircular composable docstring** — removed a self-referential mention.
- **Final comment cleanup** (`ffb4615`) — trimmed Phase 2/Phase 4/handoff references from code comments; preserved every WHY rationale and vacuous-fix guard.

---

## Quality gates passed

| Gate | Result |
|---|---|
| Vue `npm run build` (vue-tsc + vite) | clean |
| Vue `npx vitest run` | **407 / 407** (+39 from this PR: 18 useHoldGesture + 13 useSwipeGesture + 8 AstrosMobileRemote) |
| Vue `npm run format` + `npm run lint` | clean |
| Vue `npm run build-storybook` | clean (all 6 stories bundle) |
| **Per-commit code review** (`superpowers:requesting-code-review`) | Multiple findings caught + fixed iteratively across rounds; final reviews clean |
| **Pre-push toolkit** (`pr-review-toolkit:review-pr`, 5 agents parallel) | 3 rounds total. Round 1: ~25 findings. Rounds 2–3 chipped through panic-delivery contract, init clamp, exhaustive type guard, async-safe error path, post-mount watchers, and plan/code drift. All Critical + Important addressed; Minor either deferred to Phase 4 (panic delivery confirmation) or folded into the planned a11y pass |

### Vacuous-fix guards (verified by revert-and-confirm)

Per the CLAUDE.md "Mutation test defensive features" memory rule, these tests pin defensive logic that would silently regress if removed. Each verified by reverting production code locally and confirming the named test fails:

1. **`useHoldGesture` cancel during arming** — drop `clearArmTimer()` from `cancel()` → queued arm timer fires → `expect(onFire).not.toHaveBeenCalled()` fails.
2. **`useHoldGesture` reset orphan cooldown** — drop `clearCooldownTimer()` from `reset()` → orphan timer fires during a later cycle's lockout, clobbering the new STOPPED visual → cycle-2 `state === 'active'` assertion fails.
3. **`useHoldGesture` no double-arm during arming** — weaken the `state !== 'idle'` guard → second `start()` queues a second arm timer → `onFire` called twice → `toHaveBeenCalledTimes(1)` fails.
4. **`useHoldGesture` async `onError` rejection caught** — remove the `Promise.resolve(...).catch(...)` wrap → rejected promise becomes unhandled rejection → "onError handler rejected" log assertion fails.
5. **`useHoldGesture` onError throws + cooldown still recovers** — remove the inner try/catch around `onError` → uncaught throw + cooldown still schedules → unhandled-rejection assertion fails.
6. **`useSwipeGesture` multi-touch abort** — drop the `event.touches.length !== 1` guard → second-finger lift fires a spurious swipe → both directional-callback assertions fail.
7. **`useSwipeGesture` distance threshold** — drop the `Math.abs(deltaX) < threshold` early return → a 2px tap fires `onSwipeLeft`.
8. **`useSwipeGesture` vertical-max guard** — drop the `Math.abs(deltaY) > verticalMax` early return → diagonal scrolls fire swipes if they have any horizontal component over threshold.
9. **`AstrosMobileRemote` press-path timers cleared on unmount** — drop `clearPressTimer()` / `clearToast()` from `onBeforeUnmount` → pending timers still queued at unmount → `vi.getTimerCount()` assertion fails.
10. **`AstrosMobileRemote` panic-path timers cleared on unmount** — drop the same clears OR drop `useHoldGesture.onScopeDispose` → toast/cooldown timers leak → count assertion fails.
11. **`AstrosMobileRemote` `pages.length` watcher settles idx** — remove the watcher → shrink-then-grow sequence teleports the user back to a stale page → final `page-name` assertion fails.

---

## Test plan (reviewer / merge gate)

- [ ] `npm run storybook` — open `components/mobileRemote/AstrosMobileRemote`. Verify all 6 stories render and visually match the handoff screenshots at `.tmp/design_handoff_remote_control/screenshots/03-mobile-page1.png` through `05-mobile-empty.png`.
- [ ] Press the panic button and hold for 600ms — orange arming fill should reach full width, label should transition "Stop All" → "Hold…" → "STOPPED", lockout should release after 2.2s.
- [ ] Press one of the assigned slot buttons — press-flash should run for 220ms, the "Sent: …" toast should decay within 1600ms.
- [ ] Swipe LEFT-to-RIGHT on the 3×3 grid in a touch-capable tab (Chrome DevTools "Toggle device toolbar") — navigates to previous page. Swipe RIGHT-to-LEFT advances.
- [ ] Switch the story to "Compact preview" — verify the layout shrinks proportionally (top bar 8px padding instead of 14px, button labels 11px instead of 15px, etc.).
- [ ] Unmount-during-active-gesture spot-check: in DevTools console while the panic button is mid-arming, switch stories and confirm no leaked timer warnings.

---

## Deferred items / Phase 4 contract requirements

Several toolkit findings were intentionally deferred to Phase 4 because they're contracts the component exposes for the consumer to satisfy. **Phase 4's wiring is responsible for these:**

1. **Panic delivery confirmation.** The component fires `emit('panic')` and shows the STOPPED visual + "sending…" toast unconditionally. Phase 4 MUST gate the success feedback on actual websocket-PANIC delivery — either via a `panicStatus: 'idle' | 'sending' | 'sent' | 'failed'` prop or a contract change. Safety-critical: a failed panic with confirmed-success feedback misleads the operator.
2. **Press delivery confirmation.** Same shape — `emit('press', button)` is fire-and-forget. Phase 4 must surface API/WS errors so the "Sent: …" toast doesn't lie.
3. **`connected` tri-state widening.** Currently `boolean`. Phase 4 may want `'connected' | 'connecting' | 'disconnected'` to show a connecting spinner during retry windows; widen at that point (non-breaking since `true` stays the default).

### Lower-priority items deferred (intentional)

- `mouseleave` cancels panic silently — matches the handoff JSX behavior; finger-drift IS the documented UX.
- Empty-slot tap shows no toast — the dashed border IS the empty-state affordance; redundant feedback would be noise.
- a11y batched into the planned a11y pass: `aria-pressed="mixed"` during arming, `aria-describedby` on panic, `role="img"` on empty-slot buttons.
- `BUTTON_KEYS` length-9 type-level completeness check against `keyof RemoteControlPage` — type-design improvement, not a correctness bug.
- Storybook `play` functions for interaction tests — nice-to-have, not blocking.
- Rename `useHoldGesture` `active` to `firing` or `stopped` — judgment call, defer.

---

## Reviewer notes

- The biggest single decision in this PR was extracting `useSwipeGesture` from inline component code into its own composable. The trigger was the pre-push toolkit's mutation-test concern: the multi-touch guard is exactly the kind of defensive feature that must have a revert-to-confirm test. Inline-in-the-component, the guard was unverifiable. The composable now has 13 tests including the verified-by-revert multi-touch guard.
- `useHoldGesture` collapsed the plan's 4-state machine (`idle | arming | active | cooldown`) to 3 states because the STOPPED visual covers the entire post-fire lockout with no observable distinction between "just-fired" and "cooling down". Rationale lives in the composable's header comment.
- The `try/finally` around `onFire` in `useHoldGesture` is load-bearing — without it, a Phase 4 listener that throws (websocket send error, JSON parsing) would strand the gesture in `active` forever and the operator would never get a working panic button again. The async-safe `onError` (Promise.resolve wrap) extends the same property to async handlers.
- `AstrosMobileRemotePressEvent` is narrowed to `FilledPageButton` so the Phase 4 parent's `switch (event.type)` doesn't need a dead `none` branch. The exhaustive `isFilledPageButton` guard (round-3 fix) ensures a future `PageButtonType` variant breaks the build instead of being silently classified as filled.
- The plan files' "Deviations" sections enumerate plan-vs-code drift items the toolkit's comment-analyzer caught across three review rounds. Multiple drift-fixup commits sweep the plan, PR text, and code header docstrings together — same conceptual issue flagged twice = incomplete sweep, not a flaky reviewer.
- The final `ffb4615` comment cleanup is a comment-only commit (no logic touched) that trims Phase 2/4 / handoff references that would rot once those phases ship. Preserved every WHY rationale and vacuous-fix guard.
- This PR is ready for review. Task 4 (manual visual verification against the handoff screenshots) is the merge gate.
