### PR TITLE
Feature/phase2a store crud impl

### DIFF
--- a/.docs/plans/20260523-1200-phase2a-store-crud-impl.md
+++ b/.docs/plans/20260523-1200-phase2a-store-crud-impl.md
@@ -18,7 +18,7 @@
 
 - Branch off the latest `origin/develop`. The previous branch name `feature/phase2a-store-crud-foundation` is burned (PR #93 already used it).
 - Per memory `feedback_safe_feature_branch_creation`: **do NOT** use `git checkout -b feature/phase2a-store-crud-impl origin/develop` — that form makes the branch track `develop` and VS Code will push commits straight to develop. Use `git fetch origin && git switch develop && git pull && git switch -c feature/phase2a-store-crud-impl` (no upstream argument — the branch ends up with no upstream, which is what we want).
-- Per memory `feedback_prettier_pre_commit`: `npm run prettier:write` runs **before** every commit, alongside `npm run lint:fix`.
+- Per memory `feedback_prettier_pre_commit`: `npm run format` (the Vue project's prettier script — equivalent to the API's `prettier:write`) runs **before** every commit, alongside `npm run lint` (Vue's lint script already runs eslint with `--fix`).
 - Per memory `feedback_mutation_test_defensive_features`: for every defensive guard added (`deletePage`'s `pages.length <= 1`, `renamePage`'s trim/empty check, `selectPage`'s clamp, `addPage`'s `selectedIdx` invariant, the `isDirty=false` clears in load/save), revert the guard, re-run the relevant test, confirm it FAILS, then restore the guard. The plan calls this out per-task.
 - All test commands run from `astros_vue/`. The watch-mode default (`npm run test:unit`) is fine for local iteration; the plan uses `npx vitest run path/to/spec.ts -t "test name"` for one-shot runs and verification.
 
@@ -183,8 +183,8 @@ Restore the line.
 
 ```bash
 npx vitest run src/stores/__tests__/remoteControl.spec.ts
-npm run prettier:write
-npm run lint:fix
+npm run format
+npm run lint
 git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
 git commit -m "feat(remote-store): add isDirty flag cleared on load success"
 ```
@@ -333,8 +333,8 @@ Expected: both "clamps" tests FAIL. Restore the clamp.
 
 ```bash
 npx vitest run src/stores/__tests__/remoteControl.spec.ts
-npm run prettier:write
-npm run lint:fix
+npm run format
+npm run lint
 git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
 git commit -m "feat(remote-store): add selectedIdx with clamping selectPage and load reset"
 ```
@@ -430,8 +430,8 @@ Expected: that test FAILS. Restore.
 
 ```bash
 npx vitest run src/stores/__tests__/remoteControl.spec.ts
-npm run prettier:write
-npm run lint:fix
+npm run format
+npm run lint
 git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
 git commit -m "feat(remote-store): add addPage method"
 ```
@@ -582,8 +582,8 @@ Expected: that test FAILS. Restore the loop.
 
 ```bash
 npx vitest run src/stores/__tests__/remoteControl.spec.ts
-npm run prettier:write
-npm run lint:fix
+npm run format
+npm run lint
 git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
 git commit -m "feat(remote-store): add duplicatePage with deep button copy"
 ```
@@ -757,8 +757,8 @@ Expected: FAIL. Restore.
 
 ```bash
 npx vitest run src/stores/__tests__/remoteControl.spec.ts
-npm run prettier:write
-npm run lint:fix
+npm run format
+npm run lint
 git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
 git commit -m "feat(remote-store): add deletePage with single-page guard and selectedIdx clamp"
 ```
@@ -892,8 +892,8 @@ Expected: FAIL. Restore.
 
 ```bash
 npx vitest run src/stores/__tests__/remoteControl.spec.ts
-npm run prettier:write
-npm run lint:fix
+npm run format
+npm run lint
 git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
 git commit -m "feat(remote-store): add renamePage with trim + empty-string no-op"
 ```
@@ -1030,8 +1030,8 @@ Expected: FAIL. Restore.
 - [ ] **Step 7: Commit**
 
 ```bash
-npm run prettier:write
-npm run lint:fix
+npm run format
+npm run lint
 git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
 git commit -m "feat(remote-store): drop all-empty save filter; clear isDirty on save success"
 ```

--- a/.docs/plans/20260523-1200-phase2a-store-crud-impl.md
+++ b/.docs/plans/20260523-1200-phase2a-store-crud-impl.md
@@ -1,0 +1,1162 @@
+# Phase 2a — Store CRUD Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` (inline, recommended for store work — fast, single-file scope) or `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `useRemoteControlStore` with the page-CRUD methods, `selectedIdx`, and `isDirty` flag that the Phase 2b/2c/2d UI components consume. No UI changes.
+
+**Architecture:** All work confined to `astros_vue/src/stores/remoteControl.ts` + its `__tests__/remoteControl.spec.ts`. The store gains 2 reactive refs (`selectedIdx`, `isDirty`) and 5 methods (`addPage`, `duplicatePage`, `deletePage`, `renamePage`, `selectPage`). `loadRemoteControl` resets `selectedIdx` to 0 and clears `isDirty` on success; `saveRemoteControl` drops the all-empty filter and clears `isDirty` on success. Dirty tracking is a plain flag (not snapshot comparison) per design Decision 3 & 10.
+
+**Tech Stack:** Pinia (composition-API style), Vue 3 `ref`, Vitest, TypeScript.
+
+**Spec:** `.docs/plans/specs/2026-05-21-phase2-editor-design.md` Sections 2 (decisions), 4 (interface), 5 (data flow), 8 (file inventory). Refer to it for any signature/intent question.
+
+**Tracker:** `.docs/plans/current_project.md` — check off "Phase 2 / 2a" when this plan completes.
+
+---
+
+## Pre-flight context
+
+- Branch off the latest `origin/develop`. The previous branch name `feature/phase2a-store-crud-foundation` is burned (PR #93 already used it).
+- Per memory `feedback_safe_feature_branch_creation`: **do NOT** use `git checkout -b feature/phase2a-store-crud-impl origin/develop` — that form makes the branch track `develop` and VS Code will push commits straight to develop. Use `git fetch origin && git switch develop && git pull && git switch -c feature/phase2a-store-crud-impl` (no upstream argument — the branch ends up with no upstream, which is what we want).
+- Per memory `feedback_prettier_pre_commit`: `npm run prettier:write` runs **before** every commit, alongside `npm run lint:fix`.
+- Per memory `feedback_mutation_test_defensive_features`: for every defensive guard added (`deletePage`'s `pages.length <= 1`, `renamePage`'s trim/empty check, `selectPage`'s clamp, `addPage`'s `selectedIdx` invariant, the `isDirty=false` clears in load/save), revert the guard, re-run the relevant test, confirm it FAILS, then restore the guard. The plan calls this out per-task.
+- All test commands run from `astros_vue/`. The watch-mode default (`npm run test:unit`) is fine for local iteration; the plan uses `npx vitest run path/to/spec.ts -t "test name"` for one-shot runs and verification.
+
+---
+
+## File Structure
+
+**Modified files only — no new files in 2a:**
+- `astros_vue/src/stores/remoteControl.ts` — add state + methods; modify `loadRemoteControl` and `saveRemoteControl`
+- `astros_vue/src/stores/__tests__/remoteControl.spec.ts` — add ~25 tests across 6 new `describe` blocks; **invert** the existing `drops a page where all 9 buttons are id="0"` test (it currently asserts the filter; after Decision 3 it must assert non-filtering)
+
+**Out of scope for 2a (lands in later sub-phases):**
+- No new components
+- No view changes
+- No router changes
+- No i18n keys
+- No backend changes
+
+---
+
+## Task 0: Branch setup
+
+**Files:**
+- None (git operations only)
+
+- [ ] **Step 1: Fetch latest develop and confirm clean state**
+
+```bash
+git fetch origin
+git status
+```
+Expected: working tree clean; on branch `develop`. If not, stop and stash/commit before proceeding.
+
+- [ ] **Step 2: Sync local develop**
+
+```bash
+git switch develop
+git pull --ff-only
+```
+Expected: fast-forward to `origin/develop` HEAD (currently `fafe331`).
+
+- [ ] **Step 3: Create the feature branch WITHOUT tracking develop**
+
+```bash
+git switch -c feature/phase2a-store-crud-impl
+```
+Expected: branch created, no upstream set. Verify with `git status` — should say "On branch feature/phase2a-store-crud-impl" with no "Your branch is up to date with…" line. (If it says tracking, the branch was created the wrong way — delete and redo without the `origin/develop` argument.)
+
+- [ ] **Step 4: Commit this plan file**
+
+```bash
+git add .docs/plans/20260523-1200-phase2a-store-crud-impl.md
+git commit -m "docs(plan): Phase 2a store CRUD implementation plan"
+```
+
+This is a plan-only commit — per CLAUDE.md carve-outs, no pre-commit toolkit required.
+
+---
+
+## Task 1: Add `isDirty` flag + clear on load success
+
+**Why first:** Every subsequent mutation method needs to set this flag, and the load-success test pins the "flag clears" baseline. Doing isDirty first means later mutation tasks can each assert `isDirty === true` post-mutation without bootstrapping the flag separately.
+
+**Files:**
+- Modify: `astros_vue/src/stores/remoteControl.ts`
+- Test: `astros_vue/src/stores/__tests__/remoteControl.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add a new `describe` block in `remoteControl.spec.ts`, after the existing `saveRemoteControl` block:
+
+```ts
+describe('isDirty flag', () => {
+  it('starts false on a fresh store', () => {
+    const store = useRemoteControlStore();
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('stays false after a successful load', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('clears to false when a successful load follows a dirty state', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([]));
+    const store = useRemoteControlStore();
+    // Simulate a prior mutation having flipped the flag. We poke the ref
+    // directly here because the mutation methods that flip it land in
+    // later tasks; this isolates the "load clears it" behavior.
+    (store as unknown as { isDirty: boolean }).isDirty = true;
+    await store.loadRemoteControl();
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('does NOT clear isDirty when load fails (network)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    apiGet.mockRejectedValue(new Error('network down'));
+    const store = useRemoteControlStore();
+    (store as unknown as { isDirty: boolean }).isDirty = true;
+    await store.loadRemoteControl();
+    expect(store.isDirty).toBe(true);
+    errSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd astros_vue
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "isDirty flag"
+```
+Expected: 4 tests fail with `Cannot read properties of undefined` or `expected undefined to be false` (because `store.isDirty` doesn't exist yet).
+
+- [ ] **Step 3: Add the `isDirty` ref and clear-on-success in loadRemoteControl**
+
+In `remoteControl.ts`, inside the `defineStore` callback, after `const isLoading = ref(false);`:
+
+```ts
+const isDirty = ref(false);
+```
+
+In `loadRemoteControl`, immediately after the successful page assignment branch (after the `if (result.length > 0) { … } else { … }` block, before `isLoading.value = false;`):
+
+```ts
+isDirty.value = false;
+```
+
+Then in the `return { … }` at the bottom, add `isDirty` to the exposed object:
+
+```ts
+return {
+  remoteControlPages,
+  isLoading,
+  isDirty,
+  loadRemoteControl,
+  saveRemoteControl,
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "isDirty flag"
+```
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Mutation-test the "clear on load success" branch**
+
+Per memory `feedback_mutation_test_defensive_features`: revert the fix and confirm the test fails. Comment out the `isDirty.value = false;` line inside `loadRemoteControl`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "clears to false when a successful load"
+```
+Expected: FAIL (`expected true to be false`). This proves the test actually exercises the clearing logic — not a vacuous assertion.
+
+Restore the line.
+
+- [ ] **Step 6: Full test pass + commit**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts
+npm run prettier:write
+npm run lint:fix
+git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
+git commit -m "feat(remote-store): add isDirty flag cleared on load success"
+```
+
+---
+
+## Task 2: Add `selectedIdx` + `selectPage`
+
+**Why:** Selection is independent of dirtiness (Decision 7) and the simplest mutation. Tests pin the clamp invariant before later tasks rely on it for `deletePage`'s clamp behavior.
+
+**Files:**
+- Modify: `astros_vue/src/stores/remoteControl.ts`
+- Test: `astros_vue/src/stores/__tests__/remoteControl.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this `describe` block after the `isDirty flag` block:
+
+```ts
+describe('selectedIdx + selectPage', () => {
+  it('starts at 0', () => {
+    const store = useRemoteControlStore();
+    expect(store.selectedIdx).toBe(0);
+  });
+
+  it('selectPage(2) sets selectedIdx to 2 when 3 pages exist', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.selectPage(2);
+
+    expect(store.selectedIdx).toBe(2);
+  });
+
+  it('clamps selectPage(99) to last index when out of range high', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.selectPage(99);
+
+    expect(store.selectedIdx).toBe(1);
+  });
+
+  it('clamps selectPage(-3) to 0 when negative', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.selectPage(-3);
+
+    expect(store.selectedIdx).toBe(0);
+  });
+
+  it('does NOT set isDirty', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.selectPage(1);
+
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('loadRemoteControl resets selectedIdx to 0', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    store.selectPage(2);
+
+    // Reload simulates a re-entry into the view.
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    await store.loadRemoteControl();
+
+    expect(store.selectedIdx).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "selectedIdx \\+ selectPage"
+```
+Expected: 6 tests fail (`store.selectPage is not a function`, `store.selectedIdx === undefined`).
+
+- [ ] **Step 3: Implement selectedIdx + selectPage**
+
+In `remoteControl.ts`, after `const isDirty = ref(false);`:
+
+```ts
+const selectedIdx = ref(0);
+```
+
+After the existing `saveRemoteControl` function definition (or anywhere before the `return` at the bottom — match the file's existing function-then-return ordering):
+
+```ts
+function selectPage(idx: number) {
+  if (remoteControlPages.value.length === 0) {
+    selectedIdx.value = 0;
+    return;
+  }
+  const lastIdx = remoteControlPages.value.length - 1;
+  selectedIdx.value = Math.min(Math.max(idx, 0), lastIdx);
+}
+```
+
+In `loadRemoteControl`, alongside the `isDirty.value = false;` line added in Task 1 (on success):
+
+```ts
+selectedIdx.value = 0;
+```
+
+Add `selectedIdx` and `selectPage` to the return object:
+
+```ts
+return {
+  remoteControlPages,
+  isLoading,
+  isDirty,
+  selectedIdx,
+  loadRemoteControl,
+  saveRemoteControl,
+  selectPage,
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "selectedIdx \\+ selectPage"
+```
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Mutation-test the clamp**
+
+Comment out the `Math.min(Math.max(...))` clamp and replace with `selectedIdx.value = idx;`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "clamps selectPage"
+```
+Expected: both "clamps" tests FAIL. Restore the clamp.
+
+- [ ] **Step 6: Full test pass + commit**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts
+npm run prettier:write
+npm run lint:fix
+git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
+git commit -m "feat(remote-store): add selectedIdx with clamping selectPage and load reset"
+```
+
+---
+
+## Task 3: Add `addPage`
+
+**Files:**
+- Modify: `astros_vue/src/stores/remoteControl.ts`
+- Test: `astros_vue/src/stores/__tests__/remoteControl.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this `describe` block after `selectedIdx + selectPage`:
+
+```ts
+describe('addPage', () => {
+  it('appends a default page with auto-numbered name', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.addPage();
+
+    expect(store.remoteControlPages).toHaveLength(2);
+    expect(store.remoteControlPages[1]!.name).toBe('Page 2');
+    expect(store.remoteControlPages[1]!.id).toMatch(UUID_LIKE);
+  });
+
+  it('selects the newly added page', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.addPage();
+
+    expect(store.selectedIdx).toBe(1);
+  });
+
+  it('flips isDirty to true', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    expect(store.isDirty).toBe(false);
+
+    store.addPage();
+
+    expect(store.isDirty).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "addPage"
+```
+Expected: 3 tests fail (`store.addPage is not a function`).
+
+- [ ] **Step 3: Implement addPage**
+
+In `remoteControl.ts`, add this function after `selectPage`:
+
+```ts
+function addPage() {
+  const newIdx = remoteControlPages.value.length;
+  remoteControlPages.value.push(createDefaultPage(newIdx));
+  selectedIdx.value = newIdx;
+  isDirty.value = true;
+}
+```
+
+Add `addPage` to the return object.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "addPage"
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Mutation-test the isDirty flip**
+
+Comment out the `isDirty.value = true;` line in `addPage`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "flips isDirty to true"
+```
+Expected: that test FAILS. Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts
+npm run prettier:write
+npm run lint:fix
+git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
+git commit -m "feat(remote-store): add addPage method"
+```
+
+---
+
+## Task 4: Add `duplicatePage`
+
+**Files:**
+- Modify: `astros_vue/src/stores/remoteControl.ts`
+- Test: `astros_vue/src/stores/__tests__/remoteControl.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this `describe` block after `addPage`:
+
+```ts
+describe('duplicatePage', () => {
+  it('splices a copy right after the source index with a fresh id', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    const srcId = store.remoteControlPages[0]!.id;
+
+    store.duplicatePage(0);
+
+    expect(store.remoteControlPages).toHaveLength(3);
+    expect(store.remoteControlPages[1]!.id).not.toBe(srcId);
+    expect(store.remoteControlPages[1]!.id).toMatch(UUID_LIKE);
+  });
+
+  it('names the copy "<src> (copy)"', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([
+      { ...legacyPage(), name: 'Performance' },
+    ]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.duplicatePage(0);
+
+    expect(store.remoteControlPages[1]!.name).toBe('Performance (copy)');
+  });
+
+  it('deep-copies button slots (mutating original does not affect copy)', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    apiPut.mockResolvedValue(undefined);
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    store.remoteControlPages[0]!.button1 = { id: 's1', name: 'Wave', type: 'script' };
+
+    store.duplicatePage(0);
+    // Mutate the source AFTER duplicating.
+    store.remoteControlPages[0]!.button1 = { id: 's2', name: 'Bow', type: 'script' };
+
+    expect(store.remoteControlPages[1]!.button1).toEqual({ id: 's1', name: 'Wave', type: 'script' });
+  });
+
+  it('selects the copy', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.duplicatePage(0);
+
+    expect(store.selectedIdx).toBe(1);
+  });
+
+  it('flips isDirty to true', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.duplicatePage(0);
+
+    expect(store.isDirty).toBe(true);
+  });
+
+  it('no-ops on out-of-range index (negative or beyond end)', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.duplicatePage(-1);
+    store.duplicatePage(99);
+
+    expect(store.remoteControlPages).toHaveLength(1);
+    expect(store.isDirty).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "duplicatePage"
+```
+Expected: 6 tests fail (`store.duplicatePage is not a function`).
+
+- [ ] **Step 3: Implement duplicatePage**
+
+In `remoteControl.ts`, after `addPage`:
+
+```ts
+function duplicatePage(idx: number) {
+  const src = remoteControlPages.value[idx];
+  if (!src) return;
+  const copy: RemoteControlPage = {
+    ...src,
+    id: crypto.randomUUID(),
+    name: `${src.name} (copy)`,
+  };
+  // Deep-copy each button so subsequent edits to the source don't bleed in.
+  for (const key of BUTTON_KEYS) {
+    copy[key] = { ...src[key] };
+  }
+  remoteControlPages.value.splice(idx + 1, 0, copy);
+  selectedIdx.value = idx + 1;
+  isDirty.value = true;
+}
+```
+
+Add `duplicatePage` to the return object.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "duplicatePage"
+```
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Mutation-test the out-of-range guard**
+
+Comment out `if (!src) return;`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "no-ops on out-of-range"
+```
+Expected: that test FAILS (either with a thrown TypeError when accessing `src.name`, or with `expect(...).toHaveLength(1)` failing because a phantom page was spliced). Restore.
+
+Also mutation-test the deep-copy: replace the `for (const key of BUTTON_KEYS)` loop with nothing (just rely on the `...src` spread, which would share button references). Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "deep-copies button slots"
+```
+Expected: that test FAILS. Restore the loop.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts
+npm run prettier:write
+npm run lint:fix
+git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
+git commit -m "feat(remote-store): add duplicatePage with deep button copy"
+```
+
+---
+
+## Task 5: Add `deletePage` with single-page guard + selectedIdx clamp
+
+**Files:**
+- Modify: `astros_vue/src/stores/remoteControl.ts`
+- Test: `astros_vue/src/stores/__tests__/remoteControl.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this `describe` block:
+
+```ts
+describe('deletePage', () => {
+  it('removes the page at the given index', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([
+      { ...legacyPage(), name: 'A' },
+      { ...legacyPage(), name: 'B' },
+      { ...legacyPage(), name: 'C' },
+    ]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.deletePage(1);
+
+    expect(store.remoteControlPages).toHaveLength(2);
+    expect(store.remoteControlPages.map((p) => p.name)).toEqual(['A', 'C']);
+  });
+
+  it('no-ops when only one page remains', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.deletePage(0);
+
+    expect(store.remoteControlPages).toHaveLength(1);
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('clamps selectedIdx when deleting the currently-selected last page', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    store.selectPage(2);
+
+    store.deletePage(2);
+
+    expect(store.selectedIdx).toBe(1);
+  });
+
+  it('keeps selectedIdx when deleting a page below the current selection', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    store.selectPage(2);
+
+    store.deletePage(0);
+
+    // Was idx 2 ('C'), now at idx 1 because A was removed and B/C shifted down.
+    expect(store.selectedIdx).toBe(1);
+  });
+
+  it('keeps selectedIdx unchanged when deleting a page above the current selection', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+    store.selectPage(0);
+
+    store.deletePage(2);
+
+    expect(store.selectedIdx).toBe(0);
+  });
+
+  it('flips isDirty to true', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.deletePage(0);
+
+    expect(store.isDirty).toBe(true);
+  });
+
+  it('no-ops on out-of-range idx without changing pages or isDirty', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.deletePage(-1);
+    store.deletePage(99);
+
+    expect(store.remoteControlPages).toHaveLength(2);
+    expect(store.isDirty).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "deletePage"
+```
+Expected: 7 tests fail.
+
+- [ ] **Step 3: Implement deletePage**
+
+In `remoteControl.ts`, after `duplicatePage`:
+
+```ts
+function deletePage(idx: number) {
+  if (remoteControlPages.value.length <= 1) return;
+  if (idx < 0 || idx >= remoteControlPages.value.length) return;
+  remoteControlPages.value.splice(idx, 1);
+  // Clamp selectedIdx to the new last index. If the deleted page was below
+  // the selection, the selection shifts down by one; if above, unchanged;
+  // if the deleted page WAS the selection at the end, clamp moves it back.
+  if (selectedIdx.value > idx) {
+    selectedIdx.value -= 1;
+  } else if (selectedIdx.value >= remoteControlPages.value.length) {
+    selectedIdx.value = remoteControlPages.value.length - 1;
+  }
+  isDirty.value = true;
+}
+```
+
+Add `deletePage` to the return object.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "deletePage"
+```
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Mutation-test the guards**
+
+A) Single-page guard. Comment out `if (remoteControlPages.value.length <= 1) return;`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "no-ops when only one page remains"
+```
+Expected: FAIL. Restore.
+
+B) Out-of-range guard. Comment out `if (idx < 0 || idx >= remoteControlPages.value.length) return;`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "no-ops on out-of-range idx without changing"
+```
+Expected: FAIL. Restore.
+
+C) selectedIdx-shift-down. Comment out `if (selectedIdx.value > idx) { selectedIdx.value -= 1; }` (delete just the inner reassignment). Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "keeps selectedIdx when deleting a page below"
+```
+Expected: FAIL. Restore.
+
+D) selectedIdx-clamp-from-end. Comment out the `else if (selectedIdx.value >= remoteControlPages.value.length)` branch entirely. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "clamps selectedIdx when deleting the currently-selected last"
+```
+Expected: FAIL. Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts
+npm run prettier:write
+npm run lint:fix
+git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
+git commit -m "feat(remote-store): add deletePage with single-page guard and selectedIdx clamp"
+```
+
+---
+
+## Task 6: Add `renamePage`
+
+**Files:**
+- Modify: `astros_vue/src/stores/remoteControl.ts`
+- Test: `astros_vue/src/stores/__tests__/remoteControl.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('renamePage', () => {
+  it('updates the name at the given index', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.renamePage(0, 'Quick Actions');
+
+    expect(store.remoteControlPages[0]!.name).toBe('Quick Actions');
+  });
+
+  it('trims surrounding whitespace before saving', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.renamePage(0, '   Performance   ');
+
+    expect(store.remoteControlPages[0]!.name).toBe('Performance');
+  });
+
+  it('no-ops on empty string (does not overwrite existing name or set dirty)', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'Original' }]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.renamePage(0, '');
+
+    expect(store.remoteControlPages[0]!.name).toBe('Original');
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('no-ops on whitespace-only string', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'Original' }]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.renamePage(0, '   \t  ');
+
+    expect(store.remoteControlPages[0]!.name).toBe('Original');
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('no-ops on out-of-range idx', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.renamePage(99, 'NewName');
+    store.renamePage(-1, 'NewName');
+
+    expect(store.remoteControlPages[0]!.name).toBe('Page 1');
+    expect(store.isDirty).toBe(false);
+  });
+
+  it('flips isDirty to true on a valid rename', async () => {
+    apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+    const store = useRemoteControlStore();
+    await store.loadRemoteControl();
+
+    store.renamePage(0, 'New');
+
+    expect(store.isDirty).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "renamePage"
+```
+Expected: 6 tests fail.
+
+- [ ] **Step 3: Implement renamePage**
+
+In `remoteControl.ts`, after `deletePage`:
+
+```ts
+function renamePage(idx: number, name: string) {
+  const target = remoteControlPages.value[idx];
+  if (!target) return;
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return;
+  target.name = trimmed;
+  isDirty.value = true;
+}
+```
+
+Add `renamePage` to the return object.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "renamePage"
+```
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Mutation-test the empty/whitespace guard**
+
+Comment out `if (trimmed.length === 0) return;`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "no-ops on empty string"
+```
+Expected: FAIL (target.name would become ''). Restore.
+
+Comment out `const trimmed = name.trim();` and `if (trimmed.length === 0) return;`, and change `target.name = trimmed;` to `target.name = name;`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "trims surrounding whitespace"
+```
+Expected: FAIL. Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts
+npm run prettier:write
+npm run lint:fix
+git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
+git commit -m "feat(remote-store): add renamePage with trim + empty-string no-op"
+```
+
+---
+
+## Task 7: Remove the all-empty save filter + invert the existing test + clear isDirty on save success
+
+**Why this is its own task:** It touches an existing test (inverts behavior), which is a different kind of change from "add new method + new test." Separating it keeps the diff per commit easy to review.
+
+**Files:**
+- Modify: `astros_vue/src/stores/remoteControl.ts`
+- Modify: `astros_vue/src/stores/__tests__/remoteControl.spec.ts`
+
+- [ ] **Step 1: Read the current test that needs inverting**
+
+The test at `remoteControl.spec.ts:260` is currently:
+
+```ts
+it('drops a page where all 9 buttons are id="0" even when page id/name are populated strings', async () => {
+  // … asserts parsed.length === 0 after saving an all-empty page
+});
+```
+
+After Decision 3, the new contract is "every page in the array persists." Replace the assertion to assert `parsed.length === 1` and rename the test. Also remove the long mutation-test commentary (no longer relevant — there is no filter to mutation-test).
+
+- [ ] **Step 2: Write the replacement test (this becomes the failing test before code changes)**
+
+In `remoteControl.spec.ts`, REPLACE the entire existing `'drops a page where all 9 buttons are id="0"'` `it(...)` block with:
+
+```ts
+it('persists every page including ones where all 9 buttons are id="0"', async () => {
+  // Decision 3 of the Phase 2 design spec: the all-empty save filter is
+  // removed. Empty pages persist; users delete pages explicitly via the UI.
+  apiGet.mockResolvedValue(JSON.stringify([]));
+  apiPut.mockResolvedValue(undefined);
+  const store = useRemoteControlStore();
+  await store.loadRemoteControl();
+
+  expect(store.remoteControlPages).toHaveLength(1);
+  expect(store.remoteControlPages[0]!.id).toMatch(UUID_LIKE);
+  expect(store.remoteControlPages[0]!.name).toBe('Page 1');
+
+  await store.saveRemoteControl();
+
+  const sent = apiPut.mock.calls[0]![1] as { config: string };
+  const parsed = JSON.parse(sent.config) as RemoteControlPage[];
+  expect(parsed).toHaveLength(1);
+  expect(parsed[0]!.id).toBe(store.remoteControlPages[0]!.id);
+  expect(parsed[0]!.name).toBe('Page 1');
+});
+```
+
+Then add a second new test to the same `saveRemoteControl` block:
+
+```ts
+it('clears isDirty to false on save success', async () => {
+  apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+  apiPut.mockResolvedValue(undefined);
+  const store = useRemoteControlStore();
+  await store.loadRemoteControl();
+  store.addPage(); // flips isDirty true
+  expect(store.isDirty).toBe(true);
+
+  await store.saveRemoteControl();
+
+  expect(store.isDirty).toBe(false);
+});
+
+it('does NOT clear isDirty when save fails', async () => {
+  const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+  apiPut.mockRejectedValue(new Error('save failed'));
+  const store = useRemoteControlStore();
+  await store.loadRemoteControl();
+  store.addPage();
+
+  await store.saveRemoteControl();
+
+  expect(store.isDirty).toBe(true);
+  errSpy.mockRestore();
+});
+```
+
+- [ ] **Step 3: Run tests to verify the new ones fail and the old (now-replaced) one is gone**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "persists every page"
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "clears isDirty to false on save success"
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "does NOT clear isDirty when save fails"
+```
+Expected: the first test fails (`expected 0 to be 1` — the filter still drops it), the second fails (`expected true to be false` — isDirty not cleared on save yet), the third may pass already (no clearing logic = stays true). The replaced test (`drops a page where all 9 buttons…`) should no longer appear in the run output at all.
+
+- [ ] **Step 4: Implement the changes in saveRemoteControl**
+
+Replace the body of `saveRemoteControl` in `remoteControl.ts` with:
+
+```ts
+async function saveRemoteControl() {
+  const payload = JSON.stringify(remoteControlPages.value);
+
+  try {
+    await apiService.put(REMOTE_CONFIG, { config: payload });
+    isDirty.value = false;
+    return { success: true };
+  } catch (error) {
+    console.error('Failed to save remote control configuration:', error);
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+```
+
+Changes from before:
+- Dropped the `.filter(...)` call.
+- Added `isDirty.value = false;` after a successful PUT.
+- Error branch leaves isDirty unchanged (per Decision 10).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts
+```
+Expected: all tests in the file pass — including the two pre-existing `saveRemoteControl` tests (`retains a page that has at least one non-default button`, `serializes id and name on retained pages`) which still hold under the new no-filter logic.
+
+- [ ] **Step 6: Mutation-test the save-success isDirty clear**
+
+Comment out `isDirty.value = false;` in `saveRemoteControl`. Run:
+
+```bash
+npx vitest run src/stores/__tests__/remoteControl.spec.ts -t "clears isDirty to false on save success"
+```
+Expected: FAIL. Restore.
+
+- [ ] **Step 7: Commit**
+
+```bash
+npm run prettier:write
+npm run lint:fix
+git add astros_vue/src/stores/remoteControl.ts astros_vue/src/stores/__tests__/remoteControl.spec.ts
+git commit -m "feat(remote-store): drop all-empty save filter; clear isDirty on save success"
+```
+
+---
+
+## Task 8: Pre-push verification + code review
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full type-check + lint + test pass**
+
+```bash
+cd astros_vue
+npm run lint
+npm run build
+npx vitest run
+```
+Expected: all green. Build emits no type errors; vitest reports the new test counts (Task 1: +4, Task 2: +6, Task 3: +3, Task 4: +6, Task 5: +7, Task 6: +6, Task 7: +2 new + 1 replaced; ~34 new test cases total).
+
+- [ ] **Step 2: Pre-push branch review (per CLAUDE.md "Pre-push branch review" section)**
+
+Invoke the multi-agent review on the full branch diff vs develop:
+
+```
+/pr-review-toolkit:review-pr
+```
+
+This dispatches 5 agents in parallel. Per memory `feedback_pr_review_toolkit_before_push`, this is required for every non-doc-only PR.
+
+**Address findings:**
+- Critical / Important: fix before push. Re-run the toolkit if substantial changes land.
+- Minor: defer to a follow-up commit if appropriate.
+
+Per CLAUDE.md "When fixing review findings (partial-fix sweep)": grep the related sites for the same drift before marking a finding "fixed."
+
+- [ ] **Step 3: Push (user does this through VS Code)**
+
+Per memory `feedback_git_push`: do NOT run `git push` from terminal. Tell the user the branch is ready and let them push through VS Code.
+
+---
+
+## Task 9: Update tracker checkbox + open PR
+
+**Files:**
+- Modify: `.docs/plans/current_project.md`
+
+- [ ] **Step 1: Check off 2a in the tracker**
+
+In `.docs/plans/current_project.md`, change line 24 from:
+
+```
+  - [ ] **2a** — Store CRUD foundation (addPage / duplicatePage / deletePage / renamePage /
+        selectPage; isDirty flag; drop all-empty save filter). No UI changes.
+```
+
+to:
+
+```
+  - [x] **2a** — Store CRUD foundation (addPage / duplicatePage / deletePage / renamePage /
+        selectPage; isDirty flag; drop all-empty save filter). No UI changes. — shipped <DATE> via PR #<NUMBER>
+```
+
+(Fill in date and PR number after merge.)
+
+- [ ] **Step 2: Commit tracker update**
+
+```bash
+git add .docs/plans/current_project.md
+git commit -m "docs(plan): mark Phase 2a complete in tracker"
+```
+
+This is a plan-only commit — no pre-commit toolkit required.
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base develop --title "feat(remote): Phase 2a — store CRUD foundation" --body "$(cat <<'EOF'
+## Summary
+- Extends `useRemoteControlStore` with `selectedIdx`, `isDirty`, and 5 page-CRUD methods (`addPage` / `duplicatePage` / `deletePage` / `renamePage` / `selectPage`) per the Phase 2 design spec
+- Removes the all-empty save filter (Decision 3) — every page in the array now persists on save
+- Clears `isDirty` on successful load and successful save; mutations flip it true
+- ~34 new test cases including mutation-test guards on every defensive branch (single-page delete, selectedIdx clamps, renamePage trim, save-success isDirty clear)
+
+No UI changes; the new store surface is consumed by Phase 2b/2c/2d components.
+
+## Test plan
+- [x] Vitest unit suite passes (`npx vitest run`)
+- [x] Type-check passes (`npm run build`)
+- [x] Lint passes (`npm run lint`)
+- [x] Pre-push toolkit run (5 agents)
+- [ ] Verify via Storybook in Phase 2b that the new store API matches what components expect
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+After merge, update the tracker commit with the actual PR number and merge date.
+
+- [ ] **Step 4: Update the active-project memory after merge**
+
+Update `~/.claude/projects/-home-jeff-Source-astros-AstrOs-Server/memory/project_active_remote_redesign.md` to reflect 2a shipped: change the Phase 2 bullet from "in flight" to reflect 2a checked, with 2b/2c/2d still queued.
+
+---
+
+## Self-Review
+
+**Spec coverage** (cross-reference to `.docs/plans/specs/2026-05-21-phase2-editor-design.md` Section 4):
+- ✅ `selectedIdx: Ref<number>` — Task 2
+- ✅ `isDirty: Ref<boolean>` — Task 1
+- ✅ `addPage` — Task 3
+- ✅ `duplicatePage` — Task 4
+- ✅ `deletePage` — Task 5
+- ✅ `renamePage` — Task 6
+- ✅ `selectPage` — Task 2
+- ✅ `loadRemoteControl` clears isDirty + resets selectedIdx — Tasks 1 & 2
+- ✅ `saveRemoteControl` persists ALL pages (no filter) + clears isDirty — Task 7
+- ✅ Mutation-test guards on every defensive guard — Tasks 1, 2, 4, 5, 6, 7
+
+**Out-of-scope confirmations:**
+- ❌ No setButton method (spec §4: view writes directly to `pages[selectedIdx][buttonKey]` — confirmed; no method needed in 2a)
+- ❌ No new components
+- ❌ No router/i18n changes
+
+**Type consistency check:** All method signatures match the spec table exactly. `RemoteControlPage` and `PageButton` come from `@/models/...` — already imported in the store file.
+
+**Placeholder scan:** No TBDs, no "implement later" comments, no vague guidance. Every test is a complete test; every implementation snippet is the full function body.

--- a/.docs/plans/specs/2026-05-21-phase2-editor-design.md
+++ b/.docs/plans/specs/2026-05-21-phase2-editor-design.md
@@ -170,13 +170,14 @@ isDirty: Ref<boolean>;                                 // false until first muta
 addPage();                                             // pushes default page; selectedIdx = new index
 duplicatePage(idx: number);                            // splices "(copy)" suffix copy after idx; selects it
 deletePage(idx: number);                               // no-op if pages.length <= 1; clamps selectedIdx
-renamePage(idx: number, name: string);                 // trims; no-op on empty/whitespace
+renamePage(idx: number, name: string): boolean;        // trims; no-op on empty/whitespace; returns true if applied
 selectPage(idx: number);                               // clamps to valid range; does NOT set isDirty
+setButton(slotIdx: number, key: ButtonKey, value: PageButton);  // writes slot + flips isDirty; warns on out-of-range
 ```
 
 **Dirty tracking is a plain flag, not a snapshot comparison.** Each mutation method sets `isDirty = true`; `loadRemoteControl` (on success) and `saveRemoteControl` (on 200) set it back to `false`. Rationale: snapshot-comparison via `JSON.stringify` has two edge cases (badge flashes before first load resolves; failed-load leaves snapshot null so subsequent mutations never flip dirty). Flag-based tracking avoids both. The minor pessimism — mutate-then-revert-to-original keeps `isDirty` true — is acceptable; user clicks Save, save succeeds (a no-op PUT with unchanged payload), flag clears.
 
-**Slot mutations** — button assignments from `AstrosRemoteButtonCard.change` are written by `RemoteControlConfigView` directly to `store.remoteControlPages[selectedIdx][buttonKey]`. The view sets `store.isDirty = true` after the mutation. (Alternative: a `setButton(slotIdx, buttonKey, value)` store method that wraps both writes; chosen against because it adds a one-line method for a one-call-site mutation. Revisit if a second consumer appears.)
+**Slot mutations** — button assignments from `AstrosRemoteButtonCard.change` are written by `RemoteControlConfigView` via `store.setButton(selectedIdx, buttonKey, value)`. The method atomically writes the slot and sets `isDirty = true`. (This spec originally deferred `setButton` on the rationale of a one-call-site mutation; surfaced during Phase 2a PR review as a forget-prone protocol regardless of consumer count, so the helper was added to make the dirty mark impossible to forget.)
 
 ---
 
@@ -206,7 +207,7 @@ User clicks "Configure →" on empty BUTTON 5
 User types "wave", filters, clicks "Wave Hello"
   → editor emits 'change' { id:'wave', name:'Wave Hello', type:'script' }
   → card re-emits 'change', closes popover
-  → view handler: store.remoteControlPages[selectedIdx].button5 = newValue
+  → view handler: store.setButton(selectedIdx, 'button5', newValue)
   → subscribers re-render:
       • That card: assigned state (tinted blue, chip, name)
       • Live preview: button 5 now filled

--- a/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
+++ b/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
@@ -39,18 +39,17 @@ onMounted(async () => {
   scripts.value = scriptStore.scripts.map((s) => ({ id: s.id, name: s.scriptName }));
   playlists.value = playlistStore.playlists.map((p) => ({ id: p.id, name: p.playlistName }));
 
-  // Surface load failures and skip default-seeding when load fails — we don't
-  // know what's actually on the server, so seeding a fresh default risks the
-  // user saving it over real-but-unloaded config.
+  // Bail on load failure — we don't know what the server has, so seeding a
+  // fresh default here would risk the user clicking Save and clobbering
+  // real-but-unloaded config.
   if (!loadResult.success) {
     loadFailed.value = true;
     error(t('remote_view.load_error'));
     return;
   }
 
-  if (remoteControlStore.remoteControlPages.length === 0) {
-    remoteControlStore.remoteControlPages.push(createDefaultPage(0));
-  }
+  // Store guarantees pages.length >= 1 on successful load (seeds a default
+  // page when stored config is empty).
   currentPage.value = remoteControlStore.remoteControlPages[0]!;
 });
 

--- a/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
+++ b/astros_vue/src/components/remoteControl/AstrosRemoteControl.vue
@@ -39,9 +39,9 @@ onMounted(async () => {
   scripts.value = scriptStore.scripts.map((s) => ({ id: s.id, name: s.scriptName }));
   playlists.value = playlistStore.playlists.map((p) => ({ id: p.id, name: p.playlistName }));
 
-  // Surface load failures and skip default-seeding so a save can't overwrite real
-  // stored data with an empty page (the store's saveRemoteControl filter drops
-  // all-empty pages, so a seeded-then-saved state would PUT [] over real config).
+  // Surface load failures and skip default-seeding when load fails — we don't
+  // know what's actually on the server, so seeding a fresh default risks the
+  // user saving it over real-but-unloaded config.
   if (!loadResult.success) {
     loadFailed.value = true;
     error(t('remote_view.load_error'));

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -389,4 +389,39 @@ describe('remoteControl store', () => {
       expect(store.selectedIdx).toBe(0);
     });
   });
+
+  describe('addPage', () => {
+    it('appends a default page with auto-numbered name', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.addPage();
+
+      expect(store.remoteControlPages).toHaveLength(2);
+      expect(store.remoteControlPages[1]!.name).toBe('Page 2');
+      expect(store.remoteControlPages[1]!.id).toMatch(UUID_LIKE);
+    });
+
+    it('selects the newly added page', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.addPage();
+
+      expect(store.selectedIdx).toBe(1);
+    });
+
+    it('flips isDirty to true', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      expect(store.isDirty).toBe(false);
+
+      store.addPage();
+
+      expect(store.isDirty).toBe(true);
+    });
+  });
 });

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -296,4 +296,38 @@ describe('remoteControl store', () => {
       errSpy.mockRestore();
     });
   });
+
+  describe('isDirty flag', () => {
+    it('starts false on a fresh store', () => {
+      const store = useRemoteControlStore();
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('stays false after a successful load', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('clears to false when a successful load follows a dirty state', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([]));
+      const store = useRemoteControlStore();
+      // Poke directly because the mutation methods that flip the flag land
+      // in later tasks; this isolates "load clears it" behavior.
+      (store as unknown as { isDirty: boolean }).isDirty = true;
+      await store.loadRemoteControl();
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('does NOT clear isDirty when load fails (network)', async () => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      apiGet.mockRejectedValue(new Error('network down'));
+      const store = useRemoteControlStore();
+      (store as unknown as { isDirty: boolean }).isDirty = true;
+      await store.loadRemoteControl();
+      expect(store.isDirty).toBe(true);
+      errSpy.mockRestore();
+    });
+  });
 });

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -328,21 +328,34 @@ describe('remoteControl store', () => {
       expect(store.isDirty).toBe(false);
     });
 
-    it('stays false after a successful load', async () => {
-      apiGet.mockResolvedValue(JSON.stringify([]));
+    it('stays false after a successful load of stored pages', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
       expect(store.isDirty).toBe(false);
     });
 
-    it('clears to false when a successful load follows a dirty state', async () => {
+    it('flips true after a successful load of empty stored config (seeded default needs opt-in to persist)', async () => {
+      // Empty stored config triggers the seed-default-page path. The seeded
+      // page is NOT yet on the server; setting isDirty=true makes the Save
+      // button enable so the user explicitly opts in to persisting the
+      // freshly-minted default. Without this, clicking Save on a fresh
+      // install would silently write a random-UUID page the user never
+      // authored.
+      apiGet.mockResolvedValue(JSON.stringify([]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      expect(store.isDirty).toBe(true);
+    });
+
+    it('clears to false when a successful load of stored pages follows a dirty state', async () => {
       apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
       store.addPage();
       expect(store.isDirty).toBe(true);
 
-      apiGet.mockResolvedValue(JSON.stringify([]));
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       await store.loadRemoteControl();
 
       expect(store.isDirty).toBe(false);

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -101,7 +101,6 @@ describe('remoteControl store', () => {
       expect(migrated.button1.id).toBe('0');
       expect(migrated.button1.type).toBe('none');
       expect(warnSpy).toHaveBeenCalled();
-      warnSpy.mockRestore();
     });
   });
 
@@ -202,7 +201,6 @@ describe('remoteControl store', () => {
 
       expect(result.success).toBe(false);
       expect(store.remoteControlPages).toEqual([]);
-      errSpy.mockRestore();
     });
 
     it('returns {success:false, error} when the API rejects', async () => {
@@ -214,7 +212,6 @@ describe('remoteControl store', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('network down');
-      errSpy.mockRestore();
     });
   });
 
@@ -303,7 +300,6 @@ describe('remoteControl store', () => {
       await store.saveRemoteControl();
 
       expect(store.isDirty).toBe(true);
-      errSpy.mockRestore();
     });
 
     it('returns {success:false, error} when the API rejects', async () => {
@@ -318,7 +314,6 @@ describe('remoteControl store', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('save failed');
-      errSpy.mockRestore();
     });
   });
 
@@ -373,7 +368,6 @@ describe('remoteControl store', () => {
       await store.loadRemoteControl();
 
       expect(store.isDirty).toBe(true);
-      errSpy.mockRestore();
     });
   });
 
@@ -597,7 +591,6 @@ describe('remoteControl store', () => {
       expect(store.remoteControlPages).toHaveLength(1);
       expect(store.isDirty).toBe(false);
       expect(warnSpy).toHaveBeenCalledTimes(2);
-      warnSpy.mockRestore();
     });
   });
 
@@ -703,7 +696,6 @@ describe('remoteControl store', () => {
       expect(store.remoteControlPages).toHaveLength(2);
       expect(store.remoteControlPages[0]!.name).toBe('A');
       expect(warnSpy).toHaveBeenCalled();
-      warnSpy.mockRestore();
     });
 
     it('warns and no-ops on fractional idx (would otherwise truncate inside splice)', async () => {
@@ -720,7 +712,6 @@ describe('remoteControl store', () => {
       store.deletePage(0.7);
 
       expect(store.remoteControlPages).toHaveLength(2);
-      warnSpy.mockRestore();
     });
 
     it('warns on out-of-range deletePage idx (programming-error breadcrumb)', async () => {
@@ -733,7 +724,6 @@ describe('remoteControl store', () => {
       store.deletePage(99);
 
       expect(warnSpy).toHaveBeenCalledTimes(2);
-      warnSpy.mockRestore();
     });
 
     it('shifts selectedIdx down when deleting a page below the current selection', async () => {
@@ -780,7 +770,6 @@ describe('remoteControl store', () => {
 
       expect(store.remoteControlPages).toHaveLength(2);
       expect(store.isDirty).toBe(false);
-      warnSpy.mockRestore();
     });
   });
 
@@ -844,7 +833,6 @@ describe('remoteControl store', () => {
       expect(warnSpy).toHaveBeenCalledTimes(2);
       expect(store.remoteControlPages[0]!.name).toBe('Page 1');
       expect(store.isDirty).toBe(false);
-      warnSpy.mockRestore();
     });
 
     it('flips isDirty to true on a valid rename', async () => {

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -219,7 +219,7 @@ describe('remoteControl store', () => {
   });
 
   describe('saveRemoteControl', () => {
-    it('retains a page that has at least one non-default button', async () => {
+    it('serializes a page that has at least one non-default button to the wire payload', async () => {
       apiGet.mockResolvedValue(JSON.stringify([]));
       apiPut.mockResolvedValue(undefined);
       const store = useRemoteControlStore();
@@ -239,7 +239,7 @@ describe('remoteControl store', () => {
       expect(parsed).toHaveLength(1);
     });
 
-    it('serializes id and name on retained pages so they round-trip through storage', async () => {
+    it('serializes id and name through saveRemoteControl so they round-trip through storage', async () => {
       apiGet.mockResolvedValue(JSON.stringify([]));
       apiPut.mockResolvedValue(undefined);
       const store = useRemoteControlStore();
@@ -258,8 +258,9 @@ describe('remoteControl store', () => {
     });
 
     it('persists every page including ones where all 9 buttons are id="0"', async () => {
-      // Decision 3 of the Phase 2 design spec: the all-empty save filter is
-      // removed. Empty pages persist; users delete pages explicitly via the UI.
+      // Anti-regression for the old "drop pages where all 9 buttons have
+      // id=0" save filter. Empty pages now persist; users delete pages
+      // explicitly via the UI.
       apiGet.mockResolvedValue(JSON.stringify([]));
       apiPut.mockResolvedValue(undefined);
       const store = useRemoteControlStore();
@@ -335,21 +336,29 @@ describe('remoteControl store', () => {
     });
 
     it('clears to false when a successful load follows a dirty state', async () => {
-      apiGet.mockResolvedValue(JSON.stringify([]));
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       const store = useRemoteControlStore();
-      // Poke directly because the mutation methods that flip the flag land
-      // in later tasks; this isolates "load clears it" behavior.
-      (store as unknown as { isDirty: boolean }).isDirty = true;
       await store.loadRemoteControl();
+      store.addPage();
+      expect(store.isDirty).toBe(true);
+
+      apiGet.mockResolvedValue(JSON.stringify([]));
+      await store.loadRemoteControl();
+
       expect(store.isDirty).toBe(false);
     });
 
     it('does NOT clear isDirty when load fails (network)', async () => {
       const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      apiGet.mockRejectedValue(new Error('network down'));
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       const store = useRemoteControlStore();
-      (store as unknown as { isDirty: boolean }).isDirty = true;
       await store.loadRemoteControl();
+      store.addPage();
+      expect(store.isDirty).toBe(true);
+
+      apiGet.mockRejectedValue(new Error('network down'));
+      await store.loadRemoteControl();
+
       expect(store.isDirty).toBe(true);
       errSpy.mockRestore();
     });

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -400,6 +400,17 @@ describe('remoteControl store', () => {
       expect(store.selectedIdx).toBe(0);
     });
 
+    it('clamps NaN idx to 0 (avoids selectedIdx = NaN unreachable state)', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(2);
+
+      store.selectPage(NaN);
+
+      expect(store.selectedIdx).toBe(0);
+    });
+
     it('does NOT set isDirty', async () => {
       apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
       const store = useRemoteControlStore();
@@ -657,6 +668,46 @@ describe('remoteControl store', () => {
 
       expect(store.selectedIdx).toBe(0);
       expect(store.remoteControlPages[0]!.name).toBe('B');
+    });
+
+    it('warns and no-ops on NaN idx (would otherwise become splice(0,1) and delete page[0])', async () => {
+      // splice(NaN, 1) is silently treated as splice(0, 1) per ECMA's
+      // ToInteger spec. The comparison-based guard (idx < 0 || idx >= length)
+      // misses NaN because all NaN comparisons return false. The
+      // Number.isInteger check is what closes the gap.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      apiGet.mockResolvedValue(
+        JSON.stringify([
+          { ...legacyPage(), name: 'A' },
+          { ...legacyPage(), name: 'B' },
+        ]),
+      );
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.deletePage(NaN);
+
+      expect(store.remoteControlPages).toHaveLength(2);
+      expect(store.remoteControlPages[0]!.name).toBe('A');
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('warns and no-ops on fractional idx (would otherwise truncate inside splice)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      apiGet.mockResolvedValue(
+        JSON.stringify([
+          { ...legacyPage(), name: 'A' },
+          { ...legacyPage(), name: 'B' },
+        ]),
+      );
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.deletePage(0.7);
+
+      expect(store.remoteControlPages).toHaveLength(2);
+      warnSpy.mockRestore();
     });
 
     it('warns on out-of-range deletePage idx (programming-error breadcrumb)', async () => {

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -257,19 +257,14 @@ describe('remoteControl store', () => {
       expect(parsed[0]!.name).toBe('Quick Actions');
     });
 
-    it('drops a page where all 9 buttons are id="0" even when page id/name are populated strings', async () => {
+    it('persists every page including ones where all 9 buttons are id="0"', async () => {
+      // Decision 3 of the Phase 2 design spec: the all-empty save filter is
+      // removed. Empty pages persist; users delete pages explicitly via the UI.
       apiGet.mockResolvedValue(JSON.stringify([]));
       apiPut.mockResolvedValue(undefined);
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
 
-      // Guards against regressing the BUTTON_KEYS filter to a reflection-style
-      // `Object.values(page).some(b => b.id !== '0')`. The seeded page has a
-      // populated UUID id and "Page 1" name; the old form would short-circuit
-      // true on `someUuid.id !== '0'` (undefined !== '0' is true) and retain
-      // the page. The fixed form iterates BUTTON_KEYS only and drops it.
-      // Verified mechanically: reverting the filter to Object.values makes
-      // this test fail (parsed.length === 1).
       expect(store.remoteControlPages).toHaveLength(1);
       expect(store.remoteControlPages[0]!.id).toMatch(UUID_LIKE);
       expect(store.remoteControlPages[0]!.name).toBe('Page 1');
@@ -278,7 +273,36 @@ describe('remoteControl store', () => {
 
       const sent = apiPut.mock.calls[0]![1] as { config: string };
       const parsed = JSON.parse(sent.config) as RemoteControlPage[];
-      expect(parsed).toHaveLength(0);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]!.id).toBe(store.remoteControlPages[0]!.id);
+      expect(parsed[0]!.name).toBe('Page 1');
+    });
+
+    it('clears isDirty to false on save success', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      apiPut.mockResolvedValue(undefined);
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.addPage();
+      expect(store.isDirty).toBe(true);
+
+      await store.saveRemoteControl();
+
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('does NOT clear isDirty when save fails', async () => {
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      apiPut.mockRejectedValue(new Error('save failed'));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.addPage();
+
+      await store.saveRemoteControl();
+
+      expect(store.isDirty).toBe(true);
+      errSpy.mockRestore();
     });
 
     it('returns {success:false, error} when the API rejects', async () => {

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -424,4 +424,83 @@ describe('remoteControl store', () => {
       expect(store.isDirty).toBe(true);
     });
   });
+
+  describe('duplicatePage', () => {
+    it('splices a copy right after the source index with a fresh id', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      const srcId = store.remoteControlPages[0]!.id;
+
+      store.duplicatePage(0);
+
+      expect(store.remoteControlPages).toHaveLength(3);
+      expect(store.remoteControlPages[1]!.id).not.toBe(srcId);
+      expect(store.remoteControlPages[1]!.id).toMatch(UUID_LIKE);
+    });
+
+    it('names the copy "<src> (copy)"', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'Performance' }]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.duplicatePage(0);
+
+      expect(store.remoteControlPages[1]!.name).toBe('Performance (copy)');
+    });
+
+    it('deep-copies button slots (mutating source button in place does not affect copy)', async () => {
+      // Slot reassignment (`page.button1 = {...}`) would always isolate the copy
+      // even without a deep copy — it just rebinds the source's slot reference.
+      // The real shared-reference hazard is in-place property mutation, which
+      // is what a Pinia consumer would do via `page.button1.name = '...'` or
+      // `page.button1.id = '...'`. This test pokes that path.
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.remoteControlPages[0]!.button1 = { id: 's1', name: 'Wave', type: 'script' };
+
+      store.duplicatePage(0);
+      store.remoteControlPages[0]!.button1.name = 'Bow';
+      store.remoteControlPages[0]!.button1.id = 's2';
+
+      expect(store.remoteControlPages[1]!.button1).toEqual({
+        id: 's1',
+        name: 'Wave',
+        type: 'script',
+      });
+    });
+
+    it('selects the copy', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.duplicatePage(0);
+
+      expect(store.selectedIdx).toBe(1);
+    });
+
+    it('flips isDirty to true', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.duplicatePage(0);
+
+      expect(store.isDirty).toBe(true);
+    });
+
+    it('no-ops on out-of-range index (negative or beyond end)', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.duplicatePage(-1);
+      store.duplicatePage(99);
+
+      expect(store.remoteControlPages).toHaveLength(1);
+      expect(store.isDirty).toBe(false);
+    });
+  });
 });

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -330,4 +330,63 @@ describe('remoteControl store', () => {
       errSpy.mockRestore();
     });
   });
+
+  describe('selectedIdx + selectPage', () => {
+    it('starts at 0', () => {
+      const store = useRemoteControlStore();
+      expect(store.selectedIdx).toBe(0);
+    });
+
+    it('selectPage(2) sets selectedIdx to 2 when 3 pages exist', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.selectPage(2);
+
+      expect(store.selectedIdx).toBe(2);
+    });
+
+    it('clamps selectPage(99) to last index when out of range high', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.selectPage(99);
+
+      expect(store.selectedIdx).toBe(1);
+    });
+
+    it('clamps selectPage(-3) to 0 when negative', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.selectPage(-3);
+
+      expect(store.selectedIdx).toBe(0);
+    });
+
+    it('does NOT set isDirty', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.selectPage(1);
+
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('loadRemoteControl resets selectedIdx to 0', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(2);
+
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      await store.loadRemoteControl();
+
+      expect(store.selectedIdx).toBe(0);
+    });
+  });
 });

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -672,13 +672,14 @@ describe('remoteControl store', () => {
   });
 
   describe('renamePage', () => {
-    it('updates the name at the given index', async () => {
+    it('updates the name at the given index and returns true', async () => {
       apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
 
-      store.renamePage(0, 'Quick Actions');
+      const applied = store.renamePage(0, 'Quick Actions');
 
+      expect(applied).toBe(true);
       expect(store.remoteControlPages[0]!.name).toBe('Quick Actions');
     });
 
@@ -692,38 +693,45 @@ describe('remoteControl store', () => {
       expect(store.remoteControlPages[0]!.name).toBe('Performance');
     });
 
-    it('no-ops on empty string (does not overwrite existing name or set dirty)', async () => {
+    it('returns false and no-ops on empty string', async () => {
       apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'Original' }]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
 
-      store.renamePage(0, '');
+      const applied = store.renamePage(0, '');
 
+      expect(applied).toBe(false);
       expect(store.remoteControlPages[0]!.name).toBe('Original');
       expect(store.isDirty).toBe(false);
     });
 
-    it('no-ops on whitespace-only string', async () => {
+    it('returns false and no-ops on whitespace-only string', async () => {
       apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'Original' }]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
 
-      store.renamePage(0, '   \t  ');
+      const applied = store.renamePage(0, '   \t  ');
 
+      expect(applied).toBe(false);
       expect(store.remoteControlPages[0]!.name).toBe('Original');
       expect(store.isDirty).toBe(false);
     });
 
-    it('no-ops on out-of-range idx', async () => {
+    it('returns false, warns, and no-ops on out-of-range idx', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
 
-      store.renamePage(99, 'NewName');
-      store.renamePage(-1, 'NewName');
+      const high = store.renamePage(99, 'NewName');
+      const low = store.renamePage(-1, 'NewName');
 
+      expect(high).toBe(false);
+      expect(low).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
       expect(store.remoteControlPages[0]!.name).toBe('Page 1');
       expect(store.isDirty).toBe(false);
+      warnSpy.mockRestore();
     });
 
     it('flips isDirty to true on a valid rename', async () => {

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -192,6 +192,24 @@ describe('remoteControl store', () => {
       expect(new Set(ids).size).toBe(3);
     });
 
+    it('replaces existing pages when loading over a populated store', async () => {
+      // Pin the "load REPLACES" contract — the refactored isDirty tests
+      // implicitly rely on this (they addPage then re-load), but it should
+      // be tested in isolation so a load-merges-instead-of-replaces
+      // regression surfaces here rather than as a confused dirty-flag
+      // failure elsewhere.
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      expect(store.remoteControlPages).toHaveLength(2);
+
+      apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'X' }]));
+      await store.loadRemoteControl();
+
+      expect(store.remoteControlPages).toHaveLength(1);
+      expect(store.remoteControlPages[0]!.name).toBe('X');
+    });
+
     it('returns {success:false} and leaves pages untouched when the stored config is not an array', async () => {
       const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       apiGet.mockResolvedValue(JSON.stringify({ corrupt: true }));
@@ -401,6 +419,11 @@ describe('remoteControl store', () => {
       apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
+      // Move off the post-load default of 0 so a no-op mutation of
+      // selectPage (which would leave selectedIdx unchanged) doesn't
+      // pass this test by accident.
+      store.selectPage(1);
+      expect(store.selectedIdx).toBe(1);
 
       store.selectPage(-3);
 
@@ -565,18 +588,26 @@ describe('remoteControl store', () => {
     it('moves selection to the copy even when a higher page was previously selected', async () => {
       // The selectedIdx-above-target case: when the user is on page C (idx=2)
       // and duplicates page A (idx=0), the implementation jumps selection to
-      // the copy at idx=1. This pins that contract — discoverability of the
-      // new page wins over preserving the user's prior selection. Phase 2d
-      // UI can revisit if the surprise becomes a usability issue.
-      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      // the copy at idx=1. Discoverability of the new page wins over
+      // preserving the user's prior selection.
+      apiGet.mockResolvedValue(
+        JSON.stringify([
+          { ...legacyPage(), name: 'A' },
+          { ...legacyPage(), name: 'B' },
+          { ...legacyPage(), name: 'C' },
+        ]),
+      );
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
       store.selectPage(2);
 
       store.duplicatePage(0);
 
+      expect(store.remoteControlPages.map((p) => p.name)).toEqual(['A', 'A (copy)', 'B', 'C']);
       expect(store.selectedIdx).toBe(1);
-      expect(store.remoteControlPages).toHaveLength(4);
+      // The page formerly at idx 2 (C) is now at idx 3 — selection didn't
+      // "follow" the user's prior page; it jumped to the copy.
+      expect(store.remoteControlPages[3]!.name).toBe('C');
     });
 
     it('warns and no-ops on out-of-range index (negative or beyond end)', async () => {

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -589,4 +589,70 @@ describe('remoteControl store', () => {
       expect(store.isDirty).toBe(false);
     });
   });
+
+  describe('renamePage', () => {
+    it('updates the name at the given index', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.renamePage(0, 'Quick Actions');
+
+      expect(store.remoteControlPages[0]!.name).toBe('Quick Actions');
+    });
+
+    it('trims surrounding whitespace before saving', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.renamePage(0, '   Performance   ');
+
+      expect(store.remoteControlPages[0]!.name).toBe('Performance');
+    });
+
+    it('no-ops on empty string (does not overwrite existing name or set dirty)', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'Original' }]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.renamePage(0, '');
+
+      expect(store.remoteControlPages[0]!.name).toBe('Original');
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('no-ops on whitespace-only string', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([{ ...legacyPage(), name: 'Original' }]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.renamePage(0, '   \t  ');
+
+      expect(store.remoteControlPages[0]!.name).toBe('Original');
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('no-ops on out-of-range idx', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.renamePage(99, 'NewName');
+      store.renamePage(-1, 'NewName');
+
+      expect(store.remoteControlPages[0]!.name).toBe('Page 1');
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('flips isDirty to true on a valid rename', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.renamePage(0, 'New');
+
+      expect(store.isDirty).toBe(true);
+    });
+  });
 });

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -557,7 +557,29 @@ describe('remoteControl store', () => {
       expect(store.isDirty).toBe(false);
     });
 
-    it('clamps selectedIdx when deleting the currently-selected last page', async () => {
+    it('moves selectedIdx back when deleting the currently-selected mid-list page', async () => {
+      // Contract: when the user deletes the page they're viewing, selection
+      // moves to the PREVIOUS sibling — the user's mental position is
+      // preserved rather than jumping forward to whichever page took the
+      // deleted slot. Cf. most file managers / tab strips.
+      apiGet.mockResolvedValue(
+        JSON.stringify([
+          { ...legacyPage(), name: 'A' },
+          { ...legacyPage(), name: 'B' },
+          { ...legacyPage(), name: 'C' },
+        ]),
+      );
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(1);
+
+      store.deletePage(1);
+
+      expect(store.selectedIdx).toBe(0);
+      expect(store.remoteControlPages[store.selectedIdx]!.name).toBe('A');
+    });
+
+    it('moves selectedIdx back to previous page when deleting the currently-selected last page', async () => {
       apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
@@ -566,6 +588,39 @@ describe('remoteControl store', () => {
       store.deletePage(2);
 
       expect(store.selectedIdx).toBe(1);
+    });
+
+    it('keeps selectedIdx at 0 when deleting the first (selected) page', async () => {
+      // Edge of the "move back" rule: there is no page further back, so
+      // selection stays at 0 (the page that USED to be at idx 1 is now at 0).
+      apiGet.mockResolvedValue(
+        JSON.stringify([
+          { ...legacyPage(), name: 'A' },
+          { ...legacyPage(), name: 'B' },
+          { ...legacyPage(), name: 'C' },
+        ]),
+      );
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(0);
+
+      store.deletePage(0);
+
+      expect(store.selectedIdx).toBe(0);
+      expect(store.remoteControlPages[0]!.name).toBe('B');
+    });
+
+    it('warns on out-of-range deletePage idx (programming-error breadcrumb)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.deletePage(-1);
+      store.deletePage(99);
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
     });
 
     it('shifts selectedIdx down when deleting a page below the current selection', async () => {
@@ -602,6 +657,7 @@ describe('remoteControl store', () => {
     });
 
     it('no-ops on out-of-range idx without changing pages or isDirty', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
@@ -611,6 +667,7 @@ describe('remoteControl store', () => {
 
       expect(store.remoteControlPages).toHaveLength(2);
       expect(store.isDirty).toBe(false);
+      warnSpy.mockRestore();
     });
   });
 

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -515,7 +515,45 @@ describe('remoteControl store', () => {
       expect(store.isDirty).toBe(true);
     });
 
-    it('no-ops on out-of-range index (negative or beyond end)', async () => {
+    it('inserts the copy at idx+1 and selects it when duplicating a non-zero index', async () => {
+      // Pins the `splice(idx + 1, 0, copy)` and `selectedIdx = idx + 1`
+      // math. The previous coverage only exercised idx=0, where a mutation
+      // to a constant `1` would still pass.
+      apiGet.mockResolvedValue(
+        JSON.stringify([
+          { ...legacyPage(), name: 'A' },
+          { ...legacyPage(), name: 'B' },
+          { ...legacyPage(), name: 'C' },
+        ]),
+      );
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.duplicatePage(1);
+
+      expect(store.remoteControlPages.map((p) => p.name)).toEqual(['A', 'B', 'B (copy)', 'C']);
+      expect(store.selectedIdx).toBe(2);
+    });
+
+    it('moves selection to the copy even when a higher page was previously selected', async () => {
+      // The selectedIdx-above-target case: when the user is on page C (idx=2)
+      // and duplicates page A (idx=0), the implementation jumps selection to
+      // the copy at idx=1. This pins that contract — discoverability of the
+      // new page wins over preserving the user's prior selection. Phase 2d
+      // UI can revisit if the surprise becomes a usability issue.
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(2);
+
+      store.duplicatePage(0);
+
+      expect(store.selectedIdx).toBe(1);
+      expect(store.remoteControlPages).toHaveLength(4);
+    });
+
+    it('warns and no-ops on out-of-range index (negative or beyond end)', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
       const store = useRemoteControlStore();
       await store.loadRemoteControl();
@@ -525,6 +563,8 @@ describe('remoteControl store', () => {
 
       expect(store.remoteControlPages).toHaveLength(1);
       expect(store.isDirty).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+      warnSpy.mockRestore();
     });
   });
 

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -503,4 +503,90 @@ describe('remoteControl store', () => {
       expect(store.isDirty).toBe(false);
     });
   });
+
+  describe('deletePage', () => {
+    it('removes the page at the given index', async () => {
+      apiGet.mockResolvedValue(
+        JSON.stringify([
+          { ...legacyPage(), name: 'A' },
+          { ...legacyPage(), name: 'B' },
+          { ...legacyPage(), name: 'C' },
+        ]),
+      );
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.deletePage(1);
+
+      expect(store.remoteControlPages).toHaveLength(2);
+      expect(store.remoteControlPages.map((p) => p.name)).toEqual(['A', 'C']);
+    });
+
+    it('no-ops when only one page remains', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.deletePage(0);
+
+      expect(store.remoteControlPages).toHaveLength(1);
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('clamps selectedIdx when deleting the currently-selected last page', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(2);
+
+      store.deletePage(2);
+
+      expect(store.selectedIdx).toBe(1);
+    });
+
+    it('shifts selectedIdx down when deleting a page below the current selection', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(2);
+
+      store.deletePage(0);
+
+      // Was idx 2, now at idx 1 because the page below it was removed.
+      expect(store.selectedIdx).toBe(1);
+    });
+
+    it('keeps selectedIdx unchanged when deleting a page above the current selection', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      store.selectPage(0);
+
+      store.deletePage(2);
+
+      expect(store.selectedIdx).toBe(0);
+    });
+
+    it('flips isDirty to true', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.deletePage(0);
+
+      expect(store.isDirty).toBe(true);
+    });
+
+    it('no-ops on out-of-range idx without changing pages or isDirty', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.deletePage(-1);
+      store.deletePage(99);
+
+      expect(store.remoteControlPages).toHaveLength(2);
+      expect(store.isDirty).toBe(false);
+    });
+  });
 });

--- a/astros_vue/src/stores/__tests__/remoteControl.spec.ts
+++ b/astros_vue/src/stores/__tests__/remoteControl.spec.ts
@@ -876,4 +876,59 @@ describe('remoteControl store', () => {
       expect(store.isDirty).toBe(true);
     });
   });
+
+  describe('setButton', () => {
+    it('writes the button value to the given slot on the given page', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage(), legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.setButton(1, 'button3', { id: 'script-7', name: 'Wave', type: 'script' });
+
+      expect(store.remoteControlPages[1]!.button3).toEqual({
+        id: 'script-7',
+        name: 'Wave',
+        type: 'script',
+      });
+      expect(store.remoteControlPages[0]!.button3.id).toBe('0');
+    });
+
+    it('flips isDirty to true on a successful write', async () => {
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      expect(store.isDirty).toBe(false);
+
+      store.setButton(0, 'button1', { id: 's1', name: 'Wave', type: 'script' });
+
+      expect(store.isDirty).toBe(true);
+    });
+
+    it('warns and no-ops on out-of-range slotIdx', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+      const originalButton = { ...store.remoteControlPages[0]!.button1 };
+
+      store.setButton(99, 'button1', { id: 's1', name: 'Wave', type: 'script' });
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(store.remoteControlPages[0]!.button1).toEqual(originalButton);
+      expect(store.isDirty).toBe(false);
+    });
+
+    it('warns and no-ops on NaN slotIdx', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      apiGet.mockResolvedValue(JSON.stringify([legacyPage()]));
+      const store = useRemoteControlStore();
+      await store.loadRemoteControl();
+
+      store.setButton(NaN, 'button1', { id: 's1', name: 'Wave', type: 'script' });
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(store.remoteControlPages[0]!.button1.id).toBe('0');
+      expect(store.isDirty).toBe(false);
+    });
+  });
 });

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -1,7 +1,7 @@
 import apiService from '@/api/apiService';
 import { REMOTE_CONFIG } from '@/api/endpoints';
 import type { RemoteControlPage } from '@/models';
-import { BUTTON_KEYS } from '@/models/remoteControl/remoteControlPage';
+import { BUTTON_KEYS, type ButtonKey } from '@/models/remoteControl/remoteControlPage';
 import type { PageButton, PageButtonType } from '@/models/remoteControl/pageButton';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
@@ -213,6 +213,29 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     isDirty.value = true;
   }
 
+  function setButton(slotIdx: number, buttonKey: ButtonKey, value: PageButton) {
+    // Wraps the slot write + isDirty flip so consumers can't forget the
+    // dirty mark on direct page mutations. Originally the spec deferred this
+    // method on the rationale that there'd be a single consumer; surfaced
+    // during PR review as a forget-prone protocol regardless of consumer
+    // count, so we collapse the two writes into one entry point.
+    if (!Number.isInteger(slotIdx)) {
+      console.warn(
+        `[remoteControl] setButton: slotIdx ${slotIdx} is not a valid integer (pages: ${remoteControlPages.value.length})`,
+      );
+      return;
+    }
+    const page = remoteControlPages.value[slotIdx];
+    if (!page) {
+      console.warn(
+        `[remoteControl] setButton: slotIdx ${slotIdx} out of range (pages: ${remoteControlPages.value.length})`,
+      );
+      return;
+    }
+    page[buttonKey] = value;
+    isDirty.value = true;
+  }
+
   async function saveRemoteControl() {
     const payload = JSON.stringify(remoteControlPages.value);
 
@@ -238,5 +261,6 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     duplicatePage,
     deletePage,
     renamePage,
+    setButton,
   };
 });

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -95,12 +95,18 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
         throw new Error('No remote control configuration found');
       }
 
-      if (result.length > 0) {
-        remoteControlPages.value = result.map((page, idx) => migratePage(page, idx));
-      } else {
-        remoteControlPages.value = [createDefaultPage(0)];
-      }
-      isDirty.value = false;
+      const isFreshSeed = result.length === 0;
+      remoteControlPages.value = isFreshSeed
+        ? [createDefaultPage(0)]
+        : result.map((page, idx) => migratePage(page, idx));
+      // When we seed a default page because the server had nothing stored, the
+      // seeded page is NOT yet persisted — flag it dirty so the Save button
+      // lights up and the user explicitly opts in. Before the all-empty save
+      // filter was removed, this case was protected by the filter dropping the
+      // seeded default on save; without that filter, clicking Save without
+      // dirtying first would have silently written a random-UUID page the user
+      // never authored.
+      isDirty.value = isFreshSeed;
       selectedIdx.value = 0;
       isLoading.value = false;
       return { success: true, data: result };

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -164,7 +164,12 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
 
   function duplicatePage(idx: number) {
     const src = remoteControlPages.value[idx];
-    if (!src) return;
+    if (!src) {
+      console.warn(
+        `[remoteControl] duplicatePage: idx ${idx} out of range (pages: ${remoteControlPages.value.length})`,
+      );
+      return;
+    }
     const copy: RemoteControlPage = {
       ...src,
       id: crypto.randomUUID(),

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -165,14 +165,11 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
   }
 
   async function saveRemoteControl() {
-    const contentPages = remoteControlPages.value.filter((page) =>
-      BUTTON_KEYS.some((key) => page[key].id !== '0'),
-    );
-
-    const payload = JSON.stringify(contentPages);
+    const payload = JSON.stringify(remoteControlPages.value);
 
     try {
       await apiService.put(REMOTE_CONFIG, { config: payload });
+      isDirty.value = false;
       return { success: true };
     } catch (error) {
       console.error('Failed to save remote control configuration:', error);

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -81,6 +81,7 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
   const remoteControlPages = ref<RemoteControlPage[]>([]);
   const isLoading = ref(false);
   const isDirty = ref(false);
+  const selectedIdx = ref(0);
 
   async function loadRemoteControl() {
     isLoading.value = true;
@@ -100,6 +101,7 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
         remoteControlPages.value = [createDefaultPage(0)];
       }
       isDirty.value = false;
+      selectedIdx.value = 0;
       isLoading.value = false;
       return { success: true, data: result };
     } catch (error) {
@@ -107,6 +109,15 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
       isLoading.value = false;
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
+  }
+
+  function selectPage(idx: number) {
+    if (remoteControlPages.value.length === 0) {
+      selectedIdx.value = 0;
+      return;
+    }
+    const lastIdx = remoteControlPages.value.length - 1;
+    selectedIdx.value = Math.min(Math.max(idx, 0), lastIdx);
   }
 
   async function saveRemoteControl() {
@@ -129,7 +140,9 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     remoteControlPages,
     isLoading,
     isDirty,
+    selectedIdx,
     loadRemoteControl,
     saveRemoteControl,
+    selectPage,
   };
 });

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -217,22 +217,19 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     isDirty.value = true;
   }
 
-  function setButton(slotIdx: number, buttonKey: ButtonKey, value: PageButton) {
-    // Wraps the slot write + isDirty flip so consumers can't forget the
-    // dirty mark on direct page mutations. Originally the spec deferred this
-    // method on the rationale that there'd be a single consumer; surfaced
-    // during PR review as a forget-prone protocol regardless of consumer
-    // count, so we collapse the two writes into one entry point.
-    if (!Number.isInteger(slotIdx)) {
+  function setButton(pageIdx: number, buttonKey: ButtonKey, value: PageButton) {
+    // Wrap the slot write + isDirty flip so consumers have a single, safe entry
+    // point for updating a page's button configuration.
+    if (!Number.isInteger(pageIdx)) {
       console.warn(
-        `[remoteControl] setButton: slotIdx ${slotIdx} is not a valid integer (pages: ${remoteControlPages.value.length})`,
+        `[remoteControl] setButton: pageIdx ${pageIdx} is not a valid integer (pages: ${remoteControlPages.value.length})`,
       );
       return;
     }
-    const page = remoteControlPages.value[slotIdx];
+    const page = remoteControlPages.value[pageIdx];
     if (!page) {
       console.warn(
-        `[remoteControl] setButton: slotIdx ${slotIdx} out of range (pages: ${remoteControlPages.value.length})`,
+        `[remoteControl] setButton: pageIdx ${pageIdx} out of range (pages: ${remoteControlPages.value.length})`,
       );
       return;
     }

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -127,13 +127,19 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     isDirty.value = true;
   }
 
-  function renamePage(idx: number, name: string) {
+  function renamePage(idx: number, name: string): boolean {
     const target = remoteControlPages.value[idx];
-    if (!target) return;
+    if (!target) {
+      console.warn(
+        `[remoteControl] renamePage: idx ${idx} out of range (pages: ${remoteControlPages.value.length})`,
+      );
+      return false;
+    }
     const trimmed = name.trim();
-    if (trimmed.length === 0) return;
+    if (trimmed.length === 0) return false;
     target.name = trimmed;
     isDirty.value = true;
+    return true;
   }
 
   function deletePage(idx: number) {

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -127,6 +127,22 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     isDirty.value = true;
   }
 
+  function duplicatePage(idx: number) {
+    const src = remoteControlPages.value[idx];
+    if (!src) return;
+    const copy: RemoteControlPage = {
+      ...src,
+      id: crypto.randomUUID(),
+      name: `${src.name} (copy)`,
+    };
+    for (const key of BUTTON_KEYS) {
+      copy[key] = { ...src[key] };
+    }
+    remoteControlPages.value.splice(idx + 1, 0, copy);
+    selectedIdx.value = idx + 1;
+    isDirty.value = true;
+  }
+
   async function saveRemoteControl() {
     const contentPages = remoteControlPages.value.filter((page) =>
       BUTTON_KEYS.some((key) => page[key].id !== '0'),
@@ -152,5 +168,6 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     saveRemoteControl,
     selectPage,
     addPage,
+    duplicatePage,
   };
 });

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -138,12 +138,20 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
 
   function deletePage(idx: number) {
     if (remoteControlPages.value.length <= 1) return;
-    if (idx < 0 || idx >= remoteControlPages.value.length) return;
+    if (idx < 0 || idx >= remoteControlPages.value.length) {
+      console.warn(
+        `[remoteControl] deletePage: idx ${idx} out of range (pages: ${remoteControlPages.value.length})`,
+      );
+      return;
+    }
     remoteControlPages.value.splice(idx, 1);
     if (selectedIdx.value > idx) {
       selectedIdx.value -= 1;
-    } else if (selectedIdx.value >= remoteControlPages.value.length) {
-      selectedIdx.value = remoteControlPages.value.length - 1;
+    } else if (selectedIdx.value === idx) {
+      // The selected page itself was deleted — move back to the previous
+      // sibling so the user's mental position is preserved. Stays at 0 when
+      // there's nothing further back.
+      selectedIdx.value = Math.max(idx - 1, 0);
     }
     isDirty.value = true;
   }

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -120,9 +120,13 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
   function selectPage(idx: number) {
     if (!Number.isInteger(idx)) {
       // NaN, fractional, or Infinity — typically a UI bug computing idx from
-      // a stale/missing ref. Clamp to 0 so the store stays in a valid state
-      // (otherwise selectedIdx becomes NaN and pages[selectedIdx] is always
-      // undefined for the rest of the session).
+      // a stale/missing ref.
+      console.warn(
+        `[remoteControl] selectPage: idx ${idx} is not a valid integer (pages: ${remoteControlPages.value.length})`,
+      );
+      // Clamp to 0 so the store stays in a valid state (otherwise selectedIdx
+      // becomes NaN and pages[selectedIdx] is always undefined for the rest of
+      // the session).
       selectedIdx.value = 0;
       return;
     }

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -80,6 +80,7 @@ export function migratePage(page: Partial<RemoteControlPage>, idx: number): Remo
 export const useRemoteControlStore = defineStore('remoteControl', () => {
   const remoteControlPages = ref<RemoteControlPage[]>([]);
   const isLoading = ref(false);
+  const isDirty = ref(false);
 
   async function loadRemoteControl() {
     isLoading.value = true;
@@ -98,6 +99,7 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
       } else {
         remoteControlPages.value = [createDefaultPage(0)];
       }
+      isDirty.value = false;
       isLoading.value = false;
       return { success: true, data: result };
     } catch (error) {
@@ -126,6 +128,7 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
   return {
     remoteControlPages,
     isLoading,
+    isDirty,
     loadRemoteControl,
     saveRemoteControl,
   };

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -120,6 +120,13 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     selectedIdx.value = Math.min(Math.max(idx, 0), lastIdx);
   }
 
+  function addPage() {
+    const newIdx = remoteControlPages.value.length;
+    remoteControlPages.value.push(createDefaultPage(newIdx));
+    selectedIdx.value = newIdx;
+    isDirty.value = true;
+  }
+
   async function saveRemoteControl() {
     const contentPages = remoteControlPages.value.filter((page) =>
       BUTTON_KEYS.some((key) => page[key].id !== '0'),
@@ -144,5 +151,6 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     loadRemoteControl,
     saveRemoteControl,
     selectPage,
+    addPage,
   };
 });

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -127,6 +127,15 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     isDirty.value = true;
   }
 
+  function renamePage(idx: number, name: string) {
+    const target = remoteControlPages.value[idx];
+    if (!target) return;
+    const trimmed = name.trim();
+    if (trimmed.length === 0) return;
+    target.name = trimmed;
+    isDirty.value = true;
+  }
+
   function deletePage(idx: number) {
     if (remoteControlPages.value.length <= 1) return;
     if (idx < 0 || idx >= remoteControlPages.value.length) return;
@@ -182,5 +191,6 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     addPage,
     duplicatePage,
     deletePage,
+    renamePage,
   };
 });

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -112,6 +112,14 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
   }
 
   function selectPage(idx: number) {
+    if (!Number.isInteger(idx)) {
+      // NaN, fractional, or Infinity — typically a UI bug computing idx from
+      // a stale/missing ref. Clamp to 0 so the store stays in a valid state
+      // (otherwise selectedIdx becomes NaN and pages[selectedIdx] is always
+      // undefined for the rest of the session).
+      selectedIdx.value = 0;
+      return;
+    }
     if (remoteControlPages.value.length === 0) {
       selectedIdx.value = 0;
       return;
@@ -128,6 +136,12 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
   }
 
   function renamePage(idx: number, name: string): boolean {
+    if (!Number.isInteger(idx)) {
+      console.warn(
+        `[remoteControl] renamePage: idx ${idx} is not a valid integer (pages: ${remoteControlPages.value.length})`,
+      );
+      return false;
+    }
     const target = remoteControlPages.value[idx];
     if (!target) {
       console.warn(
@@ -144,7 +158,11 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
 
   function deletePage(idx: number) {
     if (remoteControlPages.value.length <= 1) return;
-    if (idx < 0 || idx >= remoteControlPages.value.length) {
+    if (!Number.isInteger(idx) || idx < 0 || idx >= remoteControlPages.value.length) {
+      // The Number.isInteger check covers NaN and fractional idx — both slip
+      // past the comparison-based guard (NaN comparisons all return false,
+      // fractional idx truncates inside splice and would silently delete the
+      // wrong page).
       console.warn(
         `[remoteControl] deletePage: idx ${idx} out of range (pages: ${remoteControlPages.value.length})`,
       );
@@ -163,6 +181,12 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
   }
 
   function duplicatePage(idx: number) {
+    if (!Number.isInteger(idx)) {
+      console.warn(
+        `[remoteControl] duplicatePage: idx ${idx} is not a valid integer (pages: ${remoteControlPages.value.length})`,
+      );
+      return;
+    }
     const src = remoteControlPages.value[idx];
     if (!src) {
       console.warn(

--- a/astros_vue/src/stores/remoteControl.ts
+++ b/astros_vue/src/stores/remoteControl.ts
@@ -127,6 +127,18 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     isDirty.value = true;
   }
 
+  function deletePage(idx: number) {
+    if (remoteControlPages.value.length <= 1) return;
+    if (idx < 0 || idx >= remoteControlPages.value.length) return;
+    remoteControlPages.value.splice(idx, 1);
+    if (selectedIdx.value > idx) {
+      selectedIdx.value -= 1;
+    } else if (selectedIdx.value >= remoteControlPages.value.length) {
+      selectedIdx.value = remoteControlPages.value.length - 1;
+    }
+    isDirty.value = true;
+  }
+
   function duplicatePage(idx: number) {
     const src = remoteControlPages.value[idx];
     if (!src) return;
@@ -169,5 +181,6 @@ export const useRemoteControlStore = defineStore('remoteControl', () => {
     selectPage,
     addPage,
     duplicatePage,
+    deletePage,
   };
 });

--- a/astros_vue/vitest.config.ts
+++ b/astros_vue/vitest.config.ts
@@ -7,6 +7,12 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'jsdom',
+      // Auto-restore vi.spyOn() mocks after every test, even when an
+      // assertion throws before a manual mockRestore() runs. Without this,
+      // a failing test that mocks console.warn/console.error leaves the
+      // mock installed across the rest of the worker, silently suppressing
+      // legitimate warnings in unrelated specs.
+      restoreMocks: true,
       exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url)),
     },


### PR DESCRIPTION
## Summary

Extends `useRemoteControlStore` with the page-CRUD methods, `selectedIdx`, and `isDirty` flag that the Phase 2b/2c/2d UI components consume. No UI changes; the new store surface sits unused until Phase 2d wires it.

Also drops the all-empty save filter (Decision 3 of the design spec) — every page in the array now persists on save regardless of slot content. Users manage page life-cycle explicitly via the upcoming Add/Delete UI rather than via implicit drop-on-save.

---

## What changed

### New store surface (additive on `useRemoteControlStore`)

```ts
// Existing — unchanged in API shape
remoteControlPages: Ref<RemoteControlPage[]>
isLoading:         Ref<boolean>
loadRemoteControl(): Promise<{ success, data?, error? }>
saveRemoteControl(): Promise<{ success, error? }>

// NEW state
isDirty:     Ref<boolean>   // false on load-of-stored-pages success; true on seed-from-empty + any mutation
selectedIdx: Ref<number>    // 0 default; clamped on every mutation; reset to 0 on load

// NEW methods
selectPage(idx): void                       // clamps; NaN-safe; does NOT set isDirty
addPage(): void                             // appends default; flips isDirty; selects new page
duplicatePage(idx): void                    // splices "(copy)" suffix after idx; deep-copies buttons
deletePage(idx): void                       // no-op if pages.length <= 1; moves selection back
renamePage(idx, name): boolean              // trims; no-op on empty/whitespace; returns true if applied
```

### Behavior changes vs `develop`

| Area | Before | After | Why |
|---|---|---|---|
| Save | `pages.filter(p => some button !== id:'0')` | `JSON.stringify(pages.value)` (no filter) | Decision 3 — implicit drop is surprising; explicit Add/Delete is in the spec |
| Empty stored config | Load → seed default → next save drops it (no-op) | Load → seed default → `isDirty=true` → user explicitly opts in to persist | Old filter masked this case; without it, Save would silently write a UUID page |
| Mid-list delete on selected page | Selection forward to whichever page took the slot | Selection moves back to previous sibling (or stays at 0) | Common file-manager / tab-strip pattern; preserves user's mental position |
| `renamePage` return | `void` | `boolean` (`true` applied, `false` rejected) | Phase 2c inline-rename UI can show "Name can't be blank" on `false` |
| Out-of-range / NaN idx | Silent return | `console.warn` then return (programming-error breadcrumb) | Matches `migratePage`'s existing warn-on-silent-degrade precedent |

### Files modified

- `astros_vue/src/stores/remoteControl.ts` — store extension
- `astros_vue/src/stores/__tests__/remoteControl.spec.ts` — 42 new test cases (63 total)
- `astros_vue/src/components/remoteControl/AstrosRemoteControl.vue` — comment rewrite + dead-code deletion
- `astros_vue/vitest.config.ts` — `restoreMocks: true` for spy hygiene across the whole Vue suite
- `.docs/plans/current_project.md` — will be checked off post-merge

---

## Test plan

**Automated (already passing):**
- [x] `npx vitest run` — 471 / 471 across full Vue suite (63 in remoteControl.spec.ts, of which ~42 are new this PR)
- [x] `npm run build` — type-check + Vite build clean
- [x] `npm run lint` — clean
- [x] `npm run format` — applied

**Mutation-test coverage on every defensive branch:**
- [x] `loadRemoteControl` isDirty clear (success path)
- [x] `loadRemoteControl` isDirty stays true on failure
- [x] `loadRemoteControl` seeds isDirty=true on empty stored config
- [x] `selectPage` low and high clamps (with non-zero starting selectedIdx to defeat vacuity)
- [x] `selectPage` NaN guard
- [x] `addPage` isDirty flip
- [x] `duplicatePage` `idx + 1` splice math (tested at idx=1, not just idx=0)
- [x] `duplicatePage` deep-copy via in-place button mutation (not slot reassignment)
- [x] `duplicatePage` out-of-range guard
- [x] `deletePage` single-page no-op guard
- [x] `deletePage` out-of-range guard
- [x] `deletePage` NaN guard (would otherwise become splice(0, 1) per ECMA)
- [x] `deletePage` fractional idx guard
- [x] `deletePage` selectedIdx shift-down (deleting a page below selection)
- [x] `deletePage` selectedIdx move-back (deleting the selected page itself)
- [x] `renamePage` trim
- [x] `renamePage` empty/whitespace no-op
- [x] `renamePage` out-of-range guard
- [x] `renamePage` boolean return value
- [x] `saveRemoteControl` isDirty clear on success
- [x] `saveRemoteControl` isDirty stays true on failure
- [x] `saveRemoteControl` persists every page (no filter)

**Manual QA (deferred to Phase 2d when the UI lands):**
- [ ] M5Stack sync round-trip — wire shape unchanged; pinned by the existing `remote_config_controller.test.ts`
- [ ] Phase 2d will add `.docs/qa/remote-control-config.md` covering all flows from the spec §5

---

## Review history

This PR went through **two full passes** of `/pr-review-toolkit:review-pr` (5 specialized agents in parallel each pass) before push.

### First pass — 5 agents, 7 fix commits

Found and addressed:
- **Critical (silent-failure)**: failed-load stale-state concern — partially deferred (Phase 2d concern); state preservation contract documented in commit messages
- **Important × 8** including stale comments, vacuous deep-copy test (was checking slot-reassignment which always isolates regardless of copy depth), `duplicatePage` only tested at idx=0, three independent reviewers flagging the same stale `(store as unknown as { isDirty: boolean })` casts

### Second pass — 5 agents, 4 fix commits

Found and addressed (catching issues introduced by the first-pass fixes):
- **Critical (type-design)**: `deletePage(NaN)` silently deleted `pages[0]` because `splice(NaN, 1)` becomes `splice(0, 1)` per ECMA's ToInteger spec and the comparison-based guard misses NaN. Same hazard for `deletePage(1.5)` and `selectPage(NaN)`. **Fixed** via `Number.isInteger` guards across all four idx-taking methods.
- **Important (silent-failure)**: the save-filter removal turned the empty-stored-config flow into an unintended write — user clicks Save on a fresh install without doing anything, server gets a random-UUID page. **Fixed** by setting `isDirty=true` when the store seeds a default on empty load, so the Save button enables and the user explicitly opts in.
- **Important (silent-failure)**: spy-leak class — every `vi.spyOn(...).mockRestore()` pattern leaks the mock if an assertion throws between them, cascading across test files in the same worker. **Fixed** via `restoreMocks: true` in `vitest.config.ts`; manual `mockRestore()` calls dropped (12 sites).
- **Important × 3 (test-analyst)**: vacuous `selectPage(-3)` test (post-load selectedIdx already 0), missing page-order assertion on selectedIdx-above-target duplicate test, missing explicit "load REPLACES" test. **All fixed.**
- **Important × 1 (comment-analyzer)**: "Phase 2d UI can revisit" plan-phasing reference in a test comment. **Dropped.**

### Deferred to Phase 2c / follow-up

These came up in review but are out of scope for 2a:
- **renamePage asymmetry**: returns `boolean` while the other four mutators return `void`. Type-design agent suggested promoting all to `{success, reason}` to match `scripter.ts`. Deferring — the boolean change already solves Phase 2c's inline-rename need; can promote if Phase 2c shows it's useful.
- **`selectedPage: ComputedRef<RemoteControlPage>`** on the store — would give consumers a non-`undefined` page ref. Additive; can land when first needed.
- **`AstrosRemoteControl.vue`** still ships in this PR with the same general structure — it'll be deleted in Phase 2d when `RemoteControlConfigView.vue` lands. Its comment block was refreshed in this PR to match current behavior.

---

## Commit log (17 commits)

```
67e57c5 test(remote-store): fix vacuous selectPage(-3); pin load-replaces; drop plan-phase ref
2eb37c2 test: enable restoreMocks; drop now-redundant manual mockRestore calls
865623d fix(remote-store): seeded-default page on empty load now starts dirty
045a52a fix(remote-store): guard idx against NaN and fractional values
fc23fed docs(remote): fix stale filter reference; correct plan script names
91c37d9 test(remote-store): drop stale isDirty casts; rename pre-existing tests
4870f76 test(remote-store): pin duplicatePage idx+1 math; warn on out-of-range
98ce066 fix(remote-store): renamePage returns boolean; warn on out-of-range idx
bcd4115 fix(remote-store): deletePage moves selection back; warn on out-of-range idx
2a9fa93 feat(remote-store): drop all-empty save filter; clear isDirty on save success
d55bb99 feat(remote-store): add renamePage with trim and empty-string no-op
1c69af7 feat(remote-store): add deletePage with single-page guard and selectedIdx clamp
d78c0e7 feat(remote-store): add duplicatePage with deep button copy
533f988 feat(remote-store): add addPage method
451dc4e feat(remote-store): add selectedIdx with clamping selectPage and load reset
cb02ee4 feat(remote-store): add isDirty flag cleared on load success
51f3c38 docs(plan): Phase 2a store CRUD implementation plan
```

Implementation commits (cb02ee4 through 2a9fa93) follow strict TDD — write failing test, confirm fail, implement, confirm pass, mutation-test the guard, restore, commit. Mutation tests for every defensive branch were verified by reverting the guard and confirming the test fails, then restoring.

---

## Wire-shape compatibility

The M5Stack `/remotecontrolsync` JSON contract is **unchanged**. Per the spec, this PR consumes Phase 1's `id` and `name` fields without modifying the wire shape. The contract is pinned by `astros_api/src/controllers/__tests__/remote_config_controller.test.ts` (from Phase 6); that test still passes.

The save-filter removal increases what *may* be sent (now sends empty pages too) but the per-page shape is unchanged. Existing M5 firmware was already handling all-`{name:'None', command:'0'}` slot entries (a configured page with 2 used slots had 7 such slots on the wire); more such pages is not a contract change.

---

## What's next (not in this PR)

- **2b**: `AstrosRemoteButtonCard` + `AstrosRemoteButtonEditor` (paired). Storybook gate.
- **2c**: `AstrosRemotePageList`. Storybook gate. Inline-rename here is the first consumer of `renamePage`'s `boolean` return.
- **2d**: `AstrosRemoteLivePreview` + `RemoteControlConfigView` assembly + router swap + delete-confirm modal + i18n sweep + manual QA + deletion of `AstrosRemoteControl.vue` / `RemoteView.vue` / `AstrosRemoteButton.vue`.

---

