### PR TITLE
Feature/phase2b button card editor

### DIFF
--- a/.docs/plans/20260523-1500-phase2b-button-card-editor.md
+++ b/.docs/plans/20260523-1500-phase2b-button-card-editor.md
@@ -1,0 +1,1464 @@
+# Phase 2b — Button Card + Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` (inline, single-component scope) or `superpowers:subagent-driven-development`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the paired `AstrosRemoteButtonEditor` (popover content with tab toggle + search + result list) and `AstrosRemoteButtonCard` (display state + popover host), verified in Storybook. No app integration — Phase 2d wires them.
+
+**Architecture:** Two new components under `components/remoteControl/`, each in its own camelCase folder per the project convention (memory `feedback_vue_component_naming`). The Card owns popover open/close state and anchors the Editor using `@floating-ui/vue`. The Editor is self-contained content with props in / events out. Both components remain props-driven; neither touches the Pinia store directly (the store call happens in Phase 2d's view).
+
+**Tech Stack:** Vue 3 `<script setup>`, TypeScript, Tailwind 4 + DaisyUI 5, `@floating-ui/vue` (new dep) for anchored positioning, `@headlessui/vue` (already installed) for focus trap, Vitest + `@vue/test-utils` for behavioral tests, Storybook 10 for the visual gate.
+
+**Spec:** `.docs/plans/specs/2026-05-21-phase2-editor-design.md` §2 Decisions 4 & 6 (visual shape + popover anchoring), §4 (component interfaces — props/emits), §5 Flow B (data flow).
+
+**Tracker:** `.docs/plans/current_project.md` — Phase 2 / 2b nested checkbox.
+
+---
+
+## Pre-flight context
+
+- **Branch:** already on `feature/phase2b-button-card-editor` (created off latest develop in the session that wrote this plan).
+- **Verification gate:** Storybook is primary. Vitest pins the behavioral contracts the Phase 2d view will rely on. Manual UI-layout polish lands via Storybook iteration per memory `feedback_tdd_exceptions` ("UI layout = manual feedback loop, not TDD").
+- **Pre-commit per CLAUDE.md:** `npm run format` (Vue's prettier script — equivalent of `prettier:write`) + `npm run lint` (already runs `--fix`) + `npm run type-check` (`vue-tsc --build`) + `npx vitest run` before each commit. `format` and `lint` run from `astros_vue/`.
+- **Mutation-test discipline per memory `feedback_mutation_test_defensive_features`:** every defensive branch (Esc handler, click-outside handler, empty-results render, tab-doesn't-clear, Clear-doesn't-open) gets a mutation test — revert the guard, confirm the test fails, restore.
+- **Out of scope for 2b:** no view integration, no router changes, no store changes, no `RemoteControlConfigView` work (that's 2d). The `AstrosRemoteButtonEditor` and `AstrosRemoteButtonCard` sit unused in the codebase until 2d wires them.
+
+---
+
+## File Structure
+
+**New files (8 component files + 2 misc):**
+
+```
+astros_vue/src/components/remoteControl/
+├── remoteButtonEditor/
+│   ├── AstrosRemoteButtonEditor.vue       — popover content; tab toggle, search, results
+│   ├── AstrosRemoteButtonEditor.spec.ts   — behavioral tests (emits, tab logic, filter)
+│   ├── AstrosRemoteButtonEditor.stories.ts — Storybook states (empty, populated, filtered)
+│   └── types.ts                            — EditorTab union; (re)exports of PageButton helpers
+└── remoteButtonCard/
+    ├── AstrosRemoteButtonCard.vue          — display state + popover host
+    ├── AstrosRemoteButtonCard.spec.ts      — display states, popover open/close, Clear/Edit
+    └── AstrosRemoteButtonCard.stories.ts   — empty/script/playlist/popover-open states
+```
+
+**Modified files:**
+- `astros_vue/package.json` — add `@floating-ui/vue` dep
+- `astros_vue/src/components/remoteControl/index.ts` — re-export `AstrosRemoteButtonCard` + `AstrosRemoteButtonEditor`
+- `astros_vue/src/locales/enUS.json` — add `remote_control_config.*` keys for tab labels, search, None row, Configure/Edit/Clear
+
+**Not modified:**
+- The existing `AstrosRemoteButton.vue` / `AstrosRemoteControl.vue` stay live until Phase 2d deletes them.
+- `useRemoteControlStore` — already complete from Phase 2a; nothing to change.
+
+---
+
+## Task 0: Install `@floating-ui/vue`
+
+**Note:** the plan file is committed separately (and first) per CLAUDE.md's "commit the plan file to the repo before writing any implementation code" rule.
+
+**Files:**
+- Modify: `astros_vue/package.json`, `astros_vue/package-lock.json`
+
+- [ ] **Step 1: Install the dep**
+
+```bash
+cd astros_vue
+npm install @floating-ui/vue
+```
+
+Expected: `package.json` gains `"@floating-ui/vue": "^x.x.x"` under `dependencies` (current latest is 1.x). `package-lock.json` updates.
+
+- [ ] **Step 2: Verify install + type resolution**
+
+```bash
+npx vue-tsc --build
+```
+
+Expected: clean. (Tests this isn't a phantom install; the package's TS declarations resolve.)
+
+- [ ] **Step 3: Commit the dep bump**
+
+```bash
+cd ..
+git add astros_vue/package.json astros_vue/package-lock.json
+git commit -m "build(deps): add @floating-ui/vue for Phase 2b popover anchoring"
+```
+
+Pure dep-add with no source logic changes — per-commit code-review carve-out applies.
+
+---
+
+## Task 1: `AstrosRemoteButtonEditor` types
+
+**Why first:** the spec's `change` payload is `PageButton`; the editor needs an internal `EditorTab` union (`'script' | 'playlist'`). Pinning the type before the component means the test file can import it.
+
+**Files:**
+- Create: `astros_vue/src/components/remoteControl/remoteButtonEditor/types.ts`
+
+- [ ] **Step 1: Create the types file**
+
+```ts
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+// The editor's two tabs map 1:1 to the two non-'none' PageButtonType values.
+// Constrain it as a derived type so adding a new PageButtonType later forces
+// the editor tab logic to update.
+export type EditorTab = Exclude<PageButton['type'], 'none'>;
+
+// Lightweight item shape for the script/playlist lists passed to the editor.
+// Intentionally NOT a full Script/Playlist model — the editor only needs id
+// + name to render the result rows. Decoupling here lets Phase 2d pass any
+// derivation of either store without forcing the editor to know about the
+// rest of the model.
+export interface EditorListItem {
+  id: string;
+  name: string;
+}
+```
+
+- [ ] **Step 2: Verify type-check passes (the file is isolated; nothing imports it yet)**
+
+```bash
+cd astros_vue && npm run type-check
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ..
+git add astros_vue/src/components/remoteControl/remoteButtonEditor/types.ts
+git commit -m "feat(remote-editor): add EditorTab and EditorListItem types"
+```
+
+Plan-only-ish (one types file, no logic) — pre-commit code-review carve-out applies.
+
+---
+
+## Task 2: `AstrosRemoteButtonEditor` — tab toggle + search filter (behavior, no styling yet)
+
+**Why this granularity:** the editor's tab and search logic are pure state — fully unit-testable. Building this first means the visual polish in Task 3 lands on top of a green test suite.
+
+**Files:**
+- Create: `astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue`
+- Create: `astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AstrosRemoteButtonEditor from '../AstrosRemoteButtonEditor.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SCRIPTS = [
+  { id: 's1', name: 'Wave Hello' },
+  { id: 's2', name: 'Bow' },
+];
+const PLAYLISTS = [
+  { id: 'p1', name: 'Morning Routine' },
+  { id: 'p2', name: 'Performance Set' },
+];
+
+function mkNoneButton(): PageButton {
+  return { id: '0', name: 'None', type: 'none' };
+}
+
+function mkScriptButton(id = 's1', name = 'Wave Hello'): PageButton {
+  return { id, name, type: 'script' };
+}
+
+function mkPlaylistButton(id = 'p1', name = 'Morning Routine'): PageButton {
+  return { id, name, type: 'playlist' };
+}
+
+describe('AstrosRemoteButtonEditor', () => {
+  it('opens with the script tab when current value is type:none', () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    // The active tab renders the scripts list; assert by finding a script name.
+    expect(wrapper.text()).toContain('Wave Hello');
+  });
+
+  it('opens with the playlist tab when current value is type:playlist', () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkPlaylistButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    expect(wrapper.text()).toContain('Morning Routine');
+  });
+
+  it('switches to playlist tab on click and shows playlist items', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
+    expect(wrapper.text()).toContain('Morning Routine');
+    expect(wrapper.text()).not.toContain('Wave Hello');
+  });
+
+  it('filters results case-insensitively as user types in search', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-search"]').setValue('WAV');
+    expect(wrapper.text()).toContain('Wave Hello');
+    expect(wrapper.text()).not.toContain('Bow');
+  });
+
+  it('renders an empty-state message when filter has no matches', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-search"]').setValue('xyzzy');
+    expect(wrapper.find('[data-testid="editor-empty"]').exists()).toBe(true);
+  });
+
+  it('tab switch does NOT auto-clear current value (per spec §4)', async () => {
+    // If the user opens the editor on a script and switches to playlist tab,
+    // no `change` event should fire from the tab switch alone. Pin this so a
+    // future "auto-clear on tab switch" change can't slip through.
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkScriptButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
+    expect(wrapper.emitted('change')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd astros_vue
+npx vitest run src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+```
+
+Expected: ALL fail (component file doesn't exist).
+
+- [ ] **Step 3: Implement the component (behavior-focused; styling is rough but functional)**
+
+```vue
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import type { EditorTab, EditorListItem } from './types';
+
+const props = defineProps<{
+  buttonNumber: number;
+  currentValue: PageButton;
+  scripts: EditorListItem[];
+  playlists: EditorListItem[];
+}>();
+
+const emit = defineEmits<{
+  change: [value: PageButton];
+  close: [];
+}>();
+
+const initialTab: EditorTab = props.currentValue.type === 'playlist' ? 'playlist' : 'script';
+const tab = ref<EditorTab>(initialTab);
+const query = ref('');
+
+const items = computed<EditorListItem[]>(() => {
+  const source = tab.value === 'script' ? props.scripts : props.playlists;
+  const q = query.value.trim().toLowerCase();
+  if (q.length === 0) return source;
+  return source.filter((i) => i.name.toLowerCase().includes(q));
+});
+
+function selectItem(item: EditorListItem) {
+  emit('change', { id: item.id, name: item.name, type: tab.value });
+}
+
+function selectNone() {
+  emit('change', { id: '0', name: 'None', type: 'none' });
+}
+</script>
+
+<template>
+  <div class="astros-remote-button-editor">
+    <header>
+      <span>BTN {{ buttonNumber }} · EDITING</span>
+      <button type="button" data-testid="editor-close" @click="emit('close')">×</button>
+    </header>
+    <div role="tablist">
+      <button
+        type="button"
+        role="tab"
+        :aria-selected="tab === 'script'"
+        data-testid="editor-tab-script"
+        @click="tab = 'script'"
+      >
+        Scripts
+      </button>
+      <button
+        type="button"
+        role="tab"
+        :aria-selected="tab === 'playlist'"
+        data-testid="editor-tab-playlist"
+        @click="tab = 'playlist'"
+      >
+        Playlists
+      </button>
+    </div>
+    <input
+      v-model="query"
+      type="search"
+      placeholder="Search…"
+      data-testid="editor-search"
+    />
+    <ul>
+      <li>
+        <button type="button" data-testid="editor-none" @click="selectNone">None</button>
+      </li>
+      <li v-for="item in items" :key="item.id">
+        <button type="button" :data-testid="`editor-item-${item.id}`" @click="selectItem(item)">
+          {{ item.name }}
+        </button>
+      </li>
+      <li v-if="items.length === 0" data-testid="editor-empty">No matches</li>
+    </ul>
+  </div>
+</template>
+```
+
+- [ ] **Step 4: Run to verify all 6 tests pass**
+
+```bash
+npx vitest run src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+```
+
+Expected: 6 / 6 pass.
+
+- [ ] **Step 5: Mutation-test the tab-doesn't-clear guard**
+
+The "tab switch does NOT auto-clear" test is the most subtle. Confirm it would catch a regression: temporarily change the `click="tab = 'playlist'"` handler in the template to also emit a change with type:'none'. Re-run that test. Expected: FAIL. Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ..
+npm --prefix astros_vue run format
+npm --prefix astros_vue run lint
+npm --prefix astros_vue run type-check
+git add astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+git commit -m "feat(remote-editor): tab toggle, search filter, None row, selection emits"
+```
+
+---
+
+## Task 3: `AstrosRemoteButtonEditor` — selection emits + Esc-close behavior
+
+**Files:**
+- Modify: `astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue`
+- Modify: `astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts`
+
+- [ ] **Step 1: Write failing tests for selection + Esc-close**
+
+Append to the spec file:
+
+```ts
+  it('emits change with the selected item and the current tab type', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-item-s2"]').trigger('click');
+
+    const events = wrapper.emitted('change');
+    expect(events).toHaveLength(1);
+    expect(events![0]![0]).toEqual({ id: 's2', name: 'Bow', type: 'script' });
+  });
+
+  it('emits change with type:playlist when a playlist item is picked', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
+    await wrapper.get('[data-testid="editor-item-p1"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({
+      id: 'p1',
+      name: 'Morning Routine',
+      type: 'playlist',
+    });
+  });
+
+  it('emits change with the None sentinel when None row is clicked', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkScriptButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-none"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
+  });
+
+  it('emits close when × button is clicked', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-close"]').trigger('click');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('emits close on Escape keydown', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      attachTo: document.body, // keydown listeners need a real document
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.trigger('keydown', { key: 'Escape' });
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    wrapper.unmount();
+  });
+```
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+```bash
+cd astros_vue
+npx vitest run src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+```
+
+Expected: 4 of 5 new tests already pass (selection emits work from Task 2). The Escape test fails — no `keydown` listener yet.
+
+- [ ] **Step 3: Add the keydown handler**
+
+In the `<template>` root, change the wrapping `<div>` to capture keydowns:
+
+```vue
+<template>
+  <div class="astros-remote-button-editor" tabindex="-1" @keydown.escape="emit('close')">
+```
+
+The `tabindex="-1"` lets the div be programmatically focusable (so the keydown bubbles from inside content), without being in the tab order.
+
+- [ ] **Step 4: Verify all editor tests pass**
+
+```bash
+npx vitest run src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+```
+
+Expected: all 11 pass.
+
+- [ ] **Step 5: Mutation-test the Escape guard**
+
+Remove `@keydown.escape="emit('close')"`. Run the Escape test. Expected: FAIL. Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ..
+npm --prefix astros_vue run format
+npm --prefix astros_vue run lint
+npm --prefix astros_vue run type-check
+git add astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+git commit -m "feat(remote-editor): close on Escape; pin selection emit shapes"
+```
+
+---
+
+## Task 4: `AstrosRemoteButtonEditor` — Storybook stories
+
+**Files:**
+- Create: `astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts`
+
+- [ ] **Step 1: Write the stories**
+
+```ts
+import { type Meta, type StoryObj } from '@storybook/vue3';
+import AstrosRemoteButtonEditor from './AstrosRemoteButtonEditor.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SAMPLE_SCRIPTS = [
+  { id: 's1', name: 'Wave Hello' },
+  { id: 's2', name: 'Bow' },
+  { id: 's3', name: 'Whistle' },
+  { id: 's4', name: 'Spin in Place' },
+];
+const SAMPLE_PLAYLISTS = [
+  { id: 'p1', name: 'Morning Routine' },
+  { id: 'p2', name: 'Performance Set' },
+  { id: 'p3', name: 'Quick Demo' },
+];
+
+// Wrap each story in a popover-shaped container so it reads how it would
+// when anchored over a button card.
+const popoverWrapper = `
+  <div style="
+    width: 260px;
+    border: 2px solid #2a5a97;
+    border-radius: 14px;
+    padding: 12px;
+    background: #fff;
+    box-shadow: 0 6px 24px rgba(42,90,151,0.18);
+  ">
+    <AstrosRemoteButtonEditor
+      v-bind="args"
+      @change="(v) => console.log('change', v)"
+      @close="() => console.log('close')"
+    />
+  </div>
+`;
+
+const meta: Meta<typeof AstrosRemoteButtonEditor> = {
+  title: 'RemoteControl/AstrosRemoteButtonEditor',
+  component: AstrosRemoteButtonEditor,
+  render: (args) => ({
+    components: { AstrosRemoteButtonEditor },
+    setup: () => ({ args }),
+    template: popoverWrapper,
+  }),
+};
+export default meta;
+
+type Story = StoryObj<typeof AstrosRemoteButtonEditor>;
+
+const NONE: PageButton = { id: '0', name: 'None', type: 'none' };
+const SCRIPT_ASSIGNED: PageButton = { id: 's1', name: 'Wave Hello', type: 'script' };
+const PLAYLIST_ASSIGNED: PageButton = { id: 'p1', name: 'Morning Routine', type: 'playlist' };
+
+export const EmptyButtonOpensOnScripts: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: NONE,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedScriptOpensOnScripts: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: SCRIPT_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedPlaylistOpensOnPlaylists: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: PLAYLIST_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const EmptyScriptList: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: NONE,
+    scripts: [],
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const LongName: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: NONE,
+    scripts: [
+      { id: 's-long', name: 'This Is A Really Long Script Name That Should Truncate' },
+      ...SAMPLE_SCRIPTS,
+    ],
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+```
+
+- [ ] **Step 2: Verify Storybook compiles**
+
+```bash
+cd astros_vue
+npm run build-storybook
+```
+
+Expected: clean build (Storybook dry-build catches story-only TS errors that vitest misses).
+
+- [ ] **Step 3: Visual verification (manual; UI-layout exception per memory `feedback_tdd_exceptions`)**
+
+```bash
+npm run storybook
+```
+
+Open http://localhost:6006 → RemoteControl / AstrosRemoteButtonEditor. Confirm each story renders without console errors and:
+- Tabs are visually distinct (active vs inactive)
+- Search input is present and styled (Tailwind / DaisyUI input)
+- Result list scrolls when overflowing
+- None row is visually distinct from regular results
+- Empty-state message reads "No matches"
+
+If the visual is rough, this is where layout polish happens (DaisyUI utility classes, Tailwind spacing). Iterate in Storybook; tests stay green throughout. Commit polish increments as you go.
+
+- [ ] **Step 4: Commit (stories + any visual polish from Step 3)**
+
+```bash
+cd ..
+npm --prefix astros_vue run format
+npm --prefix astros_vue run lint
+npm --prefix astros_vue run type-check
+git add astros_vue/src/components/remoteControl/remoteButtonEditor/
+git commit -m "feat(remote-editor): Storybook stories for all editor states"
+```
+
+---
+
+## Task 5: `AstrosRemoteButtonCard` — display state (unassigned + assigned), Clear emit
+
+**Files:**
+- Create: `astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue`
+- Create: `astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts`
+
+- [ ] **Step 1: Write failing tests for display + Clear**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AstrosRemoteButtonCard from '../AstrosRemoteButtonCard.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SCRIPTS = [{ id: 's1', name: 'Wave Hello' }];
+const PLAYLISTS = [{ id: 'p1', name: 'Morning Routine' }];
+
+function mkNone(): PageButton {
+  return { id: '0', name: 'None', type: 'none' };
+}
+function mkScript(): PageButton {
+  return { id: 's1', name: 'Wave Hello', type: 'script' };
+}
+function mkPlaylist(): PageButton {
+  return { id: 'p1', name: 'Morning Routine', type: 'playlist' };
+}
+
+describe('AstrosRemoteButtonCard — display state', () => {
+  it('renders BUTTON N label in unassigned state', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    expect(wrapper.text()).toMatch(/BUTTON 5|BTN 5/i);
+  });
+
+  it('shows a Configure button when value.type is none', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="card-clear"]').exists()).toBe(false);
+  });
+
+  it('shows assigned name and Edit/Clear buttons when value is a script', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    expect(wrapper.text()).toContain('Wave Hello');
+    expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-clear"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(false);
+  });
+
+  it('renders a SCRIPT type chip on a script-typed value', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    const chip = wrapper.find('[data-testid="card-type-chip"]');
+    expect(chip.exists()).toBe(true);
+    expect(chip.text()).toMatch(/SCRIPT/i);
+  });
+
+  it('renders a PLAYLIST type chip on a playlist-typed value', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkPlaylist(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    const chip = wrapper.find('[data-testid="card-type-chip"]');
+    expect(chip.text()).toMatch(/PLAYLIST/i);
+  });
+
+  it('Clear emits change with the none sentinel WITHOUT opening the editor', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-clear"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
+    // The editor popover must NOT have rendered (no editor element in DOM).
+    expect(wrapper.find('[data-testid="editor-search"]').exists()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd astros_vue
+npx vitest run src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+```
+
+Expected: all fail (component file doesn't exist).
+
+- [ ] **Step 3: Implement the card (display + Clear; popover host comes in Task 6)**
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import type { EditorListItem } from '../remoteButtonEditor/types';
+
+const props = defineProps<{
+  buttonNumber: number;
+  value: PageButton;
+  scripts: EditorListItem[];
+  playlists: EditorListItem[];
+}>();
+
+const emit = defineEmits<{
+  change: [value: PageButton];
+}>();
+
+const isAssigned = computed(() => props.value.type !== 'none');
+
+function clearAssignment() {
+  emit('change', { id: '0', name: 'None', type: 'none' });
+}
+</script>
+
+<template>
+  <div
+    class="astros-remote-button-card"
+    :class="{ 'astros-remote-button-card--assigned': isAssigned }"
+  >
+    <div class="astros-remote-button-card__label">BUTTON {{ buttonNumber }}</div>
+    <template v-if="isAssigned">
+      <div class="astros-remote-button-card__name">{{ value.name }}</div>
+      <span data-testid="card-type-chip" class="astros-remote-button-card__chip">
+        {{ value.type.toUpperCase() }}
+      </span>
+      <div class="astros-remote-button-card__actions">
+        <button type="button" data-testid="card-edit">Edit</button>
+        <button type="button" data-testid="card-clear" @click="clearAssignment">Clear</button>
+      </div>
+    </template>
+    <template v-else>
+      <button type="button" data-testid="card-configure">Configure →</button>
+    </template>
+  </div>
+</template>
+```
+
+Note: `scripts` and `playlists` are unused in this task — they're for the editor we host in Task 6. ESLint may warn; suppress with `// eslint-disable-line @typescript-eslint/no-unused-vars` on the props line if needed, or accept the warning until Task 6 lands them.
+
+- [ ] **Step 4: Run to verify all 6 tests pass**
+
+```bash
+npx vitest run src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+```
+
+Expected: 6 / 6 pass.
+
+- [ ] **Step 5: Mutation-test the "Clear doesn't open editor" guard**
+
+This guard matters for Phase 2d UX. If Clear ever started opening the editor (e.g., a future refactor moves both buttons into a single `@click="openEditor"` handler), tests should catch it. The current implementation has Clear in its own handler; if a future PR consolidates them, the test fails.
+
+Verify by temporarily adding `@click="openEditor"` to the Clear button (where `openEditor` is a no-op for now since the editor isn't wired). The test's check `wrapper.find('[data-testid="editor-search"]').exists()` would still be false (no editor exists yet), so this mutation test only fires once Task 6 lands the popover. Mark this as deferred mutation-coverage; add it as a post-Task-6 verification step.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ..
+npm --prefix astros_vue run format
+npm --prefix astros_vue run lint
+npm --prefix astros_vue run type-check
+git add astros_vue/src/components/remoteControl/remoteButtonCard/
+git commit -m "feat(remote-card): display state + Clear emit; assigned/unassigned variants"
+```
+
+---
+
+## Task 6: `AstrosRemoteButtonCard` — popover hosting (Floating UI + focus trap + click-outside)
+
+**Why this granularity:** the popover behavior is several interacting concerns. Doing it in one task keeps the behavior testable end-to-end (open → click outside → close) instead of leaving a partial popover that's hard to reason about.
+
+**Files:**
+- Modify: `astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue`
+- Modify: `astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts`
+
+- [ ] **Step 1: Write failing tests for popover open/close**
+
+Append to the card spec:
+
+```ts
+describe('AstrosRemoteButtonCard — popover host', () => {
+  it('opens the editor popover when Configure is clicked on an unassigned card', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+    wrapper.unmount();
+  });
+
+  it('opens the editor popover when Edit is clicked on an assigned card', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-edit"]').trigger('click');
+
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+    wrapper.unmount();
+  });
+
+  it('forwards the editor change event up and closes the popover', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    const item = document.querySelector('[data-testid="editor-item-s1"]') as HTMLElement;
+    item.click();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({
+      id: 's1',
+      name: 'Wave Hello',
+      type: 'script',
+    });
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    wrapper.unmount();
+  });
+
+  it('closes the popover when the editor emits close (Esc)', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+
+    const close = document.querySelector('[data-testid="editor-close"]') as HTMLElement;
+    close.click();
+    await wrapper.vm.$nextTick();
+
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    wrapper.unmount();
+  });
+
+  it('closes the popover when a click outside both card and popover happens', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+
+    // Simulate a click on a div appended directly to body (outside card + popover).
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.click();
+    await wrapper.vm.$nextTick();
+
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    outside.remove();
+    wrapper.unmount();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+npx vitest run src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+```
+
+Expected: the 5 new popover tests fail (no popover yet).
+
+- [ ] **Step 3: Implement the popover host**
+
+Update `AstrosRemoteButtonCard.vue` to mount the editor in a Floating UI-positioned element, with click-outside and forwarding:
+
+```vue
+<script setup lang="ts">
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue';
+import { useFloating, autoUpdate, flip, shift, offset } from '@floating-ui/vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import type { EditorListItem } from '../remoteButtonEditor/types';
+import AstrosRemoteButtonEditor from '../remoteButtonEditor/AstrosRemoteButtonEditor.vue';
+
+const props = defineProps<{
+  buttonNumber: number;
+  value: PageButton;
+  scripts: EditorListItem[];
+  playlists: EditorListItem[];
+}>();
+
+const emit = defineEmits<{
+  change: [value: PageButton];
+}>();
+
+const isAssigned = computed(() => props.value.type !== 'none');
+
+const popoverOpen = ref(false);
+const cardRef = ref<HTMLElement | null>(null);
+const popoverRef = ref<HTMLElement | null>(null);
+
+const { floatingStyles } = useFloating(cardRef, popoverRef, {
+  placement: 'bottom',
+  middleware: [offset(8), flip(), shift({ padding: 8 })],
+  whileElementsMounted: autoUpdate,
+});
+
+function openEditor() {
+  popoverOpen.value = true;
+}
+
+function closeEditor() {
+  popoverOpen.value = false;
+}
+
+function handleChange(value: PageButton) {
+  emit('change', value);
+  closeEditor();
+}
+
+function clearAssignment() {
+  emit('change', { id: '0', name: 'None', type: 'none' });
+}
+
+function handleClickOutside(e: MouseEvent) {
+  if (!popoverOpen.value) return;
+  const target = e.target as Node;
+  if (cardRef.value?.contains(target)) return;
+  if (popoverRef.value?.contains(target)) return;
+  closeEditor();
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside, true);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside, true);
+});
+</script>
+
+<template>
+  <div
+    ref="cardRef"
+    class="astros-remote-button-card"
+    :class="{ 'astros-remote-button-card--assigned': isAssigned }"
+  >
+    <div class="astros-remote-button-card__label">BUTTON {{ buttonNumber }}</div>
+    <template v-if="isAssigned">
+      <div class="astros-remote-button-card__name">{{ value.name }}</div>
+      <span data-testid="card-type-chip" class="astros-remote-button-card__chip">
+        {{ value.type.toUpperCase() }}
+      </span>
+      <div class="astros-remote-button-card__actions">
+        <button type="button" data-testid="card-edit" @click="openEditor">Edit</button>
+        <button type="button" data-testid="card-clear" @click="clearAssignment">Clear</button>
+      </div>
+    </template>
+    <template v-else>
+      <button type="button" data-testid="card-configure" @click="openEditor">Configure →</button>
+    </template>
+  </div>
+
+  <Teleport to="body">
+    <div
+      v-if="popoverOpen"
+      ref="popoverRef"
+      :style="floatingStyles"
+      class="astros-remote-button-card__popover"
+    >
+      <AstrosRemoteButtonEditor
+        :button-number="buttonNumber"
+        :current-value="value"
+        :scripts="scripts"
+        :playlists="playlists"
+        @change="handleChange"
+        @close="closeEditor"
+      />
+    </div>
+  </Teleport>
+</template>
+```
+
+Note: using `Teleport to="body"` so the popover escapes any `overflow:hidden` ancestor in the parent grid. Capture-phase click listener (third arg `true`) so the outside-click fires before the editor's own click handlers can stop propagation.
+
+- [ ] **Step 4: Run to verify all card tests pass**
+
+```bash
+npx vitest run src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+```
+
+Expected: 11 / 11 pass (6 from Task 5 + 5 from Task 6).
+
+- [ ] **Step 5: Mutation-test the click-outside guard**
+
+Remove the `document.removeEventListener('click', handleClickOutside, true);` line in `onBeforeUnmount`. The "closes the popover when a click outside" test still passes (the listener was never removed, so it still fires), but the unmount cleanup is a real leak. Add a NEW test that mounts → unmounts → clicks → asserts no error:
+
+```ts
+it('removes the document click listener on unmount (no leak)', async () => {
+  const wrapper = mount(AstrosRemoteButtonCard, {
+    attachTo: document.body,
+    props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+  });
+  await wrapper.get('[data-testid="card-configure"]').trigger('click');
+  wrapper.unmount();
+
+  // After unmount, document clicks shouldn't trigger anything in the
+  // gone-component's handler. The handler should be unregistered. If not,
+  // we'd see an attempt to read .contains() on the now-detached cardRef.
+  // We can't directly assert "listener removed" but we can confirm no
+  // error on a post-unmount click.
+  expect(() => {
+    const evt = new MouseEvent('click', { bubbles: true });
+    document.body.dispatchEvent(evt);
+  }).not.toThrow();
+});
+```
+
+This pins the cleanup. Then revert the removal of the cleanup line; the test should pass (no throw). Re-introduce the bug by removing the cleanup line again — the test as written may still pass because the listener checks `if (!popoverOpen.value) return` first. To make it more rigorous, also assert the leaked listener doesn't *re-emit*. That's overkill for Phase 2b — accept the lighter guard and move on.
+
+- [ ] **Step 6: Mutation-test the "Clear doesn't open editor" guard (deferred from Task 5)**
+
+Now that the editor IS hosted, temporarily add `openEditor()` to the start of `clearAssignment`. Run the "Clear emits change without opening" test from Task 5. Expected: FAIL (the editor element would appear in DOM). Restore.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ..
+npm --prefix astros_vue run format
+npm --prefix astros_vue run lint
+npm --prefix astros_vue run type-check
+git add astros_vue/src/components/remoteControl/remoteButtonCard/
+git commit -m "feat(remote-card): popover host with Floating UI; click-outside + Esc close"
+```
+
+---
+
+## Task 7: `AstrosRemoteButtonCard` — Storybook stories
+
+**Files:**
+- Create: `astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts`
+
+- [ ] **Step 1: Write the stories**
+
+```ts
+import { type Meta, type StoryObj } from '@storybook/vue3';
+import AstrosRemoteButtonCard from './AstrosRemoteButtonCard.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SAMPLE_SCRIPTS = [
+  { id: 's1', name: 'Wave Hello' },
+  { id: 's2', name: 'Bow' },
+];
+const SAMPLE_PLAYLISTS = [
+  { id: 'p1', name: 'Morning Routine' },
+];
+
+// Wrap each story in a 3x3 grid cell so the card sizing reads correctly.
+const gridCellWrapper = `
+  <div style="
+    width: 160px;
+    padding: 8px;
+    background: #f6f7f9;
+    border: 1px dashed #d6e0e6;
+  ">
+    <AstrosRemoteButtonCard v-bind="args" @change="(v) => console.log('change', v)" />
+  </div>
+`;
+
+const meta: Meta<typeof AstrosRemoteButtonCard> = {
+  title: 'RemoteControl/AstrosRemoteButtonCard',
+  component: AstrosRemoteButtonCard,
+  render: (args) => ({
+    components: { AstrosRemoteButtonCard },
+    setup: () => ({ args }),
+    template: gridCellWrapper,
+  }),
+};
+export default meta;
+
+type Story = StoryObj<typeof AstrosRemoteButtonCard>;
+
+const NONE: PageButton = { id: '0', name: 'None', type: 'none' };
+const SCRIPT_ASSIGNED: PageButton = { id: 's1', name: 'Wave Hello', type: 'script' };
+const PLAYLIST_ASSIGNED: PageButton = { id: 'p1', name: 'Morning Routine', type: 'playlist' };
+
+export const Unassigned: Story = {
+  args: {
+    buttonNumber: 5,
+    value: NONE,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedScript: Story = {
+  args: {
+    buttonNumber: 5,
+    value: SCRIPT_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedPlaylist: Story = {
+  args: {
+    buttonNumber: 5,
+    value: PLAYLIST_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const LongAssignedName: Story = {
+  args: {
+    buttonNumber: 5,
+    value: { id: 's-long', name: 'A Really Long Action Name', type: 'script' },
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+```
+
+Note: there's NO "popover open" story because the popover teleports to body and the click-to-open interaction is what Storybook is for. Reviewers will click Configure / Edit to see the editor anchored.
+
+- [ ] **Step 2: Verify Storybook compiles + visual sanity**
+
+```bash
+cd astros_vue
+npm run build-storybook
+```
+
+Expected: clean. Then `npm run storybook` and visit each story; click Configure / Edit on Unassigned / Assigned to see the popover anchor.
+
+- [ ] **Step 3: Commit (stories + any visual polish)**
+
+```bash
+cd ..
+npm --prefix astros_vue run format
+npm --prefix astros_vue run lint
+npm --prefix astros_vue run type-check
+git add astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts
+git commit -m "feat(remote-card): Storybook stories — unassigned, script, playlist, long name"
+```
+
+---
+
+## Task 8: i18n keys + replace hardcoded strings
+
+**Files:**
+- Modify: `astros_vue/src/locales/enUS.json`
+- Modify: `astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue`
+- Modify: `astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue`
+
+Per CLAUDE.md i18n rule: "Never hardcode user-facing strings. Use `$t('key')` in templates or `t('key')` from `useI18n()` in script setup."
+
+- [ ] **Step 1: Add the keys to `enUS.json`**
+
+Add under a new `remote_control_config` key (matches the pattern other views use). Append before the closing `}`:
+
+```json
+  "remote_control_config": {
+    "card": {
+      "label": "BUTTON {n}",
+      "configure": "Configure →",
+      "edit": "Edit",
+      "clear": "Clear",
+      "type_script": "SCRIPT",
+      "type_playlist": "PLAYLIST"
+    },
+    "editor": {
+      "header": "BTN {n} · EDITING",
+      "close": "Close",
+      "tab_script": "Scripts",
+      "tab_playlist": "Playlists",
+      "search_placeholder": "Search…",
+      "none_row": "None",
+      "empty_state": "No matches"
+    }
+  }
+```
+
+(Adjust JSON comma placement to match the surrounding file structure.)
+
+- [ ] **Step 2: Replace hardcoded strings in the Editor**
+
+In `AstrosRemoteButtonEditor.vue` `<script setup>`:
+
+```ts
+import { useI18n } from 'vue-i18n';
+const { t } = useI18n();
+```
+
+Replace template strings:
+- `BTN {{ buttonNumber }} · EDITING` → `{{ t('remote_control_config.editor.header', { n: buttonNumber }) }}`
+- `×` (close button) → `<span aria-hidden="true">×</span><span class="sr-only">{{ t('remote_control_config.editor.close') }}</span>`
+- `Scripts` → `{{ t('remote_control_config.editor.tab_script') }}`
+- `Playlists` → `{{ t('remote_control_config.editor.tab_playlist') }}`
+- `placeholder="Search…"` → `:placeholder="t('remote_control_config.editor.search_placeholder')"`
+- `None` (in the None button) → `{{ t('remote_control_config.editor.none_row') }}`
+- `No matches` → `{{ t('remote_control_config.editor.empty_state') }}`
+
+- [ ] **Step 3: Replace hardcoded strings in the Card**
+
+In `AstrosRemoteButtonCard.vue`:
+
+```ts
+import { useI18n } from 'vue-i18n';
+const { t } = useI18n();
+```
+
+Template:
+- `BUTTON {{ buttonNumber }}` → `{{ t('remote_control_config.card.label', { n: buttonNumber }) }}`
+- `Edit` → `{{ t('remote_control_config.card.edit') }}`
+- `Clear` → `{{ t('remote_control_config.card.clear') }}`
+- `Configure →` → `{{ t('remote_control_config.card.configure') }}`
+- `{{ value.type.toUpperCase() }}` → swap for a computed:
+
+```ts
+const typeChipLabel = computed(() => {
+  if (props.value.type === 'script') return t('remote_control_config.card.type_script');
+  if (props.value.type === 'playlist') return t('remote_control_config.card.type_playlist');
+  return '';
+});
+```
+
+Then in the template: `{{ typeChipLabel }}`.
+
+- [ ] **Step 4: Update tests that asserted on hardcoded strings**
+
+Some tests use literal text assertions (`expect(wrapper.text()).toContain('Wave Hello')` is fine; that's data, not chrome). But these need updating:
+- `expect(wrapper.text()).toMatch(/BUTTON 5|BTN 5/i)` — already tolerant, leave as is.
+- `expect(chip.text()).toMatch(/SCRIPT/i)` — still matches under the new "SCRIPT" key. Leave.
+
+Run the full editor + card suite:
+
+```bash
+cd astros_vue
+npx vitest run src/components/remoteControl/
+```
+
+Expected: all pass. If any vitest test broke due to a mount needing i18n setup, mock useI18n inside the test or wrap mounts with a test-i18n plugin. (Check existing tests like AstrosMobileRemote.spec.ts for the established pattern — likely `mount(Component, { global: { mocks: { $t: (key) => key } } })`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ..
+npm --prefix astros_vue run format
+npm --prefix astros_vue run lint
+npm --prefix astros_vue run type-check
+git add astros_vue/src/locales/enUS.json astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+git commit -m "feat(remote-card+editor): i18n keys for all user-facing strings"
+```
+
+---
+
+## Task 9: Re-export from `remoteControl/index.ts`
+
+**Files:**
+- Modify: `astros_vue/src/components/remoteControl/index.ts`
+
+- [ ] **Step 1: Add the exports**
+
+```ts
+export { default as AstrosRemoteButton } from './AstrosRemoteButton.vue';
+export { default as AstrosRemoteControl } from './AstrosRemoteControl.vue';
+export { default as AstrosRemoteButtonCard } from './remoteButtonCard/AstrosRemoteButtonCard.vue';
+export { default as AstrosRemoteButtonEditor } from './remoteButtonEditor/AstrosRemoteButtonEditor.vue';
+```
+
+- [ ] **Step 2: Verify build still passes**
+
+```bash
+cd astros_vue
+npm run build
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ..
+git add astros_vue/src/components/remoteControl/index.ts
+git commit -m "feat(remote): re-export AstrosRemoteButtonCard + AstrosRemoteButtonEditor"
+```
+
+---
+
+## Task 10: Pre-push branch review + tracker check-off + PR
+
+**Files:**
+- Modify: `.docs/plans/current_project.md`
+
+- [ ] **Step 1: Final verification**
+
+```bash
+cd astros_vue
+npm run lint
+npm run build
+npx vitest run
+npm run build-storybook
+```
+
+Expected: all green. New test count delta: +14 editor tests + +12 card tests ≈ +26 tests.
+
+- [ ] **Step 2: Pre-push branch review per CLAUDE.md "Pre-push branch review" section**
+
+```
+/pr-review-toolkit:review-pr
+```
+
+5 agents in parallel against the full branch diff vs develop. Address Critical + Important findings before push. Hazard categories specific to UI component work:
+- **Floating UI lifecycle**: does the popover correctly cleanup on unmount? Any orphan event listeners?
+- **Click-outside capture vs bubble**: capture-phase listener is intentional (fires before children's click handlers). Confirm it doesn't accidentally suppress legitimate clicks inside the popover.
+- **i18n key drift**: every hardcoded string moved to enUS.json; nothing left.
+- **a11y**: aria-selected on tabs, role="tablist", searchable input, focus management. The spec defers full a11y pass to a separate project memory; flag any obviously-missed basics.
+- **Mutation test coverage**: every defensive branch in Card/Editor.
+
+- [ ] **Step 3: Check off 2b in the tracker**
+
+```markdown
+  - [x] **2b** — `AstrosRemoteButtonCard` + `AstrosRemoteButtonEditor` (paired). Storybook
+        is the verification gate; no app integration. — shipped <DATE> via PR #<NUMBER>
+```
+
+```bash
+cd ..
+git add .docs/plans/current_project.md
+git commit -m "docs(plan): mark Phase 2b complete in tracker"
+```
+
+(Plan-only commit; carve-out applies.)
+
+- [ ] **Step 4: User pushes through VS Code (per memory `feedback_git_push`)**
+
+Do NOT run `git push` from terminal.
+
+- [ ] **Step 5: Open PR after push**
+
+```bash
+gh pr create --base develop --title "feat(remote): Phase 2b — AstrosRemoteButtonCard + AstrosRemoteButtonEditor" --body "$(cat <<'EOF'
+## Summary
+- Adds `AstrosRemoteButtonCard` (display state + popover host) and `AstrosRemoteButtonEditor` (popover content with tab toggle + filterable search + result list) per the Phase 2 design spec §4
+- Card uses `@floating-ui/vue` for anchored positioning with viewport collision handling
+- Popover closes on Esc, click outside, or successful selection (Decision 6)
+- Visual shape per Decision 4: tinted blue when assigned, equal-width Edit/Clear buttons, type chip
+- 26 new behavioral tests with mutation-test guards on every defensive branch
+- Storybook stories cover empty/assigned-script/assigned-playlist/long-name for the card and 5 editor states
+
+No app integration — Phase 2d wires these into the new `RemoteControlConfigView`.
+
+## Test plan
+- [x] Vitest unit suite passes
+- [x] Type-check passes
+- [x] Lint passes
+- [x] Storybook build clean
+- [x] Pre-push toolkit run (5 agents)
+- [ ] Visual verification in Storybook (will be reviewed in PR)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: After merge — update active-project memory**
+
+Update `~/.claude/projects/-home-jeff-Source-astros-AstrOs-Server/memory/project_active_remote_redesign.md` to reflect 2b shipped.
+
+---
+
+## Self-Review
+
+**Spec coverage** (`.docs/plans/specs/2026-05-21-phase2-editor-design.md` §4 AstrosRemoteButtonEditor + AstrosRemoteButtonCard):
+
+| Spec requirement | Task |
+|---|---|
+| Editor: opens with tab derived from currentValue.type | Task 2 |
+| Editor: defaults to 'script' if 'none' | Task 2 |
+| Editor: filterable search | Task 2 |
+| Editor: emits change on selection | Task 3 |
+| Editor: None row at top emits {id:'0',name:'None',type:'none'} | Tasks 2 + 3 |
+| Editor: tab switch does NOT auto-clear | Task 2 |
+| Editor: emits close on Esc / × / click outside | Task 3 + Task 6 (click outside is on Card) |
+| Card: BUTTON N label | Task 5 |
+| Card: name + type chip when assigned | Task 5 |
+| Card: equal-width Edit / Clear at bottom | Task 5 |
+| Card: Configure → for empty | Task 5 |
+| Card: Clear emits change with type:'none' WITHOUT opening editor | Task 5 |
+| Card: Edit / Configure opens popover | Task 6 |
+| Card: popover closes on Esc / click outside / successful selection | Task 6 |
+| Both: i18n keys for user-facing strings | Task 8 |
+| Both: Storybook is verification gate | Tasks 4 + 7 |
+
+**Out-of-scope confirmations:**
+- ❌ No app integration (Phase 2d)
+- ❌ No router changes
+- ❌ No store changes
+- ❌ No view assembly
+
+**Placeholder scan:** every code step has the actual code; every test step has the actual assertions.
+
+**Type consistency:** `EditorTab` defined in Task 1 used by Task 2's component. `EditorListItem` defined in Task 1 used by both Card and Editor props. `PageButton` from `@/models/remoteControl/pageButton` used uniformly. `data-testid` strings consistent between component templates and test selectors.

--- a/.docs/plans/current_project.md
+++ b/.docs/plans/current_project.md
@@ -21,8 +21,11 @@ fires the configured actions. M5Stack hardware remote continues to work in paral
       layout (page list + 3×3 grid + live preview), inline button editor, inline page CRUD.
       Design: [`specs/2026-05-21-phase2-editor-design.md`](./specs/2026-05-21-phase2-editor-design.md).
       Split into 4 PRs:
-  - [ ] **2a** — Store CRUD foundation (addPage / duplicatePage / deletePage / renamePage /
-        selectPage; isDirty flag; drop all-empty save filter). No UI changes.
+  - [x] **2a** — Store CRUD foundation (addPage / duplicatePage / deletePage / renamePage /
+        selectPage / setButton; isDirty flag; drop all-empty save filter). No UI changes. —
+        shipped 2026-05-23 via PR #94 (merge `3d6e3a4`). Two pre-push toolkit rounds; 67 store
+        tests including mutation-guards on every defensive branch; `setButton` helper added
+        post-PR-review to make the slot-write + isDirty flip atomic.
   - [ ] **2b** — `AstrosRemoteButtonCard` + `AstrosRemoteButtonEditor` (paired). Storybook
         is the verification gate; no app integration.
   - [ ] **2c** — `AstrosRemotePageList`. Storybook gate; no app integration.

--- a/astros_vue/package-lock.json
+++ b/astros_vue/package-lock.json
@@ -8,6 +8,7 @@
       "name": "astros_vue",
       "version": "1.0.0-dev.5",
       "dependencies": {
+        "@floating-ui/vue": "^1.1.11",
         "@fontsource/inter": "^5.2.8",
         "@headlessui/vue": "^1.7.23",
         "axios": "^1.13.2",
@@ -1368,6 +1369,68 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.11.tgz",
+      "integrity": "sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
+        "@floating-ui/utils": "^0.2.11",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fontsource/inter": {

--- a/astros_vue/package.json
+++ b/astros_vue/package.json
@@ -21,6 +21,7 @@
     "start:server": "cd ../astros_api &&  npm run-script start"
   },
   "dependencies": {
+    "@floating-ui/vue": "^1.1.11",
     "@fontsource/inter": "^5.2.8",
     "@headlessui/vue": "^1.7.23",
     "axios": "^1.13.2",

--- a/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
+++ b/astros_vue/src/components/mobileRemote/mobileRemote/types.ts
@@ -1,4 +1,5 @@
 import type { PageButton, PageButtonType } from '@/models/remoteControl/pageButton';
+import { assertNever } from '@/utils/assertNever';
 
 export type FilledPageButton = PageButton & {
   type: Exclude<PageButtonType, 'none'>;
@@ -7,8 +8,8 @@ export type FilledPageButton = PageButton & {
 export type AstrosMobileRemotePressEvent = FilledPageButton;
 
 // Exhaustive switch (not `type !== 'none'`) so a new PageButtonType variant
-// breaks the build at the `never` assertion instead of being silently
-// classified as filled and emitted through `press` to the parent.
+// breaks the build at assertNever instead of being silently classified as
+// filled and emitted through `press` to the parent.
 export function isFilledPageButton(button: PageButton): button is FilledPageButton {
   switch (button.type) {
     case 'script':
@@ -16,9 +17,7 @@ export function isFilledPageButton(button: PageButton): button is FilledPageButt
       return true;
     case 'none':
       return false;
-    default: {
-      const _exhaustive: never = button.type;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(button.type);
   }
 }

--- a/astros_vue/src/components/remoteControl/index.ts
+++ b/astros_vue/src/components/remoteControl/index.ts
@@ -1,2 +1,4 @@
 export { default as AstrosRemoteButton } from './AstrosRemoteButton.vue';
 export { default as AstrosRemoteControl } from './AstrosRemoteControl.vue';
+export { default as AstrosRemoteButtonCard } from './remoteButtonCard/AstrosRemoteButtonCard.vue';
+export { default as AstrosRemoteButtonEditor } from './remoteButtonEditor/AstrosRemoteButtonEditor.vue';

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createI18n } from 'vue-i18n';
 import AstrosRemoteButtonCard from './AstrosRemoteButtonCard.vue';
@@ -119,7 +119,9 @@ describe('AstrosRemoteButtonCard — popover host', () => {
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    await wrapper.vm.$nextTick();
     const item = document.querySelector('[data-testid="editor-item-s1"]') as HTMLElement;
+    expect(item).not.toBeNull();
     item.click();
     await wrapper.vm.$nextTick();
 
@@ -132,6 +134,28 @@ describe('AstrosRemoteButtonCard — popover host', () => {
     wrapper.unmount();
   });
 
+  it('closes the popover when Escape is pressed (focus-on-open routes the keydown to the editor)', async () => {
+    // Integration check for the editor's onMounted focus + the @keydown.escape
+    // handler on the editor root. If focus-on-mount stops working, Escape
+    // pressed by a user who just clicked Edit/Configure would no-op because
+    // focus would still be on the card button, not the editor.
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+
+    const escEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    (document.activeElement ?? document.body).dispatchEvent(escEvent);
+    await wrapper.vm.$nextTick();
+
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    wrapper.unmount();
+  });
+
   it('closes the popover when the editor emits close (× button)', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
@@ -139,6 +163,7 @@ describe('AstrosRemoteButtonCard — popover host', () => {
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    await wrapper.vm.$nextTick();
     expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
 
     const close = document.querySelector('[data-testid="editor-close"]') as HTMLElement;
@@ -167,18 +192,88 @@ describe('AstrosRemoteButtonCard — popover host', () => {
     wrapper.unmount();
   });
 
-  it('removes the document click listener on unmount (no leak / no error)', async () => {
+  it('removes the EXACT document click listener registered on mount (proves cleanup actually ran)', async () => {
+    // The previous "doesn't throw on post-unmount click" form was vacuous —
+    // the handler has no throwable path even when leaked. Spying on
+    // add/removeEventListener and comparing handler identity proves the
+    // listener was actually unregistered, AND pins the capture-phase third arg.
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    const addCall = addSpy.mock.calls.find(([type, , opts]) => type === 'click' && opts === true);
+    expect(addCall).toBeDefined();
+    const installedHandler = addCall![1];
+
+    wrapper.unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('click', installedHandler, true);
+  });
+
+  it('closes the popover via capture phase even when an outside element stops bubble propagation', async () => {
+    // Pins the capture-phase contract. If the outside-click listener were
+    // (incorrectly) on bubble phase, a stopPropagation in an outside child
+    // would prevent the close. Capture phase fires before any child handler,
+    // so it still closes the popover.
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
       global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
-    wrapper.unmount();
+    await wrapper.vm.$nextTick();
 
-    expect(() => {
-      const evt = new MouseEvent('click', { bubbles: true });
-      document.body.dispatchEvent(evt);
-    }).not.toThrow();
+    const outside = document.createElement('button');
+    outside.addEventListener('click', (e) => e.stopPropagation(), false);
+    document.body.appendChild(outside);
+    outside.click();
+    await wrapper.vm.$nextTick();
+
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    outside.remove();
+    wrapper.unmount();
+  });
+
+  it('can re-open the popover after a click-outside close (open→close→open lifecycle)', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.click();
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+
+    outside.remove();
+    wrapper.unmount();
+  });
+
+  it('reactively switches from unassigned to assigned display when value prop changes', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(true);
+
+    await wrapper.setProps({ value: mkScript() });
+
+    expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-type-chip"]').text()).toMatch(/SCRIPT/i);
+    expect(wrapper.text()).toContain('Wave Hello');
   });
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AstrosRemoteButtonCard from './AstrosRemoteButtonCard.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SCRIPTS = [{ id: 's1', name: 'Wave Hello' }];
+const PLAYLISTS = [{ id: 'p1', name: 'Morning Routine' }];
+
+function mkNone(): PageButton {
+  return { id: '0', name: 'None', type: 'none' };
+}
+function mkScript(): PageButton {
+  return { id: 's1', name: 'Wave Hello', type: 'script' };
+}
+function mkPlaylist(): PageButton {
+  return { id: 'p1', name: 'Morning Routine', type: 'playlist' };
+}
+
+describe('AstrosRemoteButtonCard — display state', () => {
+  it('renders BUTTON N label in unassigned state', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    expect(wrapper.text()).toMatch(/BUTTON 5|BTN 5/i);
+  });
+
+  it('shows a Configure button when value.type is none', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="card-clear"]').exists()).toBe(false);
+  });
+
+  it('shows assigned name and Edit/Clear buttons when value is a script', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    expect(wrapper.text()).toContain('Wave Hello');
+    expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-clear"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(false);
+  });
+
+  it('renders a SCRIPT type chip on a script-typed value', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    const chip = wrapper.find('[data-testid="card-type-chip"]');
+    expect(chip.exists()).toBe(true);
+    expect(chip.text()).toMatch(/SCRIPT/i);
+  });
+
+  it('renders a PLAYLIST type chip on a playlist-typed value', () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkPlaylist(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    const chip = wrapper.find('[data-testid="card-type-chip"]');
+    expect(chip.text()).toMatch(/PLAYLIST/i);
+  });
+
+  it('Clear emits change with the none sentinel WITHOUT opening the editor', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-clear"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
+    // The editor popover must NOT have rendered (no editor element in DOM).
+    expect(wrapper.find('[data-testid="editor-search"]').exists()).toBe(false);
+  });
+});

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -26,14 +26,6 @@ function mkPlaylist(): PageButton {
 }
 
 describe('AstrosRemoteButtonCard — display state', () => {
-  it('renders BUTTON N label in unassigned state', () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    expect(wrapper.text()).toMatch(/BUTTON 5|BTN 5/i);
-  });
-
   it('shows a Configure button when value.type is none', () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       global: { plugins: [i18n] },

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -68,6 +68,96 @@ describe('AstrosRemoteButtonCard — display state', () => {
 
     expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
     // The editor popover must NOT have rendered (no editor element in DOM).
-    expect(wrapper.find('[data-testid="editor-search"]').exists()).toBe(false);
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+  });
+});
+
+describe('AstrosRemoteButtonCard — popover host', () => {
+  it('opens the editor popover when Configure is clicked on an unassigned card', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+    wrapper.unmount();
+  });
+
+  it('opens the editor popover when Edit is clicked on an assigned card', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-edit"]').trigger('click');
+
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+    wrapper.unmount();
+  });
+
+  it('forwards the editor change event up and closes the popover', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    const item = document.querySelector('[data-testid="editor-item-s1"]') as HTMLElement;
+    item.click();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({
+      id: 's1',
+      name: 'Wave Hello',
+      type: 'script',
+    });
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    wrapper.unmount();
+  });
+
+  it('closes the popover when the editor emits close (× button)', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+
+    const close = document.querySelector('[data-testid="editor-close"]') as HTMLElement;
+    close.click();
+    await wrapper.vm.$nextTick();
+
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    wrapper.unmount();
+  });
+
+  it('closes the popover when a click outside both card and popover happens', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.click();
+    await wrapper.vm.$nextTick();
+
+    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
+    outside.remove();
+    wrapper.unmount();
+  });
+
+  it('removes the document click listener on unmount (no leak / no error)', async () => {
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
+    wrapper.unmount();
+
+    expect(() => {
+      const evt = new MouseEvent('click', { bubbles: true });
+      document.body.dispatchEvent(evt);
+    }).not.toThrow();
   });
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -82,7 +82,6 @@ describe('AstrosRemoteButtonCard — display state', () => {
     await wrapper.get('[data-testid="card-clear"]').trigger('click');
 
     expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
-    // The editor popover must NOT have rendered (no editor element in DOM).
     expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
   });
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -168,10 +168,15 @@ describe('AstrosRemoteButtonCard — popover host', () => {
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
     await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
     expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
+    // Pin the focus contract explicitly — if a future refactor drops the
+    // tabindex or breaks the focus chain, this assertion fires before the
+    // Escape dispatch makes the rest of the test ambiguous.
+    expect(document.activeElement).not.toBe(document.body);
 
     const escEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
-    (document.activeElement ?? document.body).dispatchEvent(escEvent);
+    document.activeElement!.dispatchEvent(escEvent);
     await wrapper.vm.$nextTick();
 
     expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
@@ -214,11 +219,13 @@ describe('AstrosRemoteButtonCard — popover host', () => {
     wrapper.unmount();
   });
 
-  it('removes the EXACT document click listener registered on mount (proves cleanup actually ran)', async () => {
+  it('removes every click+capture document listener registered on mount (proves cleanup actually ran)', async () => {
     // The previous "doesn't throw on post-unmount click" form was vacuous —
-    // the handler has no throwable path even when leaked. Spying on
-    // add/removeEventListener and comparing handler identity proves the
-    // listener was actually unregistered, AND pins the capture-phase third arg.
+    // the handler has no throwable path even when leaked. Spy on
+    // add/removeEventListener and assert every click+capture handler
+    // registered is also removed. Filter-and-subset (not .find()) so a
+    // future Floating UI upgrade that adds its own click+capture listener
+    // doesn't silently corrupt this test by hiding behind the first match.
     const addSpy = vi.spyOn(document, 'addEventListener');
     const removeSpy = vi.spyOn(document, 'removeEventListener');
 
@@ -227,13 +234,17 @@ describe('AstrosRemoteButtonCard — popover host', () => {
       global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
-    const addCall = addSpy.mock.calls.find(([type, , opts]) => type === 'click' && opts === true);
-    expect(addCall).toBeDefined();
-    const installedHandler = addCall![1];
+    const addedHandlers = addSpy.mock.calls
+      .filter(([type, , opts]) => type === 'click' && opts === true)
+      .map(([, handler]) => handler);
+    expect(addedHandlers.length).toBeGreaterThan(0);
 
     wrapper.unmount();
 
-    expect(removeSpy).toHaveBeenCalledWith('click', installedHandler, true);
+    const removedHandlers = removeSpy.mock.calls
+      .filter(([type, , opts]) => type === 'click' && opts === true)
+      .map(([, handler]) => handler);
+    expect(removedHandlers).toEqual(expect.arrayContaining(addedHandlers));
   });
 
   it('closes the popover via capture phase even when an outside element stops bubble propagation', async () => {
@@ -289,7 +300,10 @@ describe('AstrosRemoteButtonCard — popover host', () => {
       global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
+    // Pre-assert both the Configure-visible AND chip-absent baseline so a
+    // regression that renders the chip unconditionally would surface here.
     expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="card-type-chip"]').exists()).toBe(false);
 
     await wrapper.setProps({ value: mkScript() });
 
@@ -297,5 +311,33 @@ describe('AstrosRemoteButtonCard — popover host', () => {
     expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="card-type-chip"]').text()).toMatch(/SCRIPT/i);
     expect(wrapper.text()).toContain('Wave Hello');
+  });
+
+  it('restores keyboard focus to the trigger button when the popover closes', async () => {
+    // Pins the a11y contract — without focus capture/restore, every popover
+    // dismissal (Escape, close button, click outside, selection) drops
+    // focus to <body> and a keyboard user has to Tab back to where they were.
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+    const configureBtn = wrapper.get('[data-testid="card-configure"]').element as HTMLElement;
+    configureBtn.focus();
+    expect(document.activeElement).toBe(configureBtn);
+
+    await configureBtn.click();
+    await wrapper.vm.$nextTick();
+    // Editor's focus-on-mount stole focus from the trigger.
+    expect(document.activeElement).not.toBe(configureBtn);
+
+    // Close via the editor's × button.
+    const close = document.querySelector('[data-testid="editor-close"]') as HTMLElement;
+    close.click();
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(document.activeElement).toBe(configureBtn);
+    wrapper.unmount();
   });
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -84,6 +84,29 @@ describe('AstrosRemoteButtonCard — display state', () => {
     expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
     expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
   });
+
+  it('Clear emits a FRESH none-button object on each click (no shared identity across clicks)', async () => {
+    // Anti-regression for the shared-NONE_BUTTON-sentinel hazard. If both
+    // emits returned the same module-level const, an in-place mutation by
+    // any downstream consumer (`page.button1.name = 'X'` — a documented
+    // pattern in the store spec) would poison every other slot whose value
+    // came from the same sentinel.
+    const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
+      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
+    });
+
+    await wrapper.get('[data-testid="card-clear"]').trigger('click');
+    await wrapper.setProps({ value: mkPlaylist() });
+    await wrapper.get('[data-testid="card-clear"]').trigger('click');
+
+    const events = wrapper.emitted('change');
+    expect(events).toHaveLength(2);
+    const first = events![0]![0];
+    const second = events![1]![0];
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+  });
 });
 
 describe('AstrosRemoteButtonCard — popover host', () => {

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
 import AstrosRemoteButtonCard from './AstrosRemoteButtonCard.vue';
 import type { PageButton } from '@/models/remoteControl/pageButton';
+import enUS from '@/locales/enUS.json';
+
+// Use the real enUS.json so any missing key surfaces as a test failure.
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: { 'en-US': enUS },
+});
 
 const SCRIPTS = [{ id: 's1', name: 'Wave Hello' }];
 const PLAYLISTS = [{ id: 'p1', name: 'Morning Routine' }];
@@ -19,6 +28,7 @@ function mkPlaylist(): PageButton {
 describe('AstrosRemoteButtonCard — display state', () => {
   it('renders BUTTON N label in unassigned state', () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     expect(wrapper.text()).toMatch(/BUTTON 5|BTN 5/i);
@@ -26,6 +36,7 @@ describe('AstrosRemoteButtonCard — display state', () => {
 
   it('shows a Configure button when value.type is none', () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(true);
@@ -35,6 +46,7 @@ describe('AstrosRemoteButtonCard — display state', () => {
 
   it('shows assigned name and Edit/Clear buttons when value is a script', () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     expect(wrapper.text()).toContain('Wave Hello');
@@ -45,6 +57,7 @@ describe('AstrosRemoteButtonCard — display state', () => {
 
   it('renders a SCRIPT type chip on a script-typed value', () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     const chip = wrapper.find('[data-testid="card-type-chip"]');
@@ -54,6 +67,7 @@ describe('AstrosRemoteButtonCard — display state', () => {
 
   it('renders a PLAYLIST type chip on a playlist-typed value', () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkPlaylist(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     const chip = wrapper.find('[data-testid="card-type-chip"]');
@@ -62,6 +76,7 @@ describe('AstrosRemoteButtonCard — display state', () => {
 
   it('Clear emits change with the none sentinel WITHOUT opening the editor', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-clear"]').trigger('click');
@@ -76,6 +91,7 @@ describe('AstrosRemoteButtonCard — popover host', () => {
   it('opens the editor popover when Configure is clicked on an unassigned card', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
@@ -87,6 +103,7 @@ describe('AstrosRemoteButtonCard — popover host', () => {
   it('opens the editor popover when Edit is clicked on an assigned card', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-edit"]').trigger('click');
@@ -98,6 +115,7 @@ describe('AstrosRemoteButtonCard — popover host', () => {
   it('forwards the editor change event up and closes the popover', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
@@ -117,6 +135,7 @@ describe('AstrosRemoteButtonCard — popover host', () => {
   it('closes the popover when the editor emits close (× button)', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
@@ -133,6 +152,7 @@ describe('AstrosRemoteButtonCard — popover host', () => {
   it('closes the popover when a click outside both card and popover happens', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');
@@ -150,6 +170,7 @@ describe('AstrosRemoteButtonCard — popover host', () => {
   it('removes the document click listener on unmount (no leak / no error)', async () => {
     const wrapper = mount(AstrosRemoteButtonCard, {
       attachTo: document.body,
+      global: { plugins: [i18n] },
       props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
     });
     await wrapper.get('[data-testid="card-configure"]').trigger('click');

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts
@@ -28,7 +28,7 @@ const gridCellWrapper = `
 `;
 
 const meta: Meta<typeof AstrosRemoteButtonCard> = {
-  title: 'RemoteControl/AstrosRemoteButtonCard',
+  title: 'components/remoteControl/AstrosRemoteButtonCard',
   component: AstrosRemoteButtonCard,
   render: (args) => ({
     components: { AstrosRemoteButtonCard },

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts
@@ -1,0 +1,81 @@
+import { type Meta, type StoryObj } from '@storybook/vue3';
+import AstrosRemoteButtonCard from './AstrosRemoteButtonCard.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SAMPLE_SCRIPTS = [
+  { id: 's1', name: 'Wave Hello' },
+  { id: 's2', name: 'Bow' },
+  { id: 's3', name: 'Whistle' },
+];
+const SAMPLE_PLAYLISTS = [
+  { id: 'p1', name: 'Morning Routine' },
+  { id: 'p2', name: 'Performance Set' },
+];
+
+// Wrap each story in a 3x3 grid cell so the card sizing reads correctly.
+// The popover teleports to body, so the wrapper doesn't constrain it —
+// click Configure / Edit in the story to see the editor anchored.
+const gridCellWrapper = `
+  <div style="
+    width: 160px;
+    padding: 8px;
+    background: #f6f7f9;
+    border: 1px dashed #d6e0e6;
+    border-radius: 8px;
+  ">
+    <AstrosRemoteButtonCard v-bind="args" @change="(v) => console.log('change', v)" />
+  </div>
+`;
+
+const meta: Meta<typeof AstrosRemoteButtonCard> = {
+  title: 'RemoteControl/AstrosRemoteButtonCard',
+  component: AstrosRemoteButtonCard,
+  render: (args) => ({
+    components: { AstrosRemoteButtonCard },
+    setup: () => ({ args }),
+    template: gridCellWrapper,
+  }),
+};
+export default meta;
+
+type Story = StoryObj<typeof AstrosRemoteButtonCard>;
+
+const NONE: PageButton = { id: '0', name: 'None', type: 'none' };
+const SCRIPT_ASSIGNED: PageButton = { id: 's1', name: 'Wave Hello', type: 'script' };
+const PLAYLIST_ASSIGNED: PageButton = { id: 'p1', name: 'Morning Routine', type: 'playlist' };
+
+export const Unassigned: Story = {
+  args: {
+    buttonNumber: 5,
+    value: NONE,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedScript: Story = {
+  args: {
+    buttonNumber: 5,
+    value: SCRIPT_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedPlaylist: Story = {
+  args: {
+    buttonNumber: 5,
+    value: PLAYLIST_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const LongAssignedName: Story = {
+  args: {
+    buttonNumber: 5,
+    value: { id: 's-long', name: 'A Really Long Action Name', type: 'script' },
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -70,12 +70,15 @@ function openEditor() {
   popoverOpen.value = true;
 }
 
-function closeEditor() {
+function closeEditor(options: { restoreFocus?: boolean } = {}) {
   popoverOpen.value = false;
+
+  const restoreFocus = options.restoreFocus !== false;
+  const target = restoreFocus ? triggerEl : null;
+  triggerEl = null;
+
   // Restore focus AFTER the popover unmounts so the trigger button can
   // re-receive focus cleanly. nextTick lets Vue flush the v-if removal.
-  const target = triggerEl;
-  triggerEl = null;
   nextTick(() => target?.focus());
 }
 
@@ -95,7 +98,7 @@ function handleClickOutside(e: MouseEvent) {
   const path = e.composedPath();
   if (cardRef.value && path.includes(cardRef.value)) return;
   if (popoverRef.value && path.includes(popoverRef.value)) return;
-  closeEditor();
+  closeEditor({ restoreFocus: false });
 }
 
 onMounted(() => {

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -125,7 +125,7 @@ onScopeDispose(() => {
   >
     <div
       v-if="isAssigned"
-      class="flex justify-end"
+      class="flex justify-center"
     >
       <span
         :class="[

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -91,8 +91,8 @@ function handleClickOutside(e: MouseEvent) {
 }
 
 onMounted(() => {
-  // Capture phase as a defensive default — guarantees this fires regardless
-  // of whether future child handlers stop propagation.
+  // Capture phase so the outside-click fires before any child popover handler
+  // can call stopPropagation and swallow the close.
   document.addEventListener('click', handleClickOutside, true);
 });
 

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onScopeDispose, ref } from 'vue';
+import { computed, nextTick, onMounted, onScopeDispose, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
 import { makeNoneButton, type PageButton } from '@/models/remoteControl/pageButton';
@@ -56,6 +56,11 @@ const typeChipLabel = computed(() => {
 const popoverOpen = ref(false);
 const cardRef = ref<HTMLElement | null>(null);
 const popoverRef = ref<HTMLElement | null>(null);
+// Captured on openEditor so closeEditor can restore keyboard focus to the
+// element that opened the popover. Without this, every popover dismissal
+// dumps focus to <body> and a keyboard user has to Tab back to where they
+// were.
+let triggerEl: HTMLElement | null = null;
 
 const { floatingStyles } = useFloating(cardRef, popoverRef, {
   placement: 'bottom',
@@ -64,11 +69,17 @@ const { floatingStyles } = useFloating(cardRef, popoverRef, {
 });
 
 function openEditor() {
+  triggerEl = document.activeElement as HTMLElement | null;
   popoverOpen.value = true;
 }
 
 function closeEditor() {
   popoverOpen.value = false;
+  // Restore focus AFTER the popover unmounts so the trigger button can
+  // re-receive focus cleanly. nextTick lets Vue flush the v-if removal.
+  const target = triggerEl;
+  triggerEl = null;
+  nextTick(() => target?.focus());
 }
 
 function handleChange(value: PageButton) {

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onMounted, onScopeDispose, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
 import type { PageButton } from '@/models/remoteControl/pageButton';
@@ -62,21 +62,25 @@ function clearAssignment() {
 
 function handleClickOutside(e: MouseEvent) {
   if (!popoverOpen.value) return;
-  const target = e.target as Node;
-  if (cardRef.value?.contains(target)) return;
-  if (popoverRef.value?.contains(target)) return;
+  // composedPath walks through Shadow DOM boundaries too, so a future
+  // shadow-hosted child of the popover wouldn't get treated as "outside."
+  const path = e.composedPath();
+  if (cardRef.value && path.includes(cardRef.value)) return;
+  if (popoverRef.value && path.includes(popoverRef.value)) return;
   closeEditor();
 }
 
 onMounted(() => {
-  // Capture phase so the outside-click fires before any child handler can
-  // stopPropagation. Without capture, a click on the editor's None row
-  // (which calls preventDefault/stopPropagation internally) could swallow
-  // the close-on-outside check.
+  // Capture phase as a defensive default — guarantees this fires regardless
+  // of whether future child handlers stop propagation.
   document.addEventListener('click', handleClickOutside, true);
 });
 
-onBeforeUnmount(() => {
+// onScopeDispose (not onBeforeUnmount) so the listener is also torn down on
+// non-standard teardown paths (parent throws mid-render, Suspense cancels a
+// pending mount after onMounted already fired). Same pattern used by the
+// mobileRemote composables.
+onScopeDispose(() => {
   document.removeEventListener('click', handleClickOutside, true);
 });
 </script>

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorListItem } from '../remoteButtonEditor/types';
+import AstrosRemoteButtonEditor from '../remoteButtonEditor/AstrosRemoteButtonEditor.vue';
 
 const props = defineProps<{
   buttonNumber: number;
@@ -22,19 +24,57 @@ const typeChipClasses = computed(() =>
     : 'bg-primary/15 text-primary border border-primary/40',
 );
 
+const popoverOpen = ref(false);
+const cardRef = ref<HTMLElement | null>(null);
+const popoverRef = ref<HTMLElement | null>(null);
+
+const { floatingStyles } = useFloating(cardRef, popoverRef, {
+  placement: 'bottom',
+  middleware: [offset(8), flip(), shift({ padding: 8 })],
+  whileElementsMounted: autoUpdate,
+});
+
+function openEditor() {
+  popoverOpen.value = true;
+}
+
+function closeEditor() {
+  popoverOpen.value = false;
+}
+
+function handleChange(value: PageButton) {
+  emit('change', value);
+  closeEditor();
+}
+
 function clearAssignment() {
   emit('change', { id: '0', name: 'None', type: 'none' });
 }
 
-// Suppress unused-prop warnings for scripts/playlists — they're forwarded
-// to the editor popover in the next task. Reading them here keeps Vue's
-// reactivity from warning about unused destructure.
-void props.scripts;
-void props.playlists;
+function handleClickOutside(e: MouseEvent) {
+  if (!popoverOpen.value) return;
+  const target = e.target as Node;
+  if (cardRef.value?.contains(target)) return;
+  if (popoverRef.value?.contains(target)) return;
+  closeEditor();
+}
+
+onMounted(() => {
+  // Capture phase so the outside-click fires before any child handler can
+  // stopPropagation. Without capture, a click on the editor's None row
+  // (which calls preventDefault/stopPropagation internally) could swallow
+  // the close-on-outside check.
+  document.addEventListener('click', handleClickOutside, true);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside, true);
+});
 </script>
 
 <template>
   <div
+    ref="cardRef"
     class="astros-remote-button-card flex min-h-32 flex-col gap-2 rounded-xl border-2 p-3 transition-colors"
     :class="
       isAssigned
@@ -65,6 +105,7 @@ void props.playlists;
           type="button"
           class="btn btn-sm btn-outline flex-1"
           data-testid="card-edit"
+          @click="openEditor"
         >
           Edit
         </button>
@@ -83,9 +124,28 @@ void props.playlists;
         type="button"
         class="btn btn-sm btn-ghost mt-auto w-full justify-center text-base-content/60"
         data-testid="card-configure"
+        @click="openEditor"
       >
         Configure →
       </button>
     </template>
   </div>
+
+  <Teleport to="body">
+    <div
+      v-if="popoverOpen"
+      ref="popoverRef"
+      :style="floatingStyles"
+      class="z-50 w-64 rounded-xl border-2 border-primary bg-base-100 p-3 shadow-xl"
+    >
+      <AstrosRemoteButtonEditor
+        :button-number="buttonNumber"
+        :current-value="value"
+        :scripts="scripts"
+        :playlists="playlists"
+        @change="handleChange"
+        @close="closeEditor"
+      />
+    </div>
+  </Teleport>
 </template>

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, onScopeDispose, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
-import type { PageButton } from '@/models/remoteControl/pageButton';
+import { NONE_BUTTON, type PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorListItem } from '../remoteButtonEditor/types';
 import AstrosRemoteButtonEditor from '../remoteButtonEditor/AstrosRemoteButtonEditor.vue';
 
@@ -11,8 +11,8 @@ const { t } = useI18n();
 const props = defineProps<{
   buttonNumber: number;
   value: PageButton;
-  scripts: EditorListItem[];
-  playlists: EditorListItem[];
+  scripts: readonly EditorListItem[];
+  playlists: readonly EditorListItem[];
 }>();
 
 const emit = defineEmits<{
@@ -21,16 +21,36 @@ const emit = defineEmits<{
 
 const isAssigned = computed(() => props.value.type !== 'none');
 
-const typeChipClasses = computed(() =>
-  props.value.type === 'playlist'
-    ? 'bg-warning/15 text-warning-content border border-warning/40'
-    : 'bg-primary/15 text-primary border border-primary/40',
-);
+// Switch (not ternary) so a new PageButtonType variant breaks the build here
+// and forces both chip styling and chip labelling to be updated explicitly.
+const typeChipClasses = computed(() => {
+  switch (props.value.type) {
+    case 'playlist':
+      return 'bg-warning/15 text-warning-content border border-warning/40';
+    case 'script':
+      return 'bg-primary/15 text-primary border border-primary/40';
+    case 'none':
+      return '';
+    default: {
+      const _exhaustive: never = props.value.type;
+      return _exhaustive;
+    }
+  }
+});
 
 const typeChipLabel = computed(() => {
-  if (props.value.type === 'script') return t('remote_control_config.card.type_script');
-  if (props.value.type === 'playlist') return t('remote_control_config.card.type_playlist');
-  return '';
+  switch (props.value.type) {
+    case 'script':
+      return t('remote_control_config.card.type_script');
+    case 'playlist':
+      return t('remote_control_config.card.type_playlist');
+    case 'none':
+      return '';
+    default: {
+      const _exhaustive: never = props.value.type;
+      return _exhaustive;
+    }
+  }
 });
 
 const popoverOpen = ref(false);
@@ -57,7 +77,7 @@ function handleChange(value: PageButton) {
 }
 
 function clearAssignment() {
-  emit('change', { id: '0', name: 'None', type: 'none' });
+  emit('change', NONE_BUTTON);
 }
 
 function handleClickOutside(e: MouseEvent) {

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -27,7 +27,7 @@ const isAssigned = computed(() => props.value.type !== 'none');
 const typeChipClasses = computed(() => {
   switch (props.value.type) {
     case 'playlist':
-      return 'bg-warning/15 text-warning-content border border-warning/40';
+      return 'bg-orange-500/15 text-orange-700 border border-orange-500/40';
     case 'script':
       return 'bg-primary/15 text-primary border border-primary/40';
     case 'none':

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, onScopeDispose, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
-import { NONE_BUTTON, type PageButton } from '@/models/remoteControl/pageButton';
+import { makeNoneButton, type PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorListItem } from '../remoteButtonEditor/types';
 import AstrosRemoteButtonEditor from '../remoteButtonEditor/AstrosRemoteButtonEditor.vue';
 
@@ -77,7 +77,7 @@ function handleChange(value: PageButton) {
 }
 
 function clearAssignment() {
-  emit('change', NONE_BUTTON);
+  emit('change', makeNoneButton());
 }
 
 function handleClickOutside(e: MouseEvent) {
@@ -99,7 +99,7 @@ onMounted(() => {
 // onScopeDispose (not onBeforeUnmount) so the listener is also torn down on
 // non-standard teardown paths (parent throws mid-render, Suspense cancels a
 // pending mount after onMounted already fired). Same pattern used by the
-// mobileRemote composables.
+// useHoldGesture composable.
 onScopeDispose(() => {
   document.removeEventListener('click', handleClickOutside, true);
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import type { EditorListItem } from '../remoteButtonEditor/types';
+
+const props = defineProps<{
+  buttonNumber: number;
+  value: PageButton;
+  scripts: EditorListItem[];
+  playlists: EditorListItem[];
+}>();
+
+const emit = defineEmits<{
+  change: [value: PageButton];
+}>();
+
+const isAssigned = computed(() => props.value.type !== 'none');
+
+const typeChipClasses = computed(() =>
+  props.value.type === 'playlist'
+    ? 'bg-warning/15 text-warning-content border border-warning/40'
+    : 'bg-primary/15 text-primary border border-primary/40',
+);
+
+function clearAssignment() {
+  emit('change', { id: '0', name: 'None', type: 'none' });
+}
+
+// Suppress unused-prop warnings for scripts/playlists — they're forwarded
+// to the editor popover in the next task. Reading them here keeps Vue's
+// reactivity from warning about unused destructure.
+void props.scripts;
+void props.playlists;
+</script>
+
+<template>
+  <div
+    class="astros-remote-button-card flex min-h-32 flex-col gap-2 rounded-xl border-2 p-3 transition-colors"
+    :class="
+      isAssigned
+        ? 'border-primary bg-primary/5'
+        : 'border-base-300 bg-base-100 hover:border-base-content/30'
+    "
+  >
+    <div class="flex items-center justify-between">
+      <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/60">
+        BUTTON {{ buttonNumber }}
+      </span>
+      <span
+        v-if="isAssigned"
+        :class="[
+          'rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider',
+          typeChipClasses,
+        ]"
+        data-testid="card-type-chip"
+      >
+        {{ value.type }}
+      </span>
+    </div>
+
+    <template v-if="isAssigned">
+      <div class="flex-1 text-center text-sm font-semibold leading-tight">{{ value.name }}</div>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          class="btn btn-sm btn-outline flex-1"
+          data-testid="card-edit"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost flex-1"
+          data-testid="card-clear"
+          @click="clearAssignment"
+        >
+          Clear
+        </button>
+      </div>
+    </template>
+    <template v-else>
+      <button
+        type="button"
+        class="btn btn-sm btn-ghost mt-auto w-full justify-center text-base-content/60"
+        data-testid="card-configure"
+      >
+        Configure →
+      </button>
+    </template>
+  </div>
+</template>

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -123,12 +123,11 @@ onScopeDispose(() => {
         : 'border-base-300 bg-base-100 hover:border-base-content/30'
     "
   >
-    <div class="flex items-center justify-between">
-      <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/60">
-        {{ t('remote_control_config.card.label', { n: buttonNumber }) }}
-      </span>
+    <div
+      v-if="isAssigned"
+      class="flex justify-end"
+    >
       <span
-        v-if="isAssigned"
         :class="[
           'rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider',
           typeChipClasses,

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorListItem } from '../remoteButtonEditor/types';
 import AstrosRemoteButtonEditor from '../remoteButtonEditor/AstrosRemoteButtonEditor.vue';
+
+const { t } = useI18n();
 
 const props = defineProps<{
   buttonNumber: number;
@@ -23,6 +26,12 @@ const typeChipClasses = computed(() =>
     ? 'bg-warning/15 text-warning-content border border-warning/40'
     : 'bg-primary/15 text-primary border border-primary/40',
 );
+
+const typeChipLabel = computed(() => {
+  if (props.value.type === 'script') return t('remote_control_config.card.type_script');
+  if (props.value.type === 'playlist') return t('remote_control_config.card.type_playlist');
+  return '';
+});
 
 const popoverOpen = ref(false);
 const cardRef = ref<HTMLElement | null>(null);
@@ -84,7 +93,7 @@ onBeforeUnmount(() => {
   >
     <div class="flex items-center justify-between">
       <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/60">
-        BUTTON {{ buttonNumber }}
+        {{ t('remote_control_config.card.label', { n: buttonNumber }) }}
       </span>
       <span
         v-if="isAssigned"
@@ -94,7 +103,7 @@ onBeforeUnmount(() => {
         ]"
         data-testid="card-type-chip"
       >
-        {{ value.type }}
+        {{ typeChipLabel }}
       </span>
     </div>
 
@@ -107,7 +116,7 @@ onBeforeUnmount(() => {
           data-testid="card-edit"
           @click="openEditor"
         >
-          Edit
+          {{ t('remote_control_config.card.edit') }}
         </button>
         <button
           type="button"
@@ -115,7 +124,7 @@ onBeforeUnmount(() => {
           data-testid="card-clear"
           @click="clearAssignment"
         >
-          Clear
+          {{ t('remote_control_config.card.clear') }}
         </button>
       </div>
     </template>
@@ -126,7 +135,7 @@ onBeforeUnmount(() => {
         data-testid="card-configure"
         @click="openEditor"
       >
-        Configure →
+        {{ t('remote_control_config.card.configure') }}
       </button>
     </template>
   </div>

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onMounted, onScopeDispose, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
 import { makeNoneButton, type PageButton } from '@/models/remoteControl/pageButton';
+import { assertNever } from '@/utils/assertNever';
 import type { EditorListItem } from '../remoteButtonEditor/types';
 import AstrosRemoteButtonEditor from '../remoteButtonEditor/AstrosRemoteButtonEditor.vue';
 
@@ -31,10 +32,8 @@ const typeChipClasses = computed(() => {
       return 'bg-primary/15 text-primary border border-primary/40';
     case 'none':
       return '';
-    default: {
-      const _exhaustive: never = props.value.type;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(props.value.type);
   }
 });
 
@@ -46,10 +45,8 @@ const typeChipLabel = computed(() => {
       return t('remote_control_config.card.type_playlist');
     case 'none':
       return '';
-    default: {
-      const _exhaustive: never = props.value.type;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(props.value.type);
   }
 });
 

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AstrosRemoteButtonEditor from './AstrosRemoteButtonEditor.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SCRIPTS = [
+  { id: 's1', name: 'Wave Hello' },
+  { id: 's2', name: 'Bow' },
+];
+const PLAYLISTS = [
+  { id: 'p1', name: 'Morning Routine' },
+  { id: 'p2', name: 'Performance Set' },
+];
+
+function mkNoneButton(): PageButton {
+  return { id: '0', name: 'None', type: 'none' };
+}
+
+function mkScriptButton(id = 's1', name = 'Wave Hello'): PageButton {
+  return { id, name, type: 'script' };
+}
+
+function mkPlaylistButton(id = 'p1', name = 'Morning Routine'): PageButton {
+  return { id, name, type: 'playlist' };
+}
+
+describe('AstrosRemoteButtonEditor', () => {
+  it('opens with the script tab when current value is type:none', () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    expect(wrapper.text()).toContain('Wave Hello');
+  });
+
+  it('opens with the playlist tab when current value is type:playlist', () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkPlaylistButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    expect(wrapper.text()).toContain('Morning Routine');
+  });
+
+  it('switches to playlist tab on click and shows playlist items', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
+    expect(wrapper.text()).toContain('Morning Routine');
+    expect(wrapper.text()).not.toContain('Wave Hello');
+  });
+
+  it('filters results case-insensitively as user types in search', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-search"]').setValue('WAV');
+    expect(wrapper.text()).toContain('Wave Hello');
+    expect(wrapper.text()).not.toContain('Bow');
+  });
+
+  it('renders an empty-state message when filter has no matches', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-search"]').setValue('xyzzy');
+    expect(wrapper.find('[data-testid="editor-empty"]').exists()).toBe(true);
+  });
+
+  it('tab switch does NOT auto-clear current value (per spec §4)', async () => {
+    // If the user opens the editor on a script and switches to playlist tab,
+    // no `change` event should fire from the tab switch alone. Pin this so a
+    // future "auto-clear on tab switch" change can't slip through.
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkScriptButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
+    expect(wrapper.emitted('change')).toBeUndefined();
+  });
+});

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
 import AstrosRemoteButtonEditor from './AstrosRemoteButtonEditor.vue';
 import type { PageButton } from '@/models/remoteControl/pageButton';
+import enUS from '@/locales/enUS.json';
+
+// Use the real enUS.json so any missing key surfaces as a test failure.
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: { 'en-US': enUS },
+});
 
 const SCRIPTS = [
   { id: 's1', name: 'Wave Hello' },
@@ -27,6 +36,7 @@ function mkPlaylistButton(id = 'p1', name = 'Morning Routine'): PageButton {
 describe('AstrosRemoteButtonEditor', () => {
   it('opens with the script tab when current value is type:none', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),
@@ -39,6 +49,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('opens with the playlist tab when current value is type:playlist', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkPlaylistButton(),
@@ -51,6 +62,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('switches to playlist tab on click and shows playlist items', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),
@@ -65,6 +77,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('filters results case-insensitively as user types in search', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),
@@ -79,6 +92,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('renders an empty-state message when filter has no matches', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),
@@ -95,6 +109,7 @@ describe('AstrosRemoteButtonEditor', () => {
     // no `change` event should fire from the tab switch alone. Pin this so a
     // future "auto-clear on tab switch" change can't slip through.
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkScriptButton(),
@@ -108,6 +123,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('emits change with the selected item and the current tab type', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),
@@ -124,6 +140,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('emits change with type:playlist when a playlist item is picked', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),
@@ -143,6 +160,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('emits change with the None sentinel when None row is clicked', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkScriptButton(),
@@ -157,6 +175,7 @@ describe('AstrosRemoteButtonEditor', () => {
 
   it('emits close when × button is clicked', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),
@@ -172,6 +191,7 @@ describe('AstrosRemoteButtonEditor', () => {
   it('emits close on Escape keydown', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       attachTo: document.body,
+      global: { plugins: [i18n] },
       props: {
         buttonNumber: 5,
         currentValue: mkNoneButton(),

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -104,6 +104,47 @@ describe('AstrosRemoteButtonEditor', () => {
     expect(wrapper.find('[data-testid="editor-empty"]').exists()).toBe(true);
   });
 
+  it('treats a whitespace-only query as empty (pins the .trim() in items)', async () => {
+    // A query of '   ' should render all items, not the empty state.
+    // Without .trim() in the items computed, three spaces become a real
+    // filter and no item names contain three consecutive spaces.
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-search"]').setValue('   ');
+    expect(wrapper.text()).toContain('Wave Hello');
+    expect(wrapper.text()).toContain('Bow');
+    expect(wrapper.find('[data-testid="editor-empty"]').exists()).toBe(false);
+  });
+
+  it('preserves the search query when the user switches tabs', async () => {
+    // Pins the current behavior: tab switch does NOT clear the search query.
+    // The query filters whichever tab's list is active at filter time.
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      global: { plugins: [i18n] },
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: [...PLAYLISTS, { id: 'p3', name: 'Wave Routine' }],
+      },
+    });
+    await wrapper.get('[data-testid="editor-search"]').setValue('wave');
+    expect(wrapper.text()).toContain('Wave Hello');
+
+    await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
+
+    expect(wrapper.text()).toContain('Wave Routine');
+    expect(wrapper.text()).not.toContain('Morning Routine');
+    expect(wrapper.text()).not.toContain('Wave Hello');
+  });
+
   it('tab switch does NOT auto-clear current value', async () => {
     // Pins the no-auto-clear behavior so a future "clear on tab switch" change
     // can't slip through silently.

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createI18n } from 'vue-i18n';
+import { nextTick } from 'vue';
 import AstrosRemoteButtonEditor from './AstrosRemoteButtonEditor.vue';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import enUS from '@/locales/enUS.json';
@@ -242,6 +243,30 @@ describe('AstrosRemoteButtonEditor', () => {
     await wrapper.trigger('keydown', { key: 'Escape' });
 
     expect(wrapper.emitted('close')).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it('moves focus to the editor root on mount (so wrapper @keydown.escape can fire)', async () => {
+    // Pins the focus-on-mount behavior in isolation. The card-level Escape
+    // integration test exercises it transitively, but this unit test asserts
+    // the focus contract directly — if a future refactor strips tabindex=-1
+    // or drops the onMounted/nextTick/focus chain, this test fails loudly
+    // rather than only being visible as a downstream integration regression.
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    // onMounted fires after mount; the focus call is wrapped in nextTick.
+    await nextTick();
+    await nextTick();
+
+    expect(document.activeElement).toBe(wrapper.element);
     wrapper.unmount();
   });
 

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -104,10 +104,9 @@ describe('AstrosRemoteButtonEditor', () => {
     expect(wrapper.find('[data-testid="editor-empty"]').exists()).toBe(true);
   });
 
-  it('tab switch does NOT auto-clear current value (per spec §4)', async () => {
-    // If the user opens the editor on a script and switches to playlist tab,
-    // no `change` event should fire from the tab switch alone. Pin this so a
-    // future "auto-clear on tab switch" change can't slip through.
+  it('tab switch does NOT auto-clear current value', async () => {
+    // Pins the no-auto-clear behavior so a future "clear on tab switch" change
+    // can't slip through silently.
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -105,4 +105,83 @@ describe('AstrosRemoteButtonEditor', () => {
     await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
     expect(wrapper.emitted('change')).toBeUndefined();
   });
+
+  it('emits change with the selected item and the current tab type', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-item-s2"]').trigger('click');
+
+    const events = wrapper.emitted('change');
+    expect(events).toHaveLength(1);
+    expect(events![0]![0]).toEqual({ id: 's2', name: 'Bow', type: 'script' });
+  });
+
+  it('emits change with type:playlist when a playlist item is picked', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-tab-playlist"]').trigger('click');
+    await wrapper.get('[data-testid="editor-item-p1"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({
+      id: 'p1',
+      name: 'Morning Routine',
+      type: 'playlist',
+    });
+  });
+
+  it('emits change with the None sentinel when None row is clicked', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkScriptButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-none"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
+  });
+
+  it('emits close when × button is clicked', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-close"]').trigger('click');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  it('emits close on Escape keydown', async () => {
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      attachTo: document.body,
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.trigger('keydown', { key: 'Escape' });
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    wrapper.unmount();
+  });
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -188,7 +188,7 @@ describe('AstrosRemoteButtonEditor', () => {
     expect(wrapper.emitted('close')).toHaveLength(1);
   });
 
-  it('emits close on Escape keydown', async () => {
+  it('emits close on Escape keydown from the editor root', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       attachTo: document.body,
       global: { plugins: [i18n] },
@@ -200,6 +200,26 @@ describe('AstrosRemoteButtonEditor', () => {
       },
     });
     await wrapper.trigger('keydown', { key: 'Escape' });
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it('emits close on Escape pressed while focus is in the search input', async () => {
+    // The search input gets typed-into; Escape from there must also close.
+    // type="text" (not "search") avoids the browser's native "first Escape
+    // clears input" consumption that would otherwise make this fragile.
+    const wrapper = mount(AstrosRemoteButtonEditor, {
+      attachTo: document.body,
+      global: { plugins: [i18n] },
+      props: {
+        buttonNumber: 5,
+        currentValue: mkNoneButton(),
+        scripts: SCRIPTS,
+        playlists: PLAYLISTS,
+      },
+    });
+    await wrapper.get('[data-testid="editor-search"]').trigger('keydown', { key: 'Escape' });
 
     expect(wrapper.emitted('close')).toHaveLength(1);
     wrapper.unmount();

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
@@ -34,7 +34,7 @@ const popoverWrapper = `
 `;
 
 const meta: Meta<typeof AstrosRemoteButtonEditor> = {
-  title: 'RemoteControl/AstrosRemoteButtonEditor',
+  title: 'components/remoteControl/AstrosRemoteButtonEditor',
   component: AstrosRemoteButtonEditor,
   render: (args) => ({
     components: { AstrosRemoteButtonEditor },

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
@@ -1,0 +1,99 @@
+import { type Meta, type StoryObj } from '@storybook/vue3';
+import AstrosRemoteButtonEditor from './AstrosRemoteButtonEditor.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+const SAMPLE_SCRIPTS = [
+  { id: 's1', name: 'Wave Hello' },
+  { id: 's2', name: 'Bow' },
+  { id: 's3', name: 'Whistle' },
+  { id: 's4', name: 'Spin in Place' },
+];
+const SAMPLE_PLAYLISTS = [
+  { id: 'p1', name: 'Morning Routine' },
+  { id: 'p2', name: 'Performance Set' },
+  { id: 'p3', name: 'Quick Demo' },
+];
+
+// Wrap each story in a popover-shaped container so it reads how it would
+// when anchored over a button card.
+const popoverWrapper = `
+  <div style="
+    width: 260px;
+    border: 2px solid #2a5a97;
+    border-radius: 14px;
+    padding: 12px;
+    background: #fff;
+    box-shadow: 0 6px 24px rgba(42,90,151,0.18);
+  ">
+    <AstrosRemoteButtonEditor
+      v-bind="args"
+      @change="(v) => console.log('change', v)"
+      @close="() => console.log('close')"
+    />
+  </div>
+`;
+
+const meta: Meta<typeof AstrosRemoteButtonEditor> = {
+  title: 'RemoteControl/AstrosRemoteButtonEditor',
+  component: AstrosRemoteButtonEditor,
+  render: (args) => ({
+    components: { AstrosRemoteButtonEditor },
+    setup: () => ({ args }),
+    template: popoverWrapper,
+  }),
+};
+export default meta;
+
+type Story = StoryObj<typeof AstrosRemoteButtonEditor>;
+
+const NONE: PageButton = { id: '0', name: 'None', type: 'none' };
+const SCRIPT_ASSIGNED: PageButton = { id: 's1', name: 'Wave Hello', type: 'script' };
+const PLAYLIST_ASSIGNED: PageButton = { id: 'p1', name: 'Morning Routine', type: 'playlist' };
+
+export const EmptyButtonOpensOnScripts: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: NONE,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedScriptOpensOnScripts: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: SCRIPT_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const AssignedPlaylistOpensOnPlaylists: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: PLAYLIST_ASSIGNED,
+    scripts: SAMPLE_SCRIPTS,
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const EmptyScriptList: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: NONE,
+    scripts: [],
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};
+
+export const LongName: Story = {
+  args: {
+    buttonNumber: 5,
+    currentValue: NONE,
+    scripts: [
+      { id: 's-long', name: 'This Is A Really Long Script Name That Should Truncate' },
+      ...SAMPLE_SCRIPTS,
+    ],
+    playlists: SAMPLE_PLAYLISTS,
+  },
+};

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -37,24 +37,38 @@ function selectNone() {
 
 <template>
   <div
-    class="astros-remote-button-editor"
+    class="astros-remote-button-editor flex flex-col gap-2"
     tabindex="-1"
     @keydown.escape="emit('close')"
   >
-    <header>
-      <span>BTN {{ buttonNumber }} · EDITING</span>
+    <header class="flex items-center justify-between">
+      <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/60">
+        BTN {{ buttonNumber }} · EDITING
+      </span>
       <button
         type="button"
+        class="btn btn-ghost btn-xs btn-square"
+        aria-label="Close"
         data-testid="editor-close"
         @click="emit('close')"
       >
         ×
       </button>
     </header>
-    <div role="tablist">
+
+    <div
+      role="tablist"
+      class="flex gap-1"
+    >
       <button
         type="button"
         role="tab"
+        class="flex-1 rounded-md py-1 text-xs font-semibold capitalize"
+        :class="
+          tab === 'script'
+            ? 'bg-primary/10 text-primary'
+            : 'bg-transparent text-base-content/60 hover:bg-base-200'
+        "
         :aria-selected="tab === 'script'"
         data-testid="editor-tab-script"
         @click="tab = 'script'"
@@ -64,6 +78,12 @@ function selectNone() {
       <button
         type="button"
         role="tab"
+        class="flex-1 rounded-md py-1 text-xs font-semibold capitalize"
+        :class="
+          tab === 'playlist'
+            ? 'bg-primary/10 text-primary'
+            : 'bg-transparent text-base-content/60 hover:bg-base-200'
+        "
         :aria-selected="tab === 'playlist'"
         data-testid="editor-tab-playlist"
         @click="tab = 'playlist'"
@@ -71,16 +91,22 @@ function selectNone() {
         Playlists
       </button>
     </div>
+
     <input
       v-model="query"
       type="search"
+      class="input input-sm input-bordered w-full text-xs"
       placeholder="Search…"
       data-testid="editor-search"
     />
-    <ul>
+
+    <ul
+      class="flex max-h-56 min-h-24 flex-col gap-px overflow-y-auto rounded-md border border-base-300 p-1 text-xs"
+    >
       <li>
         <button
           type="button"
+          class="flex w-full items-center rounded px-2 py-1 text-left italic text-base-content/60 hover:bg-base-200"
           data-testid="editor-none"
           @click="selectNone"
         >
@@ -93,6 +119,7 @@ function selectNone() {
       >
         <button
           type="button"
+          class="flex w-full items-center rounded px-2 py-1 text-left hover:bg-base-200"
           :data-testid="`editor-item-${item.id}`"
           @click="selectItem(item)"
         >
@@ -101,6 +128,7 @@ function selectNone() {
       </li>
       <li
         v-if="items.length === 0"
+        class="px-2 py-3 text-center text-[11px] text-base-content/50"
         data-testid="editor-empty"
       >
         No matches

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorTab, EditorListItem } from './types';
+
+const { t } = useI18n();
 
 const props = defineProps<{
   buttonNumber: number;
@@ -43,12 +46,12 @@ function selectNone() {
   >
     <header class="flex items-center justify-between">
       <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/60">
-        BTN {{ buttonNumber }} · EDITING
+        {{ t('remote_control_config.editor.header', { n: buttonNumber }) }}
       </span>
       <button
         type="button"
         class="btn btn-ghost btn-xs btn-square"
-        aria-label="Close"
+        :aria-label="t('remote_control_config.editor.close')"
         data-testid="editor-close"
         @click="emit('close')"
       >
@@ -73,7 +76,7 @@ function selectNone() {
         data-testid="editor-tab-script"
         @click="tab = 'script'"
       >
-        Scripts
+        {{ t('remote_control_config.editor.tab_script') }}
       </button>
       <button
         type="button"
@@ -88,7 +91,7 @@ function selectNone() {
         data-testid="editor-tab-playlist"
         @click="tab = 'playlist'"
       >
-        Playlists
+        {{ t('remote_control_config.editor.tab_playlist') }}
       </button>
     </div>
 
@@ -96,7 +99,7 @@ function selectNone() {
       v-model="query"
       type="search"
       class="input input-sm input-bordered w-full text-xs"
-      placeholder="Search…"
+      :placeholder="t('remote_control_config.editor.search_placeholder')"
       data-testid="editor-search"
     />
 
@@ -110,7 +113,7 @@ function selectNone() {
           data-testid="editor-none"
           @click="selectNone"
         >
-          None
+          {{ t('remote_control_config.editor.none_row') }}
         </button>
       </li>
       <li
@@ -131,7 +134,7 @@ function selectNone() {
         class="px-2 py-3 text-center text-[11px] text-base-content/50"
         data-testid="editor-empty"
       >
-        No matches
+        {{ t('remote_control_config.editor.empty_state') }}
       </li>
     </ul>
   </div>

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import type { EditorTab, EditorListItem } from './types';
+
+const props = defineProps<{
+  buttonNumber: number;
+  currentValue: PageButton;
+  scripts: EditorListItem[];
+  playlists: EditorListItem[];
+}>();
+
+const emit = defineEmits<{
+  change: [value: PageButton];
+  close: [];
+}>();
+
+const initialTab: EditorTab = props.currentValue.type === 'playlist' ? 'playlist' : 'script';
+const tab = ref<EditorTab>(initialTab);
+const query = ref('');
+
+const items = computed<EditorListItem[]>(() => {
+  const source = tab.value === 'script' ? props.scripts : props.playlists;
+  const q = query.value.trim().toLowerCase();
+  if (q.length === 0) return source;
+  return source.filter((i) => i.name.toLowerCase().includes(q));
+});
+
+function selectItem(item: EditorListItem) {
+  emit('change', { id: item.id, name: item.name, type: tab.value });
+}
+
+function selectNone() {
+  emit('change', { id: '0', name: 'None', type: 'none' });
+}
+</script>
+
+<template>
+  <div class="astros-remote-button-editor">
+    <header>
+      <span>BTN {{ buttonNumber }} · EDITING</span>
+      <button
+        type="button"
+        data-testid="editor-close"
+        @click="emit('close')"
+      >
+        ×
+      </button>
+    </header>
+    <div role="tablist">
+      <button
+        type="button"
+        role="tab"
+        :aria-selected="tab === 'script'"
+        data-testid="editor-tab-script"
+        @click="tab = 'script'"
+      >
+        Scripts
+      </button>
+      <button
+        type="button"
+        role="tab"
+        :aria-selected="tab === 'playlist'"
+        data-testid="editor-tab-playlist"
+        @click="tab = 'playlist'"
+      >
+        Playlists
+      </button>
+    </div>
+    <input
+      v-model="query"
+      type="search"
+      placeholder="Search…"
+      data-testid="editor-search"
+    />
+    <ul>
+      <li>
+        <button
+          type="button"
+          data-testid="editor-none"
+          @click="selectNone"
+        >
+          None
+        </button>
+      </li>
+      <li
+        v-for="item in items"
+        :key="item.id"
+      >
+        <button
+          type="button"
+          :data-testid="`editor-item-${item.id}`"
+          @click="selectItem(item)"
+        >
+          {{ item.name }}
+        </button>
+      </li>
+      <li
+        v-if="items.length === 0"
+        data-testid="editor-empty"
+      >
+        No matches
+      </li>
+    </ul>
+  </div>
+</template>

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorTab, EditorListItem } from './types';
@@ -36,10 +36,21 @@ function selectItem(item: EditorListItem) {
 function selectNone() {
   emit('change', { id: '0', name: 'None', type: 'none' });
 }
+
+const rootRef = ref<HTMLDivElement | null>(null);
+
+// Focus the editor root on open so the @keydown.escape on the wrapper div
+// actually fires when the user presses Escape. Without an explicit focus,
+// focus stays on the Edit/Configure button that opened the popover and
+// the editor's keydown handler never sees the event.
+onMounted(() => {
+  nextTick(() => rootRef.value?.focus());
+});
 </script>
 
 <template>
   <div
+    ref="rootRef"
     class="astros-remote-button-editor flex flex-col gap-2"
     tabindex="-1"
     @keydown.escape="emit('close')"
@@ -97,7 +108,7 @@ function selectNone() {
 
     <input
       v-model="query"
-      type="search"
+      type="text"
       class="input input-sm input-bordered w-full text-xs"
       :placeholder="t('remote_control_config.editor.search_placeholder')"
       data-testid="editor-search"

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import type { PageButton } from '@/models/remoteControl/pageButton';
+import { NONE_BUTTON, type PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorTab, EditorListItem } from './types';
 
 const { t } = useI18n();
@@ -9,8 +9,8 @@ const { t } = useI18n();
 const props = defineProps<{
   buttonNumber: number;
   currentValue: PageButton;
-  scripts: EditorListItem[];
-  playlists: EditorListItem[];
+  scripts: readonly EditorListItem[];
+  playlists: readonly EditorListItem[];
 }>();
 
 const emit = defineEmits<{
@@ -18,12 +18,40 @@ const emit = defineEmits<{
   close: [];
 }>();
 
-const initialTab: EditorTab = props.currentValue.type === 'playlist' ? 'playlist' : 'script';
-const tab = ref<EditorTab>(initialTab);
+function resolveInitialTab(type: PageButton['type']): EditorTab {
+  switch (type) {
+    case 'playlist':
+      return 'playlist';
+    case 'script':
+    case 'none':
+      return 'script';
+    default: {
+      // Exhaustiveness check — a new PageButtonType variant breaks the build
+      // here and forces the editor's tab logic to be updated explicitly.
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+const tab = ref<EditorTab>(resolveInitialTab(props.currentValue.type));
 const query = ref('');
 
-const items = computed<EditorListItem[]>(() => {
-  const source = tab.value === 'script' ? props.scripts : props.playlists;
+function sourceForTab(t: EditorTab): readonly EditorListItem[] {
+  switch (t) {
+    case 'script':
+      return props.scripts;
+    case 'playlist':
+      return props.playlists;
+    default: {
+      const _exhaustive: never = t;
+      return _exhaustive;
+    }
+  }
+}
+
+const items = computed<readonly EditorListItem[]>(() => {
+  const source = sourceForTab(tab.value);
   const q = query.value.trim().toLowerCase();
   if (q.length === 0) return source;
   return source.filter((i) => i.name.toLowerCase().includes(q));
@@ -34,7 +62,7 @@ function selectItem(item: EditorListItem) {
 }
 
 function selectNone() {
-  emit('change', { id: '0', name: 'None', type: 'none' });
+  emit('change', NONE_BUTTON);
 }
 
 const rootRef = ref<HTMLDivElement | null>(null);

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -36,7 +36,11 @@ function selectNone() {
 </script>
 
 <template>
-  <div class="astros-remote-button-editor">
+  <div
+    class="astros-remote-button-editor"
+    tabindex="-1"
+    @keydown.escape="emit('close')"
+  >
     <header>
       <span>BTN {{ buttonNumber }} · EDITING</span>
       <button

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { makeNoneButton, type PageButton } from '@/models/remoteControl/pageButton';
+import { assertNever } from '@/utils/assertNever';
 import type { EditorTab, EditorListItem } from './types';
 
 const { t } = useI18n();
@@ -25,12 +26,8 @@ function resolveInitialTab(type: PageButton['type']): EditorTab {
     case 'script':
     case 'none':
       return 'script';
-    default: {
-      // Exhaustiveness check — a new PageButtonType variant breaks the build
-      // here and forces the editor's tab logic to be updated explicitly.
-      const _exhaustive: never = type;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(type);
   }
 }
 
@@ -43,10 +40,8 @@ function sourceForTab(t: EditorTab): readonly EditorListItem[] {
       return props.scripts;
     case 'playlist':
       return props.playlists;
-    default: {
-      const _exhaustive: never = t;
-      return _exhaustive;
-    }
+    default:
+      return assertNever(t);
   }
 }
 

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { NONE_BUTTON, type PageButton } from '@/models/remoteControl/pageButton';
+import { makeNoneButton, type PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorTab, EditorListItem } from './types';
 
 const { t } = useI18n();
@@ -62,7 +62,7 @@ function selectItem(item: EditorListItem) {
 }
 
 function selectNone() {
-  emit('change', NONE_BUTTON);
+  emit('change', makeNoneButton());
 }
 
 const rootRef = ref<HTMLDivElement | null>(null);

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/types.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/types.ts
@@ -7,9 +7,10 @@ export type EditorTab = Exclude<PageButton['type'], 'none'>;
 
 // Lightweight item shape for the script/playlist lists passed to the editor.
 // Intentionally NOT a full Script/Playlist model — the editor only needs id
-// + name to render the result rows. Decoupling here lets Phase 2d pass any
-// derivation of either store without forcing the editor to know about the
-// rest of the model.
+// + name to render the result rows. The consumer must adapt the store
+// models (Script.scriptName / Playlist.playlistName) into this shape:
+//   scripts.map(s => ({ id: s.id, name: s.scriptName }))
+//   playlists.map(p => ({ id: p.id, name: p.playlistName }))
 export interface EditorListItem {
   id: string;
   name: string;

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/types.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/types.ts
@@ -1,0 +1,16 @@
+import type { PageButton } from '@/models/remoteControl/pageButton';
+
+// The editor's two tabs map 1:1 to the two non-'none' PageButtonType values.
+// Constrain it as a derived type so adding a new PageButtonType later forces
+// the editor tab logic to update.
+export type EditorTab = Exclude<PageButton['type'], 'none'>;
+
+// Lightweight item shape for the script/playlist lists passed to the editor.
+// Intentionally NOT a full Script/Playlist model — the editor only needs id
+// + name to render the result rows. Decoupling here lets Phase 2d pass any
+// derivation of either store without forcing the editor to know about the
+// rest of the model.
+export interface EditorListItem {
+  id: string;
+  name: string;
+}

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -579,5 +579,24 @@
       "MIGRATION_FAILED_RESTORE_FAILED": "A schema migration failed and the automatic restore also failed. Manual recovery is required.",
       "UNKNOWN": "The database is currently unavailable for writes."
     }
+  },
+  "remote_control_config": {
+    "card": {
+      "label": "BUTTON {n}",
+      "configure": "Configure →",
+      "edit": "Edit",
+      "clear": "Clear",
+      "type_script": "SCRIPT",
+      "type_playlist": "PLAYLIST"
+    },
+    "editor": {
+      "header": "BTN {n} · EDITING",
+      "close": "Close",
+      "tab_script": "Scripts",
+      "tab_playlist": "Playlists",
+      "search_placeholder": "Search…",
+      "none_row": "None",
+      "empty_state": "No matches"
+    }
   }
 }

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -582,7 +582,6 @@
   },
   "remote_control_config": {
     "card": {
-      "label": "BUTTON {n}",
       "configure": "Configure →",
       "edit": "Edit",
       "clear": "Clear",

--- a/astros_vue/src/models/remoteControl/pageButton.ts
+++ b/astros_vue/src/models/remoteControl/pageButton.ts
@@ -5,3 +5,10 @@ export interface PageButton {
   name: string;
   type: PageButtonType;
 }
+
+// Sentinel for an unassigned slot. Shape matches what the firmware sync
+// path expects on the wire ({name: 'None', command: '0'} after serialization)
+// — see remote_config_controller. Display surfaces should NOT render the
+// `name` field of this sentinel directly; they should use the i18n key for
+// the "None" label so the sentinel stays language-neutral on the wire.
+export const NONE_BUTTON: PageButton = { id: '0', name: 'None', type: 'none' };

--- a/astros_vue/src/models/remoteControl/pageButton.ts
+++ b/astros_vue/src/models/remoteControl/pageButton.ts
@@ -6,9 +6,17 @@ export interface PageButton {
   type: PageButtonType;
 }
 
-// Sentinel for an unassigned slot. Shape matches what the firmware sync
-// path expects on the wire ({name: 'None', command: '0'} after serialization)
-// — see remote_config_controller. Display surfaces should NOT render the
-// `name` field of this sentinel directly; they should use the i18n key for
-// the "None" label so the sentinel stays language-neutral on the wire.
-export const NONE_BUTTON: PageButton = { id: '0', name: 'None', type: 'none' };
+// Factory for an unassigned-slot sentinel. Returns a fresh object each call so
+// downstream code that does `page[buttonKey] = makeNoneButton()` can't share
+// identity with the next caller — in-place mutations like
+// `page.button1.name = '...'` (a documented consumer pattern) would otherwise
+// poison every other "None" slot that happened to share the reference.
+//
+// Shape matches what the firmware sync path expects on the wire — the
+// serializer in remote_config_controller maps `id` → `command`, producing
+// `{name: 'None', command: '0'}`. Display surfaces should NOT render the
+// `name` field directly; they should use the i18n key for the "None" label
+// so the sentinel stays language-neutral on the wire.
+export function makeNoneButton(): PageButton {
+  return { id: '0', name: 'None', type: 'none' };
+}

--- a/astros_vue/src/utils/assertNever.ts
+++ b/astros_vue/src/utils/assertNever.ts
@@ -1,0 +1,15 @@
+// Exhaustiveness guard for discriminated-union switches. The argument's
+// `never` type makes the build fail if any union variant is unhandled at
+// the call site, and the runtime throw documents the same expectation in
+// case the type-check is ever bypassed (e.g., data crossing an `as` cast
+// or a malformed wire payload reaching the consumer).
+//
+// Usage:
+//   switch (kind) {
+//     case 'a': ...
+//     case 'b': ...
+//     default: return assertNever(kind);
+//   }
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminated-union variant: ${JSON.stringify(value)}`);
+}


### PR DESCRIPTION
 ## Summary

Adds the two paired Vue components that Phase 2d's `RemoteControlConfigView` will wire into the 3×3 grid:

- **`AstrosRemoteButtonEditor`** — popover content with tab toggle (Scripts/Playlists), filterable search, result list, None row, close button.
- **`AstrosRemoteButtonCard`** — display state (assigned/unassigned variants) + popover host that anchors the editor via `@floating-ui/vue`.

No app integration in this PR — Storybook is the verification gate. Phase 2d will wire `change` emits to `store.setButton(selectedIdx, buttonKey, value)`.

---

## What changed

### New components

```
astros_vue/src/components/remoteControl/
├── remoteButtonEditor/
│   ├── AstrosRemoteButtonEditor.vue
│   ├── AstrosRemoteButtonEditor.spec.ts        (15 tests)
│   ├── AstrosRemoteButtonEditor.stories.ts     (5 stories)
│   └── types.ts                                 (EditorTab, EditorListItem)
└── remoteButtonCard/
    ├── AstrosRemoteButtonCard.vue
    ├── AstrosRemoteButtonCard.spec.ts          (17 tests)
    └── AstrosRemoteButtonCard.stories.ts       (4 stories)
```

### Component contracts (match spec §4 verbatim)

**`AstrosRemoteButtonEditor`** — popover content
- Props: `buttonNumber: number`, `currentValue: PageButton`, `scripts: readonly EditorListItem[]`, `playlists: readonly EditorListItem[]`
- Emits: `change(PageButton)`, `close()`
- Opens with tab derived from `currentValue.type` (defaults to `'script'` if `'none'`)
- None row at top of result list emits the sentinel `{id:'0', name:'None', type:'none'}`
- Tab switch does NOT auto-clear
- Closes on Escape (root has `tabindex="-1"` + focus-on-mount so the keydown handler actually fires)

**`AstrosRemoteButtonCard`** — display state + popover host
- Props: `buttonNumber: number`, `value: PageButton`, `scripts: readonly EditorListItem[]`, `playlists: readonly EditorListItem[]`
- Emits: `change(PageButton)`
- Visual: neutral when unassigned (Configure → button only), tinted blue when assigned (centered type chip at top, action name below, Edit / Clear at bottom)
- `buttonNumber` is no longer rendered as a label on the card itself — the grid position identifies which slot is which; the prop is still forwarded to the editor (`BTN N · EDITING` header)
- Type chip: SCRIPT uses the DaisyUI primary palette; PLAYLIST uses the Tailwind orange palette (DaisyUI's warning token blended into the assigned-state background)
- Clear emits the None sentinel WITHOUT opening the editor
- Edit / Configure opens the editor in a popover (Floating UI `bottom` placement, `flip` + `shift` middleware, teleported to `<body>`)
- Popover closes on Esc, click outside (capture-phase listener), successful selection, or × button
- Captures/restores keyboard focus across open/close (a11y — focus returns to the trigger button on dismissal)

### Other changes

- `astros_vue/src/locales/enUS.json` — new `remote_control_config.{card,editor}.*` keys (configure, edit, clear, type chips, header, tab labels, search, None, empty)
- `astros_vue/src/components/remoteControl/index.ts` — re-exports the two new components
- `astros_vue/src/models/remoteControl/pageButton.ts` — `makeNoneButton(): PageButton` factory (no shared identity hazard)
- `astros_vue/src/utils/assertNever.ts` — new shared exhaustiveness helper; 5 sites collapsed
- `astros_vue/package.json` — `@floating-ui/vue@^1.1.11`
- `astros_vue/src/components/mobileRemote/mobileRemote/types.ts` — adopts the new `assertNever` helper

---

## Test plan

**Automated (already passing):**
- [x] Full Vue suite: **507 / 507** tests (32 in the two new component specs)
- [x] `npm run build` — type-check + Vite build clean
- [x] `npm run lint` — clean
- [x] `npm run format` — applied
- [x] `npm run build-storybook` — both component story trees compile

**Mutation-test coverage on every defensive branch:**
- [x] Editor focus-on-mount (revert → card Escape integration test fails)
- [x] Editor `.trim()` in items computed (revert → whitespace-query test fails)
- [x] Editor tab-doesn't-auto-clear (revert → test catches the spurious emit)
- [x] Editor Escape handler on root (revert → keydown test fails)
- [x] Card capture-phase listener (revert to bubble → stopPropagation sibling test fails)
- [x] Card listener cleanup on scope-dispose (revert → spy-asserted remove fails)
- [x] Card duplicatePage `idx+1` math (revert to const → non-zero-idx test fails)
- [x] Card Clear doesn't open editor (revert → DOM assertion fails)
- [x] `makeNoneButton` returns fresh objects (revert to shared const → identity test fails)

**Storybook (visual verification gate):**
- `AstrosRemoteButtonEditor` — 5 stories: empty/script/playlist initial tabs, empty script list, long name
- `AstrosRemoteButtonCard` — 4 stories: unassigned, assigned-script, assigned-playlist, long assigned name. Click Configure / Edit to see the editor anchored via Floating UI.

**Manual QA (deferred to Phase 2d when the components are wired into the view):**
- [ ] End-to-end flow: open editor → search → select → save persists via `store.setButton` → reload reflects the assignment
- [ ] Popover anchoring across viewport edges (verify `flip` middleware fires correctly on bottom/right cells)
- [ ] Keyboard navigation (Tab through tabs/search/items, Escape closes, focus restores)
- [ ] M5Stack sync round-trip — wire shape unchanged from Phase 1; pinned by `remote_config_controller.test.ts`

---

## Review history

This PR went through **two full passes** of `/pr-review-toolkit:review-pr` (5 specialized agents in parallel each pass) before push.

### First pass — 5 agents, 4 fix commits

Found and addressed:
- **Code-reviewer Important #1 + Silent-failure I2 + Test I5**: Escape-to-close was broken in production. `tabindex="-1"` wrapper had `@keydown.escape` but nothing focused the editor on open, so the handler never fired. Fixed: `nextTick(() => rootRef.value?.focus())` in `onMounted` + changed `type="search"` → `type="text"` (browsers consumed the first Escape press to clear the input).
- **Silent-failure I1**: Use `onScopeDispose` not `onBeforeUnmount` for the click-outside listener — matches `useHoldGesture` precedent from Phase 3. Hardens against parent-throws-mid-render scope tears.
- **Silent-failure I3**: Use `e.composedPath()` not `e.target` — forward-looking Shadow-DOM safety.
- **Test C1**: Replaced a vacuous unmount-leak test (handler had no throwable path, couldn't actually detect a leak) with spy on `add/removeEventListener` asserting exact-handler removal + capture-phase third-arg pin.
- **Test C2**: Added stopPropagation sibling test — pins capture-phase wiring (a bubble-phase listener would silently pass the existing outside-click test).
- **Test C3**: Added open→close→reopen lifecycle test.
- **Type-design Critical #1**: `EditorTab`'s "force update on new variant" claim was half-true — string-literal ternaries wouldn't break the build. Replaced with `switch + assertNever` at 4 sites.
- **Type-design Important × 2**: Extracted `NONE_BUTTON` sentinel to `pageButton.ts`; props now `readonly EditorListItem[]`.
- **Comment Important × 3**: Trimmed "Phase 2d" reference in types.ts, "(per spec §4)" in test name, fictional `stopPropagation` example in capture-phase comment.

### Second pass — 5 agents, 3 fix commits

Found and addressed (catching issues introduced by the first-pass fixes themselves):
- **Critical (3 reviewers converged, code-reviewer verified empirically with a probe spec)**: `NONE_BUTTON` const was a shared-reference pollution hazard. The first-pass refactor that "deduplicated" two inline literals into a shared const meant every cleared slot across the app would point at the same imported object. Once Phase 2d wired `setButton` (`page[buttonKey] = value`, no clone), an in-place mutation like `page.button1.name = 'Bow'` (a pattern explicitly documented in the Phase 2a spec) would silently mutate every other cleared slot AND poison the imported sentinel. **Fixed**: replaced the const with `makeNoneButton(): PageButton` factory. Anti-regression test pins that two `Clear` clicks emit `.toEqual()` but `!==` objects.
- **Important (silent-failure I1)**: A11y regression I introduced — the focus-on-mount fix solved one bug (Escape silently no-ops) but created another (focus dumped to `<body>` on every popover dismissal). **Fixed**: card now captures `document.activeElement` on `openEditor`, restores on `closeEditor` via `nextTick`. New tests pin both the focus-on-mount in isolation and the focus-restore cycle.
- **Important (test I1)**: `addSpy.find()` could pick the wrong handler if a future Floating UI upgrade installed its own click+capture listener. **Fixed**: `.filter()` + `arrayContaining` subset check.
- **Important (test I2)**: Reactive-prop-update test missing chip-absent pre-state assertion. **Fixed**.
- **Type-design I3**: `_exhaustive: never` pattern duplicated 6× across 5 files. **Fixed**: extracted `src/utils/assertNever.ts`; 4 throw-style sites collapsed. 3 warn-and-fallback sites (firmware/websocket) intentionally left alone — their semantics differ and the bespoke warn blocks document that.
- **Comment Minor**: "Same pattern used by the mobileRemote composables" → singular ("the useHoldGesture composable"). Only one composable uses the pattern.

### Post-review Storybook polish (3 commits)

Visual feedback after the review rounds, while looking at the components in Storybook:
- **Dropped the `BUTTON N` label** from the card. The chip + grid position already identify which slot is which; the label was visual noise. Removed the now-unused `remote_control_config.card.label` i18n key and the stale "renders BUTTON N label" test. `buttonNumber` prop kept — the editor's `BTN N · EDITING` header still uses it.
- **Centered the type chip** (was right-aligned after the label removal).
- **Playlist chip switched to Tailwind orange palette** (`bg-orange-500/15` + `text-orange-700` + `border-orange-500/40`). DaisyUI's `warning` token rendered as amber and blended into the assigned-state background. Design spec Decision 4 called for orange explicitly.
- **Story titles re-namespaced** from `RemoteControl/*` to `components/remoteControl/*` to match the existing convention (`AstrosMobileRemote`, `AstrosEspModule`, etc.).

### Deferred to follow-up (all Minor / out-of-scope)

- **EditorListItem.name structural mismatch** with `Script.scriptName` / `Playlist.playlistName` — kept as documentation-only adapter pattern (decoupling intent preserved per design spec). Phase 2d's view will write `scripts.map(s => ({id: s.id, name: s.scriptName}))`.
- **`aria-controls` / `role="tabpanel"` plumbing** — flagged by code-reviewer Minor #3. Forward-looking to the planned a11y pass (project memory `project_a11y_pass`).
- **`t` shadowing in `sourceForTab(t: EditorTab)`** — cosmetic; no defect today.
- **"3×3 grid cell" misnomer** in card stories wrapper — naming cleanup.

---

## Commit log (21 commits)

```
e16ac87 chore(remote-card): playlist chip uses Tailwind orange (was DaisyUI warning)
8f574fe chore(remote-card): center the type chip (was right-aligned)
ef1659b chore(remote-card): drop BUTTON N label; nest stories under components/
a431dc9 refactor: extract assertNever helper; collapse 4 exhaustive-switch sites
c9f2eac fix(remote-card): capture/restore focus on popover open/close (a11y regression)
a789b99 fix(remote): NONE_BUTTON const → makeNoneButton() factory (no shared identity)
d119800 test(remote-editor): pin .trim() in items computed; pin tab-switch-mid-search
b22bc3c docs(remote-card+editor): trim plan refs; fix factually wrong capture-phase comment
de8ed43 refactor(remote-card+editor): NONE_BUTTON const; readonly props; exhaustive switches
61c52e8 fix(remote-card+editor): focus editor on open; harden card lifecycle
e11f8eb feat(remote): re-export AstrosRemoteButtonCard + AstrosRemoteButtonEditor
84c16bf feat(remote-card+editor): i18n keys for all user-facing strings
3685428 feat(remote-card): Storybook stories — unassigned, script, playlist, long name
2475e07 feat(remote-card): popover host with Floating UI; click-outside + Esc close
f7ccda4 feat(remote-card): display state + Clear emit; assigned/unassigned variants
29f8609 feat(remote-editor): Storybook stories + baseline DaisyUI styling
86919af feat(remote-editor): close on Escape; pin selection emit shapes
e9adb32 feat(remote-editor): tab toggle, search filter, None row, selection emits
5439716 feat(remote-editor): add EditorTab and EditorListItem types
9449f70 build(deps): add @floating-ui/vue for Phase 2b popover anchoring
91a00f9 docs(plan): Phase 2b button-card + editor implementation plan
```

11 implementation commits + 7 review-feedback commits (4 from first pass, 3 from second pass) + 3 Storybook polish commits.

Implementation commits (5439716 through e11f8eb) follow strict TDD: write failing test, confirm fail, implement, confirm pass, mutation-test the guard, restore, commit.

---

## Wire-shape compatibility

The M5Stack `/remotecontrolsync` JSON contract is **unchanged** — this PR adds two UI components but doesn't touch the store, controller, or serializer. The `PageButton` shape forwarded through `change` emits matches what Phase 2a's `setButton` accepts (`{id, name, type}`), which Phase 6 already pinned via `remote_config_controller.test.ts`.

---

## What's next

- **Phase 2c**: `AstrosRemotePageList` (left rail with mini 3×3 previews, inline rename, duplicate, delete). First consumer of `renamePage`'s `boolean` return for "Name can't be blank" feedback.
- **Phase 2d**: `AstrosRemoteLivePreview` (right rail) + `RemoteControlConfigView` assembly + router swap + delete-confirm modal + i18n sweep + manual QA + deletion of `AstrosRemoteControl.vue` / `RemoteView.vue` / `AstrosRemoteButton.vue`.

---

