### PR TITLE
Feature/script upload status key

### DIFF
--- a/.docs/plans/20260601-1803-script-upload-status-key.md
+++ b/.docs/plans/20260601-1803-script-upload-status-key.md
@@ -38,7 +38,11 @@ frontend can't render it under any key anyway).
 - [x] Add failing repository tests: a deployed script's `deploymentStatus` from
       `getScripts()` and `getScript()` is keyed by the location name, not the id
       (assert both the name-key is present and the id-key is absent). Confirm red.
-- [x] Apply the key fix to both methods (lines 192 and 246). Confirm green.
-- [x] Run full API suite (868 pass), lint (0 errors), prettier, build (tsc clean).
-- [x] Code review the diff; address Critical/Important. (None found; ready to commit.)
+- [x] Apply the key fix to both methods (`getScripts()`/`getScript()`). Confirm green.
+- [x] Run full API suite, lint (0 errors), prettier, build (tsc clean).
+- [x] Code review the diff; address Critical/Important. (None blocking.)
 - [x] Update QA plan note if one exists for the scripts page. (No scripts QA plan exists — no-op.)
+- [x] Pre-push multi-agent review; address the one Important finding (observable
+      skip: `logger.warn` on the orphaned-deployment branch) + a regression test
+      for it. Type-key tightening + dead `locationName` removal deferred to a
+      follow-up.

--- a/.docs/plans/20260601-1803-script-upload-status-key.md
+++ b/.docs/plans/20260601-1803-script-upload-status-key.md
@@ -1,0 +1,44 @@
+# Fix: script upload status lost on page refresh
+
+## Problem
+
+On the Scripts page, uploading a script correctly updates the dome/core/body
+status badges, but after a page refresh every badge reverts to "Not uploaded" —
+even though the deployment was persisted to the database.
+
+## Root cause
+
+`deploymentStatus` is a dictionary keyed by location. The two paths that
+populate it disagree on the key:
+
+- **Live WebSocket update** (`api_server.ts:1065` → `stores/scripts.ts:87`) keys
+  by the location **name** (`'body' | 'core' | 'dome'`), the `Location` enum
+  value.
+- **Page-load read** (`script_repository.ts:192` in `getScripts()` and `:246`
+  in `getScript()`) keys by `dep.location_id` — the `locations.id` **UUID** FK.
+
+Every frontend consumer (`AstrosScriptRow.vue:26`, `ScriptsView.vue:104`,
+`AstrosScriptTestModal.vue:70/77/84`) looks up by the `Location` enum name, so on
+refresh the UUID keys never match → `undefined` → "Not uploaded".
+
+The write path correctly uses the UUID for the FK column (pinned by the existing
+`script_deployments FK contract` tests). Only the read-back key shape is wrong.
+Both queries already `select locations.name as location_name`, so the name is in
+hand — they just key by the wrong column.
+
+## Fix
+
+In `ScriptRepository.getScripts()` and `getScript()`, key `deploymentStatus` by
+`dep.location_name` (the enum name) instead of `dep.location_id` (the UUID). Skip
+rows with a null name (orphaned deployment with no matching location — the
+frontend can't render it under any key anyway).
+
+## Tasks
+
+- [ ] Add failing repository tests: a deployed script's `deploymentStatus` from
+      `getScripts()` and `getScript()` is keyed by the location name, not the id
+      (assert both the name-key is present and the id-key is absent). Confirm red.
+- [ ] Apply the key fix to both methods (lines 192 and 246). Confirm green.
+- [ ] Run full API suite, lint (both projects), prettier, build.
+- [ ] Code review the diff; address Critical/Important.
+- [ ] Update QA plan note if one exists for the scripts page.

--- a/.docs/plans/20260601-1803-script-upload-status-key.md
+++ b/.docs/plans/20260601-1803-script-upload-status-key.md
@@ -35,10 +35,10 @@ frontend can't render it under any key anyway).
 
 ## Tasks
 
-- [ ] Add failing repository tests: a deployed script's `deploymentStatus` from
+- [x] Add failing repository tests: a deployed script's `deploymentStatus` from
       `getScripts()` and `getScript()` is keyed by the location name, not the id
       (assert both the name-key is present and the id-key is absent). Confirm red.
-- [ ] Apply the key fix to both methods (lines 192 and 246). Confirm green.
-- [ ] Run full API suite, lint (both projects), prettier, build.
-- [ ] Code review the diff; address Critical/Important.
-- [ ] Update QA plan note if one exists for the scripts page.
+- [x] Apply the key fix to both methods (lines 192 and 246). Confirm green.
+- [x] Run full API suite (868 pass), lint (0 errors), prettier, build (tsc clean).
+- [x] Code review the diff; address Critical/Important. (None found; ready to commit.)
+- [x] Update QA plan note if one exists for the scripts page. (No scripts QA plan exists — no-op.)

--- a/.docs/plans/20260601-1840-deploymentstatus-type-tighten.md
+++ b/.docs/plans/20260601-1840-deploymentstatus-type-tighten.md
@@ -1,0 +1,38 @@
+# Tighten deploymentStatus key type + drop dead locationName
+
+## Why
+
+Follow-up to the script upload-status key fix (pre-push review findings):
+
+1. **Loose key type allowed the original bug.** `Script.deploymentStatus` is
+   `Record<string, DeploymentStatus>`, so `deploymentStatus[someUuid]` was
+   type-legal — the regression couldn't be caught at compile time. Tightening
+   the key to a `LocationName` union (`'body' | 'core' | 'dome'`) turns that
+   class of bug into a type error and matches the frontend's already-tight
+   `Partial<Record<Location, …>>`.
+2. **Dead field.** `DeploymentStatus.locationName` has zero readers anywhere
+   (frontend type doesn't even declare it). Now that the map key *is* the name,
+   it's a redundant second source of truth.
+
+## Scope (backend only — frontend types unchanged, wire JSON just drops a field nothing read)
+
+- `models/constants.ts`: add `LocationName` (derived from `Constants.*` to avoid
+  drift) + `isLocationName(value): value is LocationName` type guard.
+- `models/index.ts`: export both.
+- `models/scripts/script.ts`: `deploymentStatus: Partial<Record<LocationName, DeploymentStatus>>`.
+- `models/scripts/deployment_status.ts`: remove `locationName`.
+- `dal/repositories/script_repository.ts`: replace the `!dep.location_name` skip
+  with `!isLocationName(dep.location_name)` (narrows string→union, no cast),
+  drop `locationName:` from both status objects, refresh comments.
+- `script_repository.test.ts`: rewrite keying assertions — `['dome']` is now
+  `… | undefined` (optional chaining) and indexing by the UUID won't compile, so
+  assert "not keyed by UUID" via `Object.keys(...) === ['dome']` (stronger).
+
+## Tasks
+
+- [ ] Add `LocationName` + `isLocationName` to constants.ts; export from index.ts.
+- [ ] Tighten `Script.deploymentStatus`; remove `DeploymentStatus.locationName`.
+- [ ] Update repository: guard with `isLocationName`, drop `locationName` writes.
+- [ ] Update tests (Object.keys assertion); confirm still mutation-sensitive.
+- [ ] prettier, lint (0 errors), build (tsc clean), full suite green.
+- [ ] Code review; address Critical/Important.

--- a/.docs/plans/20260601-1840-deploymentstatus-type-tighten.md
+++ b/.docs/plans/20260601-1840-deploymentstatus-type-tighten.md
@@ -30,9 +30,12 @@ Follow-up to the script upload-status key fix (pre-push review findings):
 
 ## Tasks
 
-- [ ] Add `LocationName` + `isLocationName` to constants.ts; export from index.ts.
-- [ ] Tighten `Script.deploymentStatus`; remove `DeploymentStatus.locationName`.
-- [ ] Update repository: guard with `isLocationName`, drop `locationName` writes.
-- [ ] Update tests (Object.keys assertion); confirm still mutation-sensitive.
-- [ ] prettier, lint (0 errors), build (tsc clean), full suite green.
-- [ ] Code review; address Critical/Important.
+- [x] Add `LocationName` + `isLocationName` to constants.ts; export from index.ts.
+- [x] Tighten `Script.deploymentStatus`; remove `DeploymentStatus.locationName`.
+- [x] Update repository: guard with `isLocationName`, drop `locationName` writes.
+- [x] Update tests (Object.keys assertion); confirm still mutation-sensitive.
+      (Verified: reintroducing the UUID key now fails `tsc` with TS7053 — the bug
+      is a compile error, not just a test failure.)
+- [x] prettier, lint (0 errors), build (tsc clean), full suite green (869).
+- [x] Code review; address Critical/Important. (None; 2 cosmetic Minors fixed —
+      warn wording for unknown-name case + dropped unused `locId` return.)

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ testem.log
 .tmp
 
 .claude/scheduled_tasks.lock
+.pr_summary/

--- a/astros_api/src/dal/repositories/script_repository.test.ts
+++ b/astros_api/src/dal/repositories/script_repository.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Kysely } from 'kysely';
 import { Database } from '../types.js';
 import { createKyselyConnection, migrateToLatest } from '../database.js';
 import { ScriptRepository } from './script_repository.js';
+import { logger } from 'src/logger.js';
 import {
   Script,
   ScriptChannel,
@@ -36,10 +37,13 @@ import { v4 as uuid } from 'uuid';
 
 describe('Script Repository', () => {
   let db: Kysely<Database>;
+  let raw: ReturnType<typeof createKyselyConnection>['raw'];
   let locationId: string;
 
   beforeEach(async () => {
-    db = createKyselyConnection().db;
+    const conn = createKyselyConnection();
+    db = conn.db;
+    raw = conn.raw;
 
     await migrateToLatest(db);
 
@@ -1098,6 +1102,32 @@ describe('Script Repository', () => {
       expect(script.deploymentStatus['body'].value).toBe(UploadStatus.uploaded);
       expect(script.deploymentStatus['body'].date.getTime()).toBe(deployedAt.getTime());
       expect(script.deploymentStatus[locId]).toBeUndefined();
+    });
+
+    it('skips (and logs) a deployment row whose location was removed', async () => {
+      const { scriptId } = await seedDeployedScript('dome');
+      const scriptRepo = new ScriptRepository(db);
+
+      // The FK cascade (migration_6) normally prevents an orphaned deployment;
+      // manufacture one by deleting the location with foreign keys disabled, so
+      // the left join yields a null location_name on read.
+      raw.pragma('foreign_keys = OFF');
+      await db.deleteFrom('locations').where('name', '=', 'dome').execute();
+      raw.pragma('foreign_keys = ON');
+
+      const warnSpy = vi.spyOn(logger, 'warn');
+      try {
+        const fromList = (await scriptRepo.getScripts()).find((s) => s.id === scriptId);
+        expect(fromList?.deploymentStatus).toEqual({});
+
+        const single = await scriptRepo.getScript(scriptId);
+        expect(single.deploymentStatus).toEqual({});
+
+        // The skip is observable, not silent.
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/astros_api/src/dal/repositories/script_repository.test.ts
+++ b/astros_api/src/dal/repositories/script_repository.test.ts
@@ -22,6 +22,7 @@ import {
   HcrCommand,
   HumanCyborgRelationsCmd,
   HcrCommandCategory,
+  UploadStatus,
 } from '../../models/index.js';
 import type { MaestroModule } from '../../models/index.js';
 import { upsertGpioModule } from './module_repositories/gpio_repository.js';
@@ -1032,6 +1033,71 @@ describe('Script Repository', () => {
 
       expect(durations.get(a)).toBe(8);
       expect(durations.get(b)).toBe(50);
+    });
+  });
+
+  describe('deploymentStatus keying (read path)', () => {
+    // Regression: getScripts()/getScript() keyed deploymentStatus by the
+    // location id (UUID FK), but the WebSocket update path (ScriptResponse) and
+    // every frontend consumer key it by the location NAME ('body'|'core'|'dome').
+    // On page refresh the UUID-keyed entries never matched the name lookup, so
+    // every status badge reverted to "Not uploaded". The read path must key the
+    // returned deploymentStatus by the location name, never the id.
+    async function seedDeployedScript(
+      locName: string,
+    ): Promise<{ scriptId: string; locId: string; deployedAt: Date }> {
+      // The body/core/dome locations are seeded by migration_0 with a UNIQUE
+      // name; resolve the seeded id rather than inserting a duplicate.
+      const { id: locId } = await db
+        .selectFrom('locations')
+        .select('id')
+        .where('name', '=', locName)
+        .executeTakeFirstOrThrow();
+
+      const scriptId = uuid();
+      const scriptRepo = new ScriptRepository(db);
+      await scriptRepo.upsertScript({
+        id: scriptId,
+        scriptName: 'Deployed Script',
+        description: '',
+        lastSaved: new Date(),
+        durationDS: 0,
+        playlistCount: 0,
+        deploymentStatus: {},
+        scriptChannels: [],
+      });
+
+      const deployedAt = new Date('2026-05-31T12:00:00.000Z');
+      await scriptRepo.updateScriptControllerUploaded(scriptId, locId, deployedAt);
+
+      return { scriptId, locId, deployedAt };
+    }
+
+    it('getScripts keys deploymentStatus by location name, not the id', async () => {
+      const { scriptId, locId, deployedAt } = await seedDeployedScript('dome');
+      const scriptRepo = new ScriptRepository(db);
+
+      const script = (await scriptRepo.getScripts()).find((s) => s.id === scriptId);
+
+      expect(script).toBeDefined();
+      // Keyed by the location name the frontend looks up by...
+      expect(script?.deploymentStatus['dome']).toBeDefined();
+      expect(script?.deploymentStatus['dome'].value).toBe(UploadStatus.uploaded);
+      expect(script?.deploymentStatus['dome'].date.getTime()).toBe(deployedAt.getTime());
+      // ...and NOT by the location id UUID (the original bug).
+      expect(script?.deploymentStatus[locId]).toBeUndefined();
+    });
+
+    it('getScript keys deploymentStatus by location name, not the id', async () => {
+      const { scriptId, locId, deployedAt } = await seedDeployedScript('body');
+      const scriptRepo = new ScriptRepository(db);
+
+      const script = await scriptRepo.getScript(scriptId);
+
+      expect(script.deploymentStatus['body']).toBeDefined();
+      expect(script.deploymentStatus['body'].value).toBe(UploadStatus.uploaded);
+      expect(script.deploymentStatus['body'].date.getTime()).toBe(deployedAt.getTime());
+      expect(script.deploymentStatus[locId]).toBeUndefined();
     });
   });
 });

--- a/astros_api/src/dal/repositories/script_repository.test.ts
+++ b/astros_api/src/dal/repositories/script_repository.test.ts
@@ -1049,7 +1049,7 @@ describe('Script Repository', () => {
     // returned deploymentStatus by the location name, never the id.
     async function seedDeployedScript(
       locName: string,
-    ): Promise<{ scriptId: string; locId: string; deployedAt: Date }> {
+    ): Promise<{ scriptId: string; deployedAt: Date }> {
       // The body/core/dome locations are seeded by migration_0 with a UNIQUE
       // name; resolve the seeded id rather than inserting a duplicate.
       const { id: locId } = await db
@@ -1074,34 +1074,34 @@ describe('Script Repository', () => {
       const deployedAt = new Date('2026-05-31T12:00:00.000Z');
       await scriptRepo.updateScriptControllerUploaded(scriptId, locId, deployedAt);
 
-      return { scriptId, locId, deployedAt };
+      return { scriptId, deployedAt };
     }
 
     it('getScripts keys deploymentStatus by location name, not the id', async () => {
-      const { scriptId, locId, deployedAt } = await seedDeployedScript('dome');
+      const { scriptId, deployedAt } = await seedDeployedScript('dome');
       const scriptRepo = new ScriptRepository(db);
 
       const script = (await scriptRepo.getScripts()).find((s) => s.id === scriptId);
 
       expect(script).toBeDefined();
-      // Keyed by the location name the frontend looks up by...
-      expect(script?.deploymentStatus['dome']).toBeDefined();
-      expect(script?.deploymentStatus['dome'].value).toBe(UploadStatus.uploaded);
-      expect(script?.deploymentStatus['dome'].date.getTime()).toBe(deployedAt.getTime());
-      // ...and NOT by the location id UUID (the original bug).
-      expect(script?.deploymentStatus[locId]).toBeUndefined();
+      // 'dome' is the SOLE key — keyed by the location name the frontend looks up
+      // by, never the location id UUID (the original bug).
+      expect(Object.keys(script?.deploymentStatus ?? {})).toEqual(['dome']);
+      const status = script?.deploymentStatus['dome'];
+      expect(status?.value).toBe(UploadStatus.uploaded);
+      expect(status?.date.getTime()).toBe(deployedAt.getTime());
     });
 
     it('getScript keys deploymentStatus by location name, not the id', async () => {
-      const { scriptId, locId, deployedAt } = await seedDeployedScript('body');
+      const { scriptId, deployedAt } = await seedDeployedScript('body');
       const scriptRepo = new ScriptRepository(db);
 
       const script = await scriptRepo.getScript(scriptId);
 
-      expect(script.deploymentStatus['body']).toBeDefined();
-      expect(script.deploymentStatus['body'].value).toBe(UploadStatus.uploaded);
-      expect(script.deploymentStatus['body'].date.getTime()).toBe(deployedAt.getTime());
-      expect(script.deploymentStatus[locId]).toBeUndefined();
+      expect(Object.keys(script.deploymentStatus)).toEqual(['body']);
+      const status = script.deploymentStatus['body'];
+      expect(status?.value).toBe(UploadStatus.uploaded);
+      expect(status?.date.getTime()).toBe(deployedAt.getTime());
     });
 
     it('skips (and logs) a deployment row whose location was removed', async () => {

--- a/astros_api/src/dal/repositories/script_repository.ts
+++ b/astros_api/src/dal/repositories/script_repository.ts
@@ -12,6 +12,7 @@ import {
   ModuleClassType,
   MaestroEvent,
   MaestroChannel,
+  isLocationName,
 } from 'src/models/index.js';
 import { logger } from 'src/logger.js';
 import { Guid } from 'guid-typescript';
@@ -186,20 +187,19 @@ export class ScriptRepository {
       for (const dep of deployments) {
         // Key by the location name ('body'|'core'|'dome'), not the location_id
         // UUID: the WS update path and every frontend consumer look up
-        // deploymentStatus by the Location enum name. Skip orphaned rows whose
-        // location no longer exists (no name to key by) — unreachable while the
-        // FK cascade holds, so log rather than fail the whole list.
-        if (!dep.location_name) {
+        // deploymentStatus by that name. The guard narrows location_name to a
+        // LocationName and skips orphaned rows (no/unknown location) —
+        // unreachable while the FK cascade holds, so log rather than fail the list.
+        if (!isLocationName(dep.location_name)) {
           logger.warn(
             `ScriptRepository.getScripts: skipping deployment for script ${scr.id} — ` +
-              `location_id ${dep.location_id} has no matching location (orphaned FK?)`,
+              `location_id ${dep.location_id} has no recognized location name (orphaned FK?)`,
           );
           continue;
         }
         const status: DeploymentStatus = {
           date: new Date(dep.last_deployed),
           value: UploadStatus.uploaded,
-          locationName: dep.location_name,
         };
         scr.deploymentStatus[dep.location_name] = status;
       }
@@ -251,18 +251,17 @@ export class ScriptRepository {
 
     for (const dep of deployments) {
       // Key by the location name ('body'|'core'|'dome'), not the location_id
-      // UUID — see getScripts() above. Skip orphaned rows with no location.
-      if (!dep.location_name) {
+      // UUID — see getScripts() above. Skip orphaned/unknown-location rows.
+      if (!isLocationName(dep.location_name)) {
         logger.warn(
           `ScriptRepository.getScript: skipping deployment for script ${id} — ` +
-            `location_id ${dep.location_id} has no matching location (orphaned FK?)`,
+            `location_id ${dep.location_id} has no recognized location name (orphaned FK?)`,
         );
         continue;
       }
       const status: DeploymentStatus = {
         date: new Date(dep.last_deployed),
         value: UploadStatus.uploaded,
-        locationName: dep.location_name,
       };
       result.deploymentStatus[dep.location_name] = status;
     }

--- a/astros_api/src/dal/repositories/script_repository.ts
+++ b/astros_api/src/dal/repositories/script_repository.ts
@@ -187,8 +187,13 @@ export class ScriptRepository {
         // Key by the location name ('body'|'core'|'dome'), not the location_id
         // UUID: the WS update path and every frontend consumer look up
         // deploymentStatus by the Location enum name. Skip orphaned rows whose
-        // location no longer exists (no name to key by).
+        // location no longer exists (no name to key by) — unreachable while the
+        // FK cascade holds, so log rather than fail the whole list.
         if (!dep.location_name) {
+          logger.warn(
+            `ScriptRepository.getScripts: skipping deployment for script ${scr.id} — ` +
+              `location_id ${dep.location_id} has no matching location (orphaned FK?)`,
+          );
           continue;
         }
         const status: DeploymentStatus = {
@@ -248,6 +253,10 @@ export class ScriptRepository {
       // Key by the location name ('body'|'core'|'dome'), not the location_id
       // UUID — see getScripts() above. Skip orphaned rows with no location.
       if (!dep.location_name) {
+        logger.warn(
+          `ScriptRepository.getScript: skipping deployment for script ${id} — ` +
+            `location_id ${dep.location_id} has no matching location (orphaned FK?)`,
+        );
         continue;
       }
       const status: DeploymentStatus = {

--- a/astros_api/src/dal/repositories/script_repository.ts
+++ b/astros_api/src/dal/repositories/script_repository.ts
@@ -184,12 +184,19 @@ export class ScriptRepository {
         });
 
       for (const dep of deployments) {
+        // Key by the location name ('body'|'core'|'dome'), not the location_id
+        // UUID: the WS update path and every frontend consumer look up
+        // deploymentStatus by the Location enum name. Skip orphaned rows whose
+        // location no longer exists (no name to key by).
+        if (!dep.location_name) {
+          continue;
+        }
         const status: DeploymentStatus = {
           date: new Date(dep.last_deployed),
           value: UploadStatus.uploaded,
-          locationName: dep.location_name || '',
+          locationName: dep.location_name,
         };
-        scr.deploymentStatus[dep.location_id] = status;
+        scr.deploymentStatus[dep.location_name] = status;
       }
     }
 
@@ -238,12 +245,17 @@ export class ScriptRepository {
       });
 
     for (const dep of deployments) {
+      // Key by the location name ('body'|'core'|'dome'), not the location_id
+      // UUID — see getScripts() above. Skip orphaned rows with no location.
+      if (!dep.location_name) {
+        continue;
+      }
       const status: DeploymentStatus = {
         date: new Date(dep.last_deployed),
         value: UploadStatus.uploaded,
-        locationName: dep.location_name || '',
+        locationName: dep.location_name,
       };
-      result.deploymentStatus[dep.location_id] = status;
+      result.deploymentStatus[dep.location_name] = status;
     }
 
     result.scriptChannels = await this.readScriptChannels(id);

--- a/astros_api/src/models/constants.ts
+++ b/astros_api/src/models/constants.ts
@@ -3,3 +3,13 @@ export class Constants {
   static readonly DOME = 'dome';
   static readonly BODY = 'body';
 }
+
+/**
+ * The canonical location names seeded into `locations.name` and used as the key
+ * for a script's per-location deployment status. Kept in sync with `Constants`.
+ */
+export type LocationName = typeof Constants.BODY | typeof Constants.CORE | typeof Constants.DOME;
+
+export function isLocationName(value: string | null | undefined): value is LocationName {
+  return value === Constants.BODY || value === Constants.CORE || value === Constants.DOME;
+}

--- a/astros_api/src/models/index.ts
+++ b/astros_api/src/models/index.ts
@@ -45,7 +45,8 @@ export { RemotePage, PageButton } from './remotes/RemotePage.js';
 export type { RemoteScriptList } from './remotes/RemoteScriptList.js';
 export type { RemoteButton } from './remotes/RemoteButton.js';
 export type { DeploymentStatus } from './scripts/deployment_status.js';
-export { Constants } from './constants.js';
+export { Constants, isLocationName } from './constants.js';
+export type { LocationName } from './constants.js';
 export {
   ScriptChannelType,
   ModuleType,

--- a/astros_api/src/models/scripts/deployment_status.ts
+++ b/astros_api/src/models/scripts/deployment_status.ts
@@ -3,5 +3,4 @@ import { UploadStatus } from 'src/models/enums.js';
 export interface DeploymentStatus {
   date: Date;
   value: UploadStatus;
-  locationName: string;
 }

--- a/astros_api/src/models/scripts/script.ts
+++ b/astros_api/src/models/scripts/script.ts
@@ -1,3 +1,4 @@
+import { LocationName } from '../constants.js';
 import { DeploymentStatus } from './deployment_status.js';
 import { ScriptChannel } from './script_channel.js';
 
@@ -8,6 +9,8 @@ export interface Script {
   lastSaved: Date;
   durationDS: number;
   playlistCount: number;
-  deploymentStatus: Record<string, DeploymentStatus>;
+  // Keyed by location name ('body'|'core'|'dome'); the WS update path and every
+  // frontend consumer look it up by that name. A UUID key is now a type error.
+  deploymentStatus: Partial<Record<LocationName, DeploymentStatus>>;
   scriptChannels: Array<ScriptChannel>;
 }


### PR DESCRIPTION
# fix(scripts): persist & restore per-location upload status across refresh

**Branch:** `feature/script-upload-status-key` → `develop`

## Problem

On the Scripts page, uploading a script correctly updated the dome/core/body
status badges — but after a **page refresh** every badge reverted to
"Not uploaded," even though the deploy had been persisted to the database.

## Root cause

`deploymentStatus` is a per-script dictionary keyed by location. Two paths
populated it with **different keys**:

| Path | Key used | Result |
|------|----------|--------|
| Live WebSocket update after upload | location **name** (`'dome'`) | UI lookup matches → badge shows status ✓ |
| Page-load DB read (`getScripts`/`getScript`) | location **UUID** (`locations.id`) | UI lookup by name misses → "Not uploaded" ✗ |

Every frontend consumer (`AstrosScriptRow.vue`, `ScriptsView.vue`,
`AstrosScriptTestModal.vue`) looks up `deploymentStatus` by the `Location` enum
name (`'body' | 'core' | 'dome'`). The DB read path keyed it by the UUID, so
those entries were invisible to the UI. The live WebSocket update (name-keyed)
masked the defect for the whole session — it only surfaced on refresh, once the
in-memory state was gone and only the DB read remained.

This is the project's "location dual-identity" trap (UUID for DB FKs vs. enum
name for WS/frontend), surfacing on the read path as a silent UI no-op.

## The fix

`ScriptRepository.getScripts()` and `getScript()` now key `deploymentStatus` by
`dep.location_name` (already selected by the query) instead of the
`location_id` UUID, so the page-load shape matches the WebSocket-update shape and
the frontend lookup. Orphaned rows (no matching location) are skipped and logged.

### Hardening folded in from the pre-push review

- **Observable skip (not silent):** the "no/unknown location" branch now emits a
  `logger.warn` instead of silently dropping the row — so an orphaned-FK row
  (unreachable while the cascade holds, but possible if that invariant ever
  weakens) leaves a breadcrumb rather than a script mysteriously showing
  "Not uploaded."

- **Type-level prevention:** `Script.deploymentStatus` is tightened from
  `Record<string, DeploymentStatus>` to
  `Partial<Record<LocationName, DeploymentStatus>>`
  (`LocationName = 'body' | 'core' | 'dome'`, derived from `Constants`). Keying by
  a UUID is now a **compile error** (`TS7053`) rather than a runtime regression,
  and the backend type matches the frontend's already-tight
  `Partial<Record<Location, …>>`. The read guard uses an `isLocationName` type
  predicate that narrows the raw DB string to `LocationName` (no cast).

- **Dead-field removal:** dropped `DeploymentStatus.locationName` — it had zero
  readers in either project now that the map key *is* the name.

## Changes by area

**Backend (`astros_api`)**
- `dal/repositories/script_repository.ts` — key `deploymentStatus` by location
  name in both read methods; `isLocationName` guard; `logger.warn` on skip.
- `models/constants.ts` — add `LocationName` type + `isLocationName` predicate.
- `models/index.ts` — export both.
- `models/scripts/script.ts` — tighten `deploymentStatus` key type.
- `models/scripts/deployment_status.ts` — remove dead `locationName` field.

**Tests**
- `dal/repositories/script_repository.test.ts` — new `deploymentStatus keying
  (read path)` block: `getScripts`/`getScript` key by name (asserted via
  `Object.keys(...) === ['dome']`, which fails on a UUID key, a doubled key, or a
  missing key), plus an orphaned-deployment skip-and-warn test.

**Docs/plans** — light plans under `.docs/plans/` for the fix and the type tighten.

No frontend code changes were required (its types were already correct); the wire
JSON simply no longer carries the unused `locationName` field.

## Testing

- New regression tests fail without the fix and pass with it (watched RED→GREEN).
- Mutation-checked: neutering the orphan-skip guard fails the suite; reintroducing
  the UUID keying now fails `tsc` (`TS7053`) — the bug class is caught at build time.
- prettier clean · lint 0 errors · `tsc` exit 0 · full suite **869/869**.
- Pre-push multi-agent review run on the branch (code, tests, silent-failure,
  type-design, comments); the one Important finding (silent skip) was addressed,
  and the type-tighten follow-up received a dedicated focused review.

## Risk / compatibility

- Behavior change is limited to the shape of the `deploymentStatus` map returned
  by the scripts read endpoints; the persisted schema (`script_deployments`) is
  unchanged.
- Removing `DeploymentStatus.locationName` is wire-compatible — no consumer read it.
- `locations.name` is `NOT NULL UNIQUE` and seeded with exactly body/core/dome, so
  keying by name cannot collide across a script's multiple deployments.

## QA

Upload a script, confirm the dome/core/body badges turn green, then **refresh the
page** and confirm the badges remain green (previously they reverted to
"Not uploaded").
