### PR TITLE
Remote Config fixes

### DIFF
--- a/.docs/plans/20260530-0751-remote-config-empty-seed-load-fix.md
+++ b/.docs/plans/20260530-0751-remote-config-empty-seed-load-fix.md
@@ -65,6 +65,37 @@ Once the backend sends `'[]'`, the store's existing fresh-seed path seeds one
       nuance, optional `logger.warn`).
 - [x] Commit (`eba28cd`). Push via VS Code after pre-push review.
 
+## Pre-push review (`/pr-review-toolkit:review-pr`, 5 agents)
+
+No Critical/Important *code* defects in the committed fix. Addressed in a
+follow-up commit:
+
+- **Doc-drift from the seed flip** (3 agents): `syncRemoteConfig`'s comment and
+  the `getRemoteConfig` comment both still claimed "migration_0 seeds '{}' on
+  fresh installs" — reworded to "existing installs can hold '{}'; fresh installs
+  now seed '[]'." Dropped the overstated "mirrors syncRemoteConfig" claim (they
+  diverge on corrupt JSON: GET → 200 `'[]'`, sync → 500).
+- **Silent corruption swallow** (silent-failure HIGH): the corrupt-JSON `catch`
+  was empty. A non-JSON value is unreachable by any legitimate write, so it
+  signals real corruption — and the frontend's first-save-overwrites path would
+  erase it permanently with no trace. Added a `logger.warn` breadcrumb on the
+  parse-failure branch ONLY (the benign non-array seed stays silent — no log
+  noise). Mutation-checked: dropping the warn fails the new breadcrumb test.
+- **Dead metadata**: removed the unused `= '{}'` default on
+  `migration_7.test.ts` `simulateLegacySeed` (all callers pass explicit values).
+- **Contract test** (test-analyzer top pick): added `Array.isArray(JSON.parse(...))`
+  assertions on the normalize + passthrough paths so the tests pin the real
+  store contract, not just a literal string.
+
+Deferred (noted, not dropped):
+
+- `getRemoteConfig`'s 500-catch path and `saveRemoteConfig` are untested —
+  **pre-existing** gaps the sibling shares, out of scope for a load-bug fix.
+- Typed choke-point refactor (`repo.getPages(): RemotePage[]`) to collapse the
+  duplicated, slightly-divergent array guards in both controllers into one
+  tested function — type-analyzer flagged as a follow-up, not a blocker. Would
+  also resolve the corrupt-JSON 200-vs-500 divergence.
+
 ## Out of scope / notes
 
 - No `migration_8` to rewrite existing `'{}'` rows — the read-time normalization

--- a/.docs/plans/20260530-0751-remote-config-empty-seed-load-fix.md
+++ b/.docs/plans/20260530-0751-remote-config-empty-seed-load-fix.md
@@ -50,14 +50,20 @@ Once the backend sends `'[]'`, the store's existing fresh-seed path seeds one
 
 ## Tasks
 
-- [ ] Write failing `getRemoteConfig` tests in `remote_config_controller.test.ts`:
+- [x] Write failing `getRemoteConfig` tests in `remote_config_controller.test.ts`:
       `'{}'` seed → `'[]'`; saved array string → passthrough unchanged; no row →
-      `'[]'`; corrupt non-JSON value → `'[]'`. Run red.
-- [ ] Normalize `getRemoteConfig` in `remote_config_controller.ts`. Run green.
-- [ ] Change `migration_0` seed `value: '{}'` → `'[]'`.
-- [ ] Pre-commit: `prettier:write`, `lint:fix`, `build`, full `vitest run`, then
-      `superpowers:requesting-code-review` on the diff. Address Critical/Important.
-- [ ] Commit. (Push via VS Code.)
+      `'[]'`; corrupt non-JSON value → `'[]'`; non-array object → `'[]'`; fresh
+      `'[]'` seed passthrough. Watched 4 fail (RED). Plus a repo test pinning the
+      new seed value (RED: `'{}'` → expected `'[]'`).
+- [x] Normalize `getRemoteConfig` in `remote_config_controller.ts`. All green.
+- [x] Change `migration_0` seed `value: '{}'` → `'[]'`. Decoupled the two
+      seed-dependent controller tests via explicit `saveConfig('{}')` so the
+      `'{}'` defense stays covered after the flip.
+- [x] Pre-commit: `prettier:write`, `lint:fix` (0 errors), `build` (clean), full
+      `vitest run` (67 files / 856 tests pass), then `requesting-code-review` on
+      the diff (no Critical/Important; 2 Minor deferred — `migration_7` comment
+      nuance, optional `logger.warn`).
+- [x] Commit (`eba28cd`). Push via VS Code after pre-push review.
 
 ## Out of scope / notes
 

--- a/.docs/plans/20260530-0751-remote-config-empty-seed-load-fix.md
+++ b/.docs/plans/20260530-0751-remote-config-empty-seed-load-fix.md
@@ -1,0 +1,68 @@
+# Fix: Remote Control config editor fails to load on the `'{}'` seed
+
+**Branch:** `fix/remote-config-empty-seed-load` (off `develop`)
+**Tier:** Light plan (self-contained backend bug fix)
+**Date:** 2026-05-30
+
+## Symptom
+
+The live `/remote` editor (Phase 2d `RemoteControlConfigView`) renders only the
+load-error banner. Console:
+
+```
+Failed to load remote control configuration: Error: No remote control configuration found
+    at Proxy.loadRemoteControl (remoteControl.ts:96:15)
+    at async Promise.all (index 2)
+```
+
+## Root cause (confirmed by full data-flow trace)
+
+`migration_0` seeds the `remote_config` row with `value: '{}'` — an empty
+**object**, not an array. The editor's `getRemoteConfig` controller forwards
+that raw string unmodified. The frontend store `loadRemoteControl` requires a
+JSON **array** (`Array.isArray` guard at `remoteControl.ts:94-96`) and throws on
+anything else, which trips the view's three-load OR-gate → whole editor replaced
+by the error banner.
+
+The sibling firmware endpoint `syncRemoteConfig` already defends against this
+exact `'{}'` seed (controller:37-46, with a comment naming it); `getRemoteConfig`
+was never given the same guard and has **zero test coverage** — the existing
+`remote_config_controller.test.ts` only exercises `syncRemoteConfig`. That gap is
+why this shipped green.
+
+Reproduces on any install where the remote config has never been saved through
+the editor (every *saved* config is `JSON.stringify(array)`, so `'{}'` can only
+be the untouched seed).
+
+## Fix (scope: normalization + seed, no data migration — chosen by owner)
+
+1. **`getRemoteConfig`** normalizes to a guaranteed JSON-array **string**, mirroring
+   `syncRemoteConfig`'s defense: return the stored value only if it parses to an
+   array, else `'[]'`. Also removes the latent `|| {value:'[]'}` object-fallback
+   (which sends an *object* on the empty-row path → would break `JSON.parse`).
+   This fixes existing installs with **no DB migration**.
+2. **`migration_0`** seed `value: '{}'` → `'[]'` so fresh DBs are contract-correct
+   at the source. (Only affects DBs created after the change; existing installs
+   are covered by #1.)
+
+Once the backend sends `'[]'`, the store's existing fresh-seed path seeds one
+`createDefaultPage(0)` with `isDirty=true` — the intended fresh-install UX.
+
+## Tasks
+
+- [ ] Write failing `getRemoteConfig` tests in `remote_config_controller.test.ts`:
+      `'{}'` seed → `'[]'`; saved array string → passthrough unchanged; no row →
+      `'[]'`; corrupt non-JSON value → `'[]'`. Run red.
+- [ ] Normalize `getRemoteConfig` in `remote_config_controller.ts`. Run green.
+- [ ] Change `migration_0` seed `value: '{}'` → `'[]'`.
+- [ ] Pre-commit: `prettier:write`, `lint:fix`, `build`, full `vitest run`, then
+      `superpowers:requesting-code-review` on the diff. Address Critical/Important.
+- [ ] Commit. (Push via VS Code.)
+
+## Out of scope / notes
+
+- No `migration_8` to rewrite existing `'{}'` rows — the read-time normalization
+  makes them load, and the first save overwrites the seed with a real array.
+- Frontend store's hard-fail on non-array is left as-is by design (Phase 2d
+  deliberately blocks editing on a failed load); the contract is enforced
+  server-side where the other consumer (`syncRemoteConfig`) already enforces it.

--- a/astros_api/src/controllers/remote_config_controller.test.ts
+++ b/astros_api/src/controllers/remote_config_controller.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import { Kysely } from 'kysely';
 import { Database } from '../dal/types.js';
 import { createKyselyConnection, migrateToLatest } from '../dal/database.js';
 import { RemoteConfigRepository } from '../dal/repositories/remote_config_repository.js';
 import { syncRemoteConfig, getRemoteConfig } from './remote_config_controller.js';
 import { RemotePage, PageButton } from '../models/remotes/RemotePage.js';
+// Import via the same specifier the controller uses ('src/logger.js'), not the
+// relative '../logger.js'. vitest dedupes modules by resolved specifier, so a
+// mismatch would spy on a different logger instance than the controller calls.
+import { logger } from 'src/logger.js';
 
 function mockRes() {
   const res: any = {};
@@ -117,13 +121,19 @@ describe('remote_config_controller / syncRemoteConfig', () => {
 
 describe('remote_config_controller / getRemoteConfig', () => {
   let db: Kysely<Database>;
+  // Spy on the corruption breadcrumb so tests can assert it fires only on a
+  // genuine parse failure (never on the benign non-array seed), and so the
+  // real pino warn doesn't emit through the transport during the run.
+  let warnSpy: MockInstance;
 
   beforeEach(async () => {
     db = createKyselyConnection().db;
     await migrateToLatest(db);
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation((() => undefined) as never);
   });
 
   afterEach(async () => {
+    warnSpy.mockRestore();
     await db.destroy();
   });
 
@@ -143,6 +153,11 @@ describe('remote_config_controller / getRemoteConfig', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith('[]');
+    // The real contract the store enforces: the response must JSON.parse to an
+    // array, not merely equal a particular string.
+    expect(Array.isArray(JSON.parse(res.json.mock.calls[0][0]))).toBe(true);
+    // A parsed-but-non-array value is a known-benign state — no corruption log.
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('returns "[]" for the fresh-install seed', async () => {
@@ -173,6 +188,8 @@ describe('remote_config_controller / getRemoteConfig', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(stored);
+    // Pin the real contract: a saved config round-trips as a parseable array.
+    expect(Array.isArray(JSON.parse(res.json.mock.calls[0][0]))).toBe(true);
   });
 
   it('falls back to "[]" when no remote_config row exists', async () => {
@@ -190,7 +207,11 @@ describe('remote_config_controller / getRemoteConfig', () => {
     expect(res.json).toHaveBeenCalledWith('[]');
   });
 
-  it('falls back to "[]" when the stored value is not valid JSON', async () => {
+  it('falls back to "[]" and logs a breadcrumb when the stored value is not valid JSON', async () => {
+    // A non-JSON value is unreachable by any legitimate write, so it signals
+    // real corruption — the GET must still serve '[]' (so the editor opens) AND
+    // leave a server-side breadcrumb, since the user's first Save would
+    // otherwise overwrite the bad row and erase the evidence.
     const repo = new RemoteConfigRepository(db);
     await repo.saveConfig('remoteConfig', 'not-json{');
 
@@ -201,6 +222,7 @@ describe('remote_config_controller / getRemoteConfig', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith('[]');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to "[]" when the stored value parses to a non-array object', async () => {

--- a/astros_api/src/controllers/remote_config_controller.test.ts
+++ b/astros_api/src/controllers/remote_config_controller.test.ts
@@ -3,7 +3,7 @@ import { Kysely } from 'kysely';
 import { Database } from '../dal/types.js';
 import { createKyselyConnection, migrateToLatest } from '../dal/database.js';
 import { RemoteConfigRepository } from '../dal/repositories/remote_config_repository.js';
-import { syncRemoteConfig } from './remote_config_controller.js';
+import { syncRemoteConfig, getRemoteConfig } from './remote_config_controller.js';
 import { RemotePage, PageButton } from '../models/remotes/RemotePage.js';
 
 function mockRes() {
@@ -25,11 +25,14 @@ describe('remote_config_controller / syncRemoteConfig', () => {
     await db.destroy();
   });
 
-  it('returns { pages: [] } for the fresh-install seed shape "{}"', async () => {
-    // migration_0 seeds remote_config with value '{}' (an object, not an
-    // array). Before the Array.isArray guard, JSON.parse('{}') flowed past
-    // the `length === 0` check and val.forEach threw a TypeError → 500.
-    // This pins the defensive guard: the seed shape must not 500.
+  it('returns { pages: [] } for a stored "{}" object value', async () => {
+    // Existing installs (and the pre-fix migration_0 seed) hold value '{}' — an
+    // object, not an array. Before the Array.isArray guard, JSON.parse('{}')
+    // flowed past the `length === 0` check and val.forEach threw a TypeError →
+    // 500. Save '{}' explicitly so this pins the guard regardless of the seed.
+    const repo = new RemoteConfigRepository(db);
+    await repo.saveConfig('remoteConfig', '{}');
+
     const req: any = {};
     const res = mockRes();
 
@@ -76,10 +79,10 @@ describe('remote_config_controller / syncRemoteConfig', () => {
     });
   });
 
-  it('returns { pages: [] } when the stored value is the legacy "[]" empty-array shape', async () => {
-    // Operators who manually clear the config (or saved empty in an earlier
-    // version) end up with '[]'. JSON.parse('[]') is an empty array, so the
-    // length === 0 short-circuit fires correctly.
+  it('returns { pages: [] } when the stored value is the "[]" empty-array shape', async () => {
+    // The fresh-install seed (post-fix) and operators who clear the config both
+    // produce '[]'. JSON.parse('[]') is an empty array, so the length === 0
+    // short-circuit fires correctly.
     const repo = new RemoteConfigRepository(db);
     await repo.saveConfig('remoteConfig', '[]');
 
@@ -109,5 +112,108 @@ describe('remote_config_controller / syncRemoteConfig', () => {
     const response = res.json.mock.calls[0][0];
     expect(response.pages).toHaveLength(1);
     expect(response.pages[0][0]).toEqual({ name: 'Test Script', command: 'script-xyz' });
+  });
+});
+
+describe('remote_config_controller / getRemoteConfig', () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = createKyselyConnection().db;
+    await migrateToLatest(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('normalizes a stored "{}" object value to an empty-array string', async () => {
+    // Existing installs (and the pre-fix migration_0 seed) hold value '{}' — an
+    // object. The editor store JSON.parses the response and hard-fails unless it
+    // is an array, so the GET must hand back '[]', never the raw object. This is
+    // the bug that took the whole /remote editor down to the load-error banner.
+    // Save '{}' explicitly so this pins the guard regardless of the seed.
+    const repo = new RemoteConfigRepository(db);
+    await repo.saveConfig('remoteConfig', '{}');
+
+    const req: any = {};
+    const res = mockRes();
+
+    await getRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith('[]');
+  });
+
+  it('returns "[]" for the fresh-install seed', async () => {
+    // Post-fix, migration_0 seeds '[]' directly, so the untouched seed flows
+    // through as a valid empty-array string with no normalization needed.
+    const req: any = {};
+    const res = mockRes();
+
+    await getRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith('[]');
+  });
+
+  it('returns a saved array-config string unchanged', async () => {
+    // The happy path: a real saved config (always JSON.stringify(array)) must
+    // pass through verbatim so the store gets the user's actual pages.
+    const repo = new RemoteConfigRepository(db);
+    const page = new RemotePage('page-uuid', 'Quick Actions');
+    page.button1 = new PageButton('script-1', 'Beep');
+    const stored = JSON.stringify([page]);
+    await repo.saveConfig('remoteConfig', stored);
+
+    const req: any = {};
+    const res = mockRes();
+
+    await getRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(stored);
+  });
+
+  it('falls back to "[]" when no remote_config row exists', async () => {
+    // Pins the empty-row path. The prior `|| { value: '[]' }` fallback sent an
+    // OBJECT, which the store's JSON.parse(response) cannot handle (it would
+    // stringify-coerce to "[object Object]" and throw).
+    await db.deleteFrom('remote_config').execute();
+
+    const req: any = {};
+    const res = mockRes();
+
+    await getRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith('[]');
+  });
+
+  it('falls back to "[]" when the stored value is not valid JSON', async () => {
+    const repo = new RemoteConfigRepository(db);
+    await repo.saveConfig('remoteConfig', 'not-json{');
+
+    const req: any = {};
+    const res = mockRes();
+
+    await getRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith('[]');
+  });
+
+  it('falls back to "[]" when the stored value parses to a non-array object', async () => {
+    // Belt-and-suspenders for any legacy object-shaped value beyond the seed.
+    const repo = new RemoteConfigRepository(db);
+    await repo.saveConfig('remoteConfig', '{"foo":"bar"}');
+
+    const req: any = {};
+    const res = mockRes();
+
+    await getRemoteConfig(db, req, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith('[]');
   });
 });

--- a/astros_api/src/controllers/remote_config_controller.ts
+++ b/astros_api/src/controllers/remote_config_controller.ts
@@ -72,14 +72,30 @@ export async function syncRemoteConfig(db: Kysely<Database>, req: any, res: any,
   }
 }
 
-async function getRemoteConfig(db: Kysely<Database>, req: any, res: any, next: any) {
+export async function getRemoteConfig(db: Kysely<Database>, req: any, res: any, next: any) {
   try {
     const repo = new RemoteConfigRepository(db);
 
-    const scripts = await repo.getConfig('remoteConfig');
+    const stored = (await repo.getConfig('remoteConfig'))?.value;
+
+    // The editor store JSON.parses this response and hard-fails unless the
+    // result is a pages array. The column is free-form JSON and migration_0
+    // seeds it with '{}' (an object) on fresh installs, so normalize anything
+    // that is not an array to the empty-array string '[]'. Mirrors the same
+    // defensive guard in syncRemoteConfig.
+    let value = '[]';
+    if (stored) {
+      try {
+        if (Array.isArray(JSON.parse(stored))) {
+          value = stored;
+        }
+      } catch {
+        // Corrupt JSON in the column — fall through to '[]'.
+      }
+    }
 
     res.status(200);
-    res.json(scripts?.value || { value: '[]' });
+    res.json(value);
   } catch (error) {
     logger.error(error);
 

--- a/astros_api/src/controllers/remote_config_controller.ts
+++ b/astros_api/src/controllers/remote_config_controller.ts
@@ -36,9 +36,10 @@ export async function syncRemoteConfig(db: Kysely<Database>, req: any, res: any,
 
     const val = JSON.parse(scripts?.value || '[]') as Array<RemotePage>;
 
-    // Defensive: migration_0 seeds the row with value '{}' (an object, not
-    // an array) on fresh installs. Until a user saves their first config,
-    // val is the parsed object and val.forEach below would throw.
+    // Defensive: existing installs can hold value '{}' — an object, not an
+    // array (the pre-fix migration_0 seed; fresh installs now seed '[]').
+    // Until such a row is overwritten by a save, val is the parsed object and
+    // val.forEach below would throw, so treat any non-array as empty.
     if (!Array.isArray(val) || val.length === 0) {
       res.status(200);
       res.json({ pages: [] } as RemoteScriptList);
@@ -79,18 +80,32 @@ export async function getRemoteConfig(db: Kysely<Database>, req: any, res: any, 
     const stored = (await repo.getConfig('remoteConfig'))?.value;
 
     // The editor store JSON.parses this response and hard-fails unless the
-    // result is a pages array. The column is free-form JSON and migration_0
-    // seeds it with '{}' (an object) on fresh installs, so normalize anything
-    // that is not an array to the empty-array string '[]'. Mirrors the same
-    // defensive guard in syncRemoteConfig.
+    // result is a pages array, so normalize anything that is not an array to
+    // the empty-array string '[]'. The column is free-form JSON; existing
+    // installs can still hold the legacy '{}' object seed (fresh installs now
+    // seed '[]'). This applies the same non-array→empty intent as
+    // syncRemoteConfig, but unlike that path — which lets a JSON.parse failure
+    // reach the outer catch and 500 — the editor must not hard-fail on a
+    // corrupt value (a thrown load collapses the whole 3-pane view to an error
+    // banner), so it degrades to '[]'.
     let value = '[]';
     if (stored) {
       try {
         if (Array.isArray(JSON.parse(stored))) {
           value = stored;
         }
-      } catch {
-        // Corrupt JSON in the column — fall through to '[]'.
+        // A parsed-but-non-array value (e.g. the legacy '{}' object seed) is a
+        // known-benign state — normalize silently to '[]'.
+      } catch (error) {
+        // A non-JSON value is unreachable by any legitimate write (every save
+        // is JSON.stringify of a pages array), so it signals real corruption
+        // or external tampering. Leave a breadcrumb before serving '[]': the
+        // user's first Save would otherwise overwrite the bad row with the
+        // empty default and erase the evidence permanently.
+        logger.warn(
+          { err: error, type: 'remoteConfig' },
+          'Corrupt remote_config value; serving empty array',
+        );
       }
     }
 

--- a/astros_api/src/dal/migrations/migration_0.ts
+++ b/astros_api/src/dal/migrations/migration_0.ts
@@ -186,7 +186,10 @@ export const migration_0: Migration = {
 
     const remoteConfig = <NewRemoteConfig>{
       type: 'remoteConfig',
-      value: '{}',
+      // Empty pages array — the remote-config consumers (editor GET + M5 sync)
+      // expect a JSON array. Seeding '{}' (an object) here historically forced
+      // both to normalize on read; '[]' is correct at the source.
+      value: '[]',
     };
 
     await db.insertInto('remote_config').values(remoteConfig).execute();

--- a/astros_api/src/dal/migrations/migration_7.test.ts
+++ b/astros_api/src/dal/migrations/migration_7.test.ts
@@ -79,8 +79,9 @@ describe('migration_7: rename remote_config.type astrOsScreen → remoteConfig',
   }
 
   // Mutate the seeded remoteConfig row back to astrOsScreen to simulate an
-  // existing v6 install (whose original migration_0 seeded with the old key).
-  async function simulateLegacySeed(value = '{}'): Promise<void> {
+  // existing v6 install (whose original migration_0 seeded with the old
+  // `astrOsScreen` key). Callers pass the legacy `value` explicitly.
+  async function simulateLegacySeed(value: string): Promise<void> {
     await db
       .updateTable('remote_config')
       .set({ type: 'astrOsScreen', value })

--- a/astros_api/src/dal/repositories/remote_config_repository.test.ts
+++ b/astros_api/src/dal/repositories/remote_config_repository.test.ts
@@ -44,4 +44,16 @@ describe('RemoteConfigRepository', () => {
 
     expect(result).toBeUndefined();
   });
+
+  it('seeds the remoteConfig row with an empty-array string on a fresh install', async () => {
+    // migration_0 seeds value '[]' (a pages array), not the legacy '{}' object.
+    // The editor's load path expects an array, so seeding '[]' keeps a fresh
+    // install correct at the source rather than relying solely on the
+    // read-time normalization in getRemoteConfig.
+    const repo = new RemoteConfigRepository(db);
+
+    const result = await repo.getConfig('remoteConfig');
+
+    expect(result?.value).toBe('[]');
+  });
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -27,9 +27,12 @@ const isAssigned = computed(() => props.value.type !== 'none');
 const typeChipClasses = computed(() => {
   switch (props.value.type) {
     case 'playlist':
-      return 'bg-orange-500/15 text-orange-700 border border-orange-500/40';
+      // Matches the mobile-remote playlist chip: --mr-complement (#f49446) bg +
+      // black text. `bg-r2-complement` forces that exact pair via styles.css.
+      return 'bg-r2-complement';
     case 'script':
-      return 'bg-primary/15 text-primary border border-primary/40';
+      // Matches the mobile-remote filled button: --mr-primary (#2a5a97) + white.
+      return 'bg-primary text-white';
     case 'none':
       return '';
     default:
@@ -119,11 +122,11 @@ onScopeDispose(() => {
 <template>
   <div
     ref="cardRef"
-    class="astros-remote-button-card flex min-h-32 flex-col gap-2 rounded-xl border-2 p-3 transition-colors"
+    class="astros-remote-button-card flex min-h-32 flex-col gap-2 rounded-xl p-3 transition-colors"
     :class="
       isAssigned
-        ? 'border-primary bg-primary/5'
-        : 'border-base-300 bg-base-100 hover:border-base-content/30'
+        ? 'bg-r2-xlight'
+        : 'border-2 border-base-300 bg-base-100 hover:border-base-content/30'
     "
   >
     <div
@@ -146,7 +149,7 @@ onScopeDispose(() => {
       <div class="flex gap-2">
         <button
           type="button"
-          class="btn btn-sm btn-outline flex-1"
+          class="btn btn-sm btn-primary flex-1"
           data-testid="card-edit"
           @click="openEditor"
         >
@@ -154,7 +157,7 @@ onScopeDispose(() => {
         </button>
         <button
           type="button"
-          class="btn btn-sm btn-ghost flex-1"
+          class="btn btn-sm btn-primary flex-1"
           data-testid="card-clear"
           @click="clearAssignment"
         >

--- a/astros_vue/src/components/remoteControl/remotePageList/AstrosRemotePageList.spec.ts
+++ b/astros_vue/src/components/remoteControl/remotePageList/AstrosRemotePageList.spec.ts
@@ -194,7 +194,7 @@ describe('AstrosRemotePageList — mini 3x3 preview', () => {
     });
     const dots = wrapper.findAll('[data-testid="page-list-dot"]');
     expect(dots[0]!.classes()).toContain('bg-primary'); // script
-    expect(dots[4]!.classes()).toContain('bg-orange-500'); // playlist
+    expect(dots[4]!.classes()).toContain('bg-r2-complement'); // playlist
     expect(dots[1]!.classes()).toContain('bg-base-300'); // none
   });
 });

--- a/astros_vue/src/components/remoteControl/remotePageList/AstrosRemotePageList.vue
+++ b/astros_vue/src/components/remoteControl/remotePageList/AstrosRemotePageList.vue
@@ -93,9 +93,7 @@ function dotClass(type: PageButton['type']): string {
 
 <template>
   <div class="astros-remote-page-list flex h-full w-full flex-col">
-    <header
-      class="sticky top-0 z-10 flex items-center justify-between bg-primary px-3 py-2"
-    >
+    <header class="sticky top-0 z-10 flex items-center justify-between bg-primary px-3 py-2">
       <span class="text-[13px] font-bold uppercase tracking-[0.1em] text-white">
         {{ t('remote_control_config.pageList.header') }}
       </span>

--- a/astros_vue/src/components/remoteControl/remotePageList/AstrosRemotePageList.vue
+++ b/astros_vue/src/components/remoteControl/remotePageList/AstrosRemotePageList.vue
@@ -82,7 +82,7 @@ function dotClass(type: PageButton['type']): string {
     case 'script':
       return 'bg-primary';
     case 'playlist':
-      return 'bg-orange-500';
+      return 'bg-r2-complement';
     case 'none':
       return 'bg-base-300';
     default:
@@ -94,14 +94,14 @@ function dotClass(type: PageButton['type']): string {
 <template>
   <div class="astros-remote-page-list flex h-full w-full flex-col">
     <header
-      class="sticky top-0 z-10 flex items-center justify-between border-b border-base-300 bg-base-200 px-3 py-2"
+      class="sticky top-0 z-10 flex items-center justify-between bg-primary px-3 py-2"
     >
-      <span class="text-[11px] font-bold uppercase tracking-[0.1em] text-base-content/60">
+      <span class="text-[13px] font-bold uppercase tracking-[0.1em] text-white">
         {{ t('remote_control_config.pageList.header') }}
       </span>
       <button
         type="button"
-        class="btn btn-ghost btn-xs btn-square text-primary"
+        class="btn btn-ghost btn-sm btn-square text-xl leading-none text-white"
         :aria-label="t('remote_control_config.pageList.add')"
         :title="t('remote_control_config.pageList.add')"
         data-testid="page-list-add"
@@ -128,9 +128,7 @@ function dotClass(type: PageButton['type']): string {
         :aria-selected="idx === selectedIdx ? 'true' : 'false'"
         :class="[
           'flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5',
-          idx === selectedIdx
-            ? 'border border-primary/30 bg-primary/10'
-            : 'border border-transparent hover:bg-base-200',
+          idx === selectedIdx ? 'bg-r2-xlight' : 'hover:bg-base-200',
         ]"
         data-testid="page-list-row"
         @click="emit('select', idx)"
@@ -144,7 +142,7 @@ function dotClass(type: PageButton['type']): string {
           <span
             v-for="key in BUTTON_KEYS"
             :key="key"
-            :class="['block h-1.5 w-1.5 rounded-sm', dotClass(page[key].type)]"
+            :class="['block h-2 w-2 rounded-sm', dotClass(page[key].type)]"
             :data-type="page[key].type"
             data-testid="page-list-dot"
           />
@@ -154,7 +152,7 @@ function dotClass(type: PageButton['type']): string {
           :ref="captureRenameInput"
           v-model="renameDraft"
           type="text"
-          class="input input-bordered input-xs min-w-0 flex-1 text-xs"
+          class="input input-bordered input-sm min-w-0 flex-1 text-sm"
           :aria-label="t('remote_control_config.pageList.renameInput')"
           data-testid="page-list-rename-input"
           @click.stop
@@ -165,7 +163,7 @@ function dotClass(type: PageButton['type']): string {
         <span
           v-else
           :class="[
-            'min-w-0 flex-1 truncate text-xs',
+            'min-w-0 flex-1 truncate text-sm',
             idx === selectedIdx ? 'font-semibold' : 'font-medium',
           ]"
           :title="page.name"
@@ -176,7 +174,7 @@ function dotClass(type: PageButton['type']): string {
         <div class="flex flex-shrink-0 items-center gap-px">
           <button
             type="button"
-            class="btn btn-ghost btn-xs btn-square text-base-content/60"
+            class="btn btn-ghost btn-sm btn-square text-base-content/60"
             :aria-label="t('remote_control_config.pageList.rename')"
             :title="t('remote_control_config.pageList.rename')"
             data-testid="page-list-rename"
@@ -184,12 +182,12 @@ function dotClass(type: PageButton['type']): string {
           >
             <v-icon
               name="io-create"
-              scale="0.7"
+              scale="0.9"
             />
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-xs btn-square text-base-content/60"
+            class="btn btn-ghost btn-sm btn-square text-base-content/60"
             :aria-label="t('remote_control_config.pageList.duplicate')"
             :title="t('remote_control_config.pageList.duplicate')"
             data-testid="page-list-duplicate"
@@ -197,12 +195,12 @@ function dotClass(type: PageButton['type']): string {
           >
             <v-icon
               name="io-copy"
-              scale="0.7"
+              scale="0.9"
             />
           </button>
           <button
             type="button"
-            class="btn btn-ghost btn-xs btn-square text-base-content/60"
+            class="btn btn-ghost btn-sm btn-square text-base-content/60"
             :aria-label="t('remote_control_config.pageList.delete')"
             :title="t('remote_control_config.pageList.delete')"
             :disabled="pages.length <= 1"
@@ -211,7 +209,7 @@ function dotClass(type: PageButton['type']): string {
           >
             <v-icon
               name="io-trash-bin"
-              scale="0.7"
+              scale="0.9"
             />
           </button>
         </div>

--- a/astros_vue/src/views/RemoteControlConfigView.vue
+++ b/astros_vue/src/views/RemoteControlConfigView.vue
@@ -238,7 +238,7 @@ const pageCount = computed(() => remoteControlPages.value.length);
         >
           <!-- Left: page list -->
           <aside
-            class="flex flex-col w-[220px] border-r border-base-300"
+            class="flex flex-col w-[260px] border-r border-base-300"
             data-testid="pane-page-list"
           >
             <AstrosRemotePageList
@@ -254,13 +254,13 @@ const pageCount = computed(() => remoteControlPages.value.length);
 
           <!-- Center: 3x3 grid (capped at 540px wide) -->
           <main
-            class="flex-1 overflow-auto p-6"
+            class="flex-1 min-w-0 overflow-auto p-6"
             data-testid="pane-grid"
           >
             <div
               v-if="currentPage"
               class="grid grid-cols-3 gap-4 mx-auto"
-              style="max-width: 540px"
+              style="min-width: 500px; max-width: 540px"
             >
               <AstrosRemoteButtonCard
                 v-for="(key, i) in BUTTON_KEYS"


### PR DESCRIPTION
# Remote Control — fix editor load on the `'{}'` seed + theme-align the UI

**`fix/remote-config-empty-seed-load` → `develop`**

Two related pieces on the now-live `/remote` editor (the Phase 2d `RemoteControlConfigView`): a **bug fix** that makes the editor load at all, and a **visual pass** so it stops looking disjoint from the rest of the app.

## Part 1 — Bug fix: editor only showed its load-error banner

### What & why

On any install where the remote config had never been saved, `/remote` rendered **only the load-error banner** — the editor never mounted. Console:

```
Failed to load remote control configuration: Error: No remote control configuration found
    at Proxy.loadRemoteControl (remoteControl.ts:96)
    at async Promise.all (index 2)
```

**Root cause (full data-flow trace):** `migration_0` seeds the `remote_config` row with `value: '{}'` — an empty *object*, not an array. The editor's `getRemoteConfig` controller forwarded that raw; the frontend store's `loadRemoteControl` `JSON.parse`s the response and throws unless it's an **array** (`Array.isArray` guard), which fails the third leg of the view's three-load `Promise.all` OR-gate and replaces the whole editor with the banner. The sibling firmware endpoint `syncRemoteConfig` *already* guarded this exact `'{}'` seed; the editor GET never did, and had **zero test coverage** — so it shipped green.

### Approach

Mirror the guard `syncRemoteConfig` already has, and fix the seed at the source (owner-chosen scope: normalization + seed, **no data migration**):

- **`getRemoteConfig`** normalizes any non-array stored value to the string `'[]'`. Fixes existing installs on read — **no migration needed**. Also removes a latent `|| { value: '[]' }` object-fallback that would have sent an *object* on the empty-row path (which the store's `JSON.parse` can't handle).
- **`migration_0`** seed `'{}'` → `'[]'` so fresh DBs are contract-correct at the source.
- Once the backend returns `'[]'`, the store's existing fresh-seed path seeds one default page (`isDirty=true`) — the intended fresh-install UX.

### Key changes

- **`remote_config_controller.ts`:** `getRemoteConfig` array-normalization; `logger.warn` breadcrumb on the corrupt-JSON `catch` **only** (a non-JSON value can't come from any legitimate write — every save is `JSON.stringify(array)` — so it signals real corruption the operator should see before the user's first Save overwrites it; the benign non-array seed stays silent). Exported for testability.
- **`migration_0.ts`:** seed `'[]'`.
- **Tests:** 6 new `getRemoteConfig` cases (it had none) + a repo seed-value test; two seed-dependent tests decoupled via explicit `saveConfig('{}')` so the `'{}'` defense survives the seed flip; `Array.isArray(JSON.parse(...))` assertions pin the *real* store contract (not just a literal string); breadcrumb fires on corrupt JSON, not on the benign seed.

## Part 2 — Visual pass: theme-align + flatten the editor

### What & why

The page used color/treatments that appear nowhere else in the app: a hardcoded Tailwind `orange-500/700` for `playlist` (a *different* orange than the app's brand `r2-complement` #f49446 used on the header), `border-2` colored borders on configured cards, and `bg-primary/5` background tints — none of which the rest of the app does. The rest of the app uses thin neutral borders, plain fills, and the brand palette (primary blue #2a5a97 + `r2-complement` orange).

### Key changes (`AstrosRemoteButtonCard.vue`, `AstrosRemotePageList.vue`, `RemoteControlConfigView.vue`)

- **Colors → brand tokens, matching the live mobile remote:** `script` = primary blue (#2a5a97), `playlist` = `r2-complement` (#f49446) — applied to both the card type chips and the page-list mini-preview dots, replacing the off-brand `orange-500/700`.
- **Configured card + selected page row** → `bg-r2-xlight` (the Modules-page container color); colored `border-2` / `bg-primary` tints dropped.
- **Card Edit + Clear buttons and the whole PAGES header bar** → brand blue (`btn-primary` / `bg-primary`) with white text.
- **Flatter:** colored borders removed from the configured card and the selected row.
- **Legibility / layout:** larger PAGES label + add button, larger page-name font, row icon-buttons `btn-xs` → `btn-sm`, larger preview dots; page-list pane `220px` → `260px`; center grid gets `min-width: 500px` + `min-w-0` on the pane so cards keep a usable size and the pane **scrolls horizontally** on narrow screens instead of squishing the button text out of the cards.

## Testing

- **Backend:** 856 API tests pass; `tsc` build + lint clean. New tests written RED-first; the corruption breadcrumb is mutation-verified (revert the `logger.warn` → the breadcrumb test fails).
- **Frontend:** 80 tests across the three affected specs pass (`AstrosRemoteButtonCard`, `AstrosRemotePageList`, `RemoteControlConfigView`); `vue-tsc` + `vite build` + lint clean.

## Review

- **Backend** went through the per-commit reviewer plus the full 5-agent pre-push review (code / tests / silent-failure / types / comments) — **no Critical/Important**. Findings cleared: the corruption-breadcrumb silent-failure, doc-drift left by the seed flip (three comments still claimed the seed was `'{}'`), a dead `= '{}'` default in `migration_7.test.ts`, and the literal-string-vs-array contract assertions.
- **Frontend** part is visual-only (class/color/size swaps, no logic) and post-dates that review run.

## Follow-ups / notes

- **Live verification:** the seed-load fix proves out on a **rebuilt + restarted API** — no DB wipe needed (read-time normalization covers the existing `'{}'` row). Reload `/remote` → one blank "Page 1", no banner.
- **Deferred (recorded in the plan):** `getRemoteConfig`'s 500-catch path and `saveRemoteConfig` are untested — **pre-existing** gaps the sibling shares, out of scope here. A typed `repo.getPages(): RemotePage[]` choke-point would collapse the duplicated array guards in `getRemoteConfig` + `syncRemoteConfig` into one tested function and resolve their corrupt-JSON divergence (GET degrades to `'[]'` with 200; sync 500s) — flagged by the type reviewer as a follow-up, not a blocker.
- **App-wide `!important` theme overrides** (`.bg-primary`, `.btn-primary`, `.bg-r2-complement` in `styles.css`) were left untouched — explicitly out of scope for this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
