### PR TITLE
Feature/remote button editor modal

### DIFF
--- a/.docs/plans/20260530-1411-remote-button-editor-modal.md
+++ b/.docs/plans/20260530-1411-remote-button-editor-modal.md
@@ -29,25 +29,30 @@ modal-open">` form modals in `components/modals/{domain}/`).
 
 ## Tasks
 
-- [ ] Create `components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue`
+- [x] Create `components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue`
       (dialog shell wrapping `AstrosRemoteButtonEditor`; forwards `change`,
-      emits `close` on backdrop/×/Escape). Export from the modals barrel.
-- [ ] Modal spec: renders editor content; forwards `change` on item-select;
-      `close` on backdrop click, on editor `×`, and on Escape. (Mutation-check
-      the close paths.)
-- [ ] Strip `AstrosRemoteButtonCard.vue`: remove floating-ui / Teleport /
-      click-outside / editor import / open-close-handleChange; emit `edit`;
-      keep `change` for Clear. Update card spec (drop the popover-host block;
-      add `edit`-emit + `change(none)`-on-Clear coverage).
-- [ ] Wire `RemoteControlConfigView.vue`: `editingButtonKey` state, render the
-      modal singleton, `onEditRequested(key)` / `onEditorChange(v)` (→
-      `setButton(selectedIdx, editingButtonKey, v)` + close) / close. Update
-      view spec (card `edit` opens modal; modal `change` → `setButton`; close
-      clears state).
-- [ ] Remove `@floating-ui/vue` from `package.json` + lockfile; confirm no
-      remaining imports.
-- [ ] Pre-commit gate: `lint`, `build` (vue-tsc + vite build), affected specs
-      (modal / card / view / editor) green. Commit.
+      emits `close` on backdrop/×/Escape). Exported from the modals barrel
+      (`remoteControl/index.ts` re-exported by `modals/index.ts`).
+- [x] Modal spec (5 cases): renders editor in the dialog shell; forwards
+      `change` on item-select; `close` on backdrop click, editor `×`, and Escape.
+- [x] Stripped `AstrosRemoteButtonCard.vue` to presentational: removed
+      floating-ui / Teleport / click-outside / editor import / open-close
+      plumbing AND the `buttonNumber`/`scripts`/`playlists` props; emits `edit`
+      + `change` (Clear). Card spec slimmed; stories fixed.
+- [x] Wired `RemoteControlConfigView.vue`: `editingButtonKey` +
+      `editingButtonValue`/`editingButtonNumber` computeds, singleton modal
+      `v-if`, `onEditRequested`/`onEditorChange`(→`setButton`+close)/
+      `onEditorClose`. View spec gained editor-modal-wiring tests + stub.
+- [x] Removed `@floating-ui/vue` (package.json + lockfile); zero `src/` imports.
+- [x] Gate: lint clean, `vue-tsc`+`vite build` clean, full suite 613 pass.
+      Pre-commit review: no Critical/Important.
+
+## Review note (recorded decision)
+
+The old popover captured + restored keyboard focus to the trigger on close; the
+modal does not. This is **intentional** — it matches every other modal in the
+app (`AstrosServoEventModal` et al.), which was the goal of this refactor. Flag
+for the pending a11y pass; not a regression vs. the app's convention.
 
 ## Notes
 

--- a/.docs/plans/20260530-1411-remote-button-editor-modal.md
+++ b/.docs/plans/20260530-1411-remote-button-editor-modal.md
@@ -1,0 +1,59 @@
+# Refactor: button editor popover → view-owned modal (singleton)
+
+**Branch:** `feature/remote-button-editor-modal` (off `develop`)
+**Tier:** Light plan (UI refactor, single layer)
+**Date:** 2026-05-30
+
+## Goal
+
+Replace the floating-ui popover that hosts `AstrosRemoteButtonEditor` (one per
+button card) with a **single view-owned modal**, matching the app's existing
+pattern (ScripterView's `showModal` + self-contained `<dialog class="modal
+modal-open">` form modals in `components/modals/{domain}/`).
+
+## Design (approved 2026-05-30)
+
+- **View owns it.** `RemoteControlConfigView` gets `editingButtonKey =
+  ref<ButtonKey | null>(null)`; renders ONE editor modal when non-null.
+- **New `AstrosRemoteButtonEditorModal.vue`** (`components/modals/remoteControl/`):
+  `<dialog class="modal modal-open"> → modal-box → modal-backdrop` shell wrapping
+  the **unchanged** `AstrosRemoteButtonEditor` content. Props: `buttonNumber`,
+  `currentValue`, `scripts`, `playlists`. Emits: `change`, `close`. Backdrop
+  click + the editor's existing `×`/Escape all close.
+- **Card sheds the popover.** `AstrosRemoteButtonCard` drops `@floating-ui/vue`,
+  `<Teleport>`, the capture-phase click-outside listener + its lifecycle, the
+  editor import, and the open/close/handleChange plumbing. It emits `edit`
+  (open) and keeps `change` (the direct Clear action).
+- **Remove `@floating-ui/vue`** from `package.json` (this card was its only
+  consumer).
+
+## Tasks
+
+- [ ] Create `components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue`
+      (dialog shell wrapping `AstrosRemoteButtonEditor`; forwards `change`,
+      emits `close` on backdrop/×/Escape). Export from the modals barrel.
+- [ ] Modal spec: renders editor content; forwards `change` on item-select;
+      `close` on backdrop click, on editor `×`, and on Escape. (Mutation-check
+      the close paths.)
+- [ ] Strip `AstrosRemoteButtonCard.vue`: remove floating-ui / Teleport /
+      click-outside / editor import / open-close-handleChange; emit `edit`;
+      keep `change` for Clear. Update card spec (drop the popover-host block;
+      add `edit`-emit + `change(none)`-on-Clear coverage).
+- [ ] Wire `RemoteControlConfigView.vue`: `editingButtonKey` state, render the
+      modal singleton, `onEditRequested(key)` / `onEditorChange(v)` (→
+      `setButton(selectedIdx, editingButtonKey, v)` + close) / close. Update
+      view spec (card `edit` opens modal; modal `change` → `setButton`; close
+      clears state).
+- [ ] Remove `@floating-ui/vue` from `package.json` + lockfile; confirm no
+      remaining imports.
+- [ ] Pre-commit gate: `lint`, `build` (vue-tsc + vite build), affected specs
+      (modal / card / view / editor) green. Commit.
+
+## Notes
+
+- `AstrosRemoteButtonEditor` content + its 32 tests stay **unchanged** — only
+  the shell around it changes (popover → modal).
+- Emit is `change` (not `save`): selecting a list item is the immediate action;
+  there's no separate Save button. The view does `setButton` + close on change.
+- TDD exception (UI rendering) applies to layout, but the emit/close **contract**
+  is plain logic — covered by the modal + view specs and mutation-checked.

--- a/astros_vue/package-lock.json
+++ b/astros_vue/package-lock.json
@@ -8,7 +8,6 @@
       "name": "astros_vue",
       "version": "1.0.0-dev.7",
       "dependencies": {
-        "@floating-ui/vue": "^1.1.11",
         "@fontsource/inter": "^5.2.8",
         "@headlessui/vue": "^1.7.23",
         "axios": "^1.13.2",
@@ -1369,68 +1368,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
-    },
-    "node_modules/@floating-ui/vue": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.11.tgz",
-      "integrity": "sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6",
-        "@floating-ui/utils": "^0.2.11",
-        "vue-demi": ">=0.13.0"
-      }
-    },
-    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/@fontsource/inter": {

--- a/astros_vue/package.json
+++ b/astros_vue/package.json
@@ -21,7 +21,6 @@
     "start:server": "cd ../astros_api &&  npm run-script start"
   },
   "dependencies": {
-    "@floating-ui/vue": "^1.1.11",
     "@fontsource/inter": "^5.2.8",
     "@headlessui/vue": "^1.7.23",
     "axios": "^1.13.2",

--- a/astros_vue/src/components/modals/index.ts
+++ b/astros_vue/src/components/modals/index.ts
@@ -4,3 +4,4 @@ export { default as AstrosInterruptModal } from './AstrosInterruptModal.vue';
 export { default as AstrosHtmlModal } from './AstrosHtmlModal.vue';
 export * from './modules';
 export * from './scripter';
+export * from './remoteControl';

--- a/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.spec.ts
+++ b/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.spec.ts
@@ -33,6 +33,8 @@ describe('AstrosRemoteButtonEditorModal', () => {
     expect(wrapper.find('.modal-box').exists()).toBe(true);
     expect(wrapper.find('.modal-backdrop').exists()).toBe(true);
     expect(wrapper.find('[data-testid="editor-search"]').exists()).toBe(true);
+    // Title is supplied by the modal shell (button number is 1-based).
+    expect(wrapper.text()).toContain('Configure Button 3');
     wrapper.unmount();
   });
 
@@ -48,9 +50,9 @@ describe('AstrosRemoteButtonEditorModal', () => {
     wrapper.unmount();
   });
 
-  it('emits close when the editor × button is clicked', async () => {
+  it('emits close when the footer Close button is clicked', async () => {
     const wrapper = mountModal();
-    await wrapper.get('[data-testid="editor-close"]').trigger('click');
+    await wrapper.get('[data-testid="editor-modal-close"]').trigger('click');
 
     expect(wrapper.emitted('close')).toHaveLength(1);
     wrapper.unmount();

--- a/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.spec.ts
+++ b/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import AstrosRemoteButtonEditorModal from './AstrosRemoteButtonEditorModal.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import enUS from '@/locales/enUS.json';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: { 'en-US': enUS },
+});
+
+const SCRIPTS = [{ id: 's1', name: 'Wave Hello' }];
+const PLAYLISTS = [{ id: 'p1', name: 'Morning Routine' }];
+
+function mkNone(): PageButton {
+  return { id: '0', name: 'None', type: 'none' };
+}
+
+function mountModal(currentValue: PageButton = mkNone()) {
+  return mount(AstrosRemoteButtonEditorModal, {
+    attachTo: document.body,
+    global: { plugins: [i18n] },
+    props: { buttonNumber: 3, currentValue, scripts: SCRIPTS, playlists: PLAYLISTS },
+  });
+}
+
+describe('AstrosRemoteButtonEditorModal', () => {
+  it('renders the editor content inside the app modal dialog shell', () => {
+    const wrapper = mountModal();
+    expect(wrapper.find('dialog.modal').exists()).toBe(true);
+    expect(wrapper.find('.modal-box').exists()).toBe(true);
+    expect(wrapper.find('.modal-backdrop').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="editor-search"]').exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it('forwards the editor change event verbatim when an item is selected', async () => {
+    const wrapper = mountModal();
+    await wrapper.get('[data-testid="editor-item-s1"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({
+      id: 's1',
+      name: 'Wave Hello',
+      type: 'script',
+    });
+    wrapper.unmount();
+  });
+
+  it('emits close when the editor × button is clicked', async () => {
+    const wrapper = mountModal();
+    await wrapper.get('[data-testid="editor-close"]').trigger('click');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it('emits close when the modal backdrop is clicked', async () => {
+    const wrapper = mountModal();
+    await wrapper.get('.modal-backdrop').trigger('click');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it('emits close on Escape (editor focuses its root on mount so the keydown lands there)', async () => {
+    // Integration check for the editor's onMounted focus + its
+    // @keydown.escape handler. If focus-on-mount regresses, Escape would
+    // no-op because focus would sit on <body> instead of the editor root.
+    const wrapper = mountModal();
+    await wrapper.vm.$nextTick();
+    expect(document.activeElement).not.toBe(document.body);
+
+    document.activeElement!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+    wrapper.unmount();
+  });
+});

--- a/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue
+++ b/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import AstrosRemoteButtonEditor from '@/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue';
+import type { PageButton } from '@/models/remoteControl/pageButton';
+import type { EditorListItem } from '@/components/remoteControl/remoteButtonEditor/types';
+
+// View-owned singleton modal wrapper around the button editor. The editor
+// stays presentation-agnostic content; this shell supplies the app's standard
+// <dialog class="modal modal-open"> chrome (matches components/modals/scripter/).
+// `change` is forwarded verbatim from the editor (selecting an item is the
+// immediate action — there's no separate Save); `close` fires from the
+// backdrop click, the editor's × button, or Escape.
+defineProps<{
+  buttonNumber: number;
+  currentValue: PageButton;
+  scripts: readonly EditorListItem[];
+  playlists: readonly EditorListItem[];
+}>();
+
+const emit = defineEmits<{
+  change: [value: PageButton];
+  close: [];
+}>();
+</script>
+
+<template>
+  <dialog class="modal modal-open">
+    <div class="modal-box">
+      <AstrosRemoteButtonEditor
+        :button-number="buttonNumber"
+        :current-value="currentValue"
+        :scripts="scripts"
+        :playlists="playlists"
+        @change="(value) => emit('change', value)"
+        @close="emit('close')"
+      />
+    </div>
+    <form
+      method="dialog"
+      class="modal-backdrop"
+      @click="emit('close')"
+    >
+      <button>{{ $t('remote_control_config.editor.close') }}</button>
+    </form>
+  </dialog>
+</template>

--- a/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue
+++ b/astros_vue/src/components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue
@@ -3,12 +3,12 @@ import AstrosRemoteButtonEditor from '@/components/remoteControl/remoteButtonEdi
 import type { PageButton } from '@/models/remoteControl/pageButton';
 import type { EditorListItem } from '@/components/remoteControl/remoteButtonEditor/types';
 
-// View-owned singleton modal wrapper around the button editor. The editor
-// stays presentation-agnostic content; this shell supplies the app's standard
-// <dialog class="modal modal-open"> chrome (matches components/modals/scripter/).
-// `change` is forwarded verbatim from the editor (selecting an item is the
-// immediate action — there's no separate Save); `close` fires from the
-// backdrop click, the editor's × button, or Escape.
+// View-owned singleton modal wrapper around the button editor. Supplies the
+// app's standard modal chrome — title + modal-action footer Close button,
+// matching components/modals/scripter/ — around the editor content. `change`
+// is forwarded verbatim from the editor (selecting an item is the immediate
+// action — there's no separate Save); `close` fires from the footer button,
+// the backdrop click, or the editor's Escape handler.
 defineProps<{
   buttonNumber: number;
   currentValue: PageButton;
@@ -24,22 +24,36 @@ const emit = defineEmits<{
 
 <template>
   <dialog class="modal modal-open">
-    <div class="modal-box">
+    <div class="modal-box w-100 max-w-md">
+      <h1 class="text-2xl font-bold mb-4">
+        {{ $t('remote_control_config.editor.title', { n: buttonNumber }) }}
+      </h1>
+
       <AstrosRemoteButtonEditor
-        :button-number="buttonNumber"
         :current-value="currentValue"
         :scripts="scripts"
         :playlists="playlists"
         @change="(value) => emit('change', value)"
         @close="emit('close')"
       />
+
+      <div class="modal-action justify-center mt-5">
+        <button
+          type="button"
+          class="btn w-24 text-lg"
+          data-testid="editor-modal-close"
+          @click="emit('close')"
+        >
+          {{ $t('close') }}
+        </button>
+      </div>
     </div>
     <form
       method="dialog"
       class="modal-backdrop"
       @click="emit('close')"
     >
-      <button>{{ $t('remote_control_config.editor.close') }}</button>
+      <button>{{ $t('close') }}</button>
     </form>
   </dialog>
 </template>

--- a/astros_vue/src/components/modals/remoteControl/index.ts
+++ b/astros_vue/src/components/modals/remoteControl/index.ts
@@ -1,0 +1,1 @@
+export { default as AstrosRemoteButtonEditorModal } from './AstrosRemoteButtonEditorModal.vue';

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createI18n } from 'vue-i18n';
 import AstrosRemoteButtonCard from './AstrosRemoteButtonCard.vue';
@@ -12,9 +12,6 @@ const i18n = createI18n({
   messages: { 'en-US': enUS },
 });
 
-const SCRIPTS = [{ id: 's1', name: 'Wave Hello' }];
-const PLAYLISTS = [{ id: 'p1', name: 'Morning Routine' }];
-
 function mkNone(): PageButton {
   return { id: '0', name: 'None', type: 'none' };
 }
@@ -25,22 +22,23 @@ function mkPlaylist(): PageButton {
   return { id: 'p1', name: 'Morning Routine', type: 'playlist' };
 }
 
+function mountCard(value: PageButton) {
+  return mount(AstrosRemoteButtonCard, {
+    global: { plugins: [i18n] },
+    props: { value },
+  });
+}
+
 describe('AstrosRemoteButtonCard — display state', () => {
   it('shows a Configure button when value.type is none', () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
+    const wrapper = mountCard(mkNone());
     expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="card-clear"]').exists()).toBe(false);
   });
 
   it('shows assigned name and Edit/Clear buttons when value is a script', () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
+    const wrapper = mountCard(mkScript());
     expect(wrapper.text()).toContain('Wave Hello');
     expect(wrapper.find('[data-testid="card-edit"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="card-clear"]').exists()).toBe(true);
@@ -48,250 +46,20 @@ describe('AstrosRemoteButtonCard — display state', () => {
   });
 
   it('renders a SCRIPT type chip on a script-typed value', () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
+    const wrapper = mountCard(mkScript());
     const chip = wrapper.find('[data-testid="card-type-chip"]');
     expect(chip.exists()).toBe(true);
     expect(chip.text()).toMatch(/SCRIPT/i);
   });
 
   it('renders a PLAYLIST type chip on a playlist-typed value', () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkPlaylist(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
+    const wrapper = mountCard(mkPlaylist());
     const chip = wrapper.find('[data-testid="card-type-chip"]');
     expect(chip.text()).toMatch(/PLAYLIST/i);
   });
 
-  it('Clear emits change with the none sentinel WITHOUT opening the editor', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-clear"]').trigger('click');
-
-    expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
-    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
-  });
-
-  it('Clear emits a FRESH none-button object on each click (no shared identity across clicks)', async () => {
-    // Anti-regression for the shared-NONE_BUTTON-sentinel hazard. If both
-    // emits returned the same module-level const, an in-place mutation by
-    // any downstream consumer (`page.button1.name = 'X'` — a documented
-    // pattern in the store spec) would poison every other slot whose value
-    // came from the same sentinel.
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-
-    await wrapper.get('[data-testid="card-clear"]').trigger('click');
-    await wrapper.setProps({ value: mkPlaylist() });
-    await wrapper.get('[data-testid="card-clear"]').trigger('click');
-
-    const events = wrapper.emitted('change');
-    expect(events).toHaveLength(2);
-    const first = events![0]![0];
-    const second = events![1]![0];
-    expect(first).toEqual(second);
-    expect(first).not.toBe(second);
-  });
-});
-
-describe('AstrosRemoteButtonCard — popover host', () => {
-  it('opens the editor popover when Configure is clicked on an unassigned card', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-
-    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
-    wrapper.unmount();
-  });
-
-  it('opens the editor popover when Edit is clicked on an assigned card', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkScript(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-edit"]').trigger('click');
-
-    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
-    wrapper.unmount();
-  });
-
-  it('forwards the editor change event up and closes the popover', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-    await wrapper.vm.$nextTick();
-    const item = document.querySelector('[data-testid="editor-item-s1"]') as HTMLElement;
-    expect(item).not.toBeNull();
-    item.click();
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.emitted('change')![0]![0]).toEqual({
-      id: 's1',
-      name: 'Wave Hello',
-      type: 'script',
-    });
-    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
-    wrapper.unmount();
-  });
-
-  it('closes the popover when Escape is pressed (focus-on-open routes the keydown to the editor)', async () => {
-    // Integration check for the editor's onMounted focus + the @keydown.escape
-    // handler on the editor root. If focus-on-mount stops working, Escape
-    // pressed by a user who just clicked Edit/Configure would no-op because
-    // focus would still be on the card button, not the editor.
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
-    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
-    // Pin the focus contract explicitly — if a future refactor drops the
-    // tabindex or breaks the focus chain, this assertion fires before the
-    // Escape dispatch makes the rest of the test ambiguous.
-    expect(document.activeElement).not.toBe(document.body);
-
-    const escEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
-    document.activeElement!.dispatchEvent(escEvent);
-    await wrapper.vm.$nextTick();
-
-    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
-    wrapper.unmount();
-  });
-
-  it('closes the popover when the editor emits close (× button)', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-    await wrapper.vm.$nextTick();
-    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
-
-    const close = document.querySelector('[data-testid="editor-close"]') as HTMLElement;
-    close.click();
-    await wrapper.vm.$nextTick();
-
-    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
-    wrapper.unmount();
-  });
-
-  it('closes the popover when a click outside both card and popover happens', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-
-    const outside = document.createElement('div');
-    document.body.appendChild(outside);
-    outside.click();
-    await wrapper.vm.$nextTick();
-
-    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
-    outside.remove();
-    wrapper.unmount();
-  });
-
-  it('removes every click+capture document listener registered on mount (proves cleanup actually ran)', async () => {
-    // The previous "doesn't throw on post-unmount click" form was vacuous —
-    // the handler has no throwable path even when leaked. Spy on
-    // add/removeEventListener and assert every click+capture handler
-    // registered is also removed. Filter-and-subset (not .find()) so a
-    // future Floating UI upgrade that adds its own click+capture listener
-    // doesn't silently corrupt this test by hiding behind the first match.
-    const addSpy = vi.spyOn(document, 'addEventListener');
-    const removeSpy = vi.spyOn(document, 'removeEventListener');
-
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    const addedHandlers = addSpy.mock.calls
-      .filter(([type, , opts]) => type === 'click' && opts === true)
-      .map(([, handler]) => handler);
-    expect(addedHandlers.length).toBeGreaterThan(0);
-
-    wrapper.unmount();
-
-    const removedHandlers = removeSpy.mock.calls
-      .filter(([type, , opts]) => type === 'click' && opts === true)
-      .map(([, handler]) => handler);
-    expect(removedHandlers).toEqual(expect.arrayContaining(addedHandlers));
-  });
-
-  it('closes the popover via capture phase even when an outside element stops bubble propagation', async () => {
-    // Pins the capture-phase contract. If the outside-click listener were
-    // (incorrectly) on bubble phase, a stopPropagation in an outside child
-    // would prevent the close. Capture phase fires before any child handler,
-    // so it still closes the popover.
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-    await wrapper.vm.$nextTick();
-
-    const outside = document.createElement('button');
-    outside.addEventListener('click', (e) => e.stopPropagation(), false);
-    document.body.appendChild(outside);
-    outside.click();
-    await wrapper.vm.$nextTick();
-
-    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
-    outside.remove();
-    wrapper.unmount();
-  });
-
-  it('can re-open the popover after a click-outside close (open→close→open lifecycle)', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-    await wrapper.vm.$nextTick();
-    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
-
-    const outside = document.createElement('div');
-    document.body.appendChild(outside);
-    outside.click();
-    await wrapper.vm.$nextTick();
-    expect(document.querySelector('[data-testid="editor-search"]')).toBeNull();
-
-    await wrapper.get('[data-testid="card-configure"]').trigger('click');
-    await wrapper.vm.$nextTick();
-    expect(document.querySelector('[data-testid="editor-search"]')).not.toBeNull();
-
-    outside.remove();
-    wrapper.unmount();
-  });
-
   it('reactively switches from unassigned to assigned display when value prop changes', async () => {
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
+    const wrapper = mountCard(mkNone());
     // Pre-assert both the Configure-visible AND chip-absent baseline so a
     // regression that renders the chip unconditionally would surface here.
     expect(wrapper.find('[data-testid="card-configure"]').exists()).toBe(true);
@@ -304,32 +72,49 @@ describe('AstrosRemoteButtonCard — popover host', () => {
     expect(wrapper.find('[data-testid="card-type-chip"]').text()).toMatch(/SCRIPT/i);
     expect(wrapper.text()).toContain('Wave Hello');
   });
+});
 
-  it('restores keyboard focus to the trigger button when the popover closes', async () => {
-    // Pins the a11y contract — without focus capture/restore, every popover
-    // dismissal (Escape, close button, click outside, selection) drops
-    // focus to <body> and a keyboard user has to Tab back to where they were.
-    const wrapper = mount(AstrosRemoteButtonCard, {
-      attachTo: document.body,
-      global: { plugins: [i18n] },
-      props: { buttonNumber: 5, value: mkNone(), scripts: SCRIPTS, playlists: PLAYLISTS },
-    });
-    const configureBtn = wrapper.get('[data-testid="card-configure"]').element as HTMLElement;
-    configureBtn.focus();
-    expect(document.activeElement).toBe(configureBtn);
+describe('AstrosRemoteButtonCard — emits (editor is a view-owned modal)', () => {
+  it('emits edit (no change) when Configure is clicked on an unassigned card', async () => {
+    const wrapper = mountCard(mkNone());
+    await wrapper.get('[data-testid="card-configure"]').trigger('click');
 
-    await configureBtn.click();
-    await wrapper.vm.$nextTick();
-    // Editor's focus-on-mount stole focus from the trigger.
-    expect(document.activeElement).not.toBe(configureBtn);
+    expect(wrapper.emitted('edit')).toHaveLength(1);
+    expect(wrapper.emitted('change')).toBeUndefined();
+  });
 
-    // Close via the editor's × button.
-    const close = document.querySelector('[data-testid="editor-close"]') as HTMLElement;
-    close.click();
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+  it('emits edit when Edit is clicked on an assigned card', async () => {
+    const wrapper = mountCard(mkScript());
+    await wrapper.get('[data-testid="card-edit"]').trigger('click');
 
-    expect(document.activeElement).toBe(configureBtn);
-    wrapper.unmount();
+    expect(wrapper.emitted('edit')).toHaveLength(1);
+  });
+
+  it('Clear emits change with the none sentinel and does NOT emit edit', async () => {
+    const wrapper = mountCard(mkScript());
+    await wrapper.get('[data-testid="card-clear"]').trigger('click');
+
+    expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
+    expect(wrapper.emitted('edit')).toBeUndefined();
+  });
+
+  it('Clear emits a FRESH none-button object on each click (no shared identity across clicks)', async () => {
+    // Anti-regression for the shared-NONE_BUTTON-sentinel hazard. If both
+    // emits returned the same module-level const, an in-place mutation by
+    // any downstream consumer (`page.button1.name = 'X'` — a documented
+    // pattern in the store spec) would poison every other slot whose value
+    // came from the same sentinel.
+    const wrapper = mountCard(mkScript());
+
+    await wrapper.get('[data-testid="card-clear"]').trigger('click');
+    await wrapper.setProps({ value: mkPlaylist() });
+    await wrapper.get('[data-testid="card-clear"]').trigger('click');
+
+    const events = wrapper.emitted('change');
+    expect(events).toHaveLength(2);
+    const first = events![0]![0];
+    const second = events![1]![0];
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
   });
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.stories.ts
@@ -2,19 +2,10 @@ import { type Meta, type StoryObj } from '@storybook/vue3';
 import AstrosRemoteButtonCard from './AstrosRemoteButtonCard.vue';
 import type { PageButton } from '@/models/remoteControl/pageButton';
 
-const SAMPLE_SCRIPTS = [
-  { id: 's1', name: 'Wave Hello' },
-  { id: 's2', name: 'Bow' },
-  { id: 's3', name: 'Whistle' },
-];
-const SAMPLE_PLAYLISTS = [
-  { id: 'p1', name: 'Morning Routine' },
-  { id: 'p2', name: 'Performance Set' },
-];
-
 // Wrap each story in a 3x3 grid cell so the card sizing reads correctly.
-// The popover teleports to body, so the wrapper doesn't constrain it —
-// click Configure / Edit in the story to see the editor anchored.
+// The editor is now a view-owned modal (AstrosRemoteButtonEditorModal); this
+// card is presentational and just emits `edit` (open the editor) and `change`
+// (the direct Clear action) — both logged here.
 const gridCellWrapper = `
   <div style="
     width: 160px;
@@ -23,7 +14,11 @@ const gridCellWrapper = `
     border: 1px dashed #d6e0e6;
     border-radius: 8px;
   ">
-    <AstrosRemoteButtonCard v-bind="args" @change="(v) => console.log('change', v)" />
+    <AstrosRemoteButtonCard
+      v-bind="args"
+      @edit="() => console.log('edit')"
+      @change="(v) => console.log('change', v)"
+    />
   </div>
 `;
 
@@ -45,37 +40,17 @@ const SCRIPT_ASSIGNED: PageButton = { id: 's1', name: 'Wave Hello', type: 'scrip
 const PLAYLIST_ASSIGNED: PageButton = { id: 'p1', name: 'Morning Routine', type: 'playlist' };
 
 export const Unassigned: Story = {
-  args: {
-    buttonNumber: 5,
-    value: NONE,
-    scripts: SAMPLE_SCRIPTS,
-    playlists: SAMPLE_PLAYLISTS,
-  },
+  args: { value: NONE },
 };
 
 export const AssignedScript: Story = {
-  args: {
-    buttonNumber: 5,
-    value: SCRIPT_ASSIGNED,
-    scripts: SAMPLE_SCRIPTS,
-    playlists: SAMPLE_PLAYLISTS,
-  },
+  args: { value: SCRIPT_ASSIGNED },
 };
 
 export const AssignedPlaylist: Story = {
-  args: {
-    buttonNumber: 5,
-    value: PLAYLIST_ASSIGNED,
-    scripts: SAMPLE_SCRIPTS,
-    playlists: SAMPLE_PLAYLISTS,
-  },
+  args: { value: PLAYLIST_ASSIGNED },
 };
 
 export const LongAssignedName: Story = {
-  args: {
-    buttonNumber: 5,
-    value: { id: 's-long', name: 'A Really Long Action Name', type: 'script' },
-    scripts: SAMPLE_SCRIPTS,
-    playlists: SAMPLE_PLAYLISTS,
-  },
+  args: { value: { id: 's-long', name: 'A Really Long Action Name', type: 'script' } },
 };

--- a/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonCard/AstrosRemoteButtonCard.vue
@@ -1,23 +1,21 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onScopeDispose, ref } from 'vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/vue';
 import { makeNoneButton, type PageButton } from '@/models/remoteControl/pageButton';
 import { assertNever } from '@/utils/assertNever';
-import type { EditorListItem } from '../remoteButtonEditor/types';
-import AstrosRemoteButtonEditor from '../remoteButtonEditor/AstrosRemoteButtonEditor.vue';
 
 const { t } = useI18n();
 
 const props = defineProps<{
-  buttonNumber: number;
   value: PageButton;
-  scripts: readonly EditorListItem[];
-  playlists: readonly EditorListItem[];
 }>();
 
+// The editor is now a view-owned modal (AstrosRemoteButtonEditorModal); this
+// card is presentational. `edit` asks the view to open the editor for this
+// slot; `change` is the direct Clear action (no modal needed).
 const emit = defineEmits<{
   change: [value: PageButton];
+  edit: [];
 }>();
 
 const isAssigned = computed(() => props.value.type !== 'none');
@@ -53,75 +51,13 @@ const typeChipLabel = computed(() => {
   }
 });
 
-const popoverOpen = ref(false);
-const cardRef = ref<HTMLElement | null>(null);
-const popoverRef = ref<HTMLElement | null>(null);
-// Captured on openEditor so closeEditor can restore keyboard focus to the
-// element that opened the popover. Without this, every popover dismissal
-// dumps focus to <body> and a keyboard user has to Tab back to where they
-// were.
-let triggerEl: HTMLElement | null = null;
-
-const { floatingStyles } = useFloating(cardRef, popoverRef, {
-  placement: 'bottom',
-  middleware: [offset(8), flip(), shift({ padding: 8 })],
-  whileElementsMounted: autoUpdate,
-});
-
-function openEditor() {
-  triggerEl = document.activeElement as HTMLElement | null;
-  popoverOpen.value = true;
-}
-
-function closeEditor(options: { restoreFocus?: boolean } = {}) {
-  popoverOpen.value = false;
-
-  const restoreFocus = options.restoreFocus !== false;
-  const target = restoreFocus ? triggerEl : null;
-  triggerEl = null;
-
-  // Restore focus AFTER the popover unmounts so the trigger button can
-  // re-receive focus cleanly. nextTick lets Vue flush the v-if removal.
-  nextTick(() => target?.focus());
-}
-
-function handleChange(value: PageButton) {
-  emit('change', value);
-  closeEditor();
-}
-
 function clearAssignment() {
   emit('change', makeNoneButton());
 }
-
-function handleClickOutside(e: MouseEvent) {
-  if (!popoverOpen.value) return;
-  // composedPath walks through Shadow DOM boundaries too, so a future
-  // shadow-hosted child of the popover wouldn't get treated as "outside."
-  const path = e.composedPath();
-  if (cardRef.value && path.includes(cardRef.value)) return;
-  if (popoverRef.value && path.includes(popoverRef.value)) return;
-  closeEditor({ restoreFocus: false });
-}
-
-onMounted(() => {
-  // Capture phase so the outside-click fires before any child popover handler
-  // can call stopPropagation and swallow the close.
-  document.addEventListener('click', handleClickOutside, true);
-});
-
-// onScopeDispose (not onBeforeUnmount) so the listener is also torn down on
-// non-standard teardown paths (parent throws mid-render, Suspense cancels a
-// pending mount after onMounted already fired). Same pattern used by the
-// useHoldGesture composable.
-onScopeDispose(() => {
-  document.removeEventListener('click', handleClickOutside, true);
-});
 </script>
 
 <template>
   <div
-    ref="cardRef"
     class="astros-remote-button-card flex min-h-32 flex-col gap-2 rounded-xl p-3 transition-colors"
     :class="
       isAssigned
@@ -151,7 +87,7 @@ onScopeDispose(() => {
           type="button"
           class="btn btn-sm btn-primary flex-1"
           data-testid="card-edit"
-          @click="openEditor"
+          @click="emit('edit')"
         >
           {{ t('remote_control_config.card.edit') }}
         </button>
@@ -170,28 +106,10 @@ onScopeDispose(() => {
         type="button"
         class="btn btn-sm btn-ghost mt-auto w-full justify-center text-base-content/60"
         data-testid="card-configure"
-        @click="openEditor"
+        @click="emit('edit')"
       >
         {{ t('remote_control_config.card.configure') }}
       </button>
     </template>
   </div>
-
-  <Teleport to="body">
-    <div
-      v-if="popoverOpen"
-      ref="popoverRef"
-      :style="floatingStyles"
-      class="z-50 w-64 rounded-xl border-2 border-primary bg-base-100 p-3 shadow-xl"
-    >
-      <AstrosRemoteButtonEditor
-        :button-number="buttonNumber"
-        :current-value="value"
-        :scripts="scripts"
-        :playlists="playlists"
-        @change="handleChange"
-        @close="closeEditor"
-      />
-    </div>
-  </Teleport>
 </template>

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.spec.ts
@@ -39,7 +39,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -52,7 +51,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkPlaylistButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -65,7 +63,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -80,7 +77,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -95,7 +91,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -112,7 +107,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -130,7 +124,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: [...PLAYLISTS, { id: 'p3', name: 'Wave Routine' }],
@@ -152,7 +145,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkScriptButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -166,7 +158,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -183,7 +174,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -203,7 +193,6 @@ describe('AstrosRemoteButtonEditor', () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkScriptButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -214,27 +203,11 @@ describe('AstrosRemoteButtonEditor', () => {
     expect(wrapper.emitted('change')![0]![0]).toEqual({ id: '0', name: 'None', type: 'none' });
   });
 
-  it('emits close when × button is clicked', async () => {
-    const wrapper = mount(AstrosRemoteButtonEditor, {
-      global: { plugins: [i18n] },
-      props: {
-        buttonNumber: 5,
-        currentValue: mkNoneButton(),
-        scripts: SCRIPTS,
-        playlists: PLAYLISTS,
-      },
-    });
-    await wrapper.get('[data-testid="editor-close"]').trigger('click');
-
-    expect(wrapper.emitted('close')).toHaveLength(1);
-  });
-
   it('emits close on Escape keydown from the editor root', async () => {
     const wrapper = mount(AstrosRemoteButtonEditor, {
       attachTo: document.body,
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -256,7 +229,6 @@ describe('AstrosRemoteButtonEditor', () => {
       attachTo: document.body,
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,
@@ -278,7 +250,6 @@ describe('AstrosRemoteButtonEditor', () => {
       attachTo: document.body,
       global: { plugins: [i18n] },
       props: {
-        buttonNumber: 5,
         currentValue: mkNoneButton(),
         scripts: SCRIPTS,
         playlists: PLAYLISTS,

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
@@ -14,16 +14,16 @@ const SAMPLE_PLAYLISTS = [
   { id: 'p3', name: 'Quick Demo' },
 ];
 
-// Wrap each story in a popover-shaped container so it reads how it would
-// when anchored over a button card.
-const popoverWrapper = `
+// Wrap each story in a modal-box-shaped container so it reads how it appears
+// inside AstrosRemoteButtonEditorModal (the editor renders in the app's
+// standard modal-box now, not an anchored popover).
+const modalBoxWrapper = `
   <div style="
-    width: 260px;
-    border: 2px solid #2a5a97;
-    border-radius: 14px;
-    padding: 12px;
+    width: 320px;
+    border-radius: 16px;
+    padding: 24px;
     background: #fff;
-    box-shadow: 0 6px 24px rgba(42,90,151,0.18);
+    box-shadow: 0 10px 40px rgba(0,0,0,0.2);
   ">
     <AstrosRemoteButtonEditor
       v-bind="args"
@@ -39,7 +39,7 @@ const meta: Meta<typeof AstrosRemoteButtonEditor> = {
   render: (args) => ({
     components: { AstrosRemoteButtonEditor },
     setup: () => ({ args }),
-    template: popoverWrapper,
+    template: modalBoxWrapper,
   }),
 };
 export default meta;

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.stories.ts
@@ -52,7 +52,6 @@ const PLAYLIST_ASSIGNED: PageButton = { id: 'p1', name: 'Morning Routine', type:
 
 export const EmptyButtonOpensOnScripts: Story = {
   args: {
-    buttonNumber: 5,
     currentValue: NONE,
     scripts: SAMPLE_SCRIPTS,
     playlists: SAMPLE_PLAYLISTS,
@@ -61,7 +60,6 @@ export const EmptyButtonOpensOnScripts: Story = {
 
 export const AssignedScriptOpensOnScripts: Story = {
   args: {
-    buttonNumber: 5,
     currentValue: SCRIPT_ASSIGNED,
     scripts: SAMPLE_SCRIPTS,
     playlists: SAMPLE_PLAYLISTS,
@@ -70,7 +68,6 @@ export const AssignedScriptOpensOnScripts: Story = {
 
 export const AssignedPlaylistOpensOnPlaylists: Story = {
   args: {
-    buttonNumber: 5,
     currentValue: PLAYLIST_ASSIGNED,
     scripts: SAMPLE_SCRIPTS,
     playlists: SAMPLE_PLAYLISTS,
@@ -79,7 +76,6 @@ export const AssignedPlaylistOpensOnPlaylists: Story = {
 
 export const EmptyScriptList: Story = {
   args: {
-    buttonNumber: 5,
     currentValue: NONE,
     scripts: [],
     playlists: SAMPLE_PLAYLISTS,
@@ -88,7 +84,6 @@ export const EmptyScriptList: Story = {
 
 export const LongName: Story = {
   args: {
-    buttonNumber: 5,
     currentValue: NONE,
     scripts: [
       { id: 's-long', name: 'This Is A Really Long Script Name That Should Truncate' },

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -64,8 +64,8 @@ const rootRef = ref<HTMLDivElement | null>(null);
 
 // Focus the editor root on open so the @keydown.escape on the wrapper div
 // actually fires when the user presses Escape. Without an explicit focus,
-// focus stays on the Edit/Configure button that opened the popover and
-// the editor's keydown handler never sees the event.
+// focus stays on whatever triggered the open (the card's Edit/Configure
+// button) and the editor's keydown handler never sees the event.
 onMounted(() => {
   nextTick(() => rootRef.value?.focus());
 });

--- a/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
+++ b/astros_vue/src/components/remoteControl/remoteButtonEditor/AstrosRemoteButtonEditor.vue
@@ -8,7 +8,6 @@ import type { EditorTab, EditorListItem } from './types';
 const { t } = useI18n();
 
 const props = defineProps<{
-  buttonNumber: number;
   currentValue: PageButton;
   scripts: readonly EditorListItem[];
   playlists: readonly EditorListItem[];
@@ -74,38 +73,19 @@ onMounted(() => {
 <template>
   <div
     ref="rootRef"
-    class="astros-remote-button-editor flex flex-col gap-2"
+    class="astros-remote-button-editor flex flex-col gap-4"
     tabindex="-1"
     @keydown.escape="emit('close')"
   >
-    <header class="flex items-center justify-between">
-      <span class="text-[10px] font-bold uppercase tracking-[0.1em] text-base-content/60">
-        {{ t('remote_control_config.editor.header', { n: buttonNumber }) }}
-      </span>
-      <button
-        type="button"
-        class="btn btn-ghost btn-xs btn-square"
-        :aria-label="t('remote_control_config.editor.close')"
-        data-testid="editor-close"
-        @click="emit('close')"
-      >
-        ×
-      </button>
-    </header>
-
     <div
       role="tablist"
-      class="flex gap-1"
+      class="join w-full"
     >
       <button
         type="button"
         role="tab"
-        class="flex-1 rounded-md py-1 text-xs font-semibold capitalize"
-        :class="
-          tab === 'script'
-            ? 'bg-primary/10 text-primary'
-            : 'bg-transparent text-base-content/60 hover:bg-base-200'
-        "
+        class="join-item btn flex-1"
+        :class="tab === 'script' ? 'btn-primary' : 'btn-ghost'"
         :aria-selected="tab === 'script'"
         data-testid="editor-tab-script"
         @click="tab = 'script'"
@@ -115,12 +95,8 @@ onMounted(() => {
       <button
         type="button"
         role="tab"
-        class="flex-1 rounded-md py-1 text-xs font-semibold capitalize"
-        :class="
-          tab === 'playlist'
-            ? 'bg-primary/10 text-primary'
-            : 'bg-transparent text-base-content/60 hover:bg-base-200'
-        "
+        class="join-item btn flex-1"
+        :class="tab === 'playlist' ? 'btn-primary' : 'btn-ghost'"
         :aria-selected="tab === 'playlist'"
         data-testid="editor-tab-playlist"
         @click="tab = 'playlist'"
@@ -132,18 +108,18 @@ onMounted(() => {
     <input
       v-model="query"
       type="text"
-      class="input input-sm input-bordered w-full text-xs"
+      class="input input-bordered w-full text-lg"
       :placeholder="t('remote_control_config.editor.search_placeholder')"
       data-testid="editor-search"
     />
 
     <ul
-      class="flex max-h-56 min-h-24 flex-col gap-px overflow-y-auto rounded-md border border-base-300 p-1 text-xs"
+      class="flex h-64 flex-col gap-1 overflow-y-auto rounded-lg border border-base-300 p-2 text-lg"
     >
       <li>
         <button
           type="button"
-          class="flex w-full items-center rounded px-2 py-1 text-left italic text-base-content/60 hover:bg-base-200"
+          class="flex w-full items-center rounded-md px-3 py-2 text-left italic text-base-content/60 hover:bg-base-200"
           data-testid="editor-none"
           @click="selectNone"
         >
@@ -156,7 +132,7 @@ onMounted(() => {
       >
         <button
           type="button"
-          class="flex w-full items-center rounded px-2 py-1 text-left hover:bg-base-200"
+          class="flex w-full items-center rounded-md px-3 py-2 text-left hover:bg-base-200"
           :data-testid="`editor-item-${item.id}`"
           @click="selectItem(item)"
         >
@@ -165,7 +141,7 @@ onMounted(() => {
       </li>
       <li
         v-if="items.length === 0"
-        class="px-2 py-3 text-center text-[11px] text-base-content/50"
+        class="px-3 py-4 text-center text-base text-base-content/50"
         data-testid="editor-empty"
       >
         {{ t('remote_control_config.editor.empty_state') }}

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -581,7 +581,6 @@
     },
     "editor": {
       "title": "Configure Button {n}",
-      "close": "Close",
       "tab_script": "Scripts",
       "tab_playlist": "Playlists",
       "search_placeholder": "Search…",

--- a/astros_vue/src/locales/enUS.json
+++ b/astros_vue/src/locales/enUS.json
@@ -580,7 +580,7 @@
       "type_playlist": "PLAYLIST"
     },
     "editor": {
-      "header": "BTN {n} · EDITING",
+      "title": "Configure Button {n}",
       "close": "Close",
       "tab_script": "Scripts",
       "tab_playlist": "Playlists",

--- a/astros_vue/src/views/RemoteControlConfigView.vue
+++ b/astros_vue/src/views/RemoteControlConfigView.vue
@@ -8,6 +8,7 @@ import AstrosRemotePageList from '@/components/remoteControl/remotePageList/Astr
 import AstrosRemoteLivePreview from '@/components/remoteControl/remoteLivePreview/AstrosRemoteLivePreview.vue';
 import AstrosWriteButton from '@/components/common/AstrosWriteButton.vue';
 import AstrosConfirmModal from '@/components/modals/AstrosConfirmModal.vue';
+import AstrosRemoteButtonEditorModal from '@/components/modals/remoteControl/AstrosRemoteButtonEditorModal.vue';
 import { useRemoteControlStore } from '@/stores/remoteControl';
 import { useScriptsStore } from '@/stores/scripts';
 import { usePlaylistsStore } from '@/stores/playlists';
@@ -147,6 +148,38 @@ const currentPage = computed(() => {
   return page ?? null;
 });
 
+// Editor modal state — view-owned singleton (matches ScripterView's modal
+// pattern). A card's edit request sets editingButtonKey; the modal renders only
+// while it's set. The modal edits the CURRENTLY selected page's slot;
+// selectedIdx can't change while the modal is open (it overlays the page list).
+const editingButtonKey = ref<ButtonKey | null>(null);
+
+const editingButtonValue = computed<PageButton | null>(() => {
+  const page = currentPage.value;
+  if (page === null || editingButtonKey.value === null) return null;
+  return page[editingButtonKey.value];
+});
+
+const editingButtonNumber = computed(() =>
+  editingButtonKey.value === null ? 0 : BUTTON_KEYS.indexOf(editingButtonKey.value) + 1,
+);
+
+function onEditRequested(key: ButtonKey) {
+  editingButtonKey.value = key;
+}
+
+function onEditorChange(value: PageButton) {
+  // editingButtonKey is non-null whenever the modal is mounted (it gates the
+  // v-if), but guard anyway so a stray emit can't write to a null slot.
+  if (editingButtonKey.value === null) return;
+  remoteControlStore.setButton(selectedIdx.value, editingButtonKey.value, value);
+  editingButtonKey.value = null;
+}
+
+function onEditorClose() {
+  editingButtonKey.value = null;
+}
+
 // Total assigned (non-none) buttons across all pages — shown in the header
 // as "N actions". Drives the "is the user actually configuring anything"
 // signal without needing per-page math at render time.
@@ -263,12 +296,10 @@ const pageCount = computed(() => remoteControlPages.value.length);
               style="min-width: 500px; max-width: 540px"
             >
               <AstrosRemoteButtonCard
-                v-for="(key, i) in BUTTON_KEYS"
+                v-for="key in BUTTON_KEYS"
                 :key="key"
-                :button-number="i + 1"
                 :value="currentPage[key]"
-                :scripts="scripts"
-                :playlists="playlists"
+                @edit="() => onEditRequested(key)"
                 @change="(value) => onButtonChange(key, value)"
               />
             </div>
@@ -294,6 +325,16 @@ const pageCount = computed(() => remoteControlPages.value.length);
         :message-params="{ name: pendingDelete.name }"
         :on-confirm="onDeleteConfirm"
         :on-close="onDeleteCancel"
+      />
+
+      <AstrosRemoteButtonEditorModal
+        v-if="editingButtonValue !== null"
+        :button-number="editingButtonNumber"
+        :current-value="editingButtonValue"
+        :scripts="scripts"
+        :playlists="playlists"
+        @change="onEditorChange"
+        @close="onEditorClose"
       />
     </template>
   </AstrosLayout>

--- a/astros_vue/src/views/RemoteControlConfigView.vue
+++ b/astros_vue/src/views/RemoteControlConfigView.vue
@@ -150,8 +150,9 @@ const currentPage = computed(() => {
 
 // Editor modal state — view-owned singleton (matches ScripterView's modal
 // pattern). A card's edit request sets editingButtonKey; the modal renders only
-// while it's set. The modal edits the CURRENTLY selected page's slot;
-// selectedIdx can't change while the modal is open (it overlays the page list).
+// while it's set. The modal edits the CURRENTLY selected page's slot; the
+// backdrop overlays the page list so a pointer can't change selectedIdx while
+// it's open (there's no focus trap, matching the app's other modals).
 const editingButtonKey = ref<ButtonKey | null>(null);
 
 const editingButtonValue = computed<PageButton | null>(() => {

--- a/astros_vue/src/views/__tests__/RemoteControlConfigView.spec.ts
+++ b/astros_vue/src/views/__tests__/RemoteControlConfigView.spec.ts
@@ -94,9 +94,9 @@ function mountView() {
         },
         AstrosRemoteButtonCard: {
           name: 'AstrosRemoteButtonCard',
-          props: ['buttonNumber', 'value', 'scripts', 'playlists'],
-          emits: ['change'],
-          template: '<div data-testid="card-stub" :data-button="buttonNumber" />',
+          props: ['value'],
+          emits: ['change', 'edit'],
+          template: '<div data-testid="card-stub" />',
         },
         AstrosRemotePageList: {
           name: 'AstrosRemotePageList',
@@ -117,6 +117,12 @@ function mountView() {
           // the interpolated value (real modal threads it through to $t).
           template:
             '<div data-testid="confirm-modal" :data-message="message" :data-name="(messageParams && messageParams.name) || \'\'"><button data-testid="modal-confirm" @click="onConfirm" /><button data-testid="modal-close" @click="onClose" /></div>',
+        },
+        AstrosRemoteButtonEditorModal: {
+          name: 'AstrosRemoteButtonEditorModal',
+          props: ['buttonNumber', 'currentValue', 'scripts', 'playlists'],
+          emits: ['change', 'close'],
+          template: '<div data-testid="editor-modal" :data-button="buttonNumber" />',
         },
       },
     },
@@ -475,6 +481,69 @@ describe('RemoteControlConfigView — button card wiring', () => {
     await cards[0]!.vm.$emit('change', newValue);
 
     expect(spy).toHaveBeenCalledWith(1, 'button1', newValue);
+  });
+});
+
+describe('RemoteControlConfigView — editor modal wiring', () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it('opens the editor modal for the clicked card (modal absent before)', async () => {
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="editor-modal"]').exists()).toBe(false);
+
+    const cards = wrapper.findAllComponents({ name: 'AstrosRemoteButtonCard' });
+    await cards[4]!.vm.$emit('edit'); // BUTTON 5 (index 4)
+    await flushPromises();
+
+    const modal = wrapper.find('[data-testid="editor-modal"]');
+    expect(modal.exists()).toBe(true);
+    // 1-based button number derived from the slot key (button5).
+    expect(modal.attributes('data-button')).toBe('5');
+  });
+
+  it('forwards the modal change to store.setButton for the editing slot, then closes', async () => {
+    const wrapper = mountView();
+    await flushPromises();
+
+    const store = useRemoteControlStore();
+    const spy = vi.spyOn(store, 'setButton');
+
+    const cards = wrapper.findAllComponents({ name: 'AstrosRemoteButtonCard' });
+    await cards[4]!.vm.$emit('edit');
+    await flushPromises();
+
+    const modal = wrapper.findComponent({ name: 'AstrosRemoteButtonEditorModal' });
+    const newValue = { id: 's1', name: 'Wave', type: 'script' as const };
+    await modal.vm.$emit('change', newValue);
+    await flushPromises();
+
+    expect(spy).toHaveBeenCalledWith(0, 'button5', newValue);
+    // Selecting a value closes the modal.
+    expect(wrapper.find('[data-testid="editor-modal"]').exists()).toBe(false);
+  });
+
+  it('close emit dismisses the modal WITHOUT calling setButton', async () => {
+    const wrapper = mountView();
+    await flushPromises();
+
+    const store = useRemoteControlStore();
+    const spy = vi.spyOn(store, 'setButton');
+
+    const cards = wrapper.findAllComponents({ name: 'AstrosRemoteButtonCard' });
+    await cards[0]!.vm.$emit('edit');
+    await flushPromises();
+    expect(wrapper.find('[data-testid="editor-modal"]').exists()).toBe(true);
+
+    const modal = wrapper.findComponent({ name: 'AstrosRemoteButtonEditorModal' });
+    await modal.vm.$emit('close');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="editor-modal"]').exists()).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/astros_vue/src/views/__tests__/RemoteControlConfigView.spec.ts
+++ b/astros_vue/src/views/__tests__/RemoteControlConfigView.spec.ts
@@ -520,9 +520,11 @@ describe('RemoteControlConfigView — editor modal wiring', () => {
     const newValue = { id: 's1', name: 'Wave', type: 'script' as const };
     await modal.vm.$emit('change', newValue);
     await flushPromises();
+    await wrapper.vm.$nextTick();
 
     expect(spy).toHaveBeenCalledWith(0, 'button5', newValue);
-    // Selecting a value closes the modal.
+    // Selecting a value closes the modal (the v-if drops after the
+    // editingButtonKey=null reactivity flush).
     expect(wrapper.find('[data-testid="editor-modal"]').exists()).toBe(false);
   });
 
@@ -541,6 +543,7 @@ describe('RemoteControlConfigView — editor modal wiring', () => {
     const modal = wrapper.findComponent({ name: 'AstrosRemoteButtonEditorModal' });
     await modal.vm.$emit('close');
     await flushPromises();
+    await wrapper.vm.$nextTick();
 
     expect(wrapper.find('[data-testid="editor-modal"]').exists()).toBe(false);
     expect(spy).not.toHaveBeenCalled();


### PR DESCRIPTION
# Remote Control — button editor popover → view-owned modal

**`feature/remote-button-editor-modal` → `develop`**

## What & why

The button-config editor (`AstrosRemoteButtonEditor`) was hosted as a per-card **floating-ui popover** — each of the 9 button cards owned its own `useFloating` instance, a `<Teleport>`, and a hand-rolled capture-phase document click-outside listener with its own `onScopeDispose` teardown. That diverged from how the rest of the app does editing dialogs (`ScripterView` + the `components/modals/{domain}/` form modals, e.g. GPIO/servo event modals): a **single view-owned `<dialog class="modal modal-open">`** opened from view state.

This converts the editor to that pattern and brings its styling in line with the app's other modals.

## Approach (singleton modal + presentational card)

- **The view owns the modal.** `RemoteControlConfigView` holds `editingButtonKey: ref<ButtonKey|null>` (+ `editingButtonValue`/`editingButtonNumber` computeds) and renders **one** modal `v-if`, mirroring ScripterView's `showModal` + `selectedScriptEvent` gate.
- **The card became presentational.** `AstrosRemoteButtonCard` shed floating-ui, the teleport, the click-outside listener + lifecycle, the editor import, the open/close plumbing, AND the `buttonNumber`/`scripts`/`playlists` props. It now just emits `edit` (open) + `change` (the direct Clear action) — a drop from a stateful popover-host to a near-pure component.
- **New `AstrosRemoteButtonEditorModal`** (`components/modals/remoteControl/`) is the modal shell: title + `modal-action` footer + backdrop around the editor content.

## Key changes

- **New `AstrosRemoteButtonEditorModal.vue`** — `<dialog class="modal modal-open"> → modal-box (w-100 max-w-md) → modal-backdrop`, with an `<h1 class="text-2xl font-bold">` "Configure Button N" title and a footer **Close** button (`btn w-24 text-lg`). Forwards the editor's `change`; emits `close` on the footer button, backdrop click, or the editor's Escape. Barrel-exported (`modals/remoteControl/index.ts` → `modals/index.ts`).
- **`AstrosRemoteButtonCard.vue`** — stripped to presentational (−96 lines); emits `edit` + `change`.
- **`RemoteControlConfigView.vue`** — `editingButtonKey` singleton, modal render, `onEditRequested` / `onEditorChange` (→ `setButton(selectedIdx, key, value)` + close) / `onEditorClose`.
- **`AstrosRemoteButtonEditor.vue`** — restyled from popover-scale to modal-scale to match `AstrosGpioEventModal`: `text-lg` search + list, tabs are now a standard `btn` segmented control (selected = `btn-primary`, unselected = `btn-ghost`) instead of faint `bg-primary/10` pills, the corner `×` header is gone (close lives in the modal footer now), and the list has a **fixed `h-64` height** so the modal doesn't jump when toggling Scripts/Playlists with differing item counts. Dropped its `buttonNumber` prop.
- **Removed `@floating-ui/vue`** (package.json + lockfile) — this card was its only consumer; trims the index bundle ~3KB.
- **i18n** — `editor.header` ("BTN {n} · EDITING") → `editor.title` ("Configure Button {n}").

## Testing

- **612 frontend tests pass; `vue-tsc` + `vite build` + lint all clean.**
- Tests reshuffled to follow the behavior: the card's "popover host" block (open / click-outside / Escape / focus-restore / listener-cleanup) was removed because that behavior no longer lives in the card; coverage migrated to a **new modal spec** (renders editor in the dialog shell + title; forwards `change`; `close` on backdrop / footer button / Escape) and the **view spec** (card `edit` opens the modal; modal `change` → `setButton` + close; `close` clears state without `setButton`). Editor content spec retained (tabs/filter/empty/none/change/Escape), minus the obsolete `×` test.

## Review

Pre-commit review (single agent, full find-anything-wrong + boundary trace) on the refactor commit: **no Critical/Important**. It verified the card→view→modal→editor contract round-trips (no off-by-one, correct slot, `selectedIdx` consistency, page-delete safe), `@floating-ui` fully gone with no leftover props, doc-drift swept (stale "popover" comments in the editor + its story fixed), and migrated test coverage is non-vacuous.

Whole-branch **pre-push 5-agent review** (code / tests / silent-failure / types / comments): **no Critical/Important**. Mutation-verified the contract (reverting the key-null clear, the 1-based `+1`, the backdrop handler, and focus-on-mount each fail their tests) and confirmed coverage migrated (8 of 9 deleted popover behaviors re-homed). Three minor items fixed in `3ee067d`: hardened a cold-start-flaky modal-close assertion with `$nextTick`, deleted the dead `editor.close` i18n key, and softened the `selectedIdx` comment (no focus trap).

## Follow-ups / notes

- **Intentional a11y trade-off:** the old popover captured + restored keyboard focus to the trigger on close; the modal does not — this **matches every other modal in the app** (`AstrosServoEventModal` et al.), which was the goal. Recorded here so it's a decision, not an oversight; revisit in the pending a11y pass.
- **Pre-push 5-agent review: complete** — no Critical/Important; three minor fixes applied (`3ee067d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
