### PR TITLE
Feature/controller status watchdog

### DIFF
--- a/.docs/plans/20260601-2042-controller-status-watchdog.md
+++ b/.docs/plans/20260601-2042-controller-status-watchdog.md
@@ -133,7 +133,6 @@ describe('ControllerWatchdog', () => {
       controllerLocation: 'dome',
       up: false,
       synced: false,
-      firmwareVersion: '',
       firmwareCompatible: false,
     });
   });

--- a/.docs/plans/20260601-2042-controller-status-watchdog.md
+++ b/.docs/plans/20260601-2042-controller-status-watchdog.md
@@ -229,7 +229,6 @@ export function buildDownStatus(id: ControllerIdentity): StatusResponse {
     controllerLocation: id.controllerLocation,
     up: false,
     synced: false,
-    firmwareVersion: '',
     firmwareCompatible: false,
   };
 }

--- a/.docs/plans/20260601-2042-controller-status-watchdog.md
+++ b/.docs/plans/20260601-2042-controller-status-watchdog.md
@@ -149,7 +149,7 @@ Expected: FAIL — `Failed to resolve import "./controller_watchdog.js"` (module
 Create `astros_api/src/serial/controller_watchdog.ts`:
 
 ```ts
-import { StatusResponse, TransmissionType } from 'src/models/index.js';
+import { TransmissionType, type StatusResponse } from 'src/models/index.js';
 
 /** How long a controller may be silent (no POLL_ACK) before it is marked DOWN. */
 export const STATUS_STALE_TIMEOUT_MS = 10_000;

--- a/.docs/plans/20260601-2042-controller-status-watchdog.md
+++ b/.docs/plans/20260601-2042-controller-status-watchdog.md
@@ -1,0 +1,440 @@
+# Controller Status Watchdog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect when controllers go silent (master offline / serial unplug / padawan dropout) and broadcast `StatusResponse{up:false}` so the Status page flips them to DOWN instead of freezing on the last-known value.
+
+**Architecture:** A pure, unit-testable `ControllerWatchdog` module tracks per-controller last-seen timestamps from `POLL_ACK`s and decides who has gone silent (edge-triggered via a `down` set). `api_server` owns the thin wiring: it calls `recordAck` from the existing poll handler, runs a `setInterval` sweep (suppressed during an OTA flash), marks all controllers down on the serial `close`/`error` event, and broadcasts the synthesized DOWN messages. No frontend, DB, or protocol changes — the UI already renders `up:false` as DOWN.
+
+**Tech Stack:** TypeScript, Node, vitest. Design spec: `.docs/plans/specs/2026-06-01-controller-status-watchdog-design.md`.
+
+---
+
+## File structure
+
+- **Create** `astros_api/src/serial/controller_watchdog.ts` — the `ControllerWatchdog` class, `ControllerIdentity` type, `buildDownStatus()` helper, and the two timing constants. Pure logic; no serial/DB/WS/`Date.now()`.
+- **Create** `astros_api/src/serial/controller_watchdog.test.ts` — unit tests (TDD, mutation-checked).
+- **Modify** `astros_api/src/api_server.ts` — instantiate the watchdog, `recordAck` in `handlePollResponse`, the sweep `setInterval` in `setupSerialPort()`, `markAllDown` in the serial `error`/`close` handlers, and `clearInterval` in `shutdown()`.
+- **Create** `.docs/qa/controller-status-watchdog.md` — manual QA plan (the serial wiring is covered by QA, not automated tests, per the serial TDD exception).
+
+## Failure-mode inventory (brief)
+
+| Mode | Handling |
+|---|---|
+| Timer leaks past process exit | `setInterval` handle is `.unref()`'d (won't hold the event loop) and `clearInterval`'d in `shutdown()`. |
+| Sweep callback fires after teardown | `shutdown()` clears the timer before tearing down clients; `updateClients` already guards per-client send failures. |
+| `error` then `close` both fire | `markAllDown` is edge-triggered (skips controllers already in `down`) → idempotent, no duplicate broadcasts. |
+| False DOWN during OTA flash | Sweep is skipped while `flashOrchestrator.getCurrentJob()` is non-null. |
+| False DOWN on a flaky serial frame | 10 s timeout ≈ 2–3 missed ~4 s ack cycles of slack. |
+| Never-seen controller churn | Controllers absent from `lastSeen` are never emitted; cold-start DOWN is the store default. |
+| Recovery | Next `POLL_ACK` → existing `handlePollResponse` broadcasts `up:true` and `recordAck` clears the `down` flag. No recovery code. |
+
+---
+
+### Task 1: `ControllerWatchdog` module
+
+**Files:**
+- Create: `astros_api/src/serial/controller_watchdog.ts`
+- Test: `astros_api/src/serial/controller_watchdog.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `astros_api/src/serial/controller_watchdog.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { TransmissionType } from 'src/models/index.js';
+import {
+  ControllerWatchdog,
+  buildDownStatus,
+  STATUS_STALE_TIMEOUT_MS,
+  type ControllerIdentity,
+} from './controller_watchdog.js';
+
+const dome: ControllerIdentity = {
+  controllerId: 'id-dome',
+  controllerAddress: 'AA:BB:CC:DD:EE:01',
+  controllerLocation: 'dome',
+};
+const body: ControllerIdentity = {
+  controllerId: 'id-body',
+  controllerAddress: '00:00:00:00:00:00',
+  controllerLocation: 'body',
+};
+
+describe('ControllerWatchdog', () => {
+  it('does not flag a controller still within the timeout window', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 1000);
+    expect(wd.sweep(1000 + STATUS_STALE_TIMEOUT_MS)).toEqual([]); // exactly at threshold, not over
+  });
+
+  it('flags a controller that has been silent longer than the timeout', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 1000);
+    expect(wd.sweep(1000 + STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]);
+  });
+
+  it('emits a DOWN only once per outage (edge-triggered)', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    const first = wd.sweep(STATUS_STALE_TIMEOUT_MS + 1);
+    const second = wd.sweep(STATUS_STALE_TIMEOUT_MS + 5000);
+    expect(first).toEqual([dome]);
+    expect(second).toEqual([]); // already down, do not re-emit
+  });
+
+  it('re-arms after a recovering ack and can flag DOWN again', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    expect(wd.sweep(STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]);
+    wd.recordAck(dome, 100_000); // recovered
+    expect(wd.sweep(100_000 + 1)).toEqual([]); // fresh again
+    expect(wd.sweep(100_000 + STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]); // silent again
+  });
+
+  it('only flags the stale controller, not a fresh sibling', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    wd.recordAck(body, 9_000);
+    expect(wd.sweep(STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]); // body still fresh
+  });
+
+  it('never flags a controller it has never seen', () => {
+    const wd = new ControllerWatchdog();
+    expect(wd.sweep(1_000_000)).toEqual([]);
+    expect(wd.markAllDown()).toEqual([]);
+  });
+
+  it('markAllDown flags every seen controller once, idempotently', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    wd.recordAck(body, 0);
+    const all = wd.markAllDown();
+    expect(all).toEqual(expect.arrayContaining([dome, body]));
+    expect(all).toHaveLength(2);
+    expect(wd.markAllDown()).toEqual([]); // already down
+  });
+
+  it('a sweep after markAllDown does not re-emit', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    wd.markAllDown();
+    expect(wd.sweep(STATUS_STALE_TIMEOUT_MS + 1)).toEqual([]);
+  });
+
+  it('buildDownStatus produces a DOWN StatusResponse the UI renders as down', () => {
+    expect(buildDownStatus(dome)).toEqual({
+      type: TransmissionType.status,
+      success: true,
+      message: '',
+      controllerId: 'id-dome',
+      controllerAddress: 'AA:BB:CC:DD:EE:01',
+      controllerLocation: 'dome',
+      up: false,
+      synced: false,
+      firmwareVersion: '',
+      firmwareCompatible: false,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `cd astros_api && npx vitest run src/serial/controller_watchdog.test.ts`
+Expected: FAIL — `Failed to resolve import "./controller_watchdog.js"` (module not created yet).
+
+- [ ] **Step 3: Write the module**
+
+Create `astros_api/src/serial/controller_watchdog.ts`:
+
+```ts
+import { StatusResponse, TransmissionType } from 'src/models/index.js';
+
+/** How long a controller may be silent (no POLL_ACK) before it is marked DOWN. */
+export const STATUS_STALE_TIMEOUT_MS = 10_000;
+/** How often the staleness sweep runs. */
+export const STATUS_SWEEP_INTERVAL_MS = 2_000;
+
+/** The identity a DOWN broadcast needs, captured from each POLL_ACK. */
+export interface ControllerIdentity {
+  controllerId: string;
+  controllerAddress: string;
+  controllerLocation: string; // body | core | dome — the key the frontend reads
+}
+
+/**
+ * Tracks controller liveness from POLL_ACK timestamps and decides which
+ * controllers have gone silent. Pure logic: the caller passes `now` and does the
+ * broadcasting — no serial/DB/WS/Date.now() here, so it is fully unit-testable.
+ *
+ * Edge-triggered: a controller emits one DOWN on the up->down transition (via the
+ * `down` set), not once per sweep, preventing WS spam and UI flapping.
+ */
+export class ControllerWatchdog {
+  private readonly lastSeen = new Map<string, { id: ControllerIdentity; at: number }>();
+  private readonly down = new Set<string>();
+
+  constructor(private readonly staleTimeoutMs: number = STATUS_STALE_TIMEOUT_MS) {}
+
+  /** A POLL_ACK arrived: stamp last-seen and clear any DOWN flag. */
+  recordAck(id: ControllerIdentity, now: number): void {
+    this.lastSeen.set(id.controllerId, { id, at: now });
+    this.down.delete(id.controllerId);
+  }
+
+  /**
+   * Periodic check: return controllers silent longer than the timeout that are
+   * not already flagged, marking them DOWN. Caller broadcasts each as up:false.
+   */
+  sweep(now: number): ControllerIdentity[] {
+    const newlyDown: ControllerIdentity[] = [];
+    for (const [controllerId, entry] of this.lastSeen) {
+      if (this.down.has(controllerId)) {
+        continue;
+      }
+      if (now - entry.at > this.staleTimeoutMs) {
+        this.down.add(controllerId);
+        newlyDown.push(entry.id);
+      }
+    }
+    return newlyDown;
+  }
+
+  /**
+   * Serial close/error fast-path: return every seen controller not already
+   * flagged, marking them DOWN. They stay down until a fresh recordAck.
+   */
+  markAllDown(): ControllerIdentity[] {
+    const newlyDown: ControllerIdentity[] = [];
+    for (const [controllerId, entry] of this.lastSeen) {
+      if (this.down.has(controllerId)) {
+        continue;
+      }
+      this.down.add(controllerId);
+      newlyDown.push(entry.id);
+    }
+    return newlyDown;
+  }
+}
+
+/** Synthesize the DOWN StatusResponse the UI renders as ControllerStatus.DOWN. */
+export function buildDownStatus(id: ControllerIdentity): StatusResponse {
+  return {
+    type: TransmissionType.status,
+    success: true,
+    message: '',
+    controllerId: id.controllerId,
+    controllerAddress: id.controllerAddress,
+    controllerLocation: id.controllerLocation,
+    up: false,
+    synced: false,
+    firmwareVersion: '',
+    firmwareCompatible: false,
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `cd astros_api && npx vitest run src/serial/controller_watchdog.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Mutation-check the defensive guards** (per the project's defensive-feature convention)
+
+Temporarily break each guard, confirm a test fails, then restore:
+1. In `sweep`, change `now - entry.at > this.staleTimeoutMs` to `< this.staleTimeoutMs`. Run the file → "flags a controller that has been silent…" FAILS. Restore.
+2. In `sweep`, delete the `if (this.down.has(controllerId)) { continue; }` guard. Run the file → "emits a DOWN only once per outage" FAILS (second sweep re-emits). Restore.
+3. In `recordAck`, delete `this.down.delete(id.controllerId);`. Run the file → "re-arms after a recovering ack…" FAILS. Restore.
+
+Re-run the file after restoring → PASS (9 tests).
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+cd astros_api && npm run prettier:write && npm run lint:fix
+git add astros_api/src/serial/controller_watchdog.ts astros_api/src/serial/controller_watchdog.test.ts
+git commit -m "feat(status): ControllerWatchdog — detect silent controllers (pure logic + tests)"
+```
+
+---
+
+### Task 2: Wire the watchdog into `api_server`
+
+**Files:**
+- Modify: `astros_api/src/api_server.ts` (import; two fields; `handlePollResponse` `:1001-1014`; `setupSerialPort` `:659-665`; `shutdown` `:1383`)
+
+> No automated test: this wiring lives in `setupSerialPort()`, which is skipped under `NODE_ENV=test`. It is covered by the manual QA plan in Task 3 (serial TDD exception). The logic it calls is already fully unit-tested in Task 1.
+
+- [ ] **Step 1: Add the import**
+
+Add to the existing imports in `api_server.ts` (anywhere among the `src/serial/...` imports):
+
+```ts
+import {
+  ControllerWatchdog,
+  buildDownStatus,
+  STATUS_SWEEP_INTERVAL_MS,
+} from 'src/serial/controller_watchdog.js';
+```
+
+- [ ] **Step 2: Add the two fields**
+
+Next to the other private fields (near `private serialPort: any;` at `:180` and `private flashOrchestrator?` at `:212`):
+
+```ts
+  private readonly controllerWatchdog = new ControllerWatchdog();
+  private statusSweepTimer: NodeJS.Timeout | null = null;
+```
+
+- [ ] **Step 3: Record each POLL_ACK in `handlePollResponse`**
+
+In `handlePollResponse`, immediately before the existing `this.updateClients(update);` (`:1014`), add:
+
+```ts
+      this.controllerWatchdog.recordAck(
+        {
+          controllerId: controller.id,
+          controllerAddress: val.controller.address,
+          controllerLocation: location.locationName,
+        },
+        Date.now(),
+      );
+```
+
+- [ ] **Step 4: Add the sweep interval in `setupSerialPort()`**
+
+In `setupSerialPort()`, after the `this.serialParser = ...` block but still inside the `try` (i.e. just before the closing `} catch (err) {` at `:675`), add:
+
+```ts
+      // Staleness watchdog: a controller silent past the timeout flips to DOWN.
+      // Suppressed during an OTA flash — the master reboots and polls pause past
+      // the timeout, and the firmware-stages board owns status then.
+      this.statusSweepTimer = setInterval(() => {
+        if (this.flashOrchestrator?.getCurrentJob()) {
+          return;
+        }
+        for (const id of this.controllerWatchdog.sweep(Date.now())) {
+          this.updateClients(buildDownStatus(id));
+        }
+      }, STATUS_SWEEP_INTERVAL_MS);
+      this.statusSweepTimer.unref();
+```
+
+- [ ] **Step 5: Mark all down on serial `error`/`close` (the fast-path)**
+
+Replace the existing handlers (`:659-665`):
+
+```ts
+      this.serialPort.on('error', (err: any) => {
+        logger.error(`Serial port error: ${err}`);
+      });
+
+      this.serialPort.on('close', () => {
+        logger.warn('Serial port closed');
+      });
+```
+
+with:
+
+```ts
+      this.serialPort.on('error', (err: any) => {
+        logger.error(`Serial port error: ${err}`);
+        for (const id of this.controllerWatchdog.markAllDown()) {
+          this.updateClients(buildDownStatus(id));
+        }
+      });
+
+      this.serialPort.on('close', () => {
+        logger.warn('Serial port closed');
+        for (const id of this.controllerWatchdog.markAllDown()) {
+          this.updateClients(buildDownStatus(id));
+        }
+      });
+```
+
+- [ ] **Step 6: Clear the timer in `shutdown()`**
+
+In `shutdown()`, immediately after the `safeClose` helper is defined and before the first existing `await safeClose(...)` call (`:1397`), add:
+
+```ts
+    await safeClose('statusSweepTimer.clear', () => {
+      if (this.statusSweepTimer) {
+        clearInterval(this.statusSweepTimer);
+        this.statusSweepTimer = null;
+      }
+    });
+```
+
+- [ ] **Step 7: Build, lint, full suite — verify nothing broke**
+
+```bash
+cd astros_api && npm run prettier:write && npm run lint:fix && npm run build && npx vitest run
+```
+Expected: lint 0 errors; `tsc` clean; full suite green (existing count + the 9 new watchdog tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add astros_api/src/api_server.ts
+git commit -m "feat(status): wire ControllerWatchdog into api_server (sweep + serial-close fast-path)"
+```
+
+---
+
+### Task 3: Manual QA plan
+
+**Files:**
+- Create: `.docs/qa/controller-status-watchdog.md`
+
+- [ ] **Step 1: Write the QA plan**
+
+Create `.docs/qa/controller-status-watchdog.md`:
+
+```markdown
+# QA: Controller status watchdog
+
+**Preconditions:** server running against real hardware (master + at least one
+padawan), all controllers showing UP (green) on the Status page, a browser on
+the Status page with the WebSocket connected.
+
+## Test cases
+
+1. **Staleness → DOWN.** Power off / disconnect a single padawan (master stays
+   up). Expected: within ~10 s that location's badge turns grey (DOWN); the
+   others stay green.
+2. **Serial unplug → all DOWN immediately.** Unplug the master's USB-serial.
+   Expected: all three badges go grey effectively immediately (serial `close`
+   fast-path), not after the 10 s timeout.
+3. **Recovery.** Reconnect/repower. Expected: each badge returns to green on its
+   next POLL_ACK (no page refresh needed).
+4. **No flap during OTA flash.** Start a firmware flash. Expected: the Status
+   page does NOT flip controllers to DOWN while the flash is in progress, even
+   though the master reboots and goes silent > 10 s. After the flash, status
+   reflects reality.
+5. **Edge-trigger (no spam).** With a controller offline, watch the network/WS
+   frames. Expected: a single `status{up:false}` per controller per outage, not
+   one every 2 s.
+6. **Clean shutdown.** Stop the server (SIGINT). Expected: no errors about a
+   timer firing after teardown; process exits promptly (timer is unref'd).
+
+## Negative / edge
+- Master offline at page-load time still shows DOWN (store default) — unchanged.
+- A controller never seen this session is never spuriously emitted.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .docs/qa/controller-status-watchdog.md
+git commit -m "docs(qa): manual QA plan for controller status watchdog"
+```
+
+---
+
+## After all tasks
+
+- [ ] Update the spec/plan status if desired; run the pre-push branch review
+      (`/pr-review-toolkit:review-pr`) on the full diff vs `develop`; address
+      Critical/Important; then open the PR with `gh pr create --base develop`.

--- a/.docs/plans/specs/2026-06-01-controller-status-watchdog-design.md
+++ b/.docs/plans/specs/2026-06-01-controller-status-watchdog-design.md
@@ -96,8 +96,8 @@ class ControllerWatchdog {
 
   // Serial close/error: return all seen-but-not-already-down controllers; add
   // them to `down` (so a later sweep won't re-emit). They stay down until a
-  // fresh recordAck clears the flag.
-  markAllDown(now: number): ControllerIdentity[];
+  // fresh recordAck clears the flag. (No `now` — it flags, it doesn't stamp time.)
+  markAllDown(): ControllerIdentity[];
 }
 ```
 

--- a/.docs/plans/specs/2026-06-01-controller-status-watchdog-design.md
+++ b/.docs/plans/specs/2026-06-01-controller-status-watchdog-design.md
@@ -1,0 +1,189 @@
+# Design: server-side controller status watchdog
+
+**Date:** 2026-06-01
+**Branch:** `feature/controller-status-watchdog` (off `develop`)
+**Status:** design — pending user review
+
+## Problem
+
+A controller's status on the Status page is **edge-triggered on good news
+only**: every update flows from a positive `POLL_ACK` through
+`handlePollResponse`, which broadcasts a `StatusResponse` with `up: true`
+(`api_server.ts:1001-1014`). There is no path that ever broadcasts `up: false`.
+
+So if the master ESP goes offline while a browser Status page is open:
+
+- The browser↔server WebSocket stays up (the Node server is fine), so the
+  frontend's reconnect logic never fires and never resets status.
+- The serial `'close'`/`'error'` handlers only log (`api_server.ts:659-665`).
+- No server-side timeout marks a silent controller offline — there is no
+  per-controller last-seen tracking and no sweep timer.
+
+Result: the badges **freeze at their last-known value**. A controller that was
+`UP` (green) when the master died stays green indefinitely, misleading the
+operator into thinking the droid is reachable. (Confirmed by code trace
+2026-06-01; the frozen-UP case is the dangerous one — a *page load* while the
+master is offline happens to show DOWN only because the store defaults to DOWN.)
+
+## Goal
+
+Detect that controllers have gone silent and broadcast `up: false` so the UI
+flips them to `DOWN` (grey), via two complementary triggers:
+
+1. **Staleness sweep** — per-controller: no `POLL_ACK` within ~10 s → DOWN.
+2. **Serial-close fast-path** — the serial `'close'`/`'error'` event → mark all
+   known controllers DOWN immediately (don't wait out the 10 s).
+
+**Non-goals:** reconnecting the serial port (no auto-reconnect exists today and
+that stays out of scope); a distinct `UNKNOWN`/`DISCONNECTED` UI state (we reuse
+`DOWN`); the firmware OTA deploy-phase watchdog, which is a *different* concern
+with its own spec (`2026-05-29-firmware-deploy-watchdog-design.md`) — that one
+fails a flash *job*; this one tracks *liveness status* of controllers.
+
+## Design decisions (settled in brainstorming)
+
+1. **Staleness sweep + serial-close fast-path** (not either alone). The sweep
+   catches a wedged master (port open, polling stopped) and a single padawan
+   dropping while the master keeps acking; the close fast-path gives instant
+   feedback on a physical unplug instead of waiting out the timeout.
+2. **Reuse `StatusResponse{ up: false }` → frontend `DOWN`.** The frontend
+   already maps `!up` to `ControllerStatus.DOWN` (grey overlay). **No new enum,
+   no new message type, no frontend changes.** "down" already effectively means
+   "not reachable" since polls only ever send `up: true`.
+3. **~10 s silence, swept every 2 s.** Each controller is realistically heard
+   ~every 4 s (firmware polls every 2 s, alternating master self-ack / padawan
+   poll), so 10 s ≈ 2–3 missed cycles of slack — tolerates dropped serial frames
+   without false-flagging, surfaces a real outage within a few seconds.
+   Configurable; defaults `STATUS_STALE_TIMEOUT_MS = 10_000`,
+   `STATUS_SWEEP_INTERVAL_MS = 2_000`.
+4. **Edge-triggered.** Emit one DOWN on the `up → down` transition, not every
+   sweep — a `down` set turns the level condition ("still silent") into an event
+   ("just went silent"). Prevents WS spam and UI flapping.
+5. **Suppress the sweep while a flash job is active.** During an OTA flash the
+   master reboots and polls legitimately pause > 10 s; the firmware-stages board
+   already owns per-controller status then. While
+   `flashOrchestrator.getCurrentJob() !== null`, skip the sweep. The
+   serial-close fast-path stays active (a genuine unplug mid-flash is still real).
+6. **Identity captured from each `POLL_ACK`.** The DOWN message needs
+   `controllerId`, `controllerAddress`, `controllerLocation`; the watchdog stores
+   those at `recordAck` time so it can synthesize a DOWN without a DB lookup.
+
+## Mechanism
+
+### New module — `astros_api/src/serial/controller_watchdog.ts`
+
+Pure timing logic: no serial, no DB, no WebSocket, no `Date.now()` (the caller
+passes `now`). Fully unit-testable with explicit timestamps.
+
+```ts
+interface ControllerIdentity {
+  controllerId: string;
+  controllerAddress: string;
+  controllerLocation: string; // body | core | dome (the frontend key)
+}
+
+class ControllerWatchdog {
+  constructor(private readonly staleTimeoutMs = STATUS_STALE_TIMEOUT_MS) {}
+  private lastSeen = new Map<string, { id: ControllerIdentity; at: number }>();
+  private down = new Set<string>(); // controllerIds currently flagged down
+
+  // POLL_ACK arrived: stamp last-seen, clear any down flag.
+  recordAck(id: ControllerIdentity, now: number): void;
+
+  // Periodic: return controllers gone silent > staleTimeoutMs and not already
+  // down; mark them down. Caller broadcasts a DOWN StatusResponse for each.
+  sweep(now: number): ControllerIdentity[];
+
+  // Serial close/error: return all seen-but-not-already-down controllers; add
+  // them to `down` (so a later sweep won't re-emit). They stay down until a
+  // fresh recordAck clears the flag.
+  markAllDown(now: number): ControllerIdentity[];
+}
+```
+
+Keyed by `controllerId` (the DB identity `handlePollResponse` already resolves).
+A never-seen controller is absent from `lastSeen`, so it is never flagged DOWN —
+the frontend's default `DOWN` covers cold-start, with no spurious up→down churn.
+
+### Wiring in `api_server` (the only consumer; serial-adjacent, skipped in test)
+
+- **Record:** in `handlePollResponse`, right where it builds the `up:true`
+  `StatusResponse` (`:1001`), also call
+  `this.watchdog.recordAck({ controllerId, controllerAddress, controllerLocation }, Date.now())`.
+- **Sweep:** a `setInterval(STATUS_SWEEP_INTERVAL_MS)` that, **unless**
+  `this.flashOrchestrator?.getCurrentJob()` is non-null, runs
+  `for (const id of this.watchdog.sweep(Date.now())) this.updateClients(buildDownStatus(id))`.
+  The timer is `.unref()`'d (never holds the process open), stored on the
+  instance, and `clearInterval`'d in the existing shutdown path. Created inside
+  the serial-setup block that already no-ops under `NODE_ENV=test`.
+- **Fast-path:** the `'close'` and `'error'` handlers (`:659-665`) additionally
+  `for (const id of this.watchdog.markAllDown(Date.now())) this.updateClients(buildDownStatus(id))`.
+
+### The DOWN message — `buildDownStatus(id): StatusResponse`
+
+Identical shape to the live path, `up:false`, fields the frontend ignores when
+`!up` set to inert defaults:
+
+```ts
+{ type: TransmissionType.status, success: true, message: '',
+  controllerId, controllerAddress, controllerLocation,
+  up: false, synced: false, firmwareVersion: '', firmwareCompatible: false }
+```
+
+### Recovery — free
+
+The next `POLL_ACK` runs the existing `handlePollResponse`, which broadcasts
+`up:true` *and* calls `recordAck` (clearing the down flag). No recovery code.
+
+## Races & invariants
+
+- **Edge-trigger prevents spam/flap.** `down` set ⇒ one DOWN per outage; the
+  2 s sweep does not re-emit while still silent.
+- **Asymmetric ownership.** The watchdog only ever introduces the down
+  transition; the existing poll handler owns the up transition. The two can't
+  fight: a fresh ack always wins (it clears `down` and broadcasts `up:true`).
+- **`markAllDown` then `sweep` don't double-fire.** `markAllDown` adds to `down`,
+  so the subsequent sweep skips them; they stay down until a fresh `recordAck`
+  clears the flag (correct — the port stays closed, no auto-reconnect).
+- **`'error'` + `'close'` both firing is idempotent** (edge-trigger).
+- **Flash suppression is sweep-only.** Serial-close still fires during a flash;
+  a real unplug mid-flash is a real event.
+- **Timer lifecycle.** `.unref()` so tests/process aren't held open;
+  `clearInterval` on shutdown so no callback runs against a torn-down server.
+
+## Surfaces touched
+
+- **Backend only.** New `serial/controller_watchdog.ts` + `.test.ts`;
+  `api_server.ts` wiring (instantiate, `recordAck` in `handlePollResponse`, sweep
+  interval, `markAllDown` in serial handlers, `buildDownStatus` helper,
+  `clearInterval` on shutdown). Two timing constants.
+- **No frontend changes. No DB changes. No new WS message type.**
+
+## Tests
+
+- **Unit (`controller_watchdog.test.ts`, TDD, mutation-checked):**
+  recordAck-then-sweep-before-threshold → no DOWN; after-threshold → one DOWN;
+  second sweep → no re-emit (edge-trigger); ack-after-down → clears, re-fires on
+  next timeout; `markAllDown` → all seen, not unseen, idempotent; never-seen →
+  never emitted; `buildDownStatus` shape. Revert each guard and confirm the test
+  fails (per the project's defensive-feature mutation convention).
+- **Wiring** (serial/interval in `api_server`) is exercised by **manual QA**, per
+  the serial TDD exception: open the Status page with controllers UP, pull the
+  master's serial, confirm all badges go grey within ~10 s (and immediately if
+  the close event fires); reconnect/repower, confirm they return to green on the
+  next poll; start a flash and confirm the page does not flap mid-flash.
+
+## Failure-mode inventory
+
+A short inventory (template: `.docs/templates/failure-mode-inventory.md`) will be
+filled in the plan covering: timer leak on shutdown; callback firing post-teardown;
+double-fire on error+close; false-positive during flash; false-positive on a
+flaky link (threshold tuning); never-seen-controller churn; and recovery
+correctness.
+
+## Out of scope (follow-ups)
+
+- Serial **auto-reconnect** (none exists today; the watchdog reports the outage,
+  it doesn't heal it).
+- A distinct `UNKNOWN`/`DISCONNECTED` UI state (reusing `DOWN` for now).
+- A `lastSeenAt` column / persisted liveness (in-memory only this PR).

--- a/.docs/plans/specs/2026-06-01-controller-status-watchdog-design.md
+++ b/.docs/plans/specs/2026-06-01-controller-status-watchdog-design.md
@@ -117,17 +117,19 @@ the frontend's default `DOWN` covers cold-start, with no spurious up→down chur
   instance, and `clearInterval`'d in the existing shutdown path. Created inside
   the serial-setup block that already no-ops under `NODE_ENV=test`.
 - **Fast-path:** the `'close'` and `'error'` handlers (`:659-665`) additionally
-  `for (const id of this.watchdog.markAllDown(Date.now())) this.updateClients(buildDownStatus(id))`.
+  `for (const id of this.watchdog.markAllDown()) this.updateClients(buildDownStatus(id))`.
 
 ### The DOWN message — `buildDownStatus(id): StatusResponse`
 
-Identical shape to the live path, `up:false`, fields the frontend ignores when
-`!up` set to inert defaults:
+Identical shape to the live path, `up:false`. The inert `synced`/`firmwareCompatible`
+fields are ignored when `!up`. `firmwareVersion` is omitted so the UI keeps showing
+a dash (its `?? '—'` fallback) rather than a blank, which would clobber the
+last-known version during an outage.
 
 ```ts
 { type: TransmissionType.status, success: true, message: '',
   controllerId, controllerAddress, controllerLocation,
-  up: false, synced: false, firmwareVersion: '', firmwareCompatible: false }
+  up: false, synced: false, firmwareCompatible: false }
 ```
 
 ### Recovery — free

--- a/.docs/qa/controller-status-watchdog.md
+++ b/.docs/qa/controller-status-watchdog.md
@@ -18,6 +18,9 @@ the Status page with the WebSocket connected.
    page does NOT flip controllers to DOWN while the flash is in progress, even
    though the master reboots and goes silent > 10 s. After the flash, status
    reflects reality.
+   - 4b. With a padawan ALREADY offline when the flash starts: confirm it does
+     NOT flip to DOWN mid-flash (sweep suppressed for all controllers during a
+     job), and DOES flip to DOWN within ~10 s AFTER the flash completes.
 5. **Edge-trigger (no spam).** With a controller offline, watch the network/WS
    frames. Expected: a single `status{up:false}` per controller per outage, not
    one every 2 s.
@@ -27,3 +30,6 @@ the Status page with the WebSocket connected.
 ## Negative / edge
 - Master offline at page-load time still shows DOWN (store default) — unchanged.
 - A controller never seen this session is never spuriously emitted.
+- Recovering from a serial `close` (USB unplug of the master) requires a server
+  restart — there is no serial auto-reconnect (a known non-goal); the DOWN badges
+  are accurate but the remedy is operator-driven.

--- a/.docs/qa/controller-status-watchdog.md
+++ b/.docs/qa/controller-status-watchdog.md
@@ -20,7 +20,7 @@ the Status page with the WebSocket connected.
    reflects reality.
    - 4b. With a padawan ALREADY offline when the flash starts: confirm it does
      NOT flip to DOWN mid-flash (sweep suppressed for all controllers during a
-     job), and DOES flip to DOWN within ~10 s AFTER the flash completes.
+     job), and DOES flip to DOWN within ~2 s (next sweep) AFTER the flash completes.
 5. **Edge-trigger (no spam).** With a controller offline, watch the network/WS
    frames. Expected: a single `status{up:false}` per controller per outage, not
    one every 2 s.

--- a/.docs/qa/controller-status-watchdog.md
+++ b/.docs/qa/controller-status-watchdog.md
@@ -1,0 +1,29 @@
+# QA: Controller status watchdog
+
+**Preconditions:** server running against real hardware (master + at least one
+padawan), all controllers showing UP (green) on the Status page, a browser on
+the Status page with the WebSocket connected.
+
+## Test cases
+
+1. **Staleness → DOWN.** Power off / disconnect a single padawan (master stays
+   up). Expected: within ~10 s that location's badge turns grey (DOWN); the
+   others stay green.
+2. **Serial unplug → all DOWN immediately.** Unplug the master's USB-serial.
+   Expected: all three badges go grey effectively immediately (serial `close`
+   fast-path), not after the 10 s timeout.
+3. **Recovery.** Reconnect/repower. Expected: each badge returns to green on its
+   next POLL_ACK (no page refresh needed).
+4. **No flap during OTA flash.** Start a firmware flash. Expected: the Status
+   page does NOT flip controllers to DOWN while the flash is in progress, even
+   though the master reboots and goes silent > 10 s. After the flash, status
+   reflects reality.
+5. **Edge-trigger (no spam).** With a controller offline, watch the network/WS
+   frames. Expected: a single `status{up:false}` per controller per outage, not
+   one every 2 s.
+6. **Clean shutdown.** Stop the server (SIGINT). Expected: no errors about a
+   timer firing after teardown; process exits promptly (timer is unref'd).
+
+## Negative / edge
+- Master offline at page-load time still shows DOWN (store default) — unchanged.
+- A controller never seen this session is never spuriously emitted.

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -102,6 +102,11 @@ import { FirmwareUploadStore } from './firmware/firmware_upload_store.js';
 import { GitHubReleaseService } from './firmware/github_release_service.js';
 import { decidePostDeployHeartbeat } from './firmware/post_deploy_heartbeat.js';
 import { decideLateJoinSnapshot } from './firmware/late_join_snapshot.js';
+import {
+  ControllerWatchdog,
+  buildDownStatus,
+  STATUS_SWEEP_INTERVAL_MS,
+} from 'src/serial/controller_watchdog.js';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -213,6 +218,9 @@ export class ApiServer {
   // POLL_ACK-fed variant cache keyed by controller MAC. Entries never expire;
   // operator recovers stale state via syncControllers (re-poll).
   private readonly controllerVariantCache = new Map<string, string>();
+
+  private readonly controllerWatchdog = new ControllerWatchdog();
+  private statusSweepTimer: NodeJS.Timeout | null = null;
 
   // Test-only: lets the harness poll-wait for a POLL_ACK to populate the cache
   // instead of sleeping an arbitrary duration before flashing.
@@ -658,10 +666,16 @@ export class ApiServer {
 
       this.serialPort.on('error', (err: any) => {
         logger.error(`Serial port error: ${err}`);
+        for (const id of this.controllerWatchdog.markAllDown()) {
+          this.updateClients(buildDownStatus(id));
+        }
       });
 
       this.serialPort.on('close', () => {
         logger.warn('Serial port closed');
+        for (const id of this.controllerWatchdog.markAllDown()) {
+          this.updateClients(buildDownStatus(id));
+        }
       });
 
       this.serialParser = this.serialPort
@@ -672,6 +686,19 @@ export class ApiServer {
             data: data.toString(),
           });
         });
+
+      // Staleness watchdog: a controller silent past the timeout flips to DOWN.
+      // Suppressed during an OTA flash — the master reboots and polls pause past
+      // the timeout, and the firmware-stages board owns status then.
+      this.statusSweepTimer = setInterval(() => {
+        if (this.flashOrchestrator?.getCurrentJob()) {
+          return;
+        }
+        for (const id of this.controllerWatchdog.sweep(Date.now())) {
+          this.updateClients(buildDownStatus(id));
+        }
+      }, STATUS_SWEEP_INTERVAL_MS);
+      this.statusSweepTimer.unref();
     } catch (err) {
       logger.error(`Failed to open serial port: ${err}`);
     }
@@ -1010,6 +1037,15 @@ export class ApiServer {
         firmwareVersion,
         firmwareCompatible,
       };
+
+      this.controllerWatchdog.recordAck(
+        {
+          controllerId: controller.id,
+          controllerAddress: val.controller.address,
+          controllerLocation: location.locationName,
+        },
+        Date.now(),
+      );
 
       this.updateClients(update);
     } catch (error) {
@@ -1393,6 +1429,13 @@ export class ApiServer {
         logger.error(`shutdown ${label} failed: ${msg}`);
       }
     };
+
+    await safeClose('statusSweepTimer.clear', () => {
+      if (this.statusSweepTimer) {
+        clearInterval(this.statusSweepTimer);
+        this.statusSweepTimer = null;
+      }
+    });
 
     await safeClose('animationQueue.panicStop', () => this.animationQueue?.panicStop());
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -54,6 +54,7 @@ import {
   ScriptResponse,
   TransmissionStatus,
   ModuleSubType,
+  isLocationName,
 } from './models/index.js';
 import { ControllerRepository } from './dal/repositories/controller_repository.js';
 import { createConfigSync } from './models/config/config_sync.js';
@@ -666,15 +667,23 @@ export class ApiServer {
 
       this.serialPort.on('error', (err: any) => {
         logger.error(`Serial port error: ${err}`);
-        for (const id of this.controllerWatchdog.markAllDown()) {
-          this.updateClients(buildDownStatus(id));
+        try {
+          for (const id of this.controllerWatchdog.markAllDown()) {
+            this.updateClients(buildDownStatus(id));
+          }
+        } catch (e) {
+          logger.error(`markAllDown broadcast (serial error) failed: ${e}`);
         }
       });
 
       this.serialPort.on('close', () => {
         logger.warn('Serial port closed');
-        for (const id of this.controllerWatchdog.markAllDown()) {
-          this.updateClients(buildDownStatus(id));
+        try {
+          for (const id of this.controllerWatchdog.markAllDown()) {
+            this.updateClients(buildDownStatus(id));
+          }
+        } catch (e) {
+          logger.error(`markAllDown broadcast (serial close) failed: ${e}`);
         }
       });
 
@@ -691,11 +700,15 @@ export class ApiServer {
       // Suppressed during an OTA flash — the master reboots and polls pause past
       // the timeout, and the firmware-stages board owns status then.
       this.statusSweepTimer = setInterval(() => {
-        if (this.flashOrchestrator?.getCurrentJob()) {
-          return;
-        }
-        for (const id of this.controllerWatchdog.sweep(Date.now())) {
-          this.updateClients(buildDownStatus(id));
+        try {
+          if (this.flashOrchestrator?.getCurrentJob()) {
+            return;
+          }
+          for (const id of this.controllerWatchdog.sweep(Date.now())) {
+            this.updateClients(buildDownStatus(id));
+          }
+        } catch (err) {
+          logger.error(`status sweep failed: ${err}`);
         }
       }, STATUS_SWEEP_INTERVAL_MS);
       this.statusSweepTimer.unref();
@@ -1038,14 +1051,20 @@ export class ApiServer {
         firmwareCompatible,
       };
 
-      this.controllerWatchdog.recordAck(
-        {
-          controllerId: controller.id,
-          controllerAddress: val.controller.address,
-          controllerLocation: location.locationName,
-        },
-        Date.now(),
-      );
+      if (isLocationName(location.locationName)) {
+        this.controllerWatchdog.recordAck(
+          {
+            controllerId: controller.id,
+            controllerAddress: val.controller.address,
+            controllerLocation: location.locationName,
+          },
+          Date.now(),
+        );
+      } else {
+        logger.error(
+          `handlePollResponse: unexpected location name '${location.locationName}' for controller ${controller.id}; skipping watchdog tracking`,
+        );
+      }
 
       this.updateClients(update);
     } catch (error) {

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -708,7 +708,7 @@ export class ApiServer {
             this.updateClients(buildDownStatus(id));
           }
         } catch (err) {
-          logger.error(`status sweep failed: ${err}`);
+          logger.error({ err }, 'status sweep failed');
         }
       }, STATUS_SWEEP_INTERVAL_MS);
       this.statusSweepTimer.unref();

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -683,7 +683,7 @@ export class ApiServer {
             this.updateClients(buildDownStatus(id));
           }
         } catch (e) {
-          logger.error(`markAllDown broadcast (serial close) failed: ${e}`);
+          logger.error({ err: e }, 'markAllDown broadcast (serial close) failed');
         }
       });
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -672,7 +672,7 @@ export class ApiServer {
             this.updateClients(buildDownStatus(id));
           }
         } catch (e) {
-          logger.error(`markAllDown broadcast (serial error) failed: ${e}`);
+          logger.error({ err: e }, 'markAllDown broadcast (serial error) failed');
         }
       });
 

--- a/astros_api/src/api_server.ts
+++ b/astros_api/src/api_server.ts
@@ -709,9 +709,8 @@ export class ApiServer {
           }
         } catch (err) {
           logger.error({ err }, 'status sweep failed');
-        }
       }, STATUS_SWEEP_INTERVAL_MS);
-      this.statusSweepTimer.unref();
+      this.statusSweepTimer?.unref();
     } catch (err) {
       logger.error(`Failed to open serial port: ${err}`);
     }

--- a/astros_api/src/serial/controller_watchdog.test.ts
+++ b/astros_api/src/serial/controller_watchdog.test.ts
@@ -14,7 +14,7 @@ const dome: ControllerIdentity = {
 };
 const body: ControllerIdentity = {
   controllerId: 'id-body',
-  controllerAddress: '00:00:00:00:00:00',
+  controllerAddress: 'AA:BB:CC:DD:EE:02',
   controllerLocation: 'body',
 };
 
@@ -29,6 +29,13 @@ describe('ControllerWatchdog', () => {
     const wd = new ControllerWatchdog();
     wd.recordAck(dome, 1000);
     expect(wd.sweep(1000 + STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]);
+  });
+
+  it('respects a custom staleTimeoutMs passed to the constructor', () => {
+    const wd = new ControllerWatchdog(500);
+    wd.recordAck(dome, 0);
+    expect(wd.sweep(500)).toEqual([]); // exactly at the custom threshold, not over
+    expect(wd.sweep(501)).toEqual([dome]); // over it
   });
 
   it('emits a DOWN only once per outage (edge-triggered)', () => {

--- a/astros_api/src/serial/controller_watchdog.test.ts
+++ b/astros_api/src/serial/controller_watchdog.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { TransmissionType } from 'src/models/index.js';
+import {
+  ControllerWatchdog,
+  buildDownStatus,
+  STATUS_STALE_TIMEOUT_MS,
+  type ControllerIdentity,
+} from './controller_watchdog.js';
+
+const dome: ControllerIdentity = {
+  controllerId: 'id-dome',
+  controllerAddress: 'AA:BB:CC:DD:EE:01',
+  controllerLocation: 'dome',
+};
+const body: ControllerIdentity = {
+  controllerId: 'id-body',
+  controllerAddress: '00:00:00:00:00:00',
+  controllerLocation: 'body',
+};
+
+describe('ControllerWatchdog', () => {
+  it('does not flag a controller still within the timeout window', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 1000);
+    expect(wd.sweep(1000 + STATUS_STALE_TIMEOUT_MS)).toEqual([]); // exactly at threshold, not over
+  });
+
+  it('flags a controller that has been silent longer than the timeout', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 1000);
+    expect(wd.sweep(1000 + STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]);
+  });
+
+  it('emits a DOWN only once per outage (edge-triggered)', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    const first = wd.sweep(STATUS_STALE_TIMEOUT_MS + 1);
+    const second = wd.sweep(STATUS_STALE_TIMEOUT_MS + 5000);
+    expect(first).toEqual([dome]);
+    expect(second).toEqual([]); // already down, do not re-emit
+  });
+
+  it('re-arms after a recovering ack and can flag DOWN again', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    expect(wd.sweep(STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]);
+    wd.recordAck(dome, 100_000); // recovered
+    expect(wd.sweep(100_000 + 1)).toEqual([]); // fresh again
+    expect(wd.sweep(100_000 + STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]); // silent again
+  });
+
+  it('only flags the stale controller, not a fresh sibling', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    wd.recordAck(body, 9_000);
+    expect(wd.sweep(STATUS_STALE_TIMEOUT_MS + 1)).toEqual([dome]); // body still fresh
+  });
+
+  it('never flags a controller it has never seen', () => {
+    const wd = new ControllerWatchdog();
+    expect(wd.sweep(1_000_000)).toEqual([]);
+    expect(wd.markAllDown()).toEqual([]);
+  });
+
+  it('markAllDown flags every seen controller once, idempotently', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    wd.recordAck(body, 0);
+    const all = wd.markAllDown();
+    expect(all).toEqual(expect.arrayContaining([dome, body]));
+    expect(all).toHaveLength(2);
+    expect(wd.markAllDown()).toEqual([]); // already down
+  });
+
+  it('a sweep after markAllDown does not re-emit', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    wd.markAllDown();
+    expect(wd.sweep(STATUS_STALE_TIMEOUT_MS + 1)).toEqual([]);
+  });
+
+  it('buildDownStatus produces a DOWN StatusResponse the UI renders as down', () => {
+    expect(buildDownStatus(dome)).toEqual({
+      type: TransmissionType.status,
+      success: true,
+      message: '',
+      controllerId: 'id-dome',
+      controllerAddress: 'AA:BB:CC:DD:EE:01',
+      controllerLocation: 'dome',
+      up: false,
+      synced: false,
+      firmwareVersion: '',
+      firmwareCompatible: false,
+    });
+  });
+});

--- a/astros_api/src/serial/controller_watchdog.test.ts
+++ b/astros_api/src/serial/controller_watchdog.test.ts
@@ -79,6 +79,14 @@ describe('ControllerWatchdog', () => {
     expect(wd.markAllDown()).toEqual([]); // already down
   });
 
+  it('markAllDown re-arms after a recovering ack (close → reconnect → close)', () => {
+    const wd = new ControllerWatchdog();
+    wd.recordAck(dome, 0);
+    expect(wd.markAllDown()).toEqual([dome]);
+    wd.recordAck(dome, 100); // reconnected
+    expect(wd.markAllDown()).toEqual([dome]); // can be flagged again
+  });
+
   it('a sweep after markAllDown does not re-emit', () => {
     const wd = new ControllerWatchdog();
     wd.recordAck(dome, 0);
@@ -96,7 +104,6 @@ describe('ControllerWatchdog', () => {
       controllerLocation: 'dome',
       up: false,
       synced: false,
-      firmwareVersion: '',
       firmwareCompatible: false,
     });
   });

--- a/astros_api/src/serial/controller_watchdog.ts
+++ b/astros_api/src/serial/controller_watchdog.ts
@@ -1,4 +1,4 @@
-import { StatusResponse, TransmissionType } from 'src/models/index.js';
+import { StatusResponse, TransmissionType, type LocationName } from 'src/models/index.js';
 
 /** How long a controller may be silent (no POLL_ACK) before it is marked DOWN. */
 export const STATUS_STALE_TIMEOUT_MS = 10_000;
@@ -9,7 +9,7 @@ export const STATUS_SWEEP_INTERVAL_MS = 2_000;
 export interface ControllerIdentity {
   controllerId: string;
   controllerAddress: string;
-  controllerLocation: string; // body | core | dome — the key the frontend reads
+  controllerLocation: LocationName; // body | core | dome — the key the frontend reads
 }
 
 /**
@@ -79,7 +79,6 @@ export function buildDownStatus(id: ControllerIdentity): StatusResponse {
     controllerLocation: id.controllerLocation,
     up: false,
     synced: false,
-    firmwareVersion: '',
     firmwareCompatible: false,
   };
 }

--- a/astros_api/src/serial/controller_watchdog.ts
+++ b/astros_api/src/serial/controller_watchdog.ts
@@ -1,0 +1,84 @@
+import { StatusResponse, TransmissionType } from 'src/models/index.js';
+
+/** How long a controller may be silent (no POLL_ACK) before it is marked DOWN. */
+export const STATUS_STALE_TIMEOUT_MS = 10_000;
+/** How often the staleness sweep runs. */
+export const STATUS_SWEEP_INTERVAL_MS = 2_000;
+
+/** The identity a DOWN broadcast needs, captured from each POLL_ACK. */
+export interface ControllerIdentity {
+  controllerId: string;
+  controllerAddress: string;
+  controllerLocation: string; // body | core | dome — the key the frontend reads
+}
+
+/**
+ * Tracks controller liveness from POLL_ACK timestamps and decides which
+ * controllers have gone silent. Pure logic: the caller passes `now` and does the
+ * broadcasting — no serial/DB/WS/Date.now() here, so it is fully unit-testable.
+ *
+ * Edge-triggered: a controller emits one DOWN on the up->down transition (via the
+ * `down` set), not once per sweep, preventing WS spam and UI flapping.
+ */
+export class ControllerWatchdog {
+  private readonly lastSeen = new Map<string, { id: ControllerIdentity; at: number }>();
+  private readonly down = new Set<string>();
+
+  constructor(private readonly staleTimeoutMs: number = STATUS_STALE_TIMEOUT_MS) {}
+
+  /** A POLL_ACK arrived: stamp last-seen and clear any DOWN flag. */
+  recordAck(id: ControllerIdentity, now: number): void {
+    this.lastSeen.set(id.controllerId, { id, at: now });
+    this.down.delete(id.controllerId);
+  }
+
+  /**
+   * Periodic check: return controllers silent longer than the timeout that are
+   * not already flagged, marking them DOWN. Caller broadcasts each as up:false.
+   */
+  sweep(now: number): ControllerIdentity[] {
+    const newlyDown: ControllerIdentity[] = [];
+    for (const [controllerId, entry] of this.lastSeen) {
+      if (this.down.has(controllerId)) {
+        continue;
+      }
+      if (now - entry.at > this.staleTimeoutMs) {
+        this.down.add(controllerId);
+        newlyDown.push(entry.id);
+      }
+    }
+    return newlyDown;
+  }
+
+  /**
+   * Serial close/error fast-path: return every seen controller not already
+   * flagged, marking them DOWN. They stay down until a fresh recordAck.
+   */
+  markAllDown(): ControllerIdentity[] {
+    const newlyDown: ControllerIdentity[] = [];
+    for (const [controllerId, entry] of this.lastSeen) {
+      if (this.down.has(controllerId)) {
+        continue;
+      }
+      this.down.add(controllerId);
+      newlyDown.push(entry.id);
+    }
+    return newlyDown;
+  }
+}
+
+/** Synthesize the DOWN StatusResponse the UI renders as ControllerStatus.DOWN. */
+export function buildDownStatus(id: ControllerIdentity): StatusResponse {
+  return {
+    type: TransmissionType.status,
+    success: true,
+    message: '',
+    controllerId: id.controllerId,
+    controllerAddress: id.controllerAddress,
+    controllerLocation: id.controllerLocation,
+    up: false,
+    synced: false,
+    firmwareVersion: '',
+    firmwareCompatible: false,
+  };
+}

--- a/astros_api/src/serial/controller_watchdog.ts
+++ b/astros_api/src/serial/controller_watchdog.ts
@@ -53,6 +53,7 @@ export class ControllerWatchdog {
   /**
    * Serial close/error fast-path: return every seen controller not already
    * flagged, marking them DOWN. They stay down until a fresh recordAck.
+   * Subsequent calls without an intervening recordAck return [] (idempotent).
    */
   markAllDown(): ControllerIdentity[] {
     const newlyDown: ControllerIdentity[] = [];

--- a/astros_api/src/serial/controller_watchdog.ts
+++ b/astros_api/src/serial/controller_watchdog.ts
@@ -1,4 +1,4 @@
-import { StatusResponse, TransmissionType, type LocationName } from 'src/models/index.js';
+import { TransmissionType, type LocationName, type StatusResponse } from 'src/models/index.js';
 
 /** How long a controller may be silent (no POLL_ACK) before it is marked DOWN. */
 export const STATUS_STALE_TIMEOUT_MS = 10_000;


### PR DESCRIPTION
# Design: server-side controller status watchdog

**Date:** 2026-06-01
**Branch:** `feature/controller-status-watchdog` (off `develop`)
**Status:** design — pending user review

## Problem

A controller's status on the Status page is **edge-triggered on good news
only**: every update flows from a positive `POLL_ACK` through
`handlePollResponse`, which broadcasts a `StatusResponse` with `up: true`
(`api_server.ts:1001-1014`). There is no path that ever broadcasts `up: false`.

So if the master ESP goes offline while a browser Status page is open:

- The browser↔server WebSocket stays up (the Node server is fine), so the
  frontend's reconnect logic never fires and never resets status.
- The serial `'close'`/`'error'` handlers only log (`api_server.ts:659-665`).
- No server-side timeout marks a silent controller offline — there is no
  per-controller last-seen tracking and no sweep timer.

Result: the badges **freeze at their last-known value**. A controller that was
`UP` (green) when the master died stays green indefinitely, misleading the
operator into thinking the droid is reachable. (Confirmed by code trace
2026-06-01; the frozen-UP case is the dangerous one — a *page load* while the
master is offline happens to show DOWN only because the store defaults to DOWN.)

## Goal

Detect that controllers have gone silent and broadcast `up: false` so the UI
flips them to `DOWN` (grey), via two complementary triggers:

1. **Staleness sweep** — per-controller: no `POLL_ACK` within ~10 s → DOWN.
2. **Serial-close fast-path** — the serial `'close'`/`'error'` event → mark all
   known controllers DOWN immediately (don't wait out the 10 s).

**Non-goals:** reconnecting the serial port (no auto-reconnect exists today and
that stays out of scope); a distinct `UNKNOWN`/`DISCONNECTED` UI state (we reuse
`DOWN`); the firmware OTA deploy-phase watchdog, which is a *different* concern
with its own spec (`2026-05-29-firmware-deploy-watchdog-design.md`) — that one
fails a flash *job*; this one tracks *liveness status* of controllers.

## Design decisions (settled in brainstorming)

1. **Staleness sweep + serial-close fast-path** (not either alone). The sweep
   catches a wedged master (port open, polling stopped) and a single padawan
   dropping while the master keeps acking; the close fast-path gives instant
   feedback on a physical unplug instead of waiting out the timeout.
2. **Reuse `StatusResponse{ up: false }` → frontend `DOWN`.** The frontend
   already maps `!up` to `ControllerStatus.DOWN` (grey overlay). **No new enum,
   no new message type, no frontend changes.** "down" already effectively means
   "not reachable" since polls only ever send `up: true`.
3. **~10 s silence, swept every 2 s.** Each controller is realistically heard
   ~every 4 s (firmware polls every 2 s, alternating master self-ack / padawan
   poll), so 10 s ≈ 2–3 missed cycles of slack — tolerates dropped serial frames
   without false-flagging, surfaces a real outage within a few seconds.
   Configurable; defaults `STATUS_STALE_TIMEOUT_MS = 10_000`,
   `STATUS_SWEEP_INTERVAL_MS = 2_000`.
4. **Edge-triggered.** Emit one DOWN on the `up → down` transition, not every
   sweep — a `down` set turns the level condition ("still silent") into an event
   ("just went silent"). Prevents WS spam and UI flapping.
5. **Suppress the sweep while a flash job is active.** During an OTA flash the
   master reboots and polls legitimately pause > 10 s; the firmware-stages board
   already owns per-controller status then. While
   `flashOrchestrator.getCurrentJob() !== null`, skip the sweep. The
   serial-close fast-path stays active (a genuine unplug mid-flash is still real).
6. **Identity captured from each `POLL_ACK`.** The DOWN message needs
   `controllerId`, `controllerAddress`, `controllerLocation`; the watchdog stores
   those at `recordAck` time so it can synthesize a DOWN without a DB lookup.

## Mechanism

### New module — `astros_api/src/serial/controller_watchdog.ts`

Pure timing logic: no serial, no DB, no WebSocket, no `Date.now()` (the caller
passes `now`). Fully unit-testable with explicit timestamps.

```ts
interface ControllerIdentity {
  controllerId: string;
  controllerAddress: string;
  controllerLocation: string; // body | core | dome (the frontend key)
}

class ControllerWatchdog {
  constructor(private readonly staleTimeoutMs = STATUS_STALE_TIMEOUT_MS) {}
  private lastSeen = new Map<string, { id: ControllerIdentity; at: number }>();
  private down = new Set<string>(); // controllerIds currently flagged down

  // POLL_ACK arrived: stamp last-seen, clear any down flag.
  recordAck(id: ControllerIdentity, now: number): void;

  // Periodic: return controllers gone silent > staleTimeoutMs and not already
  // down; mark them down. Caller broadcasts a DOWN StatusResponse for each.
  sweep(now: number): ControllerIdentity[];

  // Serial close/error: return all seen-but-not-already-down controllers; add
  // them to `down` (so a later sweep won't re-emit). They stay down until a
  // fresh recordAck clears the flag. (No `now` — it flags, it doesn't stamp time.)
  markAllDown(): ControllerIdentity[];
}
```

Keyed by `controllerId` (the DB identity `handlePollResponse` already resolves).
A never-seen controller is absent from `lastSeen`, so it is never flagged DOWN —
the frontend's default `DOWN` covers cold-start, with no spurious up→down churn.

### Wiring in `api_server` (the only consumer; serial-adjacent, skipped in test)

- **Record:** in `handlePollResponse`, right where it builds the `up:true`
  `StatusResponse` (`:1001`), also call
  `this.watchdog.recordAck({ controllerId, controllerAddress, controllerLocation }, Date.now())`.
- **Sweep:** a `setInterval(STATUS_SWEEP_INTERVAL_MS)` that, **unless**
  `this.flashOrchestrator?.getCurrentJob()` is non-null, runs
  `for (const id of this.watchdog.sweep(Date.now())) this.updateClients(buildDownStatus(id))`.
  The timer is `.unref()`'d (never holds the process open), stored on the
  instance, and `clearInterval`'d in the existing shutdown path. Created inside
  the serial-setup block that already no-ops under `NODE_ENV=test`.
- **Fast-path:** the `'close'` and `'error'` handlers (`:659-665`) additionally
  `for (const id of this.watchdog.markAllDown()) this.updateClients(buildDownStatus(id))`.

### The DOWN message — `buildDownStatus(id): StatusResponse`

Identical shape to the live path, `up:false`. The inert `synced`/`firmwareCompatible`
fields are ignored when `!up`. `firmwareVersion` is omitted so the UI keeps showing
a dash (its `?? '—'` fallback) rather than a blank, which would clobber the
last-known version during an outage.

```ts
{ type: TransmissionType.status, success: true, message: '',
  controllerId, controllerAddress, controllerLocation,
  up: false, synced: false, firmwareCompatible: false }
```

### Recovery — free

The next `POLL_ACK` runs the existing `handlePollResponse`, which broadcasts
`up:true` *and* calls `recordAck` (clearing the down flag). No recovery code.

## Races & invariants

- **Edge-trigger prevents spam/flap.** `down` set ⇒ one DOWN per outage; the
  2 s sweep does not re-emit while still silent.
- **Asymmetric ownership.** The watchdog only ever introduces the down
  transition; the existing poll handler owns the up transition. The two can't
  fight: a fresh ack always wins (it clears `down` and broadcasts `up:true`).
- **`markAllDown` then `sweep` don't double-fire.** `markAllDown` adds to `down`,
  so the subsequent sweep skips them; they stay down until a fresh `recordAck`
  clears the flag (correct — the port stays closed, no auto-reconnect).
- **`'error'` + `'close'` both firing is idempotent** (edge-trigger).
- **Flash suppression is sweep-only.** Serial-close still fires during a flash;
  a real unplug mid-flash is a real event.
- **Timer lifecycle.** `.unref()` so tests/process aren't held open;
  `clearInterval` on shutdown so no callback runs against a torn-down server.

## Surfaces touched

- **Backend only.** New `serial/controller_watchdog.ts` + `.test.ts`;
  `api_server.ts` wiring (instantiate, `recordAck` in `handlePollResponse`, sweep
  interval, `markAllDown` in serial handlers, `buildDownStatus` helper,
  `clearInterval` on shutdown). Two timing constants.
- **No frontend changes. No DB changes. No new WS message type.**

## Tests

- **Unit (`controller_watchdog.test.ts`, TDD, mutation-checked):**
  recordAck-then-sweep-before-threshold → no DOWN; after-threshold → one DOWN;
  second sweep → no re-emit (edge-trigger); ack-after-down → clears, re-fires on
  next timeout; `markAllDown` → all seen, not unseen, idempotent; never-seen →
  never emitted; `buildDownStatus` shape. Revert each guard and confirm the test
  fails (per the project's defensive-feature mutation convention).
- **Wiring** (serial/interval in `api_server`) is exercised by **manual QA**, per
  the serial TDD exception: open the Status page with controllers UP, pull the
  master's serial, confirm all badges go grey within ~10 s (and immediately if
  the close event fires); reconnect/repower, confirm they return to green on the
  next poll; start a flash and confirm the page does not flap mid-flash.

## Failure-mode inventory

A short inventory (template: `.docs/templates/failure-mode-inventory.md`) will be
filled in the plan covering: timer leak on shutdown; callback firing post-teardown;
double-fire on error+close; false-positive during flash; false-positive on a
flaky link (threshold tuning); never-seen-controller churn; and recovery
correctness.

## Out of scope (follow-ups)

- Serial **auto-reconnect** (none exists today; the watchdog reports the outage,
  it doesn't heal it).
- A distinct `UNKNOWN`/`DISCONNECTED` UI state (reusing `DOWN` for now).
- A `lastSeenAt` column / persisted liveness (in-memory only this PR).
