### PR TITLE
Feature/firmware deploy watchdog

### DIFF
--- a/.docs/plans/20260529-1731-firmware-deploy-watchdog.md
+++ b/.docs/plans/20260529-1731-firmware-deploy-watchdog.md
@@ -1,0 +1,577 @@
+# Firmware OTA deploy-phase watchdog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bound the `FW_DEPLOY_BEGIN → FW_DEPLOY_DONE` wait with an inactivity watchdog so a master that goes silent mid-deploy fails the job cleanly (`flashJobFailed{reason:'deploy_timeout'}` + lock released) instead of hanging forever.
+
+**Architecture:** A single `deployStallTimer` on `FlashJobOrchestrator`, armed when the deploy subscriber attaches, reset on every `FW_PROGRESS` (via `handleDeployEvent`), disarmed on `FW_DEPLOY_DONE` (hand-off to the existing `finalizeTimer`/`rebootTimer`) and on `releaseLock` (every teardown). On fire it routes through the existing `failDeployPhase`/`failJob` path. All timer ops go through the injected `Clock` so they're fake-timer testable.
+
+**Tech Stack:** TypeScript, Node, vitest (fake timers + the existing `flash_orchestrator.test.ts` fixtures), the integration harness (`bootIntegrationHarness`), Vue 3 + vue-i18n (frontend banner).
+
+**Spec:** `.docs/plans/specs/2026-05-29-firmware-deploy-watchdog-design.md`
+
+---
+
+## Failure-Mode Inventory (timer-lifecycle / concurrency / crash-recovery)
+
+The watchdog is a timer touching shared orchestrator state across async boundaries — no filesystem, but concurrency + crash-recovery apply.
+
+### Timer lifecycle — arm / reset / disarm / fire coverage
+
+| Event / condition | Required response |
+|---|---|
+| Deploy subscriber attaches (`phase='deploy'`) | Arm `deployStallTimer` (via `kickDeployStallTimer`, which is guarded on `phase==='deploy'`). |
+| `FW_PROGRESS` arrives | Reset (clear + re-arm) — master is alive. |
+| `FW_DEPLOY_DONE` arrives | Disarm (`clearDeployStallTimer` at top of `handleDeployDone`); hand off to `finalizeTimer`/`rebootTimer`. |
+| `POLL_ACK` heartbeat (any version) | **MUST NOT reset** — heartbeats flow through `decidePostDeployHeartbeat`/`notifyMasterHeartbeat`, never `handleDeployEvent`, so structurally they can't kick. (The stuck-bench state was exactly a rebooted master polling forever.) |
+| Timer fires | Null the field FIRST, guard on `currentJob!==null && phase==='deploy'`, then `failDeployPhase('deploy_timeout', …)`. |
+| `cancel()` during deploy | `cancel → releaseLock → clearDeployStallTimer` (idempotent). |
+| `subscriber_attach_failed` (arm never happened) | `releaseLock` clears `null` — no-op. |
+| Validation-failed `FW_DEPLOY_DONE` (empty results / bad outcome) | Those branches run BEFORE the disarm at top of `handleDeployDone`? **No** — disarm is the first statement after the `currentJob` guard, so it runs before validation; then `failDeployPhase`→`releaseLock` clears again (idempotent). |
+
+### Concurrency / race conditions
+
+- **First-fire-wins (timer vs teardown):** JS is single-threaded; `clock.clearTimeout` before the callback's turn cancels it. The `currentJob!==null && phase==='deploy'` guard + null-field-first in `onDeployStall` make a callback that races a teardown a no-op, mirroring the existing `rebootTimer`/`finalizeTimer` first-fire-wins pattern.
+- **Kick after DONE:** kick is called ONLY in the `progress` branch of `handleDeployEvent`; the `done` branch flows to `handleDeployDone` which disarms. So a done event can't leave a re-armed timer. A late/duplicate event after the subscriber is disposed hits the `currentJob===null` guard (released) or, if `currentJob` still set but `phase!=='deploy'`, `kickDeployStallTimer`'s `phase` guard prevents re-arming.
+- **Throw isolation:** all `clock.clearTimeout` calls are wrapped in try/catch + log (matching `releaseLock`'s existing timer clears) so a misbehaving clock can't propagate out of the serial-event dispatcher into the worker.
+
+### Crash-recovery / operability
+
+- The watchdog itself is the crash-recovery mechanism for "master died mid-deploy." Its failure mode is mis-tuning: `deployStallTimeoutMs` too short → false-fail a healthy slow master self-flash. Mitigation: conservative 90s default, configurable; `onDeployStall` logs at `error` with jobId + the elapsed budget for diagnosis.
+- **Test-timing gotcha (regression risk):** any EXISTING test that enters the deploy phase and advances the fake clock past `deployStallTimeoutMs` (default 90s) WITHOUT delivering a deploy event will now trip `deploy_timeout`. Every task ends by running the FULL `flash_orchestrator.test.ts` suite; fix any tripped test by delivering an event or overriding `config.deployStallTimeoutMs`.
+
+---
+
+## File Structure
+
+- `astros_api/src/firmware/flash_orchestrator.ts` — new const, config field, state field, `kickDeployStallTimer`/`clearDeployStallTimer`/`onDeployStall`, arm/kick/disarm call sites, reason union member. (The orchestrator is already the single owner of deploy-phase lifecycle; this fits its existing responsibility — no new file.)
+- `astros_api/src/controllers/firmware_flash_controller.ts` — one entry in the exhaustive `REASON_HTTP_STATUS` map.
+- `astros_api/src/firmware/flash_orchestrator.test.ts` — unit tests (add to the existing `deploy-phase observer` describe block).
+- `astros_api/src/firmware/integration/flash_deploy_stall.integration.test.ts` — new integration test (mirrors `flash_reboot_timer_fallback.integration.test.ts`).
+- `astros_vue/src/types/firmware.ts` — add `'deploy_timeout'` to the `FLASH_ERROR_REASONS` tuple (auto-derives the union + `KNOWN_FLASH_ERROR_REASONS`).
+- `astros_vue/src/locales/enUS.json` — `firmware_view.flash_errors.deploy_timeout` copy.
+
+---
+
+### Task 1: Reason + config plumbing (no behavior yet)
+
+**Files:**
+- Modify: `astros_api/src/firmware/flash_orchestrator.ts` (reason union ~408; DEFAULT consts ~332-337; config type ~453; state fields ~543; constructor ~594)
+- Modify: `astros_api/src/controllers/firmware_flash_controller.ts` (`REASON_HTTP_STATUS` ~24)
+
+- [ ] **Step 1: Add the error reason.** In `flash_orchestrator.ts`, add `'deploy_timeout'` to the `FlashOrchestratorErrorReason` union (after `'protocol_violation'`):
+
+```ts
+  | 'protocol_violation'
+  | 'deploy_timeout'
+  | 'streamer_unknown_error'
+```
+
+- [ ] **Step 2: Verify the build FAILS (exhaustive map gap).**
+
+Run: `cd astros_api && npx tsc --noEmit`
+Expected: FAIL — `REASON_HTTP_STATUS` in `firmware_flash_controller.ts` is missing the `deploy_timeout` key (the `Record<FlashOrchestratorErrorReason, HttpStatus>` is exhaustive). This proves the map is the consumer that must stay in sync.
+
+- [ ] **Step 3: Add the HTTP mapping.** In `firmware_flash_controller.ts`, add to `REASON_HTTP_STATUS` (after `protocol_violation: 500,`):
+
+```ts
+  protocol_violation: 500,
+  // Background watchdog timeout — never returned from the synchronous start()
+  // HTTP call (it fires later, surfaced via the flashJobFailed WS event); this
+  // entry exists for Record exhaustiveness. 504 = upstream (master) timed out.
+  deploy_timeout: 504,
+```
+
+- [ ] **Step 4: Add the const, config field, and state field.** In `flash_orchestrator.ts`, after `const DEFAULT_FINALIZE_TIMEOUT_MS = 90_000;`:
+
+```ts
+// Deploy-phase inactivity watchdog: max silence (no FW_PROGRESS/FW_DEPLOY_DONE)
+// between FW_DEPLOY_BEGIN and FW_DEPLOY_DONE before the job is failed with
+// 'deploy_timeout'. Must exceed the longest quiet gap in a healthy deploy —
+// chiefly the master's own self-flash write (no FW_PROGRESS emitted during it).
+// Matches the finalizeTimer magnitude; configurable per-job.
+const DEFAULT_DEPLOY_STALL_TIMEOUT_MS = 90_000;
+```
+
+Extend the `config` type (currently `{ rebootTimeoutMs?: number; throttleWindowMs?: number; finalizeTimeoutMs?: number }`):
+
+```ts
+  config?: {
+    rebootTimeoutMs?: number;
+    throttleWindowMs?: number;
+    finalizeTimeoutMs?: number;
+    deployStallTimeoutMs?: number;
+  };
+```
+
+Add the readonly field (next to `finalizeTimeoutMs`):
+
+```ts
+  private readonly deployStallTimeoutMs: number;
+```
+
+Add the timer state field (after `finalizeTimer`):
+
+```ts
+  // Deploy-phase inactivity watchdog timer. Armed when the deploy subscriber
+  // attaches; reset on each FW_PROGRESS; disarmed on FW_DEPLOY_DONE (hand-off
+  // to finalize/reboot timers) and in releaseLock. null outside the
+  // FW_DEPLOY_BEGIN→FW_DEPLOY_DONE window. First-fire-wins via the field's
+  // null-ness in onDeployStall.
+  private deployStallTimer: NodeJS.Timeout | null = null;
+```
+
+Wire the constructor (after the `finalizeTimeoutMs` assignment ~594):
+
+```ts
+    this.deployStallTimeoutMs =
+      opts.config?.deployStallTimeoutMs ?? DEFAULT_DEPLOY_STALL_TIMEOUT_MS;
+```
+
+- [ ] **Step 5: Verify build passes.**
+
+Run: `cd astros_api && npx tsc --noEmit`
+Expected: PASS (exit 0).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add astros_api/src/firmware/flash_orchestrator.ts astros_api/src/controllers/firmware_flash_controller.ts
+git commit -m "feat(firmware-ota): add deploy_timeout reason + deployStallTimeoutMs config
+
+Plumbing for the deploy-phase watchdog: new FlashOrchestratorErrorReason
+'deploy_timeout' (→504 in the exhaustive HTTP map), DEFAULT_DEPLOY_STALL_TIMEOUT_MS
+(90s), config.deployStallTimeoutMs, and the deployStallTimer state field. No
+behavior yet.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Watchdog arm + fire (no kick/disarm wiring yet)
+
+**Files:**
+- Modify: `astros_api/src/firmware/flash_orchestrator.ts` (helpers; arm at subscriber-attach ~852; clear in `releaseLock` ~1153)
+- Test: `astros_api/src/firmware/flash_orchestrator.test.ts` (in the `deploy-phase observer` describe block)
+
+- [ ] **Step 1: Write the failing test.** Add inside the `deploy-phase observer` describe (uses the existing `setupHappyPath`/`startAndArmDeploy`/`fakeClock`/`advance`/`emittedFrames`/`controllerResults` fixtures):
+
+```ts
+    it('deploy stall: no deploy events for deployStallTimeoutMs → deploy_timeout, controllers Failed, lock released, subscriber disposed', async () => {
+      // Short timeout so the fake-clock advance is unambiguous.
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      // Subscriber armed, no deploy events delivered. Advance past the stall window.
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(true);
+      advance(5_001);
+
+      const failed = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].data).toMatchObject({ jobId: armed.jobId, reason: 'deploy_timeout' });
+
+      // Non-terminal controllers driven to Failed; lock released; subscriber disposed.
+      const results = controllerResults(fx.emitWs);
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results.every((r) => r.controller.stage === FwStage.Failed)).toBe(true);
+      expect(fx.jobLock.isLocked()).toBe(false);
+      expect(fx.orchestrator.getCurrentJob()).toBeNull();
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(false);
+    });
+```
+
+- [ ] **Step 2: Run it — verify it FAILS.**
+
+Run: `cd astros_api && npx vitest run src/firmware/flash_orchestrator.test.ts -t "deploy stall: no deploy events"`
+Expected: FAIL — no `flashJobFailed` emitted (the watchdog doesn't exist yet); `failed` has length 0.
+
+- [ ] **Step 3: Add the three helper methods.** In `flash_orchestrator.ts`, add (place them right after `handleDeployProgress`/`emitTerminalProgressPreview`, before `handleDeployDone`):
+
+```ts
+  // Arm or reset the deploy-phase inactivity watchdog. Called at subscriber
+  // attach (initial arm) and on each FW_PROGRESS (reset). Guarded on
+  // phase==='deploy' so a stray late event can't re-arm it after hand-off.
+  private kickDeployStallTimer(): void {
+    this.clearDeployStallTimer();
+    if (this.phase !== 'deploy') return;
+    this.deployStallTimer = this.clock.setTimeout(
+      () => this.onDeployStall(),
+      this.deployStallTimeoutMs,
+    );
+  }
+
+  // Disarm the watchdog. Idempotent. Wrapped like releaseLock's other timer
+  // clears: a throw from a custom clock must not propagate out of the
+  // serial-event dispatcher into the worker.
+  private clearDeployStallTimer(): void {
+    if (this.deployStallTimer === null) return;
+    try {
+      this.clock.clearTimeout(this.deployStallTimer);
+    } catch (err) {
+      logger.error(err, `flash orchestrator: clock.clearTimeout threw clearing deployStallTimer`);
+    }
+    this.deployStallTimer = null;
+  }
+
+  // Watchdog fired: the master sent no FW_PROGRESS/FW_DEPLOY_DONE for
+  // deployStallTimeoutMs. Null the field first (so releaseLock's clear is a
+  // no-op), then guard first-fire-wins before failing the deploy phase.
+  private onDeployStall(): void {
+    this.deployStallTimer = null;
+    if (this.currentJob === null || this.phase !== 'deploy') return;
+    const jobId = this.currentJob.jobId;
+    logger.error(
+      `flash orchestrator: deploy stalled — no FW_PROGRESS/FW_DEPLOY_DONE for ${this.deployStallTimeoutMs}ms on job=${jobId}; failing (deploy_timeout)`,
+    );
+    this.failDeployPhase('deploy_timeout', `no deploy progress for ${this.deployStallTimeoutMs}ms`);
+  }
+```
+
+- [ ] **Step 4: Arm at subscriber attach.** In the deploy-phase block, right after the `this.deployUnsubscriber = this.bus.subscribeDeployEvents(...)` assignment succeeds (inside the try, after the assignment ~line 852):
+
+```ts
+            this.deployUnsubscriber = this.bus.subscribeDeployEvents(transferId, (event) =>
+              this.handleDeployEvent(event),
+            );
+            // Arm the inactivity watchdog now that we're waiting on the master.
+            this.kickDeployStallTimer();
+```
+
+- [ ] **Step 5: Clear in `releaseLock`.** In `releaseLock`, after the `finalizeTimer` clear block (after `this.finalizeTimer = null;` ~line 1153) and before the `deployUnsubscriber` disposal:
+
+```ts
+    this.clearDeployStallTimer();
+```
+
+- [ ] **Step 6: Run the test — verify it PASSES, and the full file is green.**
+
+Run: `cd astros_api && npx vitest run src/firmware/flash_orchestrator.test.ts`
+Expected: PASS — the new test passes AND all existing tests still pass. If any existing test now fails with an unexpected `deploy_timeout`, it idled in the deploy phase past the default 90s; fix it by delivering a deploy event or setting `config.deployStallTimeoutMs` high in that test's `setupHappyPath`.
+
+- [ ] **Step 7: Mutation check.** Temporarily comment out the `this.kickDeployStallTimer();` arm call (Step 4); rerun the new test; confirm it FAILS (no `flashJobFailed`). Restore the line.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add astros_api/src/firmware/flash_orchestrator.ts astros_api/src/firmware/flash_orchestrator.test.ts
+git commit -m "feat(firmware-ota): deploy-phase watchdog arm + fire
+
+Arm a deployStallTimer when the deploy subscriber attaches; on timeout fire
+failDeployPhase('deploy_timeout'). Cleared in releaseLock (idempotent,
+first-fire-wins via null-field guard). Kick-on-progress + disarm-on-DONE
+follow in the next tasks.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Reset the watchdog on FW_PROGRESS
+
+**Files:**
+- Modify: `astros_api/src/firmware/flash_orchestrator.ts` (`handleDeployEvent` ~1201)
+- Test: `astros_api/src/firmware/flash_orchestrator.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+    it('deploy stall: FW_PROGRESS resets the watchdog (no false timeout while the master keeps reporting)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      // Two progress frames, each within the window, total elapsed > window.
+      advance(4_000);
+      fx.bus.deliverDeployEvent(armed.transferId, {
+        kind: 'progress',
+        payload: { transferId: armed.transferId, controllerId: 'controller-a', stage: FwStage.Verifying, bytesSent: 0, totalBytes: 0, detail: '' },
+      });
+      advance(4_000); // 8s total elapsed, but only 4s since the last event
+      fx.bus.deliverDeployEvent(armed.transferId, {
+        kind: 'progress',
+        payload: { transferId: armed.transferId, controllerId: 'controller-a', stage: FwStage.Flashing, bytesSent: 0, totalBytes: 0, detail: '' },
+      });
+
+      // No timeout yet — the master has been reporting.
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(true);
+
+      // Now go silent past the window → fires.
+      advance(5_001);
+      const failed = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].data).toMatchObject({ reason: 'deploy_timeout' });
+    });
+```
+
+- [ ] **Step 2: Run it — verify it FAILS.**
+
+Run: `cd astros_api && npx vitest run src/firmware/flash_orchestrator.test.ts -t "FW_PROGRESS resets"`
+Expected: FAIL — without the kick, the first `advance(4_000)+advance(4_000)=8s` exceeds the 5s window mid-test, so `flashJobFailed` fires early → the `toHaveLength(0)` assertion fails.
+
+- [ ] **Step 3: Add the kick to the progress branch.** In `handleDeployEvent`:
+
+```ts
+  private handleDeployEvent(event: FwDeployEvent): void {
+    if (this.currentJob === null) return;
+    if (event.kind === 'progress') {
+      // Master is alive — reset the inactivity watchdog before processing.
+      this.kickDeployStallTimer();
+      this.handleDeployProgress(event.payload);
+      return;
+    }
+    this.handleDeployDone(event.payload.results);
+  }
+```
+
+- [ ] **Step 4: Run the test — verify it PASSES and the file is green.**
+
+Run: `cd astros_api && npx vitest run src/firmware/flash_orchestrator.test.ts`
+Expected: PASS, all green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add astros_api/src/firmware/flash_orchestrator.ts astros_api/src/firmware/flash_orchestrator.test.ts
+git commit -m "feat(firmware-ota): reset deploy watchdog on each FW_PROGRESS
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Disarm the watchdog on FW_DEPLOY_DONE
+
+**Files:**
+- Modify: `astros_api/src/firmware/flash_orchestrator.ts` (`handleDeployDone` top ~1279)
+- Test: `astros_api/src/firmware/flash_orchestrator.test.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+    it('deploy stall: FW_DEPLOY_DONE disarms the watchdog (post-DONE finalize/reboot timers govern, no deploy_timeout)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      // Drive both controllers to Rebooting, then DONE all-OK (terminal).
+      for (const controllerId of armed.targets) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
+          fx.bus.deliverDeployEvent(armed.transferId, {
+            kind: 'progress',
+            payload: { transferId: armed.transferId, controllerId, stage, bytesSent: 0, totalBytes: 0, detail: '' },
+          });
+        }
+      }
+      fx.bus.deliverDeployEvent(armed.transferId, {
+        kind: 'done',
+        payload: {
+          transferId: armed.transferId,
+          results: armed.targets.map((id) => ({ controllerId: id, outcome: 'OK' as const, finalVersion: '1.4.0', error: '' })),
+        },
+      });
+
+      // Past the stall window AFTER done — the watchdog must be disarmed.
+      advance(5_001);
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
+    });
+```
+
+- [ ] **Step 2: Run it — verify it FAILS.**
+
+Run: `cd astros_api && npx vitest run src/firmware/flash_orchestrator.test.ts -t "FW_DEPLOY_DONE disarms"`
+Expected: FAIL — without the disarm, the timer (re-armed by the last FW_PROGRESS kick) is still live; `advance(5_001)` fires `deploy_timeout` → `flashJobFailed` length 1, not 0.
+
+- [ ] **Step 3: Disarm at the top of `handleDeployDone`.** Add as the first statement after the `currentJob` guard:
+
+```ts
+  private handleDeployDone(results: FwDeployDoneResult[]): void {
+    if (this.currentJob === null) return;
+    // FW_DEPLOY_DONE ends the deploy-phase wait — disarm the inactivity
+    // watchdog. The post-reboot finalizeTimer/rebootTimer (armed below) govern
+    // from here. (Runs before validation: a malformed DONE still ends the wait,
+    // and failDeployPhase→releaseLock would clear it again, idempotently.)
+    this.clearDeployStallTimer();
+```
+
+- [ ] **Step 4: Run the test — verify it PASSES and the file is green.**
+
+Run: `cd astros_api && npx vitest run src/firmware/flash_orchestrator.test.ts`
+Expected: PASS, all green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add astros_api/src/firmware/flash_orchestrator.ts astros_api/src/firmware/flash_orchestrator.test.ts
+git commit -m "feat(firmware-ota): disarm deploy watchdog on FW_DEPLOY_DONE
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Edge cases — cancel disarms, and a late event after timeout is a no-op
+
+**Files:**
+- Test only: `astros_api/src/firmware/flash_orchestrator.test.ts`
+
+- [ ] **Step 1: Write the tests** (both behaviors already hold from Tasks 2–4; these pin them against regression).
+
+```ts
+    it('deploy stall: cancel() during the deploy phase disarms the watchdog (no later deploy_timeout)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      await fx.orchestrator.cancel('user');
+      const failedAfterCancel = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed).length;
+
+      advance(5_001);
+      // No ADDITIONAL flashJobFailed from a stray watchdog fire after cancel.
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(failedAfterCancel);
+      expect(fx.orchestrator.getCurrentJob()).toBeNull();
+    });
+
+    it('deploy stall: a stray deploy event after the watchdog fired is a no-op (no second failure / no throw)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      advance(5_001); // fire deploy_timeout → job released
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(1);
+
+      // The FakeSerialBus disposed the subscriber on release; deliver directly to
+      // handleDeployEvent's guard path by re-driving through the bus only if still
+      // subscribed. After release it is not, so assert disposal instead.
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(false);
+      // A second clock advance must not produce another failure.
+      advance(5_001);
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(1);
+    });
+```
+
+- [ ] **Step 2: Run them — verify PASS (no impl change).**
+
+Run: `cd astros_api && npx vitest run src/firmware/flash_orchestrator.test.ts -t "deploy stall"`
+Expected: PASS. (If cancel does NOT disarm, the first test fails — confirming `releaseLock`'s clear covers cancel.)
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add astros_api/src/firmware/flash_orchestrator.test.ts
+git commit -m "test(firmware-ota): pin deploy-watchdog cancel-disarm + post-fire no-op
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Integration test — master goes silent end-to-end
+
+**Files:**
+- Create: `astros_api/src/firmware/integration/flash_deploy_stall.integration.test.ts`
+
+Mirror `flash_reboot_timer_fallback.integration.test.ts`: boot the harness with `flashOrchestratorConfig: { deployStallTimeoutMs: <short> }`, run a flash through the real worker/orchestrator, deliver upload acks + a couple of `FW_PROGRESS` frames via the stub, then **stop emitting** (no `FW_DEPLOY_DONE`), and assert a `flashJobFailed{reason:'deploy_timeout'}` arrives and the lock is released.
+
+- [ ] **Step 1: Write the test.** Open `flash_reboot_timer_fallback.integration.test.ts` first and copy its harness-boot + auth + `waitForWsMessage` scaffolding verbatim, changing only: the config key to `deployStallTimeoutMs`, the stub to emit a few `FW_PROGRESS` frames then go silent (NO `writeFwDeployDone`), and the assertion to:
+
+```ts
+      const failed = await harness.waitForWsMessage<{ type: number; data: { reason: string } }>(
+        (m) => (m as { type?: unknown }).type === TransmissionType.flashJobFailed &&
+               (m as { data?: { reason?: string } }).data?.reason === 'deploy_timeout',
+        SHORT_DEPLOY_STALL_TIMEOUT_MS + 5_000,
+      );
+      expect(failed.data.reason).toBe('deploy_timeout');
+
+      // Lock released after the watchdog fires.
+      const lockReleased = await harness.waitForWsMessage<{ type: number; locked: boolean }>(
+        (m) => { const msg = m as { type?: unknown; locked?: unknown };
+                 return msg.type === TransmissionType.lockStateChanged && msg.locked === false; },
+        5_000, snapshot,
+      );
+      expect(lockReleased.locked).toBe(false);
+      expect(harness.workerErrors).toEqual([]);
+```
+
+Use a real-time short timeout that comfortably exceeds the stub's progress cadence — `const SHORT_DEPLOY_STALL_TIMEOUT_MS = 3_000;` — and emit ~2 progress frames in the first ~1s, then stop. (Confirm the stub exposes a way to send progress without DONE — `writeFwProgress` exists and is public; call it directly, then never call `writeFwDeployDone`.)
+
+- [ ] **Step 2: Run it — verify PASS.**
+
+Run: `cd astros_api && npx vitest run src/firmware/integration/flash_deploy_stall.integration.test.ts`
+Expected: PASS (the watchdog fires ~3s after the last progress; `flashJobFailed{deploy_timeout}` + lock release observed through the real worker→orchestrator path).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add astros_api/src/firmware/integration/flash_deploy_stall.integration.test.ts
+git commit -m "test(firmware-ota): integration — silent master mid-deploy → deploy_timeout
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Frontend — deploy_timeout banner
+
+**Files:**
+- Modify: `astros_vue/src/types/firmware.ts` (`FLASH_ERROR_REASONS` tuple ~line 187)
+- Modify: `astros_vue/src/locales/enUS.json` (`firmware_view.flash_errors` ~line 197)
+
+- [ ] **Step 1: Write the failing test.** In the firmware store/types test (find the existing test that asserts `KNOWN_FLASH_ERROR_REASONS` membership or banner reason mapping — search `KNOWN_FLASH_ERROR_REASONS` / `post_reboot_timeout` under `astros_vue/src/**/*.spec.ts`/`*.test.ts`). Add:
+
+```ts
+  it("recognizes 'deploy_timeout' as a known flash error reason", () => {
+    expect(KNOWN_FLASH_ERROR_REASONS.has('deploy_timeout')).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run it — verify FAILS.**
+
+Run: `cd astros_vue && npx vitest run -t "deploy_timeout"`
+Expected: FAIL — `'deploy_timeout'` not in the tuple, so `.has(...)` is `false` (and TS may flag the literal — if so, that IS the red).
+
+- [ ] **Step 3: Add to the tuple.** In `astros_vue/src/types/firmware.ts`, add `'deploy_timeout'` to `FLASH_ERROR_REASONS` immediately after `'post_reboot_timeout'`:
+
+```ts
+  // post_reboot_timeout copy.
+  'post_reboot_timeout',
+  // deploy_timeout copy (server deploy-phase inactivity watchdog).
+  'deploy_timeout',
+```
+
+- [ ] **Step 4: Add the i18n copy.** In `astros_vue/src/locales/enUS.json`, add to `firmware_view.flash_errors` after the `post_reboot_timeout` entry (add the trailing comma to the prior line):
+
+```json
+      "post_reboot_timeout": "Master controller did not report a matching firmware version within 90 seconds. The flash may have failed; verify the controller and retry.",
+      "deploy_timeout": "The master controller stopped responding during the update (no progress for 90 seconds). The flash was aborted; check the master's power and USB connection, then try again."
+```
+
+- [ ] **Step 5: Run the test + i18n consistency.**
+
+Run: `cd astros_vue && npx vitest run -t "deploy_timeout"` → PASS.
+If the repo has an i18n-key-completeness test (search for a test importing `enUS.json` keys), run the full `npm run test:unit` to confirm no missing-key failure.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add astros_vue/src/types/firmware.ts astros_vue/src/locales/enUS.json astros_vue/src/<the-test-file>
+git commit -m "feat(firmware-ui): deploy_timeout flash-error banner copy
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Full verification + pre-push review
+
+- [ ] **Step 1: API gate.** `cd astros_api && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run` — all green, 0 lint errors.
+- [ ] **Step 2: Vue gate.** `cd astros_vue && npm run lint && npm run test:unit` — green.
+- [ ] **Step 3: Pre-push review.** Run `/pr-review-toolkit:review-pr` on the full branch diff vs `develop`, framed around the timer-lifecycle hazards in the FMI above (arm/kick/disarm/fire across every exit, first-fire-wins, kick-after-DONE, POLL_ACK-doesn't-kick, the test-timing regression risk). Address Critical/Important.
+- [ ] **Step 4: Update the spec/plan status** and hand off for push (user pushes via VS Code → PR into `develop`).
+
+---
+
+## Self-Review
+
+**Spec coverage:** inactivity model (Tasks 2–3) ✓; timer-only, no serial-close (out of scope, not in any task) ✓; 90s default + configurable (Task 1) ✓; arm/kick/disarm/fire lifecycle (Tasks 2–4) ✓; POLL_ACK-doesn't-kick (structural — kick only in `handleDeployEvent`; FMI + integration Task 6 exercise the real path) ✓; `deploy_timeout` reason + HTTP map (Task 1) ✓; frontend banner (Task 7) ✓; races/first-fire-wins (Task 5 + FMI) ✓; tests incl. mutation check (Task 2 Step 7) + integration (Task 6) ✓.
+
+**Placeholder scan:** the only deferred specifics are "find the existing frontend test file" (Task 7 Step 1) and "copy the reboot-timer harness scaffolding" (Task 6 Step 1) — both point at concrete existing files to read, not invented content. No TBD/TODO in code steps.
+
+**Type/name consistency:** `deployStallTimer`, `deployStallTimeoutMs`, `DEFAULT_DEPLOY_STALL_TIMEOUT_MS`, `kickDeployStallTimer`/`clearDeployStallTimer`/`onDeployStall`, reason `'deploy_timeout'` — used consistently across all tasks and match the spec.

--- a/.docs/plans/20260529-1731-firmware-deploy-watchdog.md
+++ b/.docs/plans/20260529-1731-firmware-deploy-watchdog.md
@@ -10,6 +10,8 @@
 
 **Spec:** `.docs/plans/specs/2026-05-29-firmware-deploy-watchdog-design.md`
 
+> **STATUS: COMPLETE (2026-05-29).** All tasks implemented via subagent-driven development (Tasks 2 & 4 folded into one commit to avoid a leaky intermediate timer state). Commits `5ddc064`→`5889aa4`. Verified: API 848 tests + Vue 598 tests pass, tsc + lint clean. Pre-push 5-agent review passed (no Critical/Important); findings addressed in `5889aa4` (POLL_ACK-doesn't-reset regression test + doc-drift fixes + softened banner copy). Deferred follow-ups: (1) thread `deployStallTimeoutMs`/`rebootTimeoutMs` from an env var in `ApiServer.bootstrap` so the timeout is operator-tunable without a recompile; (2) de-duplicate the 4-way `flashOrchestratorConfig` shape into one exported type. Ready to push → PR into `develop`.
+
 ---
 
 ## Failure-Mode Inventory (timer-lifecycle / concurrency / crash-recovery)

--- a/.docs/plans/specs/2026-05-29-firmware-deploy-watchdog-design.md
+++ b/.docs/plans/specs/2026-05-29-firmware-deploy-watchdog-design.md
@@ -1,0 +1,125 @@
+# Design: Firmware OTA deploy-phase watchdog
+
+**Date:** 2026-05-29
+**Branch:** `feature/firmware-deploy-watchdog` (off `develop`)
+**Status:** design — pending user review
+
+## Problem
+
+During an OTA flash, after the server sends `FW_DEPLOY_BEGIN` it enters the
+**deploy phase** (`phase = 'deploy'`, deploy subscriber armed) and waits for the
+master to drive `FW_PROGRESS` frames and finally `FW_DEPLOY_DONE`. **There is no
+timeout on this wait.** The post-`FW_DEPLOY_DONE` reboot/heartbeat wait is
+covered by `rebootTimer` (~15 s) and `finalizeTimer` (~90 s), but both are armed
+*inside* `handleDeployDone` — so if `FW_DEPLOY_DONE` never arrives, neither ever
+arms.
+
+Confirmed on the bench (2026-05-29): a master that crashed mid-self-flash
+(`ota_writer_task` stack overflow) rebooted into the old image and never sent
+`FW_DEPLOY_DONE`. The job hung indefinitely (196 s+ observed), the `JobLock`
+stayed held (blocking further flashes), and the UI sat on "reboot in progress"
+forever. Recovery required a manual `DELETE /api/firmware/flash` or a restart.
+
+This gap is pre-existing on `develop`; it was previously masked for one
+sub-case by a (buggy) `protocol_violation` self-heal that the
+`fix/firmware-progress-terminal-stage` PR correctly removed.
+
+## Goal
+
+Bound the deploy-phase wait: if the master goes silent (no deploy events) for a
+configurable interval, fail the job cleanly — release the lock and emit
+`flashJobFailed{reason:'deploy_timeout'}` so the operator sees a definite failure
+instead of a permanent hang.
+
+**Non-goal:** making a crashing/dead master *succeed*. The watchdog converts an
+infinite hang into a bounded, visible failure. (The firmware crash itself is an
+AstrOs.ESP concern, already fixed separately.)
+
+## Design decisions (settled in brainstorming)
+
+1. **Inactivity model** (not an overall deadline). Reset on each deploy event;
+   fire only after N ms of silence. Scales with deploy size and tolerates slow
+   boards; an overall deadline would have to exceed total deploy time (which
+   scales with controller count) and risks false-failing large deploys.
+2. **Timer-only this PR.** Wiring serial `close`/`error` → fail-job (a faster
+   fast-path for physical unplug) is a **separate follow-up**; the observed
+   failure (crash+reboot, USB-serial port stayed open) is caught by the timer
+   regardless.
+3. **Default 90 s, configurable** via `config.deployStallTimeoutMs`. Must exceed
+   the longest quiet gap in a *healthy* deploy — chiefly the master's own
+   self-flash write (~1.27 MB, no `FW_PROGRESS` emitted during it). Too short =
+   false-fail a working deploy (worse than a slow recovery), so the default is
+   conservative and matches the existing `finalizeTimer` magnitude.
+
+## Mechanism
+
+New state on `FlashJobOrchestrator`:
+- `private deployStallTimer: NodeJS.Timeout | null = null`
+- `private readonly deployStallTimeoutMs: number` (← config, default
+  `DEFAULT_DEPLOY_STALL_TIMEOUT_MS = 90_000`)
+
+New error reason:
+- `'deploy_timeout'` added to the `FlashOrchestratorErrorReason` union, plus an
+  entry in the exhaustive reason→HTTP-status map in
+  `firmware_flash_controller.ts`. It never fires during the synchronous HTTP
+  `start()` call (it is a background timeout surfaced via the `flashJobFailed`
+  WS event), so the HTTP map entry exists only for exhaustiveness — mapped to
+  `504 Gateway Timeout`.
+
+Lifecycle (all timer ops via the injected `Clock`, so fake-timer testable):
+
+| Event | Action |
+|---|---|
+| `phase → 'deploy'` (subscriber attaches) | **Arm** `deployStallTimer` for `deployStallTimeoutMs`. |
+| Any deploy event enters `handleDeployEvent` (`FW_PROGRESS` or `FW_DEPLOY_DONE`) | **Kick**: clear + re-arm. Proof the master is alive. |
+| `handleDeployDone` runs | **Disarm** (hand off to `finalizeTimer`/`rebootTimer`). |
+| `releaseLock` (cancel, failJob, attach-failure, any teardown) | **Disarm** (canonical chokepoint). |
+| Timer fires | Null the field, then `failDeployPhase('deploy_timeout', detail)`. |
+
+**POLL_ACK heartbeats do NOT kick the timer** — they flow through
+`decidePostDeployHeartbeat`, not `handleDeployEvent`. This is essential: a
+rebooted master polling with the wrong version every ~4 s must not keep the
+watchdog alive forever (that is exactly the bench stuck-state).
+
+On fire, `failDeployPhase('deploy_timeout', …)` reuses the existing failure path:
+transition non-terminal controllers → `Failed`, emit `flashControllerResult`
+per controller, emit `flashJobFailed{jobId, reason:'deploy_timeout', detail,
+endedAt}`, release the lock, broadcast `lockStateChanged`.
+
+## Races & invariants (to be expanded in the failure-mode inventory)
+
+- **First-fire-wins.** The timer callback guards on `currentJob !== null &&
+  phase === 'deploy'` before acting, and nulls `deployStallTimer` first — so a
+  callback that races a teardown is a no-op, and `releaseLock`'s clear is
+  idempotent.
+- **Disarm on every exit.** `releaseLock` is the single teardown chokepoint
+  (already disposes subscriber + throttle + reboot/finalize timers); clearing
+  the stall timer there + in `handleDeployDone` covers all paths. Mirror the
+  existing "timer set but currentJob null" invariant assertions.
+- **Kick-then-disarm on DONE.** Kicking at the top of `handleDeployEvent` then
+  disarming inside `handleDeployDone` nets to "cleared" (one harmless extra
+  clock op on the done path); keeps the kick unconditional and simple.
+- **No throw out of the dispatcher.** The fire path (`failDeployPhase` →
+  `failJob`) already swallows-and-logs WS emit failures; the callback itself
+  performs no throwing work beyond that.
+
+## Surfaces touched
+
+- **Backend:** `firmware/flash_orchestrator.ts` (state, config wiring, arm/kick/
+  disarm/fire, reason union, default const); `controllers/firmware_flash_controller.ts`
+  (reason→HTTP-status map).
+- **Frontend (minimal — the operability payoff):** a `deploy_timeout` banner,
+  following the existing `post_reboot_timeout` pattern — reason handling in the
+  firmware store/types + an i18n copy key. Without it the UI shows a generic/
+  blank message when the watchdog fires, undercutting the goal.
+- **Tests:** orchestrator unit tests (arm on deploy-phase entry; kick on
+  `FW_PROGRESS`; disarm on `FW_DEPLOY_DONE`; disarm on cancel; fire after
+  silence → `flashJobFailed{deploy_timeout}` + lock released + controllers
+  Failed; POLL_ACK does NOT kick; first-fire-wins vs late event) with a mutation
+  check; one integration test (drive progress, go silent, advance the clock →
+  `deploy_timeout` → lock released); frontend test for the banner copy.
+
+## Out of scope (follow-ups)
+
+- Serial `close`/`error` → fail active job (fast-path for physical unplug).
+- Any change to firmware self-flash behavior (AstrOs.ESP).

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -145,6 +145,7 @@ export interface ApiServerOptions {
   flashOrchestratorConfig?: {
     rebootTimeoutMs?: number;
     throttleWindowMs?: number;
+    deployStallTimeoutMs?: number;
   };
   configOverrides?: ConfigOverrides;
 }
@@ -184,6 +185,7 @@ export class ApiServer {
   private readonly flashOrchestratorConfig?: {
     rebootTimeoutMs?: number;
     throttleWindowMs?: number;
+    deployStallTimeoutMs?: number;
   };
   private readonly configOverrides?: ConfigOverrides;
 

--- a/astros_api/src/controllers/firmware_flash_controller.ts
+++ b/astros_api/src/controllers/firmware_flash_controller.ts
@@ -9,7 +9,7 @@ import type { FlashRequest } from '../models/firmware/flash_orchestrator.js';
 
 const route = '/firmware/flash';
 
-type HttpStatus = 400 | 409 | 500 | 502;
+type HttpStatus = 400 | 409 | 500 | 502 | 504;
 
 // Exhaustive map from every FlashOrchestratorErrorReason to its HTTP
 // status. The Record type makes this exhaustive at compile time —
@@ -38,6 +38,10 @@ const REASON_HTTP_STATUS: Record<FlashOrchestratorErrorReason, HttpStatus> = {
   controllers_lookup_failed: 500,
   subscriber_attach_failed: 500,
   protocol_violation: 500,
+  // Background watchdog timeout — never returned from the synchronous start()
+  // HTTP call (it fires later, surfaced via the flashJobFailed WS event); this
+  // entry exists for Record exhaustiveness. 504 = upstream (master) timed out.
+  deploy_timeout: 504,
   streamer_unknown_error: 500,
 
   source_read_failed: 500,

--- a/astros_api/src/firmware/flash_orchestrator.test.ts
+++ b/astros_api/src/firmware/flash_orchestrator.test.ts
@@ -2659,6 +2659,39 @@ describe('FlashJobOrchestrator', () => {
       advance(5_001);
       expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
     });
+
+    it('deploy stall: cancel() during the deploy phase disarms the watchdog (no later deploy_timeout)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      await startAndArmDeploy(fx);
+
+      // Mid-deploy (pre-DONE), the stall timer is the only armed timer.
+      expect(vi.getTimerCount()).toBe(1);
+
+      await fx.orchestrator.cancel('user');
+      const failedAfterCancel = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed).length;
+
+      // Load-bearing: cancel → releaseLock must have cleared the stall timer.
+      // (Without clearDeployStallTimer() in releaseLock this is 1, and the test fails.)
+      expect(vi.getTimerCount()).toBe(0);
+
+      advance(5_001);
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(
+        failedAfterCancel,
+      );
+      expect(fx.orchestrator.getCurrentJob()).toBeNull();
+    });
+
+    it('deploy stall: a stray clock advance after the watchdog fired is a no-op (no second failure)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      advance(5_001); // fire deploy_timeout → job released
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(1);
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(false);
+
+      advance(5_001); // a second advance must not produce another failure
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(1);
+    });
   });
 
   describe('Phase C: PENDING / Finalizing resolution', () => {

--- a/astros_api/src/firmware/flash_orchestrator.test.ts
+++ b/astros_api/src/firmware/flash_orchestrator.test.ts
@@ -2566,6 +2566,61 @@ describe('FlashJobOrchestrator', () => {
       // Deploy subscriber disposed after done.
       expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(false);
     });
+
+    it('deploy stall: no deploy events for deployStallTimeoutMs → deploy_timeout, controllers Failed, lock released, subscriber disposed', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(true);
+      advance(5_001);
+
+      const failed = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].data).toMatchObject({ jobId: armed.jobId, reason: 'deploy_timeout' });
+
+      const results = controllerResults(fx.emitWs);
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results.every((r) => r.controller.stage === FwStage.Failed)).toBe(true);
+      expect(fx.jobLock.isLocked()).toBe(false);
+      expect(fx.orchestrator.getCurrentJob()).toBeNull();
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(false);
+    });
+
+    it('deploy stall: FW_DEPLOY_DONE disarms the watchdog (post-DONE finalize/reboot timers govern, no deploy_timeout)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      for (const controllerId of armed.targets) {
+        for (const stage of [FwStage.Verifying, FwStage.Flashing, FwStage.Rebooting]) {
+          fx.bus.deliverDeployEvent(armed.transferId, {
+            kind: 'progress',
+            payload: {
+              transferId: armed.transferId,
+              controllerId,
+              stage,
+              bytesSent: 0,
+              totalBytes: 0,
+              detail: '',
+            },
+          });
+        }
+      }
+      fx.bus.deliverDeployEvent(armed.transferId, {
+        kind: 'done',
+        payload: {
+          transferId: armed.transferId,
+          results: armed.targets.map((id) => ({
+            controllerId: id,
+            outcome: 'OK' as const,
+            finalVersion: '1.4.0',
+            error: '',
+          })),
+        },
+      });
+
+      advance(5_001);
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
+    });
   });
 
   describe('Phase C: PENDING / Finalizing resolution', () => {
@@ -2683,7 +2738,8 @@ describe('FlashJobOrchestrator', () => {
       // should still receive the snapshot.
       expect(job!.endedAt).toBeUndefined();
 
-      // finalizeTimer is armed (one outstanding fake-timer).
+      // Only the finalizeTimer is armed post-DONE — the stall watchdog is
+      // disarmed by clearDeployStallTimer() at the top of handleDeployDone.
       expect(vi.getTimerCount()).toBe(1);
 
       // Mutation-resistance (per CLAUDE.md feedback_mutation_test_defensive_features):
@@ -2762,7 +2818,8 @@ describe('FlashJobOrchestrator', () => {
         },
       });
 
-      // Pre-fire: no flashJobDone, lock held, timer armed.
+      // Pre-fire: no flashJobDone, lock held, one timer armed (finalizeTimer).
+      // The stall watchdog was disarmed at FW_DEPLOY_DONE.
       expect(emittedFrames(fx.emitWs, TransmissionType.flashJobDone)).toHaveLength(0);
       expect(fx.jobLock.isLocked()).toBe(true);
       expect(vi.getTimerCount()).toBe(1);
@@ -3181,7 +3238,8 @@ describe('FlashJobOrchestrator', () => {
         },
       });
 
-      // Sanity: master is Finalizing, timer is armed.
+      // Sanity: master is Finalizing; only finalizeTimer is armed post-DONE.
+      // The stall watchdog was disarmed at FW_DEPLOY_DONE.
       expect(fx.orchestrator.getCurrentJob()).not.toBeNull();
       expect(vi.getTimerCount()).toBe(1);
 
@@ -3305,7 +3363,8 @@ describe('FlashJobOrchestrator', () => {
       // endedAt is an ISO timestamp derived from clock.now() at deploy-done.
       expect(doneData.endedAt).toBe(new Date(1_000_000).toISOString());
 
-      // Reboot timer is armed (one outstanding fake-timer).
+      // Only the reboot timer is armed post-DONE — the stall watchdog is
+      // disarmed at FW_DEPLOY_DONE; releaseLock clears the reboot timer on exit.
       expect(vi.getTimerCount()).toBe(1);
 
       // Lock still held (release is gated on heartbeat-or-timer).
@@ -3364,8 +3423,8 @@ describe('FlashJobOrchestrator', () => {
       // flashJobFailed does NOT (job-wide abort is a separate event).
       expect(emittedFrames(fx.emitWs, TransmissionType.flashJobDone)).toHaveLength(1);
       expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
-      // Reboot timer armed even with a partial failure — the master still
-      // rebooted; we still want to release the lock when its heartbeat lands.
+      // Only the reboot timer is armed post-DONE (stall watchdog disarmed at
+      // FW_DEPLOY_DONE). The master still rebooted; release via heartbeat or timer.
       expect(vi.getTimerCount()).toBe(1);
       expect(fx.jobLock.isLocked()).toBe(true);
     });
@@ -3373,6 +3432,8 @@ describe('FlashJobOrchestrator', () => {
     it('heartbeat called pre-timer: clears the timer, releases the lock, emits lockStateChanged; no leaked timers', async () => {
       const fx = setupHappyPath({ clock: fakeClock });
       const armed = await startAndCompleteDeploy(fx);
+      // Only the reboot timer is armed post-DONE (stall watchdog disarmed at
+      // FW_DEPLOY_DONE; cleared by releaseLock → notifyMasterHeartbeat path).
       expect(vi.getTimerCount()).toBe(1);
 
       const lockEventsBefore = emittedFrames(fx.emitWs, TransmissionType.lockStateChanged).length;
@@ -3404,6 +3465,7 @@ describe('FlashJobOrchestrator', () => {
     it('reboot timer fires (no heartbeat): releases the lock, emits lockStateChanged; subsequent heartbeat is a no-op', async () => {
       const fx = setupHappyPath({ clock: fakeClock });
       await startAndCompleteDeploy(fx);
+      // Only the reboot timer is armed post-DONE (stall watchdog disarmed at FW_DEPLOY_DONE).
       expect(vi.getTimerCount()).toBe(1);
       const lockEventsBefore = emittedFrames(fx.emitWs, TransmissionType.lockStateChanged).length;
 
@@ -3484,6 +3546,7 @@ describe('FlashJobOrchestrator', () => {
           })),
         },
       });
+      // Only the reboot timer is armed post-DONE (stall watchdog disarmed at FW_DEPLOY_DONE).
       expect(vi.getTimerCount()).toBe(1);
 
       // Advance just under the configured timeout — must NOT have released yet.
@@ -3568,9 +3631,9 @@ describe('FlashJobOrchestrator', () => {
       const armed = await startPromise;
 
       // We're now post-FW_DEPLOY_BEGIN, mid-deploy. Subscribers armed; no
-      // reboot timer yet.
+      // reboot timer yet — only the deploy stall timer (Task 2).
       expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(true);
-      expect(vi.getTimerCount()).toBe(0);
+      expect(vi.getTimerCount()).toBe(1);
 
       const allEventsBefore = fx.emitWs.mock.calls.length;
       fx.orchestrator.notifyMasterHeartbeat('1.4.0');
@@ -4608,7 +4671,7 @@ describe('FlashJobOrchestrator', () => {
       });
 
       // We're now in the post-flashJobDone, pre-release window. Lock still
-      // held; reboot timer armed; phase === 'done'.
+      // held; only the reboot timer is armed (stall watchdog disarmed at FW_DEPLOY_DONE).
       expect(fx.jobLock.isLocked()).toBe(true);
       expect(vi.getTimerCount()).toBe(1);
       const failedBefore = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed).length;

--- a/astros_api/src/firmware/flash_orchestrator.test.ts
+++ b/astros_api/src/firmware/flash_orchestrator.test.ts
@@ -2656,8 +2656,25 @@ describe('FlashJobOrchestrator', () => {
         },
       });
 
+      // Stall timer was cleared at DONE — only the post-DONE reboot timer remains.
+      expect(vi.getTimerCount()).toBe(1);
+
       advance(5_001);
       expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
+    });
+
+    it('deploy stall: a master POLL_ACK heartbeat does NOT reset the watchdog (heartbeats are not deploy events)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      await startAndArmDeploy(fx);
+
+      // A heartbeat mid-deploy must NOT kick the stall timer (only FW_PROGRESS does).
+      advance(4_000);
+      fx.orchestrator.notifyMasterHeartbeat('1.4.0');
+      advance(1_001); // 5_001 total since arm, with NO deploy event in between
+
+      const failed = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].data).toMatchObject({ reason: 'deploy_timeout' });
     });
 
     it('deploy stall: cancel() during the deploy phase disarms the watchdog (no later deploy_timeout)', async () => {

--- a/astros_api/src/firmware/flash_orchestrator.test.ts
+++ b/astros_api/src/firmware/flash_orchestrator.test.ts
@@ -2586,6 +2586,44 @@ describe('FlashJobOrchestrator', () => {
       expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(false);
     });
 
+    it('deploy stall: FW_PROGRESS resets the watchdog (no false timeout while the master keeps reporting)', async () => {
+      const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
+      const armed = await startAndArmDeploy(fx);
+
+      advance(4_000);
+      fx.bus.deliverDeployEvent(armed.transferId, {
+        kind: 'progress',
+        payload: {
+          transferId: armed.transferId,
+          controllerId: 'controller-a',
+          stage: FwStage.Verifying,
+          bytesSent: 0,
+          totalBytes: 0,
+          detail: '',
+        },
+      });
+      advance(4_000); // 8s total elapsed, only 4s since the last event
+      fx.bus.deliverDeployEvent(armed.transferId, {
+        kind: 'progress',
+        payload: {
+          transferId: armed.transferId,
+          controllerId: 'controller-a',
+          stage: FwStage.Flashing,
+          bytesSent: 0,
+          totalBytes: 0,
+          detail: '',
+        },
+      });
+
+      expect(emittedFrames(fx.emitWs, TransmissionType.flashJobFailed)).toHaveLength(0);
+      expect(fx.bus.deploySubscribers.has(armed.transferId)).toBe(true);
+
+      advance(5_001); // now go silent past the window
+      const failed = emittedFrames(fx.emitWs, TransmissionType.flashJobFailed);
+      expect(failed).toHaveLength(1);
+      expect(failed[0].data).toMatchObject({ reason: 'deploy_timeout' });
+    });
+
     it('deploy stall: FW_DEPLOY_DONE disarms the watchdog (post-DONE finalize/reboot timers govern, no deploy_timeout)', async () => {
       const fx = setupHappyPath({ clock: fakeClock, config: { deployStallTimeoutMs: 5_000 } });
       const armed = await startAndArmDeploy(fx);

--- a/astros_api/src/firmware/flash_orchestrator.ts
+++ b/astros_api/src/firmware/flash_orchestrator.ts
@@ -526,6 +526,7 @@ export class FlashJobOrchestrator {
   // alongside rebootTimer in releaseLock (covers cancel-during-Finalizing
   // and other teardown paths).
   private readonly finalizeTimeoutMs: number;
+  // Inactivity watchdog window for the deploy phase (FW_DEPLOY_BEGIN→DONE).
   private readonly deployStallTimeoutMs: number;
 
   private currentJob: FlashJobState | null = null;
@@ -871,6 +872,8 @@ export class FlashJobOrchestrator {
             this.deployUnsubscriber = this.bus.subscribeDeployEvents(transferId, (event) =>
               this.handleDeployEvent(event),
             );
+            // Arm the inactivity watchdog now that we're waiting on the master.
+            this.kickDeployStallTimer();
           } catch (err) {
             const detail = err instanceof Error ? err.message : String(err);
             throw new FlashOrchestratorError('subscriber_attach_failed', detail);
@@ -1173,6 +1176,7 @@ export class FlashJobOrchestrator {
       }
       this.finalizeTimer = null;
     }
+    this.clearDeployStallTimer();
     // Disposer calls run in their own try/catch so a misbehaving
     // subscriber or throttle can't propagate up through `failJob` into
     // the background-IIFE `.catch` belt. Without this guard, a throw
@@ -1343,8 +1347,51 @@ export class FlashJobOrchestrator {
     this.throttle.submit(target.controllerId, preview, true);
   }
 
+  // Arm or reset the deploy-phase inactivity watchdog. Called at subscriber
+  // attach (initial arm) and on each FW_PROGRESS (reset). Guarded on
+  // phase==='deploy' so a stray late event can't re-arm it after hand-off.
+  private kickDeployStallTimer(): void {
+    this.clearDeployStallTimer();
+    if (this.phase !== 'deploy') return;
+    this.deployStallTimer = this.clock.setTimeout(
+      () => this.onDeployStall(),
+      this.deployStallTimeoutMs,
+    );
+  }
+
+  // Disarm the watchdog. Idempotent. Wrapped like releaseLock's other timer
+  // clears: a throw from a custom clock must not propagate out of the
+  // serial-event dispatcher into the worker.
+  private clearDeployStallTimer(): void {
+    if (this.deployStallTimer === null) return;
+    try {
+      this.clock.clearTimeout(this.deployStallTimer);
+    } catch (err) {
+      logger.error(err, `flash orchestrator: clock.clearTimeout threw clearing deployStallTimer`);
+    }
+    this.deployStallTimer = null;
+  }
+
+  // Watchdog fired: the master sent no FW_PROGRESS/FW_DEPLOY_DONE for
+  // deployStallTimeoutMs. Null the field first (so releaseLock's clear is a
+  // no-op), then guard first-fire-wins before failing the deploy phase.
+  private onDeployStall(): void {
+    this.deployStallTimer = null;
+    if (this.currentJob === null || this.phase !== 'deploy') return;
+    const jobId = this.currentJob.jobId;
+    logger.error(
+      `flash orchestrator: deploy stalled — no FW_PROGRESS/FW_DEPLOY_DONE for ${this.deployStallTimeoutMs}ms on job=${jobId}; failing (deploy_timeout)`,
+    );
+    this.failDeployPhase('deploy_timeout', `no deploy progress for ${this.deployStallTimeoutMs}ms`);
+  }
+
   private handleDeployDone(results: FwDeployDoneResult[]): void {
     if (this.currentJob === null) return;
+    // FW_DEPLOY_DONE ends the deploy-phase wait — disarm the inactivity
+    // watchdog. The post-reboot finalizeTimer/rebootTimer (armed below) govern
+    // from here. (Runs before validation: a malformed DONE still ends the wait,
+    // and failDeployPhase→releaseLock would clear it again, idempotently.)
+    this.clearDeployStallTimer();
     if (results.length === 0) {
       // Empty results array = master sent "done" with no per-controller
       // outcomes. Per FMI §1's hostile-input guard, treat as protocol

--- a/astros_api/src/firmware/flash_orchestrator.ts
+++ b/astros_api/src/firmware/flash_orchestrator.ts
@@ -336,10 +336,10 @@ const DEFAULT_THROTTLE_WINDOW_MS = 250;
 // design Section 6 cross-repo coordination.
 const DEFAULT_FINALIZE_TIMEOUT_MS = 90_000;
 // Deploy-phase inactivity watchdog: max silence (no FW_PROGRESS/FW_DEPLOY_DONE)
-// between FW_DEPLOY_BEGIN and FW_DEPLOY_DONE before the job is failed with
-// 'deploy_timeout'. Must exceed the longest quiet gap in a healthy deploy —
-// chiefly the master's own self-flash write (no FW_PROGRESS emitted during it).
-// Matches the finalizeTimer magnitude; configurable per-job.
+// between FW_DEPLOY_BEGIN and FW_DEPLOY_DONE before failing with 'deploy_timeout'.
+// Must exceed the longest quiet gap in the deploy phase; per .docs/protocol.md the
+// master's self-flash/commit+reboot happens after FW_DEPLOY_DONE and is covered by the
+// post-DONE finalize/reboot timers (not this watchdog).
 const DEFAULT_DEPLOY_STALL_TIMEOUT_MS = 90_000;
 
 // Discriminated union of every shape the orchestrator broadcasts. Each

--- a/astros_api/src/firmware/flash_orchestrator.ts
+++ b/astros_api/src/firmware/flash_orchestrator.ts
@@ -536,7 +536,7 @@ export class FlashJobOrchestrator {
   // asynchronously through `handleDeployEvent`. Both fields are disposed on
   // every exit path: FW_DEPLOY_DONE drops the subscriber inline; the
   // canonical `releaseLock` helper disposes both idempotently for the
-  // protocol_violation, reboot-timeout, heartbeat, and cancel paths.
+  // protocol_violation, deploy_timeout, reboot-timeout, heartbeat, and cancel paths.
   // A leaked subscriber would route a stale prior job's deploy events into
   // the next job; a leaked throttle would carry per-controller flush timers
   // across jobs.
@@ -634,7 +634,7 @@ export class FlashJobOrchestrator {
    * try/catch maps them to typed `FlashOrchestratorError` and the
    * controller's catch block maps THAT to the right HTTP status code.
    * Background errors (streamer rejection, deploy-begin bus_send_failed,
-   * subscriber_attach_failed) route through `failJob` exactly the same
+   * subscriber_attach_failed, deploy-phase inactivity timeout `deploy_timeout`) route through `failJob` exactly the same
    * way the prior all-sync catch did, but emit on the WS surface only —
    * by the time they fire, HTTP has already responded 200.
    *
@@ -1661,10 +1661,11 @@ export class FlashJobOrchestrator {
     this.releaseLock(jobId);
   }
 
-  // Mid-deploy failure entry — `handleDeployEvent` calls this when FW_PROGRESS
-  // / FW_DEPLOY_DONE wire validation trips `protocol_violation`. The deploy
-  // subscriber fires asynchronously off a serial event so it can't throw out
-  // of an orchestrator try/catch; this wrapper delegates to `failJob`.
+  // Mid-deploy failure entry. Callers: handleDeployProgress / handleDeployDone on
+  // a `protocol_violation` (FW_PROGRESS / FW_DEPLOY_DONE wire-validation failure),
+  // and onDeployStall on a `deploy_timeout` (the inactivity watchdog fired).
+  // Reached either off an async serial event or off the watchdog timer callback —
+  // both run outside an orchestrator try/catch — so this wrapper delegates to failJob.
   private failDeployPhase(reason: FlashOrchestratorErrorReason, detail: string): void {
     if (this.currentJob === null) return;
     this.failJob(this.currentJob.jobId, reason, detail);
@@ -1688,7 +1689,7 @@ export class FlashJobOrchestrator {
   //   3. Emit `flashJobFailed { jobId, reason, detail, endedAt }` (with
   //      `abortReason` mixed in when the bucket-B path supplied one).
   //   4. `releaseLock(jobId)` for canonical teardown — disposes
-  //      subscriber, throttle, reboot timer, AbortController, clears
+  //      subscriber, throttle, reboot/finalize/deploy-stall timers, AbortController, clears
   //      `currentJob`, releases the lock, broadcasts `lockStateChanged`.
   //
   // Idempotent against `currentJob === null`: pre-streamer failures still

--- a/astros_api/src/firmware/flash_orchestrator.ts
+++ b/astros_api/src/firmware/flash_orchestrator.ts
@@ -335,6 +335,12 @@ const DEFAULT_THROTTLE_WINDOW_MS = 250;
 // first poll cycle (~2s) + ~10× safety margin. Per the Phase C firmware
 // design Section 6 cross-repo coordination.
 const DEFAULT_FINALIZE_TIMEOUT_MS = 90_000;
+// Deploy-phase inactivity watchdog: max silence (no FW_PROGRESS/FW_DEPLOY_DONE)
+// between FW_DEPLOY_BEGIN and FW_DEPLOY_DONE before the job is failed with
+// 'deploy_timeout'. Must exceed the longest quiet gap in a healthy deploy —
+// chiefly the master's own self-flash write (no FW_PROGRESS emitted during it).
+// Matches the finalizeTimer magnitude; configurable per-job.
+const DEFAULT_DEPLOY_STALL_TIMEOUT_MS = 90_000;
 
 // Discriminated union of every shape the orchestrator broadcasts. Each
 // `safeEmitWs` call site now structurally matches one arm, so a new event
@@ -419,6 +425,7 @@ export type FlashOrchestratorErrorReason =
   | 'controllers_lookup_failed'
   | 'subscriber_attach_failed'
   | 'protocol_violation'
+  | 'deploy_timeout'
   | 'streamer_unknown_error'
   | TransferErrorCode;
 
@@ -450,7 +457,12 @@ export interface FlashJobOrchestratorOpts {
   // doesn't need to know about the streamer factory.
   streamerFactory?: (opts: { bus: SerialBus }) => Streamer;
   clock?: Clock;
-  config?: { rebootTimeoutMs?: number; throttleWindowMs?: number; finalizeTimeoutMs?: number };
+  config?: {
+    rebootTimeoutMs?: number;
+    throttleWindowMs?: number;
+    finalizeTimeoutMs?: number;
+    deployStallTimeoutMs?: number;
+  };
 }
 
 // Default real-clock + real-streamer factories. Exported test-helper-style so
@@ -514,6 +526,7 @@ export class FlashJobOrchestrator {
   // alongside rebootTimer in releaseLock (covers cancel-during-Finalizing
   // and other teardown paths).
   private readonly finalizeTimeoutMs: number;
+  private readonly deployStallTimeoutMs: number;
 
   private currentJob: FlashJobState | null = null;
   // Deploy-phase resources owned beyond the synchronous span of `start()`.
@@ -541,6 +554,12 @@ export class FlashJobOrchestrator {
   // Failed("post_reboot_timeout") and completes the job. First-fire-wins
   // shared with notifyMasterHeartbeat via the null check at both sites.
   private finalizeTimer: NodeJS.Timeout | null = null;
+  // Deploy-phase inactivity watchdog timer. Armed when the deploy subscriber
+  // attaches; reset on each FW_PROGRESS; disarmed on FW_DEPLOY_DONE (hand-off
+  // to finalize/reboot timers) and in releaseLock. null outside the
+  // FW_DEPLOY_BEGIN→FW_DEPLOY_DONE window. First-fire-wins via the field's
+  // null-ness in onDeployStall.
+  private deployStallTimer: NodeJS.Timeout | null = null;
   // AbortController whose signal threads through `streamer.run`'s `opts.signal`.
   // Created at upload-phase entry, fired by `cancel()` during the upload
   // phase to reject the in-flight `streamer.run()` with TransferError 'aborted'
@@ -592,6 +611,8 @@ export class FlashJobOrchestrator {
     this.rebootTimeoutMs = opts.config?.rebootTimeoutMs ?? DEFAULT_REBOOT_TIMEOUT_MS;
     this.throttleWindowMs = opts.config?.throttleWindowMs ?? DEFAULT_THROTTLE_WINDOW_MS;
     this.finalizeTimeoutMs = opts.config?.finalizeTimeoutMs ?? DEFAULT_FINALIZE_TIMEOUT_MS;
+    this.deployStallTimeoutMs =
+      opts.config?.deployStallTimeoutMs ?? DEFAULT_DEPLOY_STALL_TIMEOUT_MS;
   }
 
   /**

--- a/astros_api/src/firmware/flash_orchestrator.ts
+++ b/astros_api/src/firmware/flash_orchestrator.ts
@@ -1226,6 +1226,8 @@ export class FlashJobOrchestrator {
   private handleDeployEvent(event: FwDeployEvent): void {
     if (this.currentJob === null) return;
     if (event.kind === 'progress') {
+      // Master is alive — reset the inactivity watchdog before processing.
+      this.kickDeployStallTimer();
       this.handleDeployProgress(event.payload);
       return;
     }

--- a/astros_api/src/firmware/integration/flash_deploy_stall.integration.test.ts
+++ b/astros_api/src/firmware/integration/flash_deploy_stall.integration.test.ts
@@ -1,0 +1,145 @@
+// Integration test: deploy-phase inactivity watchdog.
+//
+// Pins the contract: if FW_DEPLOY_BEGIN is sent but the master never emits
+// FW_PROGRESS or FW_DEPLOY_DONE (silent master mid-deploy), the watchdog
+// fires flashJobFailed{reason:'deploy_timeout'} and releases the lock within
+// deployStallTimeoutMs. Without this, a bricked master mid-deploy would hold
+// the JobLock forever and block every subsequent flash attempt.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  bootIntegrationHarness,
+  type IntegrationHarness,
+} from '../../test_harness/integration_harness.js';
+import { TransmissionType } from '../../models/enums.js';
+import { SerialMessageType } from '../../serial/serial_message.js';
+
+const skipIfNotLinux = process.platform !== 'linux' ? it.skip : it;
+
+const MASTER_SENTINEL_MAC = '00:00:00:00:00:00';
+const MASTER_VARIANT = 'astros-controller-v1';
+const PRE_FLASH_FW = '1.0.0';
+const POST_FLASH_FW = '1.5.0';
+// Short watchdog so the test completes in seconds rather than the default 90 s.
+const SHORT_DEPLOY_STALL_TIMEOUT_MS = 3_000;
+
+describe('integration: deploy-stall watchdog (silent master mid-deploy)', () => {
+  let harness: IntegrationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.dispose();
+    harness = undefined;
+  });
+
+  skipIfNotLinux(
+    'no FW_PROGRESS/FW_DEPLOY_DONE after FW_DEPLOY_BEGIN → deploy_timeout → lockStateChanged{locked:false}',
+    async () => {
+      // 1. Boot with a shrunken deploy-stall timeout so the watchdog fires in
+      //    ~3 s instead of the default 90 s. Pattern mirrors the reboot-timer
+      //    fallback test which shrinks rebootTimeoutMs the same way.
+      harness = await bootIntegrationHarness({
+        masterFirmwareVersion: PRE_FLASH_FW,
+        masterVariant: MASTER_VARIANT,
+        masterMac: MASTER_SENTINEL_MAC,
+        flashOrchestratorConfig: { deployStallTimeoutMs: SHORT_DEPLOY_STALL_TIMEOUT_MS },
+      });
+      harness.stub.writePollAck();
+      await harness.waitForVariantCachePopulated(MASTER_SENTINEL_MAC, MASTER_VARIANT);
+
+      // 2. Seed the upload store so the flash reaches the deploy phase.
+      const binBytes = Buffer.alloc(4096, 0x42);
+      await harness.populateUpload({
+        binBytes,
+        originalFilename: 'astros-esp-1.5.0.bin',
+        version: POST_FLASH_FW,
+      });
+
+      // 3. Approach (A) — total deploy silence: configure upload auto-ack so
+      //    the streamer completes and FW_DEPLOY_BEGIN is sent, but do NOT call
+      //    scriptDeploy(). When FW_DEPLOY_BEGIN arrives, the stub's
+      //    dispatchScriptedResponse case sees scriptDeployCfg===null and breaks
+      //    without emitting any FW_PROGRESS or FW_DEPLOY_DONE. The deploy phase
+      //    is silent from the start → watchdog fires after deployStallTimeoutMs.
+      harness.stub.autoAckUpload({});
+      // Deliberately omit harness.stub.scriptDeploy() — deploy silence is the
+      // test vector. The stub emits no deploy events after FW_DEPLOY_BEGIN.
+
+      // 4. POST /api/firmware/flash and confirm the server accepted it.
+      const flashRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${harness.authToken}`,
+        },
+        body: JSON.stringify({
+          source: { kind: 'upload' },
+          controllers: [MASTER_SENTINEL_MAC],
+        }),
+      });
+      expect(flashRes.status).toBe(200);
+      const flashBody = (await flashRes.json()) as { jobId: string };
+      expect(flashBody.jobId).toBeTruthy();
+
+      // 5. Wait for flashJobStarted to confirm the job is in flight, then
+      //    gate on the stub receiving FW_DEPLOY_BEGIN before snapshotting.
+      //    The gate deterministically confirms the deploy phase was entered
+      //    and the watchdog is armed, removing upload-phase duration from
+      //    the timeout budget. The snapshot is taken after the gate so the
+      //    lock-release assertion below skips the connect-time
+      //    lockStateChanged{locked:false} frame and only sees
+      //    watchdog-driven messages.
+      await harness.waitForWsMessage<{ type: number }>(
+        (m) => (m as { type?: unknown }).type === TransmissionType.flashJobStarted,
+        10_000,
+      );
+      await harness.stub.waitForFrame((f) => f.type === SerialMessageType.FW_DEPLOY_BEGIN, 10_000);
+      const snapshot = harness.receivedWsMessages.length;
+
+      // 6. Wait for flashJobFailed{reason:'deploy_timeout'}. The watchdog is
+      //    already armed (FW_DEPLOY_BEGIN confirmed above), so elapsed time
+      //    is only deployStallTimeoutMs + WS delivery lag.
+      //    SHORT_DEPLOY_STALL_TIMEOUT_MS + 5 s is comfortably generous.
+      const failed = await harness.waitForWsMessage<{
+        type: number;
+        data: { reason: string; jobId: string };
+      }>(
+        (m) =>
+          (m as { type?: unknown }).type === TransmissionType.flashJobFailed &&
+          (m as { data?: { reason?: string } }).data?.reason === 'deploy_timeout',
+        SHORT_DEPLOY_STALL_TIMEOUT_MS + 5_000,
+      );
+      expect(failed.data.reason).toBe('deploy_timeout');
+      expect(failed.data.jobId).toBe(flashBody.jobId);
+
+      // 7. Wait for lockStateChanged{locked:false}. The watchdog calls
+      //    failDeployPhase → failJob → releaseLock, which broadcasts the lock
+      //    release in the same synchronous call — it should arrive in the same
+      //    WS batch as or immediately after flashJobFailed. fromIndex=snapshot
+      //    skips the connect-time lockStateChanged{locked:false} snapshot.
+      const lockReleased = await harness.waitForWsMessage<{
+        type: number;
+        locked: boolean;
+      }>(
+        (m) => {
+          const msg = m as { type?: unknown; locked?: unknown };
+          return msg.type === TransmissionType.lockStateChanged && msg.locked === false;
+        },
+        5000,
+        snapshot,
+      );
+      expect(lockReleased.locked).toBe(false);
+
+      // 8. GET /api/firmware/flash → null (lock released, no active job).
+      const getRes = await fetch(`${harness.httpBaseUrl}/api/firmware/flash`, {
+        headers: { authorization: `Bearer ${harness.authToken}` },
+      });
+      expect((await getRes.json()) as unknown).toBeNull();
+
+      // 9. Worker and stub stayed healthy throughout.
+      expect(harness.workerErrors).toEqual([]);
+      expect(harness.stub.parsingErrors()).toEqual([]);
+      expect(harness.pty.unexpectedExits).toEqual([]);
+    },
+    30_000,
+  );
+});

--- a/astros_api/src/test_harness/integration_harness.ts
+++ b/astros_api/src/test_harness/integration_harness.ts
@@ -28,15 +28,19 @@ export interface BootIntegrationHarnessOpts {
    */
   firmwareReleaseFetcher?: typeof fetch;
   /**
-   * Override the FlashJobOrchestrator's reboot-timeout / throttle-window to
-   * keep timer-fallback tests fast. Default reboot timeout is 15000ms;
-   * tests exercising the timer fallback set this to a small value (e.g.
-   * 1000ms) so a wrong-version-heartbeat or no-heartbeat scenario doesn't
-   * burn 15 seconds of wall-clock.
+   * Override the FlashJobOrchestrator's reboot-timeout / throttle-window /
+   * deploy-stall-timeout to keep timer-fallback tests fast. Default reboot
+   * timeout is 15000ms; tests exercising the timer fallback set this to a
+   * small value (e.g. 1000ms) so a wrong-version-heartbeat or no-heartbeat
+   * scenario doesn't burn 15 seconds of wall-clock. Default deploy-stall
+   * timeout is 90000ms; tests exercising the deploy watchdog set this to a
+   * small value (e.g. 3000ms) so total silence in the deploy phase fires
+   * quickly without burning wall-clock.
    */
   flashOrchestratorConfig?: {
     rebootTimeoutMs?: number;
     throttleWindowMs?: number;
+    deployStallTimeoutMs?: number;
   };
 }
 

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -194,7 +194,8 @@
       "aborted": "Flash cancelled. The controllers were not updated.",
       "internal_server_error": "The server hit an unexpected error. Check the server logs and try again.",
       "network_error": "Couldn't reach the server. Check your network connection and try again.",
-      "post_reboot_timeout": "Master controller did not report a matching firmware version within 90 seconds. The flash may have failed; verify the controller and retry."
+      "post_reboot_timeout": "Master controller did not report a matching firmware version within 90 seconds. The flash may have failed; verify the controller and retry.",
+      "deploy_timeout": "The master controller stopped responding during the update (no progress for 90 seconds). The flash was aborted; check the master's power and USB connection, then try again."
     },
     "lock_active": "A firmware update is in progress — write actions are disabled until it completes.",
     "lock_banner": "Firmware update in progress — write actions are disabled across the app.",

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -195,7 +195,7 @@
       "internal_server_error": "The server hit an unexpected error. Check the server logs and try again.",
       "network_error": "Couldn't reach the server. Check your network connection and try again.",
       "post_reboot_timeout": "Master controller did not report a matching firmware version within 90 seconds. The flash may have failed; verify the controller and retry.",
-      "deploy_timeout": "The master controller stopped responding during the update (no progress for 90 seconds). The flash was aborted; check the master's power and USB connection, then try again."
+      "deploy_timeout": "The master controller stopped responding during the update (no deploy progress for an extended period). The flash was aborted; check the master's power and USB connection, then try again."
     },
     "lock_active": "A firmware update is in progress — write actions are disabled until it completes.",
     "lock_banner": "Firmware update in progress — write actions are disabled across the app.",

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -185,9 +185,9 @@ export const FLASH_ERROR_REASONS = [
   // operator's per-row error renders the firmware_view.flash_errors.
   // post_reboot_timeout copy.
   'post_reboot_timeout',
-  // server-emitted when the deploy-phase inactivity watchdog fires
-  // (no FW_PROGRESS from master for 90 s during SENDING/VERIFYING/
-  // REBOOTING). Renders firmware_view.flash_errors.deploy_timeout copy.
+  // Server deploy-phase inactivity watchdog: no deploy events (FW_PROGRESS /
+  // FW_DEPLOY_DONE) from the master for the configured window (default 90s)
+  // anywhere between FW_DEPLOY_BEGIN and FW_DEPLOY_DONE → flashJobFailed.
   'deploy_timeout',
   // Streamer-emitted reasons (mirror of TransferErrorCode in
   // astros_api/src/models/firmware/chunk_streamer.ts). The orchestrator

--- a/astros_vue/src/types/firmware.ts
+++ b/astros_vue/src/types/firmware.ts
@@ -185,6 +185,10 @@ export const FLASH_ERROR_REASONS = [
   // operator's per-row error renders the firmware_view.flash_errors.
   // post_reboot_timeout copy.
   'post_reboot_timeout',
+  // server-emitted when the deploy-phase inactivity watchdog fires
+  // (no FW_PROGRESS from master for 90 s during SENDING/VERIFYING/
+  // REBOOTING). Renders firmware_view.flash_errors.deploy_timeout copy.
+  'deploy_timeout',
   // Streamer-emitted reasons (mirror of TransferErrorCode in
   // astros_api/src/models/firmware/chunk_streamer.ts). The orchestrator
   // routes these onto `flashJobFailed` so the same envelope/locale path

--- a/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
+++ b/astros_vue/src/utils/__tests__/firmwareStageMapping.spec.ts
@@ -5,6 +5,7 @@ import {
   mapServerStageToUiStage,
 } from '../firmwareStageMapping';
 import type { ControllerFlashState, ServerFwStage } from '@/types/firmware';
+import { KNOWN_FLASH_ERROR_REASONS } from '@/types/firmware';
 
 function state(stage: ServerFwStage): ControllerFlashState {
   // The discriminated union requires finalVersion on VERSION_CONFIRMED,
@@ -172,5 +173,9 @@ describe('FlashErrorReason i18n key contract', () => {
     for (const reason of FLASH_ERROR_REASONS) {
       expect(enUS.firmware_view.flash_errors).toHaveProperty(reason);
     }
+  });
+
+  it("recognizes 'deploy_timeout' as a known flash error reason", () => {
+    expect(KNOWN_FLASH_ERROR_REASONS.has('deploy_timeout')).toBe(true);
   });
 });


### PR DESCRIPTION
# Firmware OTA — deploy-phase inactivity watchdog

**`feature/firmware-deploy-watchdog` → `develop`**

## What & why

During an OTA flash, after the server sends `FW_DEPLOY_BEGIN` it waits — with **no timeout** — for the master to drive `FW_PROGRESS`/`FW_DEPLOY_DONE`. The post-`FW_DEPLOY_DONE` reboot/heartbeat wait is covered (`rebootTimer` 15s / `finalizeTimer` 90s), but both arm *inside* `handleDeployDone`, so if `FW_DEPLOY_DONE` never arrives nothing fires. **Confirmed on the bench:** a master that crashed mid-self-flash (an `ota_writer_task` stack overflow, fixed separately in AstrOs.ESP) rebooted into the old image and never sent `FW_DEPLOY_DONE` — the job hung indefinitely, held the `JobLock` (blocking further flashes), and left the UI on "reboot in progress" until a manual `DELETE /api/firmware/flash` or restart.

This adds a bounded, visible failure for that case.

## Approach (inactivity watchdog; FW_DEPLOY_DONE stays the hand-off)

A `deployStallTimer` on `FlashJobOrchestrator`:
- **Armed** when the deploy subscriber attaches (right after `FW_DEPLOY_BEGIN`).
- **Reset** on every `FW_PROGRESS` (in `handleDeployEvent`) — scales with deploy size, tolerates slow boards. **POLL_ACK heartbeats deliberately do NOT reset it** (they never reach `handleDeployEvent`), so a rebooted wrong-version master polling every ~4s can't keep it alive.
- **Disarmed** on `FW_DEPLOY_DONE` (hand-off to the existing finalize/reboot timers) and in `releaseLock` (every teardown path).
- **On timeout** (`deployStallTimeoutMs`, default **90s**, configurable) → `failDeployPhase('deploy_timeout')` → non-terminal controllers → Failed, `flashJobFailed{reason:'deploy_timeout'}`, lock released. The UI shows a `deploy_timeout` banner.

90s is conservative (matches `finalizeTimer`): the master's own self-flash write — the longest healthy quiet gap — happens *after* `FW_DEPLOY_DONE` per `protocol.md`, so it's covered by `finalizeTimer`, not this watchdog; the largest documented *in-phase* gap is the 15s reboot-confirm poll. Too-short would false-fail a working deploy, so the default errs long.

## Key changes

- **Backend (`flash_orchestrator.ts`):** `deployStallTimer` + `kickDeployStallTimer`/`clearDeployStallTimer`/`onDeployStall`; arm/kick/disarm wiring; `'deploy_timeout'` added to `FlashOrchestratorErrorReason` (→504 in the exhaustive `REASON_HTTP_STATUS` map — background-only, for Record exhaustiveness); `DEFAULT_DEPLOY_STALL_TIMEOUT_MS=90_000` + `config.deployStallTimeoutMs`, plumbed through `ApiServerOptions` + the integration harness.
- **Frontend:** `deploy_timeout` added to the `FLASH_ERROR_REASONS` tuple + a banner copy string (mirrors `post_reboot_timeout`).

## Testing

- API **848** + Vue **598** tests pass; `tsc` + lint clean.
- New orchestrator unit tests: fire-after-silence, FW_PROGRESS-resets, FW_DEPLOY_DONE-disarms (with a `getTimerCount` self-guard), cancel-disarms (load-bearing `getTimerCount()===0`), post-fire no-op, and **POLL_ACK-does-not-reset** (the key invariant). Mutation-checked: each fails when its production line is reverted.
- Integration test (`flash_deploy_stall.integration.test.ts`): drives a real flash through the worker to the deploy phase (gated on `FW_DEPLOY_BEGIN`), withholds `FW_DEPLOY_DONE`, and asserts `deploy_timeout` + lock release within a short configured timeout.

## Review

Built via subagent-driven development (per-task spec + code-quality review). Whole-branch pre-push 5-agent review (code/tests/silent-failure/types/comments) returned **no Critical/Important**; findings addressed in the last commit (POLL_ACK regression test, doc-drift fixes, softened banner copy that no longer hardcodes "90 seconds").

## Follow-ups (separate PRs)

- Make `deployStallTimeoutMs` (and `rebootTimeoutMs`) **operator-tunable via env var** in `ApiServer.bootstrap` — today, like the sibling timeouts, it's only injectable in code/tests.
- De-duplicate the 4-way `flashOrchestratorConfig` shape (orchestrator / `ApiServerOptions` / its private field / harness) into one exported type.
- Serial `close`/`error` → fail active job (fast-path for physical unplug) — the timer is the backstop; this would catch a disconnect instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
