### PR TITLE
Feature/fw progress flashing stage

### DIFF
--- a/.docs/plans/20260527-0210-fw-progress-flashing-stage-server.md
+++ b/.docs/plans/20260527-0210-fw-progress-flashing-stage-server.md
@@ -1,0 +1,623 @@
+# FwStage.Flashing + state-machine + UI-mapping + row-order Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `Flashing` stage to the server-side firmware state machine + UI mapping, fix the UI's `FIRMWARE_STAGES` row order so verify precedes flash (matching the firmware lifecycle), and clear the path for the M4 firmware deploy to render `✓ download ✓ transfer ✓ verify ! flash idle-reboot`.
+
+**Architecture:** Adds one variant to `FwStage`, two state-machine transitions (`Verifying → Flashing`, `Flashing → Rebooting`, plus `Flashing → Failed` via the universal terminal arm), one UI stage mapping (`FLASHING → 'flash'`), and reorders the visual row constant. No new files, no orchestrator behavior change — just the state-machine surface area needed for the firmware-side work in the sister plan (`AstrOs.ESP/.docs/plans/20260527-0211-fw-progress-flashing-stage-firmware.md`) to land cleanly.
+
+**Tech Stack:** TypeScript, vitest, Vue 3, Pinia.
+
+**Parent design:** [`AstrOs.ESP/.docs/plans/20260527-0143-firmware-ota-progress-emission-design.md`](../../../AstrOs.ESP/.docs/plans/20260527-0143-firmware-ota-progress-emission-design.md)
+
+**Branch:** Create `feature/fw-progress-flashing-stage` off `ota_testing`.
+
+---
+
+## Migration order
+
+This plan ships **first**. Existing M4 firmware in the field continues to hit the `illegal flash-job transition: SENDING → VERSION_CONFIRMED` bug after this plan lands — no regression, because that's already broken. The firmware-side plan ships second; only after both ship does the M4 deploy render correctly in the UI.
+
+## Pre-commit workflow (per AstrOs.Server CLAUDE.md)
+
+Each implementation commit (not plan-only commits) runs:
+
+```bash
+cd astros_api && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run
+cd astros_vue && npm run lint && npm run build && npx vitest run
+```
+
+Then invoke `superpowers:requesting-code-review` on the diff against the prior commit. Fix Critical / Important items before committing.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change type |
+|---|---|---|
+| `astros_api/src/models/firmware/firmware_messages.ts` | Single source of truth for `FwStage` enum | Modify — add `Flashing` variant |
+| `astros_api/src/firmware/flash_job_state_machine.ts` | Per-controller transition graph | Modify — add Flashing transitions |
+| `astros_api/src/firmware/flash_job_state_machine.test.ts` | State machine tests | Modify — new transition tests |
+| `astros_api/src/serial/message_handler.ts` | FW_PROGRESS parser | Already works via `FW_STAGE_VALUES.has(stage)` — verify no changes needed |
+| `astros_vue/src/types/firmware.ts` | UI-side `ServerFwStage` union | Modify — add `'FLASHING'` |
+| `astros_vue/src/utils/firmwareStageMapping.ts` | Server stage → UI stage | Modify — add FLASHING arm |
+| `astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts` | Mapping tests | Modify — new FLASHING tests |
+| `astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts` | `FIRMWARE_STAGES` constant | Modify — reorder to put verify before flash |
+| `astros_vue/src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts` | Stage-row state tests | Audit — any tests that hard-code indices need updating |
+| `.docs/protocol.md` | Wire-protocol source of truth | Modify — document new FLASHING stage |
+
+---
+
+## Tasks
+
+### Task 0: Commit plan file
+
+**Files:**
+- Stage: this plan file
+
+- [ ] **Step 1: Create branch and commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.Server
+git checkout ota_testing
+git pull
+git checkout -b feature/fw-progress-flashing-stage
+git add .docs/plans/20260527-0210-fw-progress-flashing-stage-server.md
+git commit -m "$(cat <<'EOF'
+docs(firmware): plan — add FwStage.Flashing + state machine + UI mapping
+
+Plan for the server-side half of the FW_PROGRESS emission feature.
+Ships before the AstrOs.ESP firmware plan so the server can accept
+the new FLASHING stage. See parent design at:
+AstrOs.ESP/.docs/plans/20260527-0143-firmware-ota-progress-emission-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 1: Add `FwStage.Flashing` to the enum
+
+**Files:**
+- Modify: `astros_api/src/models/firmware/firmware_messages.ts:20-28`
+
+- [ ] **Step 1: Add the variant**
+
+Open `astros_api/src/models/firmware/firmware_messages.ts` and edit lines 20-28:
+
+```typescript
+export enum FwStage {
+  Queued = 'QUEUED',
+  UploadingToMaster = 'UPLOADING_TO_MASTER',
+  Sending = 'SENDING',
+  Verifying = 'VERIFYING',
+  Flashing = 'FLASHING',
+  Rebooting = 'REBOOTING',
+  VersionConfirmed = 'VERSION_CONFIRMED',
+  Failed = 'FAILED',
+}
+```
+
+The enum is string-valued, so the new variant has no ordinal impact. The wire format carries `'FLASHING'` literally.
+
+- [ ] **Step 2: Verify the `FW_STAGE_VALUES` derived set picks it up**
+
+`grep -n "FW_STAGE_VALUES" astros_api/src/`. If the set is derived from `Object.values(FwStage)`, no further change is needed. If it's a hand-maintained literal list, add `'FLASHING'` to it. Document the location you found in the commit message.
+
+- [ ] **Step 3: Build + test**
+
+```bash
+cd astros_api
+npm run prettier:write && npm run lint:fix && npm run build && npx vitest run
+```
+
+Expected: all existing tests pass. No new tests needed yet (next tasks add them).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add astros_api/src/models/firmware/firmware_messages.ts
+git commit -m "feat(firmware): add FwStage.Flashing variant
+
+String enum value 'FLASHING'. Wire-format compatible — the parser at
+message_handler.ts:308 reads the string directly via FW_STAGE_VALUES.has.
+State-machine transitions land in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: State-machine — allow Verifying → Flashing → {Rebooting, Failed}
+
+**Files:**
+- Modify: `astros_api/src/firmware/flash_job_state_machine.ts:18-32`
+- Modify: `astros_api/src/firmware/flash_job_state_machine.test.ts`
+
+- [ ] **Step 1: Write failing tests for the new transitions**
+
+Open `astros_api/src/firmware/flash_job_state_machine.test.ts` and add to the legal-transitions describe block:
+
+```typescript
+describe('transitionControllerState — Flashing transitions', () => {
+  const withStage = (stage: FwStage): ControllerFlashState => ({
+    controllerId: 'pad1',
+    stage: stage as FwStage.UploadingToMaster | FwStage.Sending | FwStage.Verifying | FwStage.Rebooting,
+    bytesSent: 0,
+    totalBytes: 100,
+    detail: '',
+  });
+
+  it('Verifying → Flashing is legal', () => {
+    const before = withStage(FwStage.Verifying);
+    const after = transitionControllerState(before, FwStage.Flashing);
+    expect(after.stage).toBe(FwStage.Flashing);
+  });
+
+  it('Flashing → Rebooting is legal', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    const after = transitionControllerState(flashing, FwStage.Rebooting);
+    expect(after.stage).toBe(FwStage.Rebooting);
+  });
+
+  it('Flashing → Failed is legal', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    const after = transitionControllerState(flashing, FwStage.Failed, {
+      error: 'flash_not_implemented',
+    });
+    expect(after.stage).toBe(FwStage.Failed);
+  });
+
+  it('Flashing → Flashing (self-edge) is legal', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    const after = transitionControllerState(flashing, FwStage.Flashing);
+    expect(after.stage).toBe(FwStage.Flashing);
+  });
+
+  it('Sending → Flashing is illegal (must go through Verifying)', () => {
+    expect(() =>
+      transitionControllerState(withStage(FwStage.Sending), FwStage.Flashing),
+    ).toThrow(/illegal/i);
+  });
+
+  it('Flashing → VersionConfirmed is illegal (must go through Rebooting)', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    expect(() =>
+      transitionControllerState(flashing, FwStage.VersionConfirmed, { finalVersion: 'v1' }),
+    ).toThrow(/illegal/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd astros_api
+npx vitest run flash_job_state_machine.test.ts
+```
+
+Expected: 6 new tests fail with `illegal flash-job transition`.
+
+- [ ] **Step 3: Update the transition graph**
+
+In `astros_api/src/firmware/flash_job_state_machine.ts:18-32`, change the map entries:
+
+```typescript
+const LEGAL_NEXT_STAGES: ReadonlyMap<FwStage, ReadonlySet<FwStage>> = new Map<
+  FwStage,
+  ReadonlySet<FwStage>
+>([
+  [FwStage.Queued, new Set([FwStage.Queued, FwStage.UploadingToMaster, FwStage.Failed])],
+  [
+    FwStage.UploadingToMaster,
+    new Set([FwStage.UploadingToMaster, FwStage.Sending, FwStage.Failed]),
+  ],
+  [FwStage.Sending, new Set([FwStage.Sending, FwStage.Verifying, FwStage.Failed])],
+  [FwStage.Verifying, new Set([FwStage.Verifying, FwStage.Flashing, FwStage.Failed])],
+  [FwStage.Flashing, new Set([FwStage.Flashing, FwStage.Rebooting, FwStage.Failed])],
+  [FwStage.Rebooting, new Set([FwStage.Rebooting, FwStage.VersionConfirmed, FwStage.Failed])],
+  [FwStage.VersionConfirmed, EMPTY_STAGE_SET],
+  [FwStage.Failed, EMPTY_STAGE_SET],
+]);
+```
+
+Verify the `NonTerminalStage` type discriminator at line 52-57 covers `FwStage.Flashing`:
+
+```typescript
+type NonTerminalStage =
+  | FwStage.Queued
+  | FwStage.UploadingToMaster
+  | FwStage.Sending
+  | FwStage.Verifying
+  | FwStage.Flashing
+  | FwStage.Rebooting;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd astros_api
+npx vitest run flash_job_state_machine.test.ts
+```
+
+Expected: all tests pass (existing + 6 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.Server
+git add astros_api/src/firmware/flash_job_state_machine.ts astros_api/src/firmware/flash_job_state_machine.test.ts
+git commit -m "feat(firmware): state machine — Verifying → Flashing → {Rebooting, Failed}
+
+Adds the Flashing stage to the per-controller transition graph.
+- Verifying → Flashing (verification complete, padawan entering pre-flash delay)
+- Flashing → Rebooting (PR set 2: flash committed, padawan rebooting)
+- Flashing → Failed (M4: flash deliberately not implemented; or PR set 2: esp_ota_set_boot_partition returned error)
+
+Sending → Flashing remains illegal (must traverse Verifying) and
+Flashing → VersionConfirmed remains illegal (must traverse Rebooting)
+— the state machine still catches genuine skip-bugs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: UI mapping — FLASHING → 'flash'
+
+**Files:**
+- Modify: `astros_vue/src/types/firmware.ts` (find the `ServerFwStage` union)
+- Modify: `astros_vue/src/utils/firmwareStageMapping.ts:15-47, 50-80`
+- Modify: `astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts`
+
+- [ ] **Step 1: Update `ServerFwStage` union**
+
+```bash
+grep -n "ServerFwStage" astros_vue/src/types/firmware.ts
+```
+
+Add `'FLASHING'` to the union, in lifecycle order between `'VERIFYING'` and `'REBOOTING'`. Example shape (actual code may differ slightly — match the existing style):
+
+```typescript
+export type ServerFwStage =
+  | 'QUEUED'
+  | 'UPLOADING_TO_MASTER'
+  | 'SENDING'
+  | 'VERIFYING'
+  | 'FLASHING'
+  | 'REBOOTING'
+  | 'VERSION_CONFIRMED'
+  | 'FAILED';
+```
+
+- [ ] **Step 2: Write failing tests for the new mapping**
+
+Open `astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts` and add:
+
+```typescript
+describe('mapServerStageToUiStage — FLASHING', () => {
+  it("maps 'FLASHING' to UI stage 'flash'", () => {
+    expect(mapServerStageToUiStage('FLASHING')).toBe('flash');
+  });
+});
+
+describe('controllerStatePillKind — FLASHING', () => {
+  it("returns 'updating' for FLASHING state (mid-flight visual indicator)", () => {
+    const state: ControllerFlashState = {
+      controllerId: 'pad1',
+      stage: 'FLASHING',
+      bytesSent: 100,
+      totalBytes: 100,
+      detail: '',
+    };
+    expect(controllerStatePillKind(state)).toBe('updating');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd astros_vue
+npx vitest run firmwareStageMapping.spec.ts
+```
+
+Expected: 2 new tests fail (mapping returns null for FLASHING, pill kind returns 'updating' via fallback with a warn).
+
+- [ ] **Step 4: Add mapping arms**
+
+In `astros_vue/src/utils/firmwareStageMapping.ts`, add to `mapServerStageToUiStage`:
+
+```typescript
+case 'FLASHING':
+  return 'flash';
+```
+
+And to `controllerStatePillKind`:
+
+```typescript
+case 'UPLOADING_TO_MASTER':
+case 'SENDING':
+case 'VERIFYING':
+case 'FLASHING':
+case 'REBOOTING':
+  return 'updating';
+```
+
+(Add `'FLASHING'` to the existing fall-through group.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd astros_vue
+npx vitest run firmwareStageMapping.spec.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.Server
+git add astros_vue/src/types/firmware.ts astros_vue/src/utils/firmwareStageMapping.ts astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+git commit -m "feat(firmware-ui): map FLASHING server stage to 'flash' UI row
+
+ServerFwStage union gains FLASHING in lifecycle order.
+mapServerStageToUiStage projects FLASHING → 'flash' so the existing
+FIRMWARE_STAGES 'flash' row can finally be reached.
+controllerStatePillKind treats FLASHING as 'updating' (mid-flight),
+joining the SENDING/VERIFYING/REBOOTING fall-through group.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Reorder `FIRMWARE_STAGES` — verify before flash
+
+**Files:**
+- Modify: `astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts:3`
+- Audit: `astros_vue/src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts`
+
+- [ ] **Step 1: Reorder the constant**
+
+In `astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts` line 3:
+
+```typescript
+// BEFORE — verify rendered after flash; contradicts firmware lifecycle
+export const FIRMWARE_STAGES = ['download', 'transfer', 'flash', 'verify', 'reboot'] as const;
+
+// AFTER — matches transfer → verify → flash → reboot lifecycle
+export const FIRMWARE_STAGES = ['download', 'transfer', 'verify', 'flash', 'reboot'] as const;
+```
+
+Background: the firmware verifies (3 integrity gates on padawan: SHA, esp_ota_end, readback rehash) **before** the boot-partition commit (the "flash" step). Rendering verify after flash was a pre-existing UI bug.
+
+- [ ] **Step 2: Audit test file for index-coupled assertions**
+
+```bash
+cd astros_vue
+grep -n "FIRMWARE_STAGES\[" src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts
+grep -n "'flash'\|'verify'" src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts
+```
+
+For each match: if the test hard-codes an index (e.g. `FIRMWARE_STAGES[2]`) or asserts the visual order, update it to reflect the new ordering. If it just iterates `FIRMWARE_STAGES` or uses stage names directly, no change needed.
+
+Specifically check that tests asserting `stageRowState({ stage: 'verify', currentStage: 'flash', ... })` style behavior account for the swap: `verify` now precedes `flash`, so if `currentStage='flash'`, `verify` should be 'done' (not 'idle'). And if `currentStage='verify'`, `flash` should be 'idle' (not 'done').
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd astros_vue
+npx vitest run stageRowState.spec.ts
+```
+
+Expected: all tests pass after audit-driven updates.
+
+- [ ] **Step 4: Build + run full Vue test suite**
+
+```bash
+cd astros_vue
+npm run build && npx vitest run
+```
+
+Expected: clean build, all tests pass. If a snapshot test renders `FIRMWARE_STAGES`-derived UI it may need a snapshot refresh — review the diff before accepting.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.Server
+git add astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts astros_vue/src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts
+git commit -m "fix(firmware-ui): reorder FIRMWARE_STAGES so verify precedes flash
+
+The firmware lifecycle is transfer → verify (3 integrity gates) → flash
+(boot-partition commit) → reboot. The UI's stage row order had verify
+*after* flash, which would render nonsensically once any controller
+actually reaches the flash stage. Reorder matches the lifecycle so row
+position reflects progression direction.
+
+Drive-by correctness fix inside the surface area touched by the
+FwStage.Flashing addition.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Orchestrator integration test — M4 sequence end-to-end
+
+**Files:**
+- Modify: `astros_api/src/firmware/flash_orchestrator.test.ts` (or create a new integration test file under `astros_api/src/firmware/integration/`)
+
+- [ ] **Step 1: Find the existing orchestrator-test fixture**
+
+```bash
+grep -rn "handleDeployEvent\|handleDeployProgress\|handleDeployDone" astros_api/src/firmware/*.test.ts astros_api/src/firmware/integration/*.test.ts | head -20
+```
+
+Use the test-fixture pattern already established in that file (or in the nearest sibling).
+
+- [ ] **Step 2: Write the failing integration test**
+
+Add a test that simulates the M4 sequence:
+
+```typescript
+describe('flash orchestrator — M4 deploy (transfer + verify + flash placeholder)', () => {
+  it('walks Sending → Verifying → Flashing → Failed(flash_not_implemented) cleanly', () => {
+    const fx = makeOrchestratorFixture();
+    fx.startJob({ jobId: 'j1', controllers: ['pad1'] });
+
+    // Simulate FW_PROGRESS chain
+    fx.deliverProgress({ transferId: 't1', controllerId: 'pad1', stage: FwStage.Sending, bytesSent: 0, totalBytes: 1000, detail: '' });
+    fx.deliverProgress({ transferId: 't1', controllerId: 'pad1', stage: FwStage.Sending, bytesSent: 500, totalBytes: 1000, detail: '' });
+    fx.deliverProgress({ transferId: 't1', controllerId: 'pad1', stage: FwStage.Sending, bytesSent: 1000, totalBytes: 1000, detail: '' });
+    fx.deliverProgress({ transferId: 't1', controllerId: 'pad1', stage: FwStage.Verifying, bytesSent: 1000, totalBytes: 1000, detail: '' });
+    fx.deliverProgress({ transferId: 't1', controllerId: 'pad1', stage: FwStage.Flashing, bytesSent: 1000, totalBytes: 1000, detail: '' });
+
+    // FW_DEPLOY_DONE with M4 placeholder failure
+    fx.deliverDeployDone({
+      transferId: 't1',
+      results: [{ controllerId: 'pad1', outcome: 'FAILED', finalVersion: '', error: 'flash_not_implemented' }],
+    });
+
+    const controller = fx.currentControllerState('pad1');
+    expect(controller.stage).toBe(FwStage.Failed);
+    expect(controller.error).toBe('flash_not_implemented');
+
+    const events = fx.collectedWsEvents();
+    const stages = events
+      .filter((e) => e.type === TransmissionType.flashControllerUpdate || e.type === TransmissionType.flashControllerResult)
+      .map((e) => e.data.controller.stage);
+    expect(stages).toContain(FwStage.Sending);
+    expect(stages).toContain(FwStage.Verifying);
+    expect(stages).toContain(FwStage.Flashing);
+    expect(stages[stages.length - 1]).toBe(FwStage.Failed);
+  });
+});
+```
+
+If the existing fixture doesn't have `makeOrchestratorFixture` / `deliverProgress` / `deliverDeployDone` / `collectedWsEvents` helpers, adapt to whatever pattern the file uses (typically `new FlashOrchestrator({ ... })`, then `.handleDeployEvent(...)` directly).
+
+- [ ] **Step 3: Run test to verify it fails (or already passes)**
+
+```bash
+cd astros_api
+npx vitest run flash_orchestrator.test.ts -t "M4 deploy"
+```
+
+If this test passes immediately, that's good — Tasks 1-2 wired up the state machine correctly. If it fails, the failure mode reveals what's wrong (state machine, orchestrator, fixture).
+
+- [ ] **Step 4: Fix any issues and re-run**
+
+If the test fails, walk the failure: state-machine throw means a transition is missing; orchestrator throw means dispatch is wrong; assertion failure means events aren't being emitted as expected. Most likely outcome: passes on first try because Tasks 1-2 covered the state-machine surface.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.Server
+git add astros_api/src/firmware/flash_orchestrator.test.ts
+git commit -m "test(firmware): orchestrator walks M4 sequence Sending→…→Failed
+
+Pins the M4 deploy contract end-to-end on the server side: FW_PROGRESS
+chain advances the controller through Sending → Verifying → Flashing,
+then FW_DEPLOY_DONE outcome=FAILED with reason=flash_not_implemented
+lands as the Failed terminal. WS events emitted in the same order so
+the UI surface gets each transition.
+
+Sister-repo firmware emission lands in AstrOs.ESP plan
+20260527-0211-fw-progress-flashing-stage-firmware.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Update `.docs/protocol.md`
+
+**Files:**
+- Modify: `.docs/protocol.md` (Stage enum section)
+
+- [ ] **Step 1: Find and update the Stage enum docs**
+
+```bash
+grep -n "Stage enum\|VERIFYING\|REBOOTING" .docs/protocol.md | head -10
+```
+
+Add `FLASHING` to the documented stage list, between `VERIFYING` and `REBOOTING`. Document its meaning: "Padawan has completed verification and is in the pre-flash delay window. PR set 2: padawan calls `esp_ota_set_boot_partition`. M4: padawan reports FLASH_NOT_IMPLEMENTED placeholder via the new OTA_FLASH_RESULT message."
+
+- [ ] **Step 2: Note that the AstrOs.ESP copy must stay in sync**
+
+The protocol doc lives in both repos (per `firmware_messages.ts:3-4`). Confirm whether updating both is in scope for this PR or the firmware PR. Recommendation: update both copies in lockstep — easier review, no drift window.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .docs/protocol.md
+git commit -m "docs(protocol): document FwStage.FLASHING
+
+New stage between VERIFYING and REBOOTING. Documents the M4 vs PR set 2
+semantics. The sister AstrOs.ESP copy of protocol.md is updated in
+lockstep in the firmware-side plan.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Push + open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/jeff/Source/astros/AstrOs.Server
+git push -u origin feature/fw-progress-flashing-stage
+```
+
+Note: `git push` is auth-dependent — run in VS Code terminal if Claude Code's bash environment hits an auth wall.
+
+- [ ] **Step 2: Open PR against the appropriate base**
+
+Determine base: `develop`, `main`, or the parent feature branch (`ota_testing`). Per the project's branching workflow, this likely targets `ota_testing` since it's continuing the OTA-development arc.
+
+```bash
+gh pr create --title "feat(firmware): add FwStage.Flashing + state machine + UI mapping + row order" --body "$(cat <<'EOF'
+## Summary
+
+Server-side half of the FW_PROGRESS emission feature. Unblocks the M4 firmware deploy from rendering "Flash failed: illegal flash-job transition: SENDING → VERSION_CONFIRMED" in the UI on a successful transfer.
+
+- Adds `FwStage.Flashing` string enum variant
+- State machine: `Verifying → Flashing → {Rebooting, Failed}`
+- UI mapping: `FLASHING → 'flash'`
+- Reorders `FIRMWARE_STAGES` to put verify before flash (fixes pre-existing UI bug)
+- Orchestrator integration test covering full M4 sequence
+- `.docs/protocol.md` updated
+
+Per the parent design doc, ships **first**; the AstrOs.ESP firmware-side PR ships after this lands.
+
+## Parent design
+
+`AstrOs.ESP/.docs/plans/20260527-0143-firmware-ota-progress-emission-design.md`
+
+## Test plan
+
+- [ ] All vitest suites pass (`astros_api` and `astros_vue`)
+- [ ] Manual: existing M4 firmware deploy still produces the illegal-transition error (no regression — the firmware side hasn't shipped yet)
+- [ ] When sister firmware PR lands: deploy a 2-padawan M4 firmware, UI renders `✓ download ✓ transfer ✓ verify ! flash idle-reboot`, controller-detail surfaces `flash_not_implemented`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (run before declaring complete)
+
+- [ ] All 7 tasks completed and committed
+- [ ] `npm run build` clean in both `astros_api` and `astros_vue`
+- [ ] Full `vitest run` passes in both directories
+- [ ] No new ESLint warnings
+- [ ] PR opened with the right base branch
+- [ ] Sister firmware PR's coordination notes mention this PR's number

--- a/.docs/protocol.md
+++ b/.docs/protocol.md
@@ -34,8 +34,19 @@ When extending either enum, **append** — never reorder existing entries. Both 
 Master emits these in `FW_PROGRESS.stage` (table A). Server forwards them to the UI via `flashControllerUpdate`. Both sides must agree on the spelling.
 
 ```
-QUEUED | UPLOADING_TO_MASTER | SENDING | VERIFYING | REBOOTING | VERSION_CONFIRMED | FAILED
+QUEUED | UPLOADING_TO_MASTER | SENDING | VERIFYING | FLASHING | REBOOTING | VERSION_CONFIRMED | FAILED
 ```
+
+**Stage definitions:**
+
+- **QUEUED** — Job enqueued by server, awaiting master dispatch.
+- **UPLOADING_TO_MASTER** — Master receiving chunks from server over serial.
+- **SENDING** — Master pushing image to padawan via ESP-NOW.
+- **VERIFYING** — Padawan has written all chunks; awaiting `esp_ota_end` hash verification.
+- **FLASHING** — Padawan has completed verification and is in the pre-flash delay window. PR set 2: padawan calls `esp_ota_set_boot_partition`. M4: padawan reports `FLASH_NOT_IMPLEMENTED` placeholder via the new `OTA_FLASH_RESULT` message (firmware-side wire format, separate from this serial protocol).
+- **REBOOTING** — Padawan rebooting; master polling for version heartbeat.
+- **VERSION_CONFIRMED** — Padawan heartbeat received with new version; flash successful.
+- **FAILED** — Transfer, write, hash, or reboot failure.
 
 ## A. Server ↔ Master (serial)
 

--- a/astros_api/src/firmware/flash_job_state_machine.test.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.test.ts
@@ -27,7 +27,12 @@ function queued(
 }
 
 function withStage(
-  stage: FwStage.UploadingToMaster | FwStage.Sending | FwStage.Verifying | FwStage.Rebooting,
+  stage:
+    | FwStage.UploadingToMaster
+    | FwStage.Sending
+    | FwStage.Verifying
+    | FwStage.Flashing
+    | FwStage.Rebooting,
   overrides: Partial<{ bytesSent: number; totalBytes: number; detail: string }> = {},
 ): ControllerFlashState {
   return {
@@ -88,6 +93,7 @@ describe('isControllerStageTerminal', () => {
     [FwStage.UploadingToMaster, false],
     [FwStage.Sending, false],
     [FwStage.Verifying, false],
+    [FwStage.Flashing, false],
     [FwStage.Rebooting, false],
   ])('%s → %s', (stage, expected) => {
     expect(isControllerStageTerminal(stage)).toBe(expected);
@@ -103,6 +109,8 @@ describe('transitionControllerState — happy path', () => {
     expect(state.stage).toBe(FwStage.Sending);
     state = transitionControllerState(state, FwStage.Verifying);
     expect(state.stage).toBe(FwStage.Verifying);
+    state = transitionControllerState(state, FwStage.Flashing);
+    expect(state.stage).toBe(FwStage.Flashing);
     state = transitionControllerState(state, FwStage.Rebooting);
     expect(state.stage).toBe(FwStage.Rebooting);
     state = transitionControllerState(state, FwStage.VersionConfirmed, {
@@ -126,6 +134,7 @@ describe('transitionControllerState — happy path', () => {
     FwStage.UploadingToMaster,
     FwStage.Sending,
     FwStage.Verifying,
+    FwStage.Flashing,
     FwStage.Rebooting,
   ] as const)('Failed is reachable from %s', (fromStage) => {
     const start: ControllerFlashState =
@@ -236,6 +245,7 @@ describe('transitionControllerState — same-stage progress updates', () => {
     FwStage.UploadingToMaster,
     FwStage.Sending,
     FwStage.Verifying,
+    FwStage.Flashing,
     FwStage.Rebooting,
   ] as const)(
     'FW_PROGRESS during %s updates byte counts without forcing a stage transition',
@@ -301,6 +311,47 @@ describe('transitionControllerState — payload merging on legal in-flight trans
     expect(next.bytesSent).toBe(1024);
     expect(next.totalBytes).toBe(1024);
     expect(next.detail).toBe('verifying hash');
+  });
+});
+
+describe('transitionControllerState — Flashing transitions', () => {
+  it('Verifying → Flashing is legal', () => {
+    const before = withStage(FwStage.Verifying);
+    const after = transitionControllerState(before, FwStage.Flashing);
+    expect(after.stage).toBe(FwStage.Flashing);
+  });
+
+  it('Flashing → Rebooting is legal', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    const after = transitionControllerState(flashing, FwStage.Rebooting);
+    expect(after.stage).toBe(FwStage.Rebooting);
+  });
+
+  it('Flashing → Failed is legal', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    const after = transitionControllerState(flashing, FwStage.Failed, {
+      error: 'flash_not_implemented',
+    });
+    expect(after.stage).toBe(FwStage.Failed);
+  });
+
+  it('Flashing → Flashing (self-edge) is legal', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    const after = transitionControllerState(flashing, FwStage.Flashing);
+    expect(after.stage).toBe(FwStage.Flashing);
+  });
+
+  it('Sending → Flashing is illegal (must go through Verifying)', () => {
+    expect(() => transitionControllerState(withStage(FwStage.Sending), FwStage.Flashing)).toThrow(
+      /illegal/i,
+    );
+  });
+
+  it('Flashing → VersionConfirmed is illegal (must go through Rebooting)', () => {
+    const flashing = transitionControllerState(withStage(FwStage.Verifying), FwStage.Flashing);
+    expect(() =>
+      transitionControllerState(flashing, FwStage.VersionConfirmed, { finalVersion: 'v1' }),
+    ).toThrow(/illegal/i);
   });
 });
 

--- a/astros_api/src/firmware/flash_job_state_machine.ts
+++ b/astros_api/src/firmware/flash_job_state_machine.ts
@@ -25,7 +25,8 @@ const LEGAL_NEXT_STAGES: ReadonlyMap<FwStage, ReadonlySet<FwStage>> = new Map<
     new Set([FwStage.UploadingToMaster, FwStage.Sending, FwStage.Failed]),
   ],
   [FwStage.Sending, new Set([FwStage.Sending, FwStage.Verifying, FwStage.Failed])],
-  [FwStage.Verifying, new Set([FwStage.Verifying, FwStage.Rebooting, FwStage.Failed])],
+  [FwStage.Verifying, new Set([FwStage.Verifying, FwStage.Flashing, FwStage.Failed])],
+  [FwStage.Flashing, new Set([FwStage.Flashing, FwStage.Rebooting, FwStage.Failed])],
   [FwStage.Rebooting, new Set([FwStage.Rebooting, FwStage.VersionConfirmed, FwStage.Failed])],
   [FwStage.VersionConfirmed, EMPTY_STAGE_SET],
   [FwStage.Failed, EMPTY_STAGE_SET],
@@ -54,6 +55,7 @@ type NonTerminalStage =
   | FwStage.UploadingToMaster
   | FwStage.Sending
   | FwStage.Verifying
+  | FwStage.Flashing
   | FwStage.Rebooting;
 
 // Overloaded so the type system enforces stage-specific payloads at the

--- a/astros_api/src/firmware/flash_orchestrator.test.ts
+++ b/astros_api/src/firmware/flash_orchestrator.test.ts
@@ -1724,7 +1724,7 @@ describe('FlashJobOrchestrator', () => {
       );
     }
 
-    it('happy path: streamer succeeds → FW_DEPLOY_BEGIN sent → controllers transition to Sending → FW_PROGRESS drives Sending→Verifying→Rebooting → FW_DEPLOY_DONE all OK transitions to VersionConfirmed', async () => {
+    it('happy path: streamer succeeds → FW_DEPLOY_BEGIN sent → controllers transition to Sending → FW_PROGRESS drives Sending→Verifying→Flashing→Rebooting → FW_DEPLOY_DONE all OK transitions to VersionConfirmed', async () => {
       const fx = setupHappyPath({ clock: fakeClock });
       const armed = await startAndArmDeploy(fx);
 
@@ -1751,11 +1751,11 @@ describe('FlashJobOrchestrator', () => {
         'controller-b',
       ]);
 
-      // Drive each controller through Sending→Verifying→Rebooting via
+      // Drive each controller through Sending→Verifying→Flashing→Rebooting via
       // FW_PROGRESS. Each stage transition forces an emit (force=true);
       // mid-stage progress would throttle (covered in a separate test).
       for (const controllerId of armed.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(armed.transferId, {
             kind: 'progress',
             payload: {
@@ -1770,9 +1770,9 @@ describe('FlashJobOrchestrator', () => {
         }
       }
 
-      // 4 baseline emits + 2 controllers * 2 stage transitions = 8 emits.
+      // 4 baseline emits + 2 controllers * 3 stage transitions = 10 emits.
       const updatesPreDone = emittedFrames(fx.emitWs, TransmissionType.flashControllerUpdate);
-      expect(updatesPreDone).toHaveLength(8);
+      expect(updatesPreDone).toHaveLength(10);
 
       // Deliver FW_DEPLOY_DONE with all OK outcomes.
       fx.bus.deliverDeployEvent(armed.transferId, {
@@ -1850,11 +1850,11 @@ describe('FlashJobOrchestrator', () => {
       const fx = setupHappyPath({ clock: fakeClock });
       const armed = await startAndArmDeploy(fx);
 
-      // Drive each controller through Sending→Verifying→Rebooting via
+      // Drive each controller through Sending→Verifying→Flashing→Rebooting via
       // FW_PROGRESS so the terminal transition (Rebooting→VersionConfirmed
       // for OK; any-non-terminal→Failed for FAILED) is FSM-legal.
       for (const controllerId of armed.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(armed.transferId, {
             kind: 'progress',
             payload: {
@@ -2047,7 +2047,7 @@ describe('FlashJobOrchestrator', () => {
       // Advance controllers to Rebooting so the Rebooting→VersionConfirmed
       // terminal transition is FSM-legal.
       for (const controllerId of armed.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(armed.transferId, {
             kind: 'progress',
             payload: {
@@ -2179,10 +2179,10 @@ describe('FlashJobOrchestrator', () => {
       fx.streamerControls.resolve(makeTransferResult(run.spec));
       const result = await startPromise;
 
-      // Drive each controller through Sending→Verifying→Rebooting so the
+      // Drive each controller through Sending→Verifying→Flashing→Rebooting so the
       // FW_DEPLOY_DONE Rebooting→VersionConfirmed transition is FSM-legal.
       for (const controllerId of result.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(result.transferId, {
             kind: 'progress',
             payload: {
@@ -2250,7 +2250,7 @@ describe('FlashJobOrchestrator', () => {
       // Walk both controllers to Rebooting so the OK controller's terminal
       // transition is legal; the FAILED outcome is legal from any non-terminal.
       for (const controllerId of result.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(result.transferId, {
             kind: 'progress',
             payload: {
@@ -2379,7 +2379,7 @@ describe('FlashJobOrchestrator', () => {
       const result = await startPromise;
       // Drive controllers terminal to arm the (5s) timer.
       for (const controllerId of result.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(result.transferId, {
             kind: 'progress',
             payload: {
@@ -3230,12 +3230,12 @@ describe('FlashJobOrchestrator', () => {
       const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
 
       try {
-        // Drive controllers through Verifying → Rebooting so the
+        // Drive controllers through Verifying → Flashing → Rebooting so the
         // FW_DEPLOY_DONE results are accepted by the FSM as terminal
         // transitions. Without the pre-progress, the OK outcome would
         // trip the LEGAL_NEXT_STAGES guard.
         for (const controllerId of armed.targets) {
-          for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+          for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
             fx.bus.deliverDeployEvent(armed.transferId, {
               kind: 'progress',
               payload: {
@@ -3500,7 +3500,7 @@ describe('FlashJobOrchestrator', () => {
 
       // Walk both controllers to Rebooting then deliver FW_DEPLOY_DONE all OK.
       for (const controllerId of armed.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(armed.transferId, {
             kind: 'progress',
             payload: {
@@ -3663,7 +3663,7 @@ describe('FlashJobOrchestrator', () => {
       const armed = await startPromise;
 
       for (const controllerId of armed.targets) {
-        for (const stage of [FwStage.Verifying, FwStage.Rebooting]) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
           fx.bus.deliverDeployEvent(armed.transferId, {
             kind: 'progress',
             payload: {

--- a/astros_api/src/firmware/flash_orchestrator.test.ts
+++ b/astros_api/src/firmware/flash_orchestrator.test.ts
@@ -547,7 +547,7 @@ describe('createFlashProgressThrottle', () => {
 describe('DEFAULT_STREAMER_CONFIG (production wiring)', () => {
   it('pins the four production-tuned values against silent regression to TRANSPORT_DEFAULTS', () => {
     expect(DEFAULT_STREAMER_CONFIG).toEqual({
-      windowSize: 1,
+      windowSize: 2,
       ackTimeoutMs: 5_000,
       maxRetriesPerChunk: 3,
       transferTimeoutMs: 600_000,

--- a/astros_api/src/firmware/flash_orchestrator.test.ts
+++ b/astros_api/src/firmware/flash_orchestrator.test.ts
@@ -2134,6 +2134,102 @@ describe('FlashJobOrchestrator', () => {
       // No deploy subscriber attached (we threw before subscribe).
       expect(fx.bus.deploySubscribers.size).toBe(0);
     });
+
+    it('M4 deploy: Sending → Verifying → Flashing → Failed(flash_not_implemented) — single controller walks FSM cleanly and emits in order', async () => {
+      // M4 firmware writes to flash locally and reports failure rather than
+      // transitioning to Rebooting. The sequence stops at Flashing because the
+      // M4 OtaWriter placeholder returns flash_not_implemented instead of
+      // calling esp_ota_end/esp_restart. Flashing→Failed is a legal FSM edge
+      // (flash_job_state_machine.ts line 29), so no protocol_violation fires.
+      const fx = setupHappyPath({
+        clock: fakeClock,
+        controllers: [{ id: 'pad1', variant: 'lolin_d32_pro' }],
+      });
+      const armed = await startAndArmDeploy(fx);
+
+      // Post-arm: controller-pad1 is at Sending (startAndArmDeploy transitions
+      // UploadingToMaster→Sending for all targets after streamer success).
+      expect(fx.orchestrator.getCurrentJob()?.controllers[0].stage).toBe(FwStage.Sending);
+
+      // Drive Sending→Verifying→Flashing via FW_PROGRESS (M4 stops here —
+      // no Rebooting stage because the OtaWriter never calls esp_ota_end).
+      for (const stage of [FwStage.Verifying, FwStage.Flashing]) {
+        fx.bus.deliverDeployEvent(armed.transferId, {
+          kind: 'progress',
+          payload: {
+            transferId: armed.transferId,
+            controllerId: 'pad1',
+            stage,
+            bytesSent: 0,
+            totalBytes: 0,
+            detail: '',
+          },
+        });
+      }
+
+      // Verify intermediate state: controller reached Flashing before done.
+      expect(fx.orchestrator.getCurrentJob()?.controllers[0].stage).toBe(FwStage.Flashing);
+
+      // FW_DEPLOY_DONE with FAILED outcome — M4 placeholder reports
+      // flash_not_implemented instead of a successful reboot handshake.
+      fx.bus.deliverDeployEvent(armed.transferId, {
+        kind: 'done',
+        payload: {
+          transferId: armed.transferId,
+          results: [
+            {
+              controllerId: 'pad1',
+              outcome: 'FAILED',
+              finalVersion: '',
+              error: 'flash_not_implemented',
+            },
+          ],
+        },
+      });
+
+      // Terminal state: controller is Failed with the placeholder error.
+      const job = fx.orchestrator.getCurrentJob();
+      expect(job).not.toBeNull();
+      const controllers = job?.controllers ?? [];
+      expect(controllers).toHaveLength(1);
+      const controller = controllers[0];
+      expect(controller.stage).toBe(FwStage.Failed);
+      if (controller.stage === FwStage.Failed) {
+        expect(controller.error).toBe('flash_not_implemented');
+      }
+
+      // flashControllerResult emitted for the terminal transition (bypasses throttle).
+      const results = controllerResults(fx.emitWs);
+      expect(results).toHaveLength(1);
+      expect(results[0].jobId).toBe(armed.jobId);
+      expect(results[0].controller.stage).toBe(FwStage.Failed);
+      if (results[0].controller.stage === FwStage.Failed) {
+        expect(results[0].controller.error).toBe('flash_not_implemented');
+      }
+
+      // WS event stage sequence: UploadingToMaster → Sending emits from arm;
+      // then Verifying + Flashing from FW_PROGRESS; then Failed from done.
+      const updates = emittedFrames(fx.emitWs, TransmissionType.flashControllerUpdate);
+      const updateStages = updates.map((f) => (f as { data: ControllerFlashState }).data.stage);
+      // Verify the sequence is exactly UploadingToMaster → Sending → Verifying → Flashing (in order).
+      expect(updateStages).toEqual([
+        FwStage.UploadingToMaster,
+        FwStage.Sending,
+        FwStage.Verifying,
+        FwStage.Flashing,
+      ]);
+      // Terminal Failed arrived via flashControllerResult, not flashControllerUpdate.
+      const resultStages = results.map((r) => r.controller.stage);
+      expect(resultStages[resultStages.length - 1]).toBe(FwStage.Failed);
+
+      // job-level: mixed-terminal (just Failed) counts as 'done' —
+      // flashJobDone fires, flashJobFailed does NOT (no protocol violation).
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobDone)).toHaveLength(1);
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
+
+      // Deploy subscriber disposed after done.
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(false);
+    });
   });
 
   describe('reboot timer + heartbeat', () => {

--- a/astros_api/src/firmware/flash_orchestrator.ts
+++ b/astros_api/src/firmware/flash_orchestrator.ts
@@ -1178,6 +1178,7 @@ export class FlashJobOrchestrator {
           | FwStage.UploadingToMaster
           | FwStage.Sending
           | FwStage.Verifying
+          | FwStage.Flashing
           | FwStage.Rebooting,
         {
           bytesSent: payload.bytesSent,

--- a/astros_api/src/firmware/flash_orchestrator.ts
+++ b/astros_api/src/firmware/flash_orchestrator.ts
@@ -442,19 +442,22 @@ const defaultClock: Clock = {
   clearTimeout: (t) => globalThis.clearTimeout(t),
 };
 
-// Production streamer config. The AstrOs master is processing-bound
-// (astrosRxTask shares CPU with poll / heartbeat / I2C, landing ~1
-// chunk/sec). Stop-and-wait (`windowSize: 1`) avoids the OUT_OF_ORDER
-// NAK cascades a larger window triggers under that bottleneck.
+// Production streamer config. windowSize=2 lets the second chunk start
+// transmitting while the master is still processing the first, which is
+// necessary on this Pi↔master link: bench-measured cycle is ~485 ms with
+// windowSize=2 vs ~1550 ms with windowSize=1, a 3× throughput win at
+// ~8.4 KB/s. The fixed ~1 s per-chunk wire pause the Linux ftdi_sio
+// driver imposes on each USB-OUT batch is hidden by the overlap.
+// windowSize=1 was originally chosen because the master was thought to
+// be CPU-bound; current instrumentation shows ~52 ms of master CPU per
+// chunk (9× headroom vs the 480 ms wire fill), so the OUT_OF_ORDER NAK
+// cascades that justified stop-and-wait don't materialize at this size.
 // `ackTimeoutMs: 5_000` is ~5× the observed ~1 s round-trip; the
 // 3-retry × 5 s = 15 s per-chunk budget plus the 10-min whole-transfer
-// watchdog (a 1.2 MB image is 294 chunks ≈ 295 s steady state, so 5 min
-// was tight) gives ~2× headroom. If the master gets fast enough for the
-// wire to be the bottleneck, bump `windowSize` and recompute
-// `ackTimeoutMs`; the streamer's sliding-window machinery is exercised
-// against `TRANSPORT_DEFAULTS.windowSize=16` in its own tests.
+// watchdog gives ~2× headroom. The streamer's sliding-window machinery
+// is exercised against `TRANSPORT_DEFAULTS.windowSize=16` in its own tests.
 export const DEFAULT_STREAMER_CONFIG = {
-  windowSize: 1,
+  windowSize: 2,
   ackTimeoutMs: 5_000,
   maxRetriesPerChunk: 3,
   transferTimeoutMs: 600_000,

--- a/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_partial_failure.integration.test.ts
@@ -87,7 +87,7 @@ describe('integration: per-controller deploy mixed OK/FAILED', () => {
       //    distributed). scriptDeploy carries mixed outcomes: master
       //    OK with finalVersion, padawan FAILED with error. The stub
       //    emits FW_PROGRESS frames per controller through the default
-      //    Sending → Verifying → Rebooting stage progression, then ONE
+      //    Sending → Verifying → Flashing → Rebooting stage progression, then ONE
       //    FW_DEPLOY_DONE whose results[] array has both entries.
       harness.stub.autoAckUpload({});
       harness.stub.scriptDeploy({
@@ -156,8 +156,8 @@ describe('integration: per-controller deploy mixed OK/FAILED', () => {
       //      * padawan → Failed (error=PADAWAN_ERROR)
       //
       //    Note: scriptDeploy's per-stage FW_PROGRESS frames generate
-      //    `flashControllerUpdate` events (Sending/Verifying/Rebooting
-      //    × 2 controllers = 6 events on the WS bus); the terminal
+      //    `flashControllerUpdate` events (Sending/Verifying/Flashing/Rebooting
+      //    × 2 controllers = 8 events on the WS bus); the terminal
       //    transitions are the separate `flashControllerResult` stream.
       type ControllerResult = {
         type: number;

--- a/astros_api/src/models/firmware/firmware_messages.ts
+++ b/astros_api/src/models/firmware/firmware_messages.ts
@@ -22,6 +22,7 @@ export enum FwStage {
   UploadingToMaster = 'UPLOADING_TO_MASTER',
   Sending = 'SENDING',
   Verifying = 'VERIFYING',
+  Flashing = 'FLASHING',
   Rebooting = 'REBOOTING',
   VersionConfirmed = 'VERSION_CONFIRMED',
   Failed = 'FAILED',

--- a/astros_api/src/models/firmware/flash_job_state.ts
+++ b/astros_api/src/models/firmware/flash_job_state.ts
@@ -18,6 +18,7 @@ export type ControllerFlashState =
   | (BaseControllerFlashState & { stage: FwStage.UploadingToMaster })
   | (BaseControllerFlashState & { stage: FwStage.Sending })
   | (BaseControllerFlashState & { stage: FwStage.Verifying })
+  | (BaseControllerFlashState & { stage: FwStage.Flashing })
   | (BaseControllerFlashState & { stage: FwStage.Rebooting })
   | (BaseControllerFlashState & { stage: FwStage.VersionConfirmed; finalVersion: string })
   | (BaseControllerFlashState & { stage: FwStage.Failed; error: string });

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -481,9 +481,9 @@ describe('StubMaster (PTY-backed)', () => {
         }
 
         // Frame 8: FW_DEPLOY_DONE with both controller outcomes
-        const f6 = requireFrame(frames, 8);
-        expect(f6.type).toBe(SerialMessageType.FW_DEPLOY_DONE);
-        const done = handler.handleFwDeployDone(f6.data);
+        const doneFrame = requireFrame(frames, 8);
+        expect(doneFrame.type).toBe(SerialMessageType.FW_DEPLOY_DONE);
+        const done = handler.handleFwDeployDone(doneFrame.data);
         expect(done.type).toBe(SerialWorkerResponseType.FW_DEPLOY_DONE);
         if (done.type === SerialWorkerResponseType.FW_DEPLOY_DONE) {
           expect(done.payload.transferId).toBe(XFER);

--- a/astros_api/src/test_harness/stub_master.test.ts
+++ b/astros_api/src/test_harness/stub_master.test.ts
@@ -431,8 +431,8 @@ describe('StubMaster (PTY-backed)', () => {
         const generator = new MessageGenerator();
         const XFER = 'xfer-1';
 
-        // 3 stages × 2 controllers + 1 FW_DEPLOY_DONE = 7 frames
-        const framesPromise = collectFrames(serverPort, 7);
+        // 4 stages × 2 controllers + 1 FW_DEPLOY_DONE = 9 frames
+        const framesPromise = collectFrames(serverPort, 9);
 
         const deployData: FwDeployBegin = {
           transferId: XFER,
@@ -445,10 +445,15 @@ describe('StubMaster (PTY-backed)', () => {
         const frames = await framesPromise;
         const handler = new MessageHandler();
 
-        const defaultStages = [FwStage.Sending, FwStage.Verifying, FwStage.Rebooting];
+        const defaultStages = [
+          FwStage.Sending,
+          FwStage.Verifying,
+          FwStage.Flashing,
+          FwStage.Rebooting,
+        ];
 
-        // Frames 0-2: FW_PROGRESS for ctrl-A (Sending, Verifying, Rebooting)
-        for (let i = 0; i < 3; i++) {
+        // Frames 0-3: FW_PROGRESS for ctrl-A (Sending, Verifying, Flashing, Rebooting)
+        for (let i = 0; i < 4; i++) {
           const f = requireFrame(frames, i);
           expect(f.type).toBe(SerialMessageType.FW_PROGRESS);
           const prog = handler.handleFwProgress(f.data);
@@ -462,9 +467,9 @@ describe('StubMaster (PTY-backed)', () => {
           }
         }
 
-        // Frames 3-5: FW_PROGRESS for ctrl-B (Sending, Verifying, Rebooting)
-        for (let i = 0; i < 3; i++) {
-          const f = requireFrame(frames, i + 3);
+        // Frames 4-7: FW_PROGRESS for ctrl-B (Sending, Verifying, Flashing, Rebooting)
+        for (let i = 0; i < 4; i++) {
+          const f = requireFrame(frames, i + 4);
           expect(f.type).toBe(SerialMessageType.FW_PROGRESS);
           const prog = handler.handleFwProgress(f.data);
           expect(prog.type).toBe(SerialWorkerResponseType.FW_PROGRESS);
@@ -475,8 +480,8 @@ describe('StubMaster (PTY-backed)', () => {
           }
         }
 
-        // Frame 6: FW_DEPLOY_DONE with both controller outcomes
-        const f6 = requireFrame(frames, 6);
+        // Frame 8: FW_DEPLOY_DONE with both controller outcomes
+        const f6 = requireFrame(frames, 8);
         expect(f6.type).toBe(SerialMessageType.FW_DEPLOY_DONE);
         const done = handler.handleFwDeployDone(f6.data);
         expect(done.type).toBe(SerialWorkerResponseType.FW_DEPLOY_DONE);

--- a/astros_api/src/test_harness/stub_master.ts
+++ b/astros_api/src/test_harness/stub_master.ts
@@ -211,9 +211,9 @@ export interface ScriptDeployControllerOpts {
   // Required when outcome === 'FAILED'. Validated at scriptDeploy() call time.
   error?: string;
   // FW_PROGRESS stages to emit for this controller before FW_DEPLOY_DONE.
-  // Default [Sending, Verifying, Rebooting]. Terminal stages (VersionConfirmed
-  // / Failed) come from FW_DEPLOY_DONE, not a final FW_PROGRESS, so they
-  // should NOT appear here.
+  // Default [Sending, Verifying, Flashing, Rebooting]. Terminal stages
+  // (VersionConfirmed / Failed) come from FW_DEPLOY_DONE, not a final
+  // FW_PROGRESS, so they should NOT appear here.
   stages?: FwStage[];
 }
 
@@ -563,7 +563,12 @@ export class StubMaster {
         outcome: c.outcome,
         finalVersion: c.finalVersion ?? '',
         error: c.error ?? '',
-        stages: c.stages ?? [FwStage.Sending, FwStage.Verifying, FwStage.Rebooting],
+        stages: c.stages ?? [
+          FwStage.Sending,
+          FwStage.Verifying,
+          FwStage.Flashing,
+          FwStage.Rebooting,
+        ],
       };
     });
     this.scriptDeployCfg = { controllers };

--- a/astros_vue/src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts
+++ b/astros_vue/src/components/firmware/firmwareStagesList/__tests__/stageRowState.spec.ts
@@ -31,11 +31,13 @@ describe('stageRowState', () => {
   });
 
   it("marks earlier stages 'done', the matching stage 'current', later stages 'idle' when flashing", () => {
+    // verify is at index 2, flash is at index 3 in the lifecycle order:
+    // download → transfer → verify → flash → reboot
     expect(rowsForPhase({ phase: 'flashing', currentStage: 'flash' })).toEqual([
       'done',
       'done',
+      'done',
       'current',
-      'idle',
       'idle',
     ]);
   });

--- a/astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts
+++ b/astros_vue/src/components/firmware/firmwareStagesList/stageRowState.ts
@@ -1,6 +1,6 @@
 import type { FirmwarePhase, FirmwareStage } from '@/types/firmware';
 
-export const FIRMWARE_STAGES = ['download', 'transfer', 'flash', 'verify', 'reboot'] as const;
+export const FIRMWARE_STAGES = ['download', 'transfer', 'verify', 'flash', 'reboot'] as const;
 
 export type StageRowState = 'idle' | 'done' | 'current' | 'failed';
 

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -226,6 +226,7 @@ export type ServerFwStage =
   | 'UPLOADING_TO_MASTER'
   | 'SENDING'
   | 'VERIFYING'
+  | 'FLASHING'
   | 'REBOOTING'
   | 'VERSION_CONFIRMED'
   | 'FAILED';
@@ -261,7 +262,7 @@ export type SlotId = Exclude<`${Location}`, `${Location.UNKNOWN}`>;
 export type ControllerFlashState =
   | {
       controllerId: string;
-      stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING';
+      stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'FLASHING' | 'REBOOTING';
       bytesSent?: number;
       totalBytes?: number;
     }
@@ -276,7 +277,7 @@ export type ControllerFlashState =
 export type ControllerFlashStateBySlot =
   | {
       controllerId: SlotId;
-      stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'REBOOTING';
+      stage: 'QUEUED' | 'UPLOADING_TO_MASTER' | 'SENDING' | 'VERIFYING' | 'FLASHING' | 'REBOOTING';
       bytesSent?: number;
       totalBytes?: number;
     }

--- a/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
@@ -36,6 +36,10 @@ describe('mapServerStageToUiStage', () => {
     expect(mapServerStageToUiStage('REBOOTING')).toBe('reboot');
   });
 
+  it("maps 'FLASHING' to UI stage 'flash'", () => {
+    expect(mapServerStageToUiStage('FLASHING')).toBe('flash');
+  });
+
   it('returns null for QUEUED, VERSION_CONFIRMED, FAILED (no specific UI stage row)', () => {
     expect(mapServerStageToUiStage('QUEUED')).toBeNull();
     expect(mapServerStageToUiStage('VERSION_CONFIRMED')).toBeNull();
@@ -73,6 +77,7 @@ describe('controllerStatePillKind', () => {
     expect(controllerStatePillKind(state('UPLOADING_TO_MASTER'))).toBe('updating');
     expect(controllerStatePillKind(state('SENDING'))).toBe('updating');
     expect(controllerStatePillKind(state('VERIFYING'))).toBe('updating');
+    expect(controllerStatePillKind(state('FLASHING'))).toBe('updating');
     expect(controllerStatePillKind(state('REBOOTING'))).toBe('updating');
   });
 

--- a/astros_vue/src/utils/firmwareStageMapping.ts
+++ b/astros_vue/src/utils/firmwareStageMapping.ts
@@ -20,6 +20,8 @@ export function mapServerStageToUiStage(stage: ServerFwStage): FirmwareStage | n
       return 'transfer';
     case 'VERIFYING':
       return 'verify';
+    case 'FLASHING':
+      return 'flash';
     case 'REBOOTING':
       return 'reboot';
     case 'QUEUED':
@@ -54,6 +56,7 @@ export function controllerStatePillKind(state: ControllerFlashState): FirmwareSt
     case 'UPLOADING_TO_MASTER':
     case 'SENDING':
     case 'VERIFYING':
+    case 'FLASHING':
     case 'REBOOTING':
       return 'updating';
     case 'VERSION_CONFIRMED':


### PR DESCRIPTION
## Summary

  Server-side half of the FW_PROGRESS emission feature. Unblocks the M4 firmware deploy from rendering "Flash failed:  illegal flash-job transition: SENDING → VERSION_CONFIRMED" in the UI on a successful transfer.

  - Adds \`FwStage.Flashing\` string enum variant (`'FLASHING'`) between `VERIFYING` and `REBOOTING`
  - State machine: \`Verifying → Flashing → {Rebooting, Failed}\` transitions added
  - UI mapping: \`FLASHING → 'flash'\` row; \`ControllerFlashState\` union widened; pill kind treats FLASHING as
  'updating'
  - Reorders \`FIRMWARE_STAGES\` from \`['download', 'transfer', 'flash', 'verify', 'reboot']\` to \`['download',
  'transfer', 'verify', 'flash', 'reboot']\` so row order matches the firmware lifecycle (drive-by correctness fix for
   a pre-existing inversion bug)
  - Orchestrator integration test covering full M4 sequence (\`Sending → Verifying → Flashing →
  Failed(flash_not_implemented)\`); pins WS-event order
  - \`.docs/protocol.md\` updated with new stage + full stage definitions

  Ships **first** per the parent design doc's migration order; the AstrOs.ESP firmware-side PR ships after this lands.

  ## ⚠ Rollout note

  The state-machine widening is **additive only** in terms of new legal transitions, but the old chain \`Verifying →
  Rebooting\` becomes **illegal** (must traverse Flashing). Until the sister firmware PR ships, no master is emitting
  \`FW_PROGRESS{stage=FLASHING}\` — the server simply has unused capacity to accept the new stage, so live traffic is  unchanged. After firmware PR ships: any deployed master still skipping straight Verifying → Rebooting will trip
  \`protocol_violation\`. Mixed-fleet deploys across this boundary are not safe.

  ## Parent design

  [\`AstrOs.ESP/.docs/plans/20260527-0143-firmware-ota-progress-emission-design.md\`](../AstrOs.ESP/.docs/plans/202605
  27-0143-firmware-ota-progress-emission-design.md)

  ## Implementation plan

  [\`.docs/plans/20260527-0210-fw-progress-flashing-stage-server.md\`](.docs/plans/20260527-0210-fw-progress-flashing-stage-server.md)

  ## Commit history

  \`\`\`
  c438797 docs(protocol): document FwStage.FLASHING
  dd2f028 test(firmware): orchestrator walks M4 sequence Sending→…→Failed
  20bc027 fix(firmware-ui): reorder FIRMWARE_STAGES so verify precedes flash
  3c3ca94 feat(firmware-ui): map FLASHING server stage to 'flash' UI row
  c34b502 feat(firmware): add FwStage.Flashing + state-machine transitions
  ab809e2 docs(firmware): plan — add FwStage.Flashing + state machine + UI mapping
  \`\`\`

  (Note: Tasks 1+2 from the plan were combined into commit \`c34b502\` because TypeScript exhaustiveness checking on  \`NonTerminalStage\`, \`LEGAL_NEXT_STAGES\`, and \`ControllerFlashState\` means the enum-add and FSM-widening don't  compile in isolation.)

  ## Test plan

  - [x] All vitest suites pass (\`astros_api\`: 816 / \`astros_vue\`: 590)
  - [x] \`npm run build\` clean in both
  - [ ] Manual: existing M4 firmware deploy still produces the illegal-transition error (no regression — firmware side
   hasn't shipped yet)
  - [ ] When sister firmware PR lands: deploy a 2-padawan M4 firmware, UI renders \`✓ download ✓ transfer ✓ verify !
  flash idle-reboot\`, controller-detail surfaces \`flash_not_implemented\`